### PR TITLE
PT-162549365 appveyor config buildonly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ data/aecore/keys
 _checkouts/
 tmp/
 rebar3.crashdump
+REVISION_appveyor

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,3 @@ data/aecore/keys
 _checkouts/
 tmp/
 rebar3.crashdump
-REVISION_appveyor

--- a/apps/aevm/src/aevm.app.src
+++ b/apps/aevm/src/aevm.app.src
@@ -7,7 +7,8 @@
     stdlib,
     lager,
     jsx,
-    aebytecode
+    aebytecode,
+    aesophia
    ]},
   {env,[]},
   {modules, []},

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,6 @@ matrix:
   fast_finish: false
   allow_failures:
     - OTP_VERSION: 21.2
-    - TEST_STEP: ct
 
 init:
   - systeminfo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,8 +62,8 @@ init:
   - systeminfo
 # Attempt to ensure we don't try to convert line endings to Win32 CRLF as this will cause build to fail
   - git config --global core.autocrlf true
-# Allows RDP
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# Allows RDP, uses Git tag build-agent-v6.1.0%2B1300
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/ab48d6e110f2feb585b6b908a72d6e7dbfb83cb3/scripts/enable-rdp.ps1'))
   - echo "%APPVEYOR_REPO_COMMIT%">"%TMP%\\REVISION_appveyor_%ERTS_VERSION%"
 
 install:
@@ -78,5 +78,5 @@ build_script:
 deploy: off
 
 on_finish:
-# Set blockRdp to true to allow RDP
-  - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# Set blockRdp to true to allow RDP, uses Git tag build-agent-v6.1.0%2B1300
+  - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/ab48d6e110f2feb585b6b908a72d6e7dbfb83cb3/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,20 +24,14 @@ environment:
     - OTP_VERSION: 20.1
       ERTS_VERSION: 9.1
       BUILD_STEP: build
-    - OTP_VERSION: 20.3
-      ERTS_VERSION: 9.3
-      BUILD_STEP: build
-    - OTP_VERSION: 21.2
-      ERTS_VERSION: 10.2
-      BUILD_STEP: build
-    - OTP_VERSION: 20.1
-      ERTS_VERSION: 9.1
       TEST_STEP: ct
     - OTP_VERSION: 20.3
       ERTS_VERSION: 9.3
+      BUILD_STEP: build
       TEST_STEP: ct
     - OTP_VERSION: 21.2
       ERTS_VERSION: 10.2
