### PR TITLE
PT-162541397 Improve cleanup of UPnP/NAT-PMP mappings and assert ther…

### DIFF
--- a/apps/aecore/src/aec_upnp.erl
+++ b/apps/aecore/src/aec_upnp.erl
@@ -54,7 +54,7 @@ prep_stop() ->
             case catch gen_server:call(?MODULE, prep_stop, 10000) of
                 ok -> ok;
                 Error ->
-                    epoch_sync:info("UPnP/NAT-PMP port cleanup failed: ~p", [Error])
+                    epoch_sync:warning("UPnP/NAT-PMP port cleanup failed: ~p", [Error])
             end;
         false ->
             ok
@@ -72,7 +72,6 @@ start_link() ->
 
 init(_Args) ->
     epoch_sync:info("Starting UPnP/NAT-PMP service"),
-    process_flag(trap_exit, true),
     erlang:send_after(rand:uniform(1000), self(), add_port_mapping),
     {ok, #state{}}.
 
@@ -95,9 +94,6 @@ handle_info(add_port_mapping, State0) ->
     %% Give additional 10 secs for UPnP/NAT-PMP discovery and setup, to
     %% make sure there is continuity in port mapping.
     erlang:send_after(1000 * (?MAPPING_LIFETIME - 10), self(), add_port_mapping),
-    {noreply, State};
-handle_info({'EXIT', _Pid, normal}, State) ->
-    %% Received when calling delete_port_mapping/0 during prep_stop
     {noreply, State};
 handle_info({'DOWN', Ref, process, Pid, normal}, #state{pid = Pid, mon = Ref}) ->
     {noreply, #state{}};

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -32,6 +32,7 @@
     jsx,
     unicode_util_compat, %% to be removed, not needed in OTP 20
     idna,
+    inets,
     nat,
     aecuckoo,
     aecuckooprebuilt,

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -37,7 +37,8 @@ start_phase(start_reporters, _StartType, _PhaseArgs) ->
 
 prep_stop(State) ->
     aec_block_generator:prep_stop(),
-    aec_metrics:prep_stop(State).
+    aec_metrics:prep_stop(State),
+    aec_upnp:prep_stop().
 
 stop(_State) ->
     ok.

--- a/rebar.config
+++ b/rebar.config
@@ -43,7 +43,7 @@
         {idna, {git, "https://github.com/benoitc/erlang-idna",
                {ref, "6cff727"}}}, % tag: 6.0.0
         {nat, {git, "https://github.com/aeternity/erlang-nat.git",
-              {ref, "caa6ba6"}}},
+              {ref, "dcdfb9c"}}},
 
         %% deps originally from aeternity
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -64,7 +64,7 @@
   0},
  {<<"nat">>,
   {git,"https://github.com/aeternity/erlang-nat.git",
-      {ref,"caa6ba6c4cc416799d6fe4208c6052517d02a6d6"}},
+      {ref,"dcdfb9cd29900e05b35f60b5ffad727af41ede61"}},
   0},
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
  {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.1">>},0},


### PR DESCRIPTION
…e is maximum one process maintainting the mapping.

* Assert processes adding UPnP/NAT-PMP mappings do not accumulate - there as at maximum one such process.

* Move cleanup of UPnP/NAT-PMP mapping to `prep-stop` phase. This goes together with https://github.com/aeternity/erlang-nat/commit/e8d8eeb9909f83daae7215934b58c6bf6efd34dc, which does not start `inets` application in `erlang-nat` lib. This was not working well during application shutdown phase (when the mapping is to be removed, but `erlang-nat` was trying to do `_ = application:start(inets)` anyways).