### PR TITLE
Fix IF in sync SUITE

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -708,9 +708,6 @@ config_apply_options(Node, Cfg, [{block_peers, BlockedPeers}| T]) ->
 config_apply_options(Node, Cfg, [{add_peers, true}| T]) ->
     Cfg1 = Cfg#{<<"peers">> =>
               [peer_info(N1) || N1 <- [dev1, dev2, dev3] -- [Node]]},
-    config_apply_options(Node, Cfg1, T);
-config_apply_options(Node, Cfg, [{add_peers, false}| T]) ->
-    Cfg1 = Cfg#{<<"peers">> => []},
     config_apply_options(Node, Cfg1, T).
 
 write_keys(Node, Config) ->

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -151,21 +151,10 @@ init_per_group(TwoNodes, Config) when
         TwoNodes == two_nodes; TwoNodes == semantically_invalid_tx;
         TwoNodes == mempool_sync ->
     config({devs, [dev1, dev2]}, Config);
-init_per_group(large_msgs, Config) -> 
-    Config1 = config({devs, [dev1, dev2]}, Config),
-    [Dev1, Dev2] = proplists:get_value(devs, Config1),
-    Epoch1Cfg = aecore_suite_utils:epoch_config(Dev1, Config),
-    Epoch2Cfg = aecore_suite_utils:epoch_config(Dev2, Config),
-    aecore_suite_utils:create_config(Dev1, Config, Epoch1Cfg,
-                                            [{add_peers, false}
-                                            ]),
-    aecore_suite_utils:create_config(Dev2, Config, Epoch2Cfg,
-                                            [{add_peers, false}
-                                            ]),
-    Config1;
 init_per_group(three_nodes, Config) ->
     config({devs, [dev1, dev2, dev3]}, Config);
-init_per_group(one_blocked, Config) ->
+init_per_group(Group, Config) when Group =:= one_blocked;
+                                   Group =:= large_msgs ->
     Config1 = config({devs, [dev1, dev2]}, Config),
     [Dev1, Dev2 | _] = proplists:get_value(devs, Config1),
     EpochCfg = aecore_suite_utils:epoch_config(Dev1, Config),
@@ -177,22 +166,8 @@ init_per_group(one_blocked, Config) ->
 init_per_group(_Group, Config) ->
     Config.
 
-end_per_group(large_msgs, Config) ->
-    ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
-    aec_metrics_test_utils:stop_statsd_loggers(Config),
-    stop_devs(Config),
-    %% reset dev1 and dev2 config 
-    Config1 = config({devs, [dev1, dev2]}, Config),
-    [Dev1, Dev2] = proplists:get_value(devs, Config1),
-    Epoch1Cfg = aecore_suite_utils:epoch_config(Dev1, Config),
-    Epoch2Cfg = aecore_suite_utils:epoch_config(Dev2, Config),
-    aecore_suite_utils:create_config(Dev1, Config,
-                                     Epoch1Cfg,
-                                     [{add_peers, true}]),
-    aecore_suite_utils:create_config(Dev2, Config,
-                                     Epoch2Cfg,
-                                     [{add_peers, true}]);
-end_per_group(one_blocked, Config) ->
+end_per_group(Group, Config) when Group =:= one_blocked;
+                                   Group =:= large_msgs ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
     aec_metrics_test_utils:stop_statsd_loggers(Config),
     stop_devs(Config),
@@ -605,14 +580,7 @@ large_msgs(Config) ->
 
     ok = rpc:call(N2, application, set_env, [aecore, block_gas_limit, 10000000]),
 
-    <<"aenode://", Peer1Url/binary>> = aecore_suite_utils:peer_info(Dev1),
-    [EncodedPeer, Host, Port] = binary:split(Peer1Url, [<<"@">>,<<":">>], [global]),
-    {ok, PeerKey} = aehttp_api_encoder:safe_decode(peer_pubkey, EncodedPeer),
-    Peer1 = #{pubkey => PeerKey,
-              host   => binary_to_list(Host),
-              port   => binary_to_integer(Port)},
-
-    ok = rpc:call(N2, aec_peers, add_trusted, [Peer1]),
+    rpc:call(N1, aec_peers, unblock_all, [], 5000),
 
     true = expect_same(T0, Config).
 


### PR DESCRIPTION
This is fixing the issue #2058 tried to fix. This time with actual logs of [large_msgs](https://1977-99802036-gh.circle-artifacts.com/1/home/builder/aeternity/_build/test/logs/ct_run.aeternity_ct%40localhost.2019-01-25_10.21.50/lib.aecore.aecore_sync_SUITE.logs/run.2019-01-25_10.24.18/aecore_sync_suite.large_msgs.html).

The last approach did not work because even with empty `peers` list, the peers are taken from the `sys.config` instead. This time `dev2` is blocked until it has a proper setting of the max gas limit (that can accept a tx with a fee of 8 000 000)