+      BUILD_STEP: build
       TEST_STEP: ct
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,82 @@
+version: 1.3.0-{branch}-{build}
+
+skip_tags: false
+skip_non_tags: false
+skip_branch_with_pr: false
+
+image: Visual Studio 2017
+
+clone_folder: C:\projects\build
+shallow_clone: false
+clone_depth: 5
+
+environment:
+  global:
+    APPVEYOR_RDP_PASSWORD:
+      secure: KN38AnwEZQ6wMS1ktlkybV0BEvTUgnvajLAPBJWdH8I4lttpWzTkLdU+XgLoG6X//t76IbiaIdEPFKEDzgoHyY2xGIxofmS2BDtQD+I9T3o=
+    MSVC_VERSION: 14.16.27023
+    WIN_SDK_VERSION: 10.0.26624.0
+    WIN_MSYS2_ROOT: C:\msys64
+    WIN_MSYS2_CACHE: C:\msys64\var\cache\pacman\pkg
+    WIN_OTP_PATH: C:\Program Files\erl
+    BUILD_PATH: /c/projects/build
+  matrix:
+    - OTP_VERSION: 20.1
+      ERTS_VERSION: 9.1
+      BUILD_STEP: build
+    - OTP_VERSION: 20.3
+      ERTS_VERSION: 9.3
+      BUILD_STEP: build
+    - OTP_VERSION: 21.2
+      ERTS_VERSION: 10.2
+      BUILD_STEP: build
+    - OTP_VERSION: 20.1
+      ERTS_VERSION: 9.1
+      TEST_STEP: ct
+    - OTP_VERSION: 20.3
+      ERTS_VERSION: 9.3
+      TEST_STEP: ct
+    - OTP_VERSION: 21.2
+      ERTS_VERSION: 10.2
+      TEST_STEP: ct
+
+cache:
+  - '%WIN_MSYS2_CACHE%'                       # msys2
+  - '%LocalAppData%\NuGet\Cache'              # NuGet < v3
+  - '%LocalAppData%\NuGet\v3-cache'           # NuGet v3
+  - '%WIN_OTP_PATH%9.1'                       # Erlang/OTP 20.1
+  - '%WIN_OTP_PATH%9.3'                       # Erlang/OTP 20.3
+  - '%WIN_OTP_PATH%10.2'                      # Erlang/OTP 21.2
+  - '%USERPROFILE%\.cache\rebar3'             # rebar3 cache
+  - '_build\default_%ERTS_VERSION% -> %TMP%\REVISION_appveyor_%ERTS_VERSION%'   # local build files
+
+platform: x64
+
+matrix:
+  fast_finish: false
+  allow_failures:
+    - OTP_VERSION: 21.2
+    - TEST_STEP: ct
+
+init:
+  - systeminfo
+# Attempt to ensure we don't try to convert line endings to Win32 CRLF as this will cause build to fail
+  - git config --global core.autocrlf true
+# Allows RDP
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - echo "%APPVEYOR_REPO_COMMIT%">"%TMP%\\REVISION_appveyor_%ERTS_VERSION%"
+
+install:
+  - '%APPVEYOR_BUILD_FOLDER%\scripts\windows\msys2_prepare.bat'
+
+build_script:
+  - '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\build.bat'
+
+# test_script:
+#  - '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\test.bat'
+
+deploy: off
+
+on_finish:
+# Set blockRdp to true to allow RDP
+  - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/ci/appveyor/build.bat
+++ b/ci/appveyor/build.bat
@@ -1,0 +1,41 @@
+@echo on
+@rem Matrix-driven Appveyor CI build script
+@rem Currently only supports MSYS2 builds.
+@rem See https://www.appveyor.com/docs/installed-software#mingw-msys-cygwin
+@rem Required vars:
+@rem    BUILD_STEP
+@rem    WIN_MSYS2_ROOT
+@rem    PLATFORM
+
+SETLOCAL ENABLEEXTENSIONS
+cd %APPVEYOR_BUILD_FOLDER%
+
+rem Set required vars defaults
+IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
+IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
+IF "%PLATFORM%"=="" SET "PLATFORM=x64"
+IF "%BUILD_STEP%"=="" SET "BUILD_STEP=build"
+SET BASH_BIN="%WIN_MSYS2_ROOT%\usr\bin\bash"
+
+@echo Current time: %time%
+rem Set the paths appropriately
+
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\\vcvarsall.bat" %PLATFORM%
+@echo on
+SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
+
+:BUILDSTART
+GOTO BUILD_%BUILD_STEP%
+
+:BUILD_build
+@echo Current time: %time%
+rem Run build: build
+%BASH_BIN% -lc "cd %BUILD_PATH% && make KIND=test local-build"
+
+GOTO BUILD_DONE
+
+:BUILD_
+:BUILD_DONE
+
+@echo Current time: %time%
+rem Finished build phase

