### PR TITLE
PT-158864866: Remove keys.password from config

### DIFF
--- a/apps/aeutils/priv/epoch_config_schema.json
+++ b/apps/aeutils/priv/epoch_config_schema.json
@@ -304,11 +304,6 @@
                     "Location (directory) of the public/private key pair(s)",
                     "type" : "string"
                 },
-                "password" : {
-                    "description" :
-                    "Password used to encrypt the key-pair files",
-                    "type" : "string"
-                },
                 "peer_password" : {
                     "description" :
                     "Password used to encrypt the peer key-pair files - if left blank `password` will be used",

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -92,7 +92,6 @@ websocket:
 
 keys:
     dir: keys
-    password: "secret"
     peer_password: "secret"
 
 chain:


### PR DESCRIPTION
Remove `keys.password` from configuration. 

It's a follow-up for https://github.com/aeternity/epoch/pull/1681 
It's blocked by infrastructure update: https://github.com/aeternity/infrastructure/pull/133