### PR TITLE
Cleanup aec_conductor workers better and don't log lager:error

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -392,7 +392,7 @@ handle_worker_reply(Pid, Reply, State) ->
                                 },
             worker_reply(Tag, Reply, State1);
         error ->
-            epoch_mining:error("Got unsolicited worker reply: ~p",
+            epoch_mining:info("Got unsolicited worker reply: ~p",
                                [{Pid, Reply}]),
             State
     end.
@@ -456,6 +456,9 @@ kill_worker(Pid, Info, State) ->
     Blocked = State#state.blocked_tags,
     cleanup_after_worker(Info),
     exit(Pid, shutdown),
+    %% Flush messages from this worker.
+    receive {worker_reply, Pid, _} -> ok
+    after 0 -> ok end,
     State#state{workers = orddict:erase(Pid, Workers),
                 blocked_tags = ordsets:del_element(
                                  Info#worker_info.tag,

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -492,8 +492,8 @@ handle_info({'DOWN', Ref, process, Pid, _}, #state{peer_monitors = PMons} = Stat
         {value, _, #peer{connection = {_, Pid}}} ->
             %% This was an unexpected process down. Clean it up.
             %% TODO: This should probably be restarted.
-            lager:error("Peer connection died - removing: ~p : ~p",
-                        [Pid, ppp(PeerId)]),
+            lager:warning("Peer connection died - removing: ~p : ~p",
+                          [Pid, ppp(PeerId)]),
             Peers = remove_peer(PeerId, State#state.peers),
             {noreply, State#state{peers = Peers}};
         _ ->

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -146,7 +146,7 @@ handle_call({fetch_next, PeerId, HeightIn, HashIn, Result}, _, State) ->
     lager:debug("fetch next from Hashpool ~p", [ [ {H, maps:is_key(block, Map)} || {{H,_}, Map} <- HashPool] ]),
     case update_chain_from_pool(HeightIn, HashIn, HashPool) of
         {error, Reason} ->
-            lager:error("chain update failed ~p", [Reason]),
+            lager:info("chain update failed ~p", [Reason]),
             {reply, {error, sync_stopped}, State#state{hash_pool = HashPool}};
         {ok, NewHeight, NewHash, []} ->
             lager:debug("Got all the blocks in hash pool"),


### PR DESCRIPTION
We should flush messages from workers that are pre-empted.