--- a/ci/appveyor/build.ps1
+++ b/ci/appveyor/build.ps1
@@ -1,0 +1,22 @@
+$ErrorActionPreference = "Stop"
+
+. "$env:APPVEYOR_BUILD_FOLDER\ci\appveyor\util.ps1"
+
+Prepare
+
+if (-not (Test-Path '_build\default_$env:ERTS_VERSION')) {
+  Exec 'Use cached build artifacts' 'robocopy "_build\default_$env:ERTS_VERSION" "_build\default" /MIR /COPYALL /NP /NS /NC /NFL /NDL'
+}
+
+switch ( $env:BUILD_STEP ) {
+  'build' {
+    Exec 'Run build: build' 'bash -lc "cd $env:BUILD_PATH && make KIND=test local-build"'
+  }
+  default {
+    Write-Host 'Unknown build step'
+  }
+}
+
+Exec 'Mirror build artifacts' 'robocopy "_build\default" "_build\default_$env:ERTS_VERSION" /MIR /COPYALL /NP /NS /NC /NFL /NDL'
+
+Info 'Finished build phase'

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -1,0 +1,43 @@
+@echo on
+@rem Matrix-driven Appveyor CI test script
+@rem Currently only supports MSYS2 builds.
+@rem See https://www.appveyor.com/docs/installed-software#mingw-msys-cygwin
+@rem Required vars:
+@rem    TEST_STEP
+@rem    WIN_MSYS2_ROOT
+
+SETLOCAL ENABLEEXTENSIONS
+cd %APPVEYOR_BUILD_FOLDER%
+
+@echo Current time: %time%
+rem Set the paths appropriately
+
+call "C:\Program Files (x86)\Microsoft Visual Studio %VS_VERSION%\VC\vcvarsall.bat" %PLATFORM%
+@echo on
+SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
+
+GOTO TEST_%TEST_STEP%
+
+:TEST_ct
+@echo Current time: %time%
+rem Run test: ct
+bash -lc "cd %BUILD_PATH% && epmd -daemon && make ct"
+
+GOTO TEST_DONE
+
+:TEST_eunit
+@echo Current time: %time%
+rem Run test: eunit
+bash -lc "cd %BUILD_PATH% && epmd -daemon && make eunit"
+
+GOTO TEST_DONE
+
+:TEST_
+:TEST_DONE
+
+@echo Current time: %time%
+rem Mirror build artifacts
+robocopy "_build\default" "_build\default_%ERTS_VERSION%" /MIR /COPYALL /NP /NS /NC /NFL /NDL
+
+@echo Current time: %time%
+rem Finished test phase

--- a/ci/appveyor/util.ps1
+++ b/ci/appveyor/util.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+
+Function Info([string]$info) {
+  Write-Host Current time: (Get-Date -format r)
+  Write-Host $info
+}
+
+Function Exec([string]$info, [string]$cmd) {
+  Write-Host Current time: (Get-Date -format r)
+  Write-Host $info
+  Write-Host $cmd
+  $cmd
+}
+
+Function Prepare() {
+  cd $env:APPVEYOR_BUILD_FOLDER
+  Exec 'Set the paths appropriately' "'C:\Program Files (x86)\Microsoft Visual Studio 2017\Community\VC\Auxiliary\Build\vcvarsall.bat' $env:PLATFORM"
+  $env:PATH='$env:MSYS2_ROOT\mingw64\bin;$env:MSYS2_ROOT\usr\bin;$env:PATH'
+}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -33,8 +33,8 @@ AdaptOverlayBin = fun(Overlay) ->
 %% Update relx config
 Relx0 = lists:keyfind(relx, 1, CONFIG),
 {relx, [{release, {aeternity, _}, RelxApps0} | RelxT0]} = Relx0,
-RelxOverlay0 = lists:keyfind(overlay, 1, RelxT0),
-RelxT1 = lists:keyreplace(overlay, 1, RelxT0, AdaptOverlayBin(RelxOverlay0)),
+{overlay, RelxOverlay0} = lists:keyfind(overlay, 1, RelxT0),
+RelxT1 = lists:keyreplace(overlay, 1, RelxT0, {overlay, AdaptOverlayBin(RelxOverlay0)}),
 {ok, VersionBin} = file:read_file(<<"VERSION">>),
 Version = string:trim(binary_to_list(VersionBin)),
 %% the release should be in front
