### PR TITLE
Add SSH key to allow pusing to API docs repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,9 @@ jobs:
     <<: *container_config
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "8b:3c:dd:50:78:e0:3b:a7:39:4e:7d:6e:0c:f9:fd:f6"
       - run:
           name: Deploy API docs
           command: ./deployment/deploy_api_docs.sh


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163455889

Add SSH key is needed because we changed the integration method from [Checkout SSH keys](https://circleci.com/gh/aeternity/aeternity/edit#checkout) to [SSH Permissions](https://circleci.com/gh/aeternity/aeternity/edit#ssh).

A matching SSH key is setup already.

I did a [simulating test run](https://circleci.com/gh/aeternity/aeternity/2363) in another branch.