### PR TITLE
PT-163383284 no more wrap-around arithmetic

### DIFF
--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -173,6 +173,7 @@ error_to_binary(unknown_error) -> <<"unknown_error">>;
 error_to_binary(unknown_contract) -> <<"unknown_contract">>;
 error_to_binary(unknown_function) -> <<"unknown_function">>;
 error_to_binary(reentrant_call) -> <<"reentrant_call">>;
+error_to_binary(arithmetic_error) -> <<"arithmetic_error">>;
 error_to_binary({illegal_instruction, OP}) when is_integer(OP), 0 =< OP, OP =< 255 ->
     X = <<_:2/bytes>> = list_to_binary(io_lib:format("~2.16.0B",[OP])),
     <<"illegal_instruction_", X:2/bytes>>;

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -3208,16 +3208,18 @@ sophia_operators(_Cfg) ->
     ?assertEqual(4,  ?call(call_contract, Acc, IdC, int_op, word, {9, 5, <<"mod">>})),
     ?assertEqual(81,  ?call(call_contract, Acc, IdC, int_op, word, {3, 4, <<"^">>})),
 
+    ArithError = {error, <<"arithmetic_error">>},
+
     ?assertEqual(IMax band (bnot 45), ?call(call_contract, Acc, IdC, int_op, word, {45, 0, <<"bnot">>})),
     ?assertEqual(45 band 127,         ?call(call_contract, Acc, IdC, int_op, word, {45, 127, <<"band">>})),
     ?assertEqual(45 bor 127,          ?call(call_contract, Acc, IdC, int_op, word, {45, 127, <<"bor">>})),
     ?assertEqual(45 bxor 127,         ?call(call_contract, Acc, IdC, int_op, word, {45, 127, <<"bxor">>})),
     ?assertEqual(4252 bsl 9,          ?call(call_contract, Acc, IdC, int_op, word, {4252, 9, <<"bsl">>})),
     ?assertEqual(0,                   ?call(call_contract, Acc, IdC, int_op, word, {2, 255, <<"bsl">>})), %% overflow
-    ?assertEqual(0,                   ?call(call_contract, Acc, IdC, int_op, word, {4252, 300, <<"bsl">>})), %% overflow
+    ?assertEqual(ArithError,          ?call(call_contract, Acc, IdC, int_op, word, {4252, 300, <<"bsl">>})), %% overflow
     ?assertEqual(4252 bsr 3,          ?call(call_contract, Acc, IdC, int_op, word, {4252, 3, <<"bsr">>})),
     ?assertEqual(0,                   ?call(call_contract, Acc, IdC, int_op, word, {4252, 15, <<"bsr">>})),  %% underflow
-    ?assertEqual(0,                   ?call(call_contract, Acc, IdC, int_op, word, {IMax, 256, <<"bsr">>})),  %% underflow
+    ?assertEqual(ArithError,          ?call(call_contract, Acc, IdC, int_op, word, {IMax, 256, <<"bsr">>})),  %% underflow
 
     ?assertEqual(1, ?call(call_contract, Acc, IdC, bool_op, word, {0, 0, <<"!">>})),
     ?assertEqual(1, ?call(call_contract, Acc, IdC, bool_op, word, {1, 1, <<"&&">>})),
@@ -3261,12 +3263,12 @@ sophia_int_to_str(_Cfg) ->
 
     BAcc = list_to_binary(base58:binary_to_base58(Acc)),
     io:format("Address: ~p\n", [Acc]),