@@ -42,5 +42,5 @@ Relx = {relx, [{release, {aeternity, Version}, FilterRelxRocksDb(RelxApps0)}] ++
 CONFIG1 = lists:keyreplace(relx, 1, CONFIG, Relx),
 
 %% Update rebar deps
-Deps0 = lists:keyfind(deps, 1, CONFIG1),
-lists:keyreplace(deps, 1, CONFIG1, FilterDepsRocksDb(Deps0)).
+{deps, Deps0} = lists:keyfind(deps, 1, CONFIG1),
+lists:keyreplace(deps, 1, CONFIG1, {deps, FilterDepsRocksDb(Deps0)}).

--- a/scripts/windows/msys2_env_build.sh
+++ b/scripts/windows/msys2_env_build.sh
@@ -31,6 +31,9 @@ obe_otp_64_gcc_vsn_map="
     .*=>default
 "
 
+MSYS2_ROOT=${MSYS2_ROOT:-"${C_DRV}/msys64"}
+WIN_MSYS2_ROOT=${WIN_MSYS2_ROOT:-"${WIN_C_DRV}\\msys64"}
+
 C_DRV="/c"
 WIN_C_DRV="C:\\"
 IN_CYGWIN=false
@@ -51,11 +54,9 @@ WIN_MSVC_ROOT=${WIN_VISUAL_STUDIO_ROOT}\\VC\\Tools\\MSVC\\${MSVC_VERSION}
 WIN_MSVC=${WIN_MSVC_ROOT}/bin\\Hostx64\\x64
 
 PATH="/usr/local/bin:/usr/bin:/bin:/c/Windows/system32:/c/Windows:/c/Windows/System32/Wbem:${PATH}"
-PATH="${MSVC}:${ERL_TOP}/bin:${PATH}:${ERL_TOP}/erts-${ERTS_VERSION}/bin:${MSYS_ROOT}/mingw64/bin"
+PATH="${MSVC}:${ERL_TOP}/bin:${PATH}:${ERL_TOP}/erts-${ERTS_VERSION}/bin:${MSYS2_ROOT}/mingw64/bin"
 
-WIN_MSYS_ROOT="${WIN_C_DRV}\\msys64"
-
-INCLUDE="${INCLUDE};${WIN_MSYS_ROOT}\\mingw64\\include;${WIN_MSYS_ROOT}\\usr\\include"
-LIB="${LIB};${WIN_MSYS_ROOT}\\mingw64\\lib;${WIN_MSYS_ROOT}\\mingw64\\bin;${WIN_ERL_TOP}\\usr\\lib;"
+INCLUDE="${INCLUDE};${WIN_MSYS2_ROOT}\\mingw64\\include;${WIN_MSYS2_ROOT}\\usr\\include"
+LIB="${LIB};${WIN_MSYS2_ROOT}\\mingw64\\lib;${WIN_MSYS2_ROOT}\\mingw64\\bin;${WIN_ERL_TOP}\\usr\\lib;"
 
 export INCLUDE LIB PATH ERL_TOP WIN_ERL_TOP COMSPEC

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -3,8 +3,8 @@
 @rem Required vars:
 @rem    ERTS_VERSION
 @rem    OTP_VERSION
-@rem    OTP_PATH
-@rem    MSYS2_ROOT
+@rem    WIN_OTP_PATH
+@rem    WIN_MSYS2_ROOT
 @rem    PLATFORM
 
 SETLOCAL ENABLEEXTENSIONS
@@ -12,34 +12,35 @@ SETLOCAL ENABLEEXTENSIONS
 rem Set required vars defaults
 IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
 IF "%OTP_VERSION%"=="" SET "OTP_VERSION=20.3"
-IF "%OTP_PATH%"=="" SET "OTP_PATH=C:\Program Files\erl"
-IF "%MSYS2_ROOT%"=="" SET "MSYS2_ROOT=C:\msys64"
+IF "%WIN_OTP_PATH%"=="" SET "WIN_OTP_PATH=C:\Program Files\erl"
+IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
+SET BASH_BIN="%WIN_MSYS2_ROOT%\usr\bin\bash"
 
 @echo Current time: %time%
 rem Set the paths appropriately
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\\vcvarsall.bat" %PLATFORM%
 @echo on
-SET PATH=%MSYS2_ROOT%\mingw64\bin;%MSYS2_ROOT%\usr\bin;%PATH%
+SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
 @echo Current time: %time%
 rem Upgrade the MSYS2 platform
 
-bash -lc "pacman --noconfirm --needed -Sy pacman"
-bash -lc "pacman --noconfirm -Su"
+%BASH_BIN% -lc "pacman --noconfirm --needed -Sy pacman"
+%BASH_BIN% -lc "pacman --noconfirm --needed -Su"
 
 @echo Current time: %time%
 rem Install required tools
 
-bash -lc "pacman --noconfirm --needed -S base-devel cmake curl gcc gcc-fortran git make patch"
-bash -lc "pacman --noconfirm --needed -S mingw-w64-x86_64-SDL mingw-w64-x86_64-libsodium mingw-w64-x86_64-ntldd-git mingw-w64-x86_64-yasm"
-bash -lc "pacman --noconfirm --needed -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-gcc-objc"
+%BASH_BIN% -lc "pacman --noconfirm --needed -S base-devel cmake curl gcc gcc-fortran git make patch"
+%BASH_BIN% -lc "pacman --noconfirm --needed -S mingw-w64-x86_64-SDL mingw-w64-x86_64-libsodium mingw-w64-x86_64-ntldd-git mingw-w64-x86_64-yasm"
+%BASH_BIN% -lc "pacman --noconfirm --needed -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-gcc-objc"
 
 @echo Current time: %time%
 rem Ensure Erlang/OTP %OTP_VERSION% is installed
 
-IF EXIST "%OTP_PATH%%ERTS_VERSION%\bin\" GOTO OTPINSTALLED
+IF EXIST "%WIN_OTP_PATH%%ERTS_VERSION%\bin\" GOTO OTPINSTALLED
 SET OTP_PACKAGE=otp_win64_%OTP_VERSION%.exe
 PowerShell -Command "Invoke-WebRequest http://erlang.org/download/%OTP_PACKAGE% -OutFile %TMP%\%OTP_PACKAGE%"
 START "" /WAIT "%TMP%\%OTP_PACKAGE%" /S
@@ -48,12 +49,12 @@ START "" /WAIT "%TMP%\%OTP_PACKAGE%" /S
 @echo Current time: %time%
 rem Set up msys2 env variables
 
-COPY msys2_env_build.sh %MSYS2_ROOT%\etc\profile.d\env_build.sh
+COPY %~dp0\msys2_env_build.sh %WIN_MSYS2_ROOT%\etc\profile.d\env_build.sh
 
 @echo Current time: %time%
 rem Remove link.exe from msys2, so it does not interfere with MSVC's link.exe
 
-bash -lc "rm -f /bin/link.exe /usr/bin/link.exe"
+%BASH_BIN% -lc "rm -f /bin/link.exe /usr/bin/link.exe"
 
 @echo Current time: %time%
 rem Finished preparation

--- a/scripts/windows/msys2_shell.bat
+++ b/scripts/windows/msys2_shell.bat
@@ -1,13 +1,13 @@
 @echo on
 @rem Script to open a msys2 shell ready for building.
 @rem Required vars:
-@rem    MSYS2_ROOT
+@rem    WIN_MSYS2_ROOT
 @rem    PLATFORM
 
 SETLOCAL ENABLEEXTENSIONS
 
 rem Set required vars defaults
-IF "%MSYS2_ROOT%"=="" SET "MSYS2_ROOT=C:\msys64"
+IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 
 @echo Current time: %time%
@@ -15,9 +15,9 @@ rem Set the paths appropriately
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\\vcvarsall.bat" %PLATFORM%
 @echo on
-SET PATH=%MSYS2_ROOT%\mingw64\bin;%MSYS2_ROOT%\usr\bin;%PATH%
+SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
 @echo Current time: %time%
 rem Open shell
 
-%MSYS2_ROOT%\mingw64.exe
+%WIN_MSYS2_ROOT%\mingw64.exe


### PR DESCRIPTION
This change adds a basic appveyor configuration which builds the system using 3 different OTP versions. It allows failures on OTP 21, because the build isn't supported as of now.

Once merged, new PRs and `master` will be build on appveyor similar to CircleCI.

Status on Appveyor: [here](https://ci.appveyor.com/project/aeternity/aeternity/builds/21823519)