### PR TITLE
Fix IF in sync SUITE

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -708,6 +708,9 @@ config_apply_options(Node, Cfg, [{block_peers, BlockedPeers}| T]) ->
 config_apply_options(Node, Cfg, [{add_peers, true}| T]) ->
     Cfg1 = Cfg#{<<"peers">> =>
               [peer_info(N1) || N1 <- [dev1, dev2, dev3] -- [Node]]},
+    config_apply_options(Node, Cfg1, T);
+config_apply_options(Node, Cfg, [{add_peers, false}| T]) ->
+    Cfg1 = Cfg#{<<"peers">> => []},
     config_apply_options(Node, Cfg1, T).
 
 write_keys(Node, Config) ->

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -574,9 +574,7 @@ large_msgs(Config) ->
     aecore_suite_utils:start_node(Dev1, Config),
     aecore_suite_utils:connect(aecore_suite_utils:node_name(Dev1)),
 
-
     ok = rpc:call(N1, application, set_env, [aecore, block_gas_limit, 100000000]),
-
 
     %% Insert enough transactions to make a large generation
     Blob = fun(Size) -> << <<171:8>> || _ <- lists:seq(1, Size) >> end,

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -149,8 +149,20 @@ end_per_suite(Config) ->
 
 init_per_group(TwoNodes, Config) when
         TwoNodes == two_nodes; TwoNodes == semantically_invalid_tx;
-        TwoNodes == large_msgs; TwoNodes == mempool_sync ->
+        TwoNodes == mempool_sync ->
     config({devs, [dev1, dev2]}, Config);
+init_per_group(large_msgs, Config) -> 
+    Config1 = config({devs, [dev1, dev2]}, Config),
+    [Dev1, Dev2] = proplists:get_value(devs, Config1),
+    Epoch1Cfg = aecore_suite_utils:epoch_config(Dev1, Config),
+    Epoch2Cfg = aecore_suite_utils:epoch_config(Dev2, Config),
+    aecore_suite_utils:create_config(Dev1, Config, Epoch1Cfg,
+                                            [{add_peers, false}
+                                            ]),
+    aecore_suite_utils:create_config(Dev2, Config, Epoch2Cfg,
+                                            [{add_peers, false}
+                                            ]),
+    Config1;
 init_per_group(three_nodes, Config) ->
     config({devs, [dev1, dev2, dev3]}, Config);
 init_per_group(one_blocked, Config) ->
@@ -165,6 +177,21 @@ init_per_group(one_blocked, Config) ->
 init_per_group(_Group, Config) ->
     Config.
 
+end_per_group(large_msgs, Config) ->
+    ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
+    aec_metrics_test_utils:stop_statsd_loggers(Config),
+    stop_devs(Config),
+    %% reset dev1 and dev2 config 
+    Config1 = config({devs, [dev1, dev2]}, Config),
+    [Dev1, Dev2] = proplists:get_value(devs, Config1),
+    Epoch1Cfg = aecore_suite_utils:epoch_config(Dev1, Config),
+    Epoch2Cfg = aecore_suite_utils:epoch_config(Dev2, Config),
+    aecore_suite_utils:create_config(Dev1, Config,
+                                     Epoch1Cfg,
+                                     [{add_peers, true}]),
+    aecore_suite_utils:create_config(Dev2, Config,
+                                     Epoch2Cfg,
+                                     [{add_peers, true}]);
 end_per_group(one_blocked, Config) ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
     aec_metrics_test_utils:stop_statsd_loggers(Config),
@@ -547,7 +574,9 @@ large_msgs(Config) ->
     aecore_suite_utils:start_node(Dev1, Config),
     aecore_suite_utils:connect(aecore_suite_utils:node_name(Dev1)),
 
+
     ok = rpc:call(N1, application, set_env, [aecore, block_gas_limit, 100000000]),
+
 
     %% Insert enough transactions to make a large generation
     Blob = fun(Size) -> << <<171:8>> || _ <- lists:seq(1, Size) >> end,
@@ -577,6 +606,15 @@ large_msgs(Config) ->
     aecore_suite_utils:connect(N2),
 
     ok = rpc:call(N2, application, set_env, [aecore, block_gas_limit, 10000000]),
+
+    <<"aenode://", Peer1Url/binary>> = aecore_suite_utils:peer_info(Dev1),
+    [EncodedPeer, Host, Port] = binary:split(Peer1Url, [<<"@">>,<<":">>], [global]),
+    {ok, PeerKey} = aehttp_api_encoder:safe_decode(peer_pubkey, EncodedPeer),
+    Peer1 = #{pubkey => PeerKey,
+              host   => binary_to_list(Host),
+              port   => binary_to_integer(Port)},
+
+    ok = rpc:call(N2, aec_peers, add_trusted, [Peer1]),
 
     true = expect_same(T0, Config).
 


### PR DESCRIPTION
PT [Intermittent test failure: aecore_sync_SUITE retry_exhausted](https://www.pivotaltracker.com/story/show/163116525)

I was not able to reproduce the issue locally. My assumption is that there was a race in the test:
1. `dev1`  starts and has its max gas limit raised. This breaks backwards compatibility with an unmodified node
2. `dev1` mines some transactions, presumably exceeds the original maximum gas limit so there are microblocks that are to be rejected by a non-modified node
3. We start `dev2` and it
3.1 Is updated with the correct value for maximum gas
3.2 Starts syncing with `dev1`

My assumption is that there is a race if steps. `3.1` and `3.2` progress in a reversed order.

This PR spawns both `dev1` and `dev2` without any peers, `dev1` proceeds with the same approach as it did, then we spawn `dev2`, set its max gas limit and only then add `dev1`'s peer address as a trusted peer so they can sync.

In order to test the hypothesis, I will restart the CI a couple of times. Adding `WIP` till then.