### PR TITLE
rename aeternity binary in docker entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,4 +2,4 @@
 set -e
 
 # Using console with extra arguments because "foreground" does not handle SIGTERM/SIGQUIT
-exec ./bin/epoch console -noshell -noinput $@
+exec ./bin/aeternity console -noshell -noinput $@


### PR DESCRIPTION
Split from https://github.com/aeternity/aeternity/pull/2060
Prevents unneeded warning after https://github.com/aeternity/aeternity/pull/2062 merged