-    ?assertMatch({BAcc, _},
-                  ?call(call_contract, Acc, IdC, a2s, string, {Acc}, #{ return_gas_used => true })),
+    ?assertMatch({_, {BAcc, _}},
+                  {Acc, ?call(call_contract, Acc, IdC, a2s, string, {Acc}, #{ return_gas_used => true })}),
 
     BIdC = list_to_binary(base58:binary_to_base58(IdC)),
-    ?assertMatch({BIdC, _},
-                  ?call(call_contract, Acc, IdC, a2s, string, {IdC}, #{ return_gas_used => true })),
+    ?assertMatch({_, {BIdC, _}},
+                  {IdC, ?call(call_contract, Acc, IdC, a2s, string, {IdC}, #{ return_gas_used => true })}),
 
     Addr = <<90,139,56,117,121,128,91,84,78,146,81,166,106,181,248,87,147,41,74,158,109,135,221,178,120,168,101,101,80,152,186,248>>,
     BAddr = list_to_binary(base58:binary_to_base58(Addr)),

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -1347,35 +1347,49 @@ is_valid_instruction(?SUICIDE       , VM) -> not ?IS_VM_SOPHIA(VM).
 %% ARITHMETIC
 %% ------------------------------------------------------------------------
 
-add(Arg1, Arg2, _VMVersion) -> (Arg1 + Arg2) band ?MASK256.
-mul(Arg1, Arg2, _VMVersion) -> (Arg1 * Arg2) band ?MASK256.
-sub(Arg1, Arg2, _VMVersion) -> (Arg1 - Arg2) band ?MASK256.
-exp(Arg1, Arg2, _VMVersion) -> pow(Arg1, Arg2) band ?MASK256.
-idiv(_Arg1,    0, _VMVersion)-> 0;
-idiv(Arg1, Arg2, _VMVersion)-> (Arg1 div Arg2) band ?MASK256.
-sdiv(_Arg1, 0, _VMVersion)-> 0;
-sdiv(?NEG2TO255, -1, _VMVersion) -> ?NEG2TO255;
-sdiv(Arg1, Arg2, _VMVersion) ->
-    <<SArg1:256/integer-signed>> = <<Arg1:256/integer-unsigned>>,
-    <<SArg2:256/integer-signed>> = <<Arg2:256/integer-unsigned>>,
-    (SArg1 div SArg2) band ?MASK256.
+%% Truncate a signed word. Throw arithmetic error on VM_AEVM_SOPHIA_2 and above
+%% if this is not a no op.
+truncate(X, VM) -> check_safe_math(X, signed(X), VM).
 
-mod(_Arg1,   0, _VMVersion) -> 0;
-mod(Arg1, Arg2, _VMVersion) -> modulo(Arg1, Arg2) band ?MASK256.
+%% VM_AEVM_SOPHIA_2 and above uses safe arithmetic
+arith_error(_, VM) when ?IS_VM_SOPHIA(VM), VM >= ?VM_AEVM_SOPHIA_2 ->
+    eval_error(arithmetic_error);
+arith_error(X, _) -> X.
 
-smod(_Arg1,   0, _VMVersion) -> 0;
-smod(Arg1, Arg2, _VMVersion) -> smodulo(Arg1, Arg2) band ?MASK256.
+check_safe_math(X, X, _)  -> unsigned(X);
+check_safe_math(_, X, VM) -> arith_error(unsigned(X), VM).
 
+add(Arg1, Arg2, VM) -> truncate(signed(Arg1) + signed(Arg2), VM).
+mul(Arg1, Arg2, VM) -> truncate(signed(Arg1) * signed(Arg2), VM).
+sub(Arg1, Arg2, VM) -> truncate(signed(Arg1) - signed(Arg2), VM).
 
-addmod(_Arg1,_Arg2,   0, _VMVersion) -> 0;
-addmod(Arg1, Arg2, Arg3, _VMVersion) -> modulo((Arg1 + Arg2), Arg3) band ?MASK256.
+exp(Arg1, Arg2, VM) when ?IS_VM_SOPHIA(VM), VM >= ?VM_AEVM_SOPHIA_2 ->
+    pow(signed(Arg1), signed(Arg2), VM);
+exp(Arg1, Arg2, VM) -> pow(Arg1, Arg2, VM). %% Allow negative exponents for VM < SOPHIA_2
+
+idiv(_Arg1,   0, VM)  -> arith_error(0, VM);
+idiv(Arg1, Arg2, _VM) -> (Arg1 div Arg2) band ?MASK256.
+
+sdiv(_Arg1, 0, VM)-> arith_error(0, VM);
+sdiv(?NEG2TO255, -1, VM) -> arith_error(?NEG2TO255, VM);
+sdiv(Arg1, Arg2, VM) ->
+    truncate(signed(Arg1) div signed(Arg2), VM).
+
+mod(_Arg1,   0, VM) -> arith_error(0, VM);
+mod(Arg1, Arg2, VM) -> truncate(modulo(Arg1, Arg2), VM).
+
+smod(_Arg1,   0, VM) -> arith_error(0, VM);
+smod(Arg1, Arg2, VM) -> truncate(smodulo(Arg1, Arg2), VM).
+
+addmod(_Arg1,_Arg2,   0, VM) -> arith_error(0, VM);
+addmod(Arg1, Arg2, Arg3, VM) -> truncate(modulo(Arg1 + Arg2, Arg3), VM).
 
 modulo(Arg1, Arg2) ->
     Res = (Arg1 rem Arg2 + Arg2) rem Arg2,
     Res.
 
-mulmod(_Arg1,_Arg2,   0, _VMVersion) -> 0;
-mulmod(Arg1, Arg2, Arg3, _VMVersion) -> modulo((Arg1 * Arg2), Arg3) band ?MASK256.
+mulmod(_Arg1,_Arg2,   0, VM) -> arith_error(0, VM);
+mulmod(Arg1, Arg2, Arg3, VM) -> truncate(modulo(Arg1 * Arg2, Arg3), VM).
 
 signed(UVal) ->
     <<SVal:256/integer-signed>> = <<UVal:256/integer-unsigned>>,
@@ -1386,21 +1400,21 @@ unsigned(SVal) ->
     UVal.
 
 smodulo(Arg1, Arg2) ->
-    <<SArg1:256/integer-signed>> = <<Arg1:256/integer-unsigned>>,
-    <<SArg2:256/integer-signed>> = <<Arg2:256/integer-unsigned>>,
-    Res = (SArg1 rem (SArg2 + SArg2)) rem SArg2,
-    Res.
+    SArg1 = signed(Arg1),
+    SArg2 = signed(Arg2),
+    (SArg1 rem (SArg2 + SArg2)) rem SArg2.
 
-pow(X, Y) when is_integer(X), is_integer(Y), Y >= 0 ->
-    pow(1, X, Y).
+pow(X, Y, VM) when is_integer(X), is_integer(Y), Y >= 0 ->
+    truncate(pow(1, X, Y, VM), VM);
+pow(_, _, _) -> eval_error(arithmetic_error).
 
-pow(N, _, 0) ->     N;
-pow(N, X, 1) -> X * N;
-pow(N, X, Y) ->
-    Square = (X * X) band ?MASK256,
+pow(N, _, 0, _) ->     N;
+pow(N, X, 1, _) -> X * N;
+pow(N, X, Y, VM) ->
+    Square = truncate(X * X, VM),
     Exp = Y bsr 1,
-    if (Y band 1) =:= 0 -> pow(    N, Square, Exp);
-       true             -> pow(X * N, Square, Exp)
+    if (Y band 1) =:= 0 -> pow(    N, Square, Exp, VM);
+       true             -> pow(X * N, Square, Exp, VM)
     end.
 
 shl(Arg1, _Arg2) when Arg1 > 255 -> 0;

--- a/docs/release-notes/next-minerva/PT-163383284-no-more-wrap-around-arith.md
+++ b/docs/release-notes/next-minerva/PT-163383284-no-more-wrap-around-arith.md
@@ -1,0 +1,1 @@
+* Changes AEVM semantics of arithmetic operations to fail on over/underflow.

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
                      {ref,"720510a"}}},
 
         {aesophia, {git, "https://github.com/aeternity/aesophia.git",
-                     {ref,"c5c7309"}}},
+                     {ref,"922107e"}}},
 
         %% forks
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,7 +10,7 @@
   0},
  {<<"aesophia">>,
   {git,"https://github.com/aeternity/aesophia.git",
-      {ref,"c5c73097fc793ef73ee03102fa9cd91cb3006acb"}},
+      {ref,"922107e438077694c190f999375ebe15602a44a2"}},
   0},
  {<<"base58">>,
   {git,"https://github.com/aeternity/erl-base58.git",

--- a/test/contracts/safe_math.aes
+++ b/test/contracts/safe_math.aes
@@ -1,0 +1,10 @@
+
+contract SafeMath =
+
+  function add(x, y) = x + y
+  function sub(x, y) = x - y
+  function mul(x, y) = x * y
+  function div(x, y) = x / y
+  function rem(x, y) = x mod y
+  function pow(x, y) = x ^ y
+


### PR DESCRIPTION
Pivotal: [PT-163383284](https://www.pivotaltracker.com/story/show/163383284)

Changes semantics of arithmetic operations to fail (with `arithmetic_error`) on over/underflow and division by zero.

~~TODO: this breaks string concatenation which relies on `A bsr 256 == 0`.~~

~~Waiting for https://github.com/aeternity/aesophia/pull/15 which fixes the string concat issue.~~

Good to go.