### PR TITLE
remove catch-all base_gas clause

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -127,10 +127,7 @@ tx_base_gas(name_update_tx) -> ?TX_BASE_GAS;
 tx_base_gas(oracle_extend_tx) -> ?TX_BASE_GAS;
 tx_base_gas(oracle_query_tx) -> ?TX_BASE_GAS;
 tx_base_gas(oracle_register_tx) -> ?TX_BASE_GAS;
-tx_base_gas(oracle_response_tx) -> ?TX_BASE_GAS;
-tx_base_gas(_) ->
-    %% never accept unknown transaction types
-    block_gas_limit().
+tx_base_gas(oracle_response_tx) -> ?TX_BASE_GAS.
 
 byte_gas() ->
     ?BYTE_GAS.


### PR DESCRIPTION
See [PT #163250430](https://www.pivotaltracker.com/story/show/163250430)

Main motivation: Make dialyzer able to detect whether a clause is missing after adding a tx type, rather than relying on testing to find out.