### PR TITLE
Search for new aeternity config locations

### DIFF
--- a/apps/aecore/src/aec_jobs_queues.erl
+++ b/apps/aecore/src/aec_jobs_queues.erl
@@ -52,7 +52,7 @@ metric(Queue, Sub) ->
 %% This function, called from aecore_app:start(), adds the configurable jobs
 %% queues for epoch.
 %%
-%% The configuration is done in the $EPOCH_CONFIG (.yaml or .json).
+%% The configuration is done in the $AETERNITY_CONFIG (.yaml or .json).
 %% To define a new queue, add it to the epoch_config_schema.json under
 %% the "regulators" section. The name of the object becomes the name of the
 %% queue. Currently supported parameters are 'rate' and 'counter' limits,

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -177,7 +177,7 @@ start_node(N, Config) ->
     cmd("epoch", node_shortcut(N, Config), "bin", ["start"],
         [
          {"ERL_FLAGS", Flags},
-         {"EPOCH_CONFIG", "data/epoch.json"},
+         {"AETERNITY_CONFIG", "data/aeternity.json"},
          {"RUNNER_LOG_DIR","log"},
          {"CODE_LOADING_MODE", "interactive"}
         ]).
@@ -751,7 +751,7 @@ default_config(N, Config) ->
      }.
 
 epoch_config_dir(N, Config) ->
-    filename:join(data_dir(N, Config), "epoch.json").
+    filename:join(data_dir(N, Config), "aeternity.json").
 
 %% dirs
 node_shortcut(N, Config) ->

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -311,7 +311,8 @@ search_default_config() ->
     search_config(Dirs, "aeternity.{json,yaml}").
 
 search_deprecated_config() ->
-    Dirs = [filename:join([os:getenv("HOME"), ".epoch", "epoch"])],
+    Dirs = [filename:join([os:getenv("HOME"), ".epoch", "epoch"]),
+            setup:home()],
     search_config(Dirs, "epoch.{json,yaml}").
 
 search_config(Dirs, FileWildcard) ->

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -273,8 +273,20 @@ check_config(F) ->
 check_config(F, Schema) ->
     do_read_config(F, Schema, check, silent).
 
+data_dir(Name) when is_atom(Name) ->
+    filename:join([setup:data_dir(), Name]).
+
 config_file() ->
-    case os:getenv("EPOCH_CONFIG") of
+    case default_config_file()  of
+        undefined ->
+            undefined;
+%%            deprecated_config_file();
+        F ->
+            F
+    end.
+
+default_config_file() ->
+    case os:getenv("AETERNITY_CONFIG") of
         false ->
             case setup:get_env(aecore, config) of
                 {ok, F} ->
@@ -286,18 +298,29 @@ config_file() ->
             F
     end.
 
-data_dir(Name) when is_atom(Name) ->
-  filename:join([setup:data_dir(), Name]).
+deprecated_config_file() ->
+    case os:getenv("EPOCH_CONFIG") of
+        false ->
+            search_deprecated_config();
+        F ->
+            F
+    end.
 
 search_default_config() ->
-    Dirs = [filename:join([os:getenv("HOME"), ".epoch", nodename()]),
+    Dirs = [filename:join([os:getenv("HOME"), ".aeternity", "aeternity"]),
             setup:home()],
+    search_config(Dirs, "aeternity.{json,yaml}").
+
+search_deprecated_config() ->
+    Dirs = [filename:join([os:getenv("HOME"), ".epoch", "epoch"])],
+    search_config(Dirs, "epoch.{json,yaml}").
+
+search_config(Dirs, FileWildcard) ->
     lists:foldl(
       fun(D, undefined) ->
-              W = "epoch.{json,yaml}",
-              error_logger:info_msg("Searching for default config file ~s "
-                                    "in directory ~s~n", [W, D]),
-              case filelib:wildcard(W, D) of
+              error_logger:info_msg("Searching for config file ~s "
+                                    "in directory ~s~n", [FileWildcard, D]),
+              case filelib:wildcard(FileWildcard, D) of
                   [] -> undefined;
                   [F|_] -> filename:join(D, F)
               end;
@@ -310,14 +333,6 @@ do_read_config(F, Schema, Action, Mode) ->
         {".yaml", store} -> store(read_yaml(F, Schema, Mode));
         {".json", check} -> check_config_(catch read_json(F, Schema, Mode));
         {".yaml", check} -> check_config_(catch read_yaml(F, Schema, Mode))
-    end.
-
-nodename() ->
-    case node() of
-        nonode@nohost ->
-            [];
-        N ->
-            hd(re:split(atom_to_list(N), "@", [{return,list}]))
     end.
 
 store([Vars0]) ->

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -279,8 +279,7 @@ data_dir(Name) when is_atom(Name) ->
 config_file() ->
     case default_config_file()  of
         undefined ->
-            undefined;
-%%            deprecated_config_file();
+            deprecated_config_file();
         F ->
             F
     end.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: aeternity/aeternity:${IMAGE_TAG-latest}
     hostname: node1
     environment:
-      EPOCH_CONFIG: /home/aeternity/aeternity.yaml
+      AETERNITY_CONFIG: /home/aeternity/aeternity.yaml
     command: >
       -aecore expected_mine_rate ${AETERNITY_MINE_RATE:-15000}
     volumes:
@@ -18,7 +18,7 @@ services:
     image: aeternity/aeternity:${IMAGE_TAG-latest}
     hostname: node2
     environment:
-      EPOCH_CONFIG: /home/aeternity/aeternity.yaml
+      AETERNITY_CONFIG: /home/aeternity/aeternity.yaml
     command: >
       -aecore expected_mine_rate ${AETERNITY_MINE_RATE:-15000}
     volumes:
@@ -30,7 +30,7 @@ services:
     image: aeternity/aeternity:${IMAGE_TAG-latest}
     hostname: node3
     environment:
-      EPOCH_CONFIG: /home/aeternity/aeternity.yaml
+      AETERNITY_CONFIG: /home/aeternity/aeternity.yaml
     command: >
       -aecore expected_mine_rate ${AETERNITY_MINE_RATE:-15000}
     volumes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,14 +10,12 @@ The `aeternity` system supports user-provided parameters via a JSON- or YAML-for
 The format of the config file is determined from the file extension: `.json` for JSON, or `.yaml` for YAML.
 
 The location of the file can be specified in a few different ways, in order of priority:
-1. The OS environment variable `EPOCH_CONFIG` contains a filename
+1. The OS environment variable `AETERNITY_CONFIG` contains a filename
 2. The Erlang/OTP environment variable `-aecore config` contains a filename
-3. A file named `epoch.{yaml,json}` exists in `${HOME}/.epoch/${sname}/`
-4. A file named `epoch.{yaml,json}` exists in `${AETERNITY_TOP}/`
+3. A file named `aeternity.{yaml,json}` exists in `${HOME}/.aeternity/aeternity/`
+4. A file named `aeternity.{yaml,json}` exists in `${AETERNITY_TOP}/`
 
 If all above checks fail, no user configuration is applied.
-
-`${sname}` represents the name part of the Erlang node name (the part before `'@'`).
 
 ### Validation
 The contents of the config file will be validated against a JSON-Schema, located in the node at path `data/epoch_config_schema.json`. If any parameters violate the schema, the node will fail to start.
@@ -165,7 +163,7 @@ Note that YAML files have significant whitespace so make sure that you indent th
 You can validate the configuration file before starting the node:
 ```bash
 cd ~/aeternity/node
-bin/aeternity check_config epoch.yaml
+bin/aeternity check_config aeternity.yaml
 ```
 You shall read output like the following:
 ```
@@ -183,7 +181,7 @@ mining:
     beneficiary: "beneficiary_pubkey_to_be_replaced"
     autostart: true
 ```
-in the epoch.yaml configuration file.
+in the aeternity.yaml configuration file.
 
 Make sure you replace `mining` > `beneficiary` parameter with your public key!
 

--- a/docs/cuda-miner.md
+++ b/docs/cuda-miner.md
@@ -19,7 +19,7 @@ Please refer to the NVIDIA documentation for how to [download][cuda-downloads] a
 ### Configuration of the manually built CUDA miner
 
 Once the CUDA Drive is installed, one should change the node configuration to start using the CUDA miner.
-The `mining.cuckoo.miner` section of `~/aeternity/node/epoch.yaml` should be changed to:
+The `mining.cuckoo.miner` section of `~/aeternity/node/aeternity.yaml` should be changed to:
 
 ```yaml
 mining:
@@ -114,7 +114,7 @@ cp priv/bin/cuda29 ~/aeternity/node/lib/aecuckoo-0.1.0/priv/bin
 
 ### Configuration of the manually built CUDA miner
 
-Once the CUDA miner is in place, one should change the node configuration to start using it. The `mining.cuckoo.miner` section of `~/aeternity/node/epoch.yaml` should be changed to:
+Once the CUDA miner is in place, one should change the node configuration to start using it. The `mining.cuckoo.miner` section of `~/aeternity/node/aeternity.yaml` should be changed to:
 
 ```yaml
 mining:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -45,11 +45,11 @@ Always make sure you have the latest docker image prior running any of the below
 ### Node Configuration
 
 Тo change the node configuration, a [Docker bind mount](https://docs.docker.com/storage/bind-mounts/) should be used
-to mount the configuration file to a special path on the container (`/home/aeternity/.epoch/epoch/epoch.yaml`).
-For example, assuming your configuration file is located at `~/.aeternity/myepoch.yaml` on the host machine:
+to mount the configuration file to a special path on the container (`/home/aeternity/.aeternity/aeternity/aeternity.yaml`).
+For example, assuming your configuration file is located at `~/.aeternity/myaeternity.yaml` on the host machine:
 
 ```bash
-docker run -p 3013:3013 -p 3015:3015 -v ~/.aeternity/myepoch.yaml:/home/aeternity/.epoch/epoch/epoch.yaml aeternity/aeternity
+docker run -p 3013:3013 -p 3015:3015 -v ~/.aeternity/myaeternity.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml aeternity/aeternity
 ```
 
 Arguments can also be passed to the node, for example to change expected mine rate:
@@ -71,13 +71,13 @@ chain:
 # SNIP ...
 ```
 
-Assuming your configuration file path is `~/.aeternity/myepoch.yaml` on host machine.
+Assuming your configuration file path is `~/.aeternity/myaeternity.yaml` on host machine.
 Replace `~/.aeternity/db_roma` with location of your choice where the data will be stored in.
 
 ```bash
 mkdir -p ~/.aeternity/db_roma
 docker run -p 3013:3013 -p 3015:3015 \
-  -v ~/.aeternity/myepoch.yaml:/home/aeternity/.epoch/epoch/epoch.yaml \
+  -v ~/.aeternity/myaeternity.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml \
   -v ~/.aeternity/db_roma:/home/aeternity/node/data/mnesia \
   aeternity/aeternity
 ```
@@ -125,10 +125,10 @@ fork_management:
 
 ```
 
-Assuming your configuration file is located at `~/.aeternity/myepoch.yaml` on the host machine:
+Assuming your configuration file is located at `~/.aeternity/myaeternity.yaml` on the host machine:
 
 ```bash
-docker run -p 3013:3013 -p 3015:3015 -v ~/.aeternity/myepoch.yaml:/home/aeternity/.epoch/epoch/epoch.yaml aeternity/aeternity
+docker run -p 3013:3013 -p 3015:3015 -v ~/.aeternity/myaeternity.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml aeternity/aeternity
 ```
 
 You should see the console output of the running node and a lot of information related to syncing with the network.

--- a/docs/release-notes/next/PT-163191737-config-discovery-renaming.md
+++ b/docs/release-notes/next/PT-163191737-config-discovery-renaming.md
@@ -1,0 +1,5 @@
+* Changes user config discovery paths, i.e. the node is looking for the user config in:
+  - AETERNITY_CONFIG environment variable instead of EPOCH_CONFIG,
+  - ~/.aeternity/aeternity/aeternity.yaml file instead of ~/.epoch/epoch/epoch.yaml,
+  - ${AETERNITY_TOP}/aeternity.yaml file instead of ${AETERNITY_TOP}/epoch.yaml.
+  Backwards compatibility is kept for now, so user config defined in old locations will be working.

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -67,7 +67,7 @@ def setup_node(node):
     root_dir = tempfile.mkdtemp()
 
     # setup the dir with non-mining node
-    user_config = make_no_mining_user_config(root_dir, "epoch.yaml")
+    user_config = make_no_mining_user_config(root_dir, "aeternity.yaml")
     start_node(node, user_config)
     ext_api = external_api(node)
     int_api = internal_api(node)
@@ -79,7 +79,7 @@ def setup_node_with_tokens(node, beneficiary, blocks_to_mine):
     root_dir = tempfile.mkdtemp()
 
     # setup the dir with mining node
-    user_config = make_mining_user_config(root_dir, beneficiary, "epoch.yaml")
+    user_config = make_mining_user_config(root_dir, beneficiary, "aeternity.yaml")
     start_node(node, user_config)
     ext_api = external_api(node)
     int_api = internal_api(node)
@@ -154,9 +154,9 @@ def start_node(name, config_filename):
         print("\nNode " + name + " starting")
         config_prefix = ""
         if config_filename[0] == "/": # absolute path
-            config_prefix =  'EPOCH_CONFIG="' + config_filename + '" '
+            config_prefix =  'AETERNITY_CONFIG="' + config_filename + '" '
         else:
-            config_prefix =  'EPOCH_CONFIG="`pwd`/' + config_filename + '" '
+            config_prefix =  'AETERNITY_CONFIG="`pwd`/' + config_filename + '" '
 
         print("Starting node with config prefix " + config_prefix)
         p = os.popen("(cd ../.. && " + config_prefix + "make " + name + "-start;)","r")

--- a/py/tests/integration/test_use_cases.py
+++ b/py/tests/integration/test_use_cases.py
@@ -19,8 +19,8 @@ def test_syncing():
     test_settings = settings["test_syncing"]
 
     root_dir = tempfile.mkdtemp()
-    mining_user_config = make_fast_mining_user_config(root_dir, "mining_epoch.yaml")
-    no_mining_user_config = make_no_mining_user_config(root_dir, "no_mining_epoch.yaml")
+    mining_user_config = make_fast_mining_user_config(root_dir, "mining_aeternity.yaml")
+    no_mining_user_config = make_no_mining_user_config(root_dir, "no_mining_aeternity.yaml")
 
     # start Bob's node
     bob_node = test_settings["nodes"]["bob"]
@@ -94,8 +94,8 @@ chain:
 mining:
     beneficiary: "ak_2QLChDdERfod9QajLkCTsJnYP3RNqZJmAFWQWQZWr99fSrC55h"
 """
-    persistence_mining_user_config = common.install_user_config(root_dir, "p_m_epoch.yaml", p_m_conf)
-    minimal_user_config_with_persistence = common.install_user_config(root_dir, "p_epoch.yaml", p_conf)
+    persistence_mining_user_config = common.install_user_config(root_dir, "p_m_aeternity.yaml", p_m_conf)
+    minimal_user_config_with_persistence = common.install_user_config(root_dir, "p_aeternity.yaml", p_conf)
 
     bob_node = test_settings["nodes"]["bob"]
     common.start_node(bob_node, persistence_mining_user_config)
@@ -140,21 +140,21 @@ def test_node_discovery_transitively():
 
     # Alice's config: no peers
     alice_peers = "peers: []"
-    alice_user_config = make_peers_user_config(root_dir, "alice_epoch.yaml",
+    alice_user_config = make_peers_user_config(root_dir, "alice_aeternity.yaml",
                             "node1", "3015", alice_peers, "true")
     # Bob's config: only peer is Alice
     bob_peers = """\
 peers:
     - "aenode://pp_HdcpgTX2C1aZ5sjGGysFEuup67K9XiFsWqSPJs4RahEcSyF7X@localhost:3015"
 """
-    bob_user_config = make_peers_user_config(root_dir, "bob_epoch.yaml",
+    bob_user_config = make_peers_user_config(root_dir, "bob_aeternity.yaml",
                             "node2", "3025", bob_peers, "false")
     # Carol's config: only peer is Bob
     carol_peers = """\
 peers:
     - "aenode://pp_28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@localhost:3025"
 """
-    carol_user_config = make_peers_user_config(root_dir, "carol_epoch.yaml",
+    carol_user_config = make_peers_user_config(root_dir, "carol_aeternity.yaml",
                             "node3", "3035", carol_peers, "false")
 
     # start Alice's node
@@ -208,18 +208,18 @@ def test_node_discovery_from_common_friend():
 peers:
     - "aenode://pp_28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@localhost:3025"
 """
-    alice_user_config = make_peers_user_config(root_dir, "alice_epoch.yaml",
+    alice_user_config = make_peers_user_config(root_dir, "alice_aeternity.yaml",
                             "node1", "3015", alice_peers, "true")
     # Bob's config: no peers
     bob_peers = "peers: []"
-    bob_user_config = make_peers_user_config(root_dir, "bob_epoch.yaml",
+    bob_user_config = make_peers_user_config(root_dir, "bob_aeternity.yaml",
                             "node2", "3025", bob_peers, "false")
     # Carol's config: only peer is Bob
     carol_peers = """\
 peers:
     - "aenode://pp_28uQUgsPcsy7TQwnRxhF8GMKU4ykFLKsgf4TwDwPMNaSCXwWV8@localhost:3025"
 """
-    carol_user_config = make_peers_user_config(root_dir, "carol_epoch.yaml",
+    carol_user_config = make_peers_user_config(root_dir, "carol_aeternity.yaml",
                             "node3", "3035", carol_peers, "false")
 
     # start Alice's node

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -1,8 +1,6 @@
 import os
-import getopt
 import sys
 import time
-import unittest
 import argparse
 import urllib3
 import shutil
@@ -10,7 +8,6 @@ import pystache
 import logging
 from waiting import wait
 
-import swagger_client
 from swagger_client.rest import ApiException
 from swagger_client.api.external_api import ExternalApi
 from swagger_client.api_client import ApiClient
@@ -264,7 +261,7 @@ def setup_node(node, path, test_dir, version):
     for command in NODE_SETUP_COMMANDS:
         os.system(pystache.render(command, {"version": version, \
                                             "name": SETUP[node]["name"]}))
-    ucfg = open(os.path.join(path, "epoch.yaml"), "w")
+    ucfg = open(os.path.join(path, "aeternity.yaml"), "w")
     ucfg.write(SETUP[node]["user_config"])
     ucfg.close()
     cfg = open(os.path.join(path, "p.config"), "w")

--- a/system_test/aest_channels_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_channels_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -18,6 +18,11 @@ http:
     endpoints:
         debug: true
         dev: true
+
+websocket:
+    channel:
+        listen_address: 0.0.0.0
+        port: {{services.ext_ws.port}}
 
 keys:
     peer_password: {{key_password}}
@@ -39,4 +44,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_commands_SUITE.erl
+++ b/system_test/aest_commands_SUITE.erl
@@ -63,7 +63,7 @@ epoch_commands(Cfg) ->
     ?assertEqual(ExpPeerKey, PeerKey),
 
     {0, Output3} = run_cmd_in_node_dir(node1,
-        ["bin/epoch", "check_config", "../epoch.yaml"], Cfg),
+        ["bin/epoch", "check_config", "../aeternity.yaml"], Cfg),
     ?assertMatch({match, _}, re:run(Output3, "OK[\r\n]*")),
 
     {0, Output4} = run_cmd_in_node_dir(node1, ["bin/epoch", "pid"], Cfg),

--- a/system_test/aest_commands_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_commands_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -7,12 +7,14 @@ peers: {{^peers}}[]{{/peers}}
 
 sync:
     port: {{services.sync.port}}
-    ping_interval: 5000
     single_outbound_per_group: false
 
 http:
     external:
         port: {{services.ext_http.port}}
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_http.port}}
 
 keys:
     peer_password: {{key_password}}
@@ -22,11 +24,8 @@ chain:
     persist: true
 
 mining:
-    beneficiary: {{config.beneficiary}}
-    beneficiary_reward_delay: 2
+    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     autostart: true
-    micro_block_cycle: 100
-    expected_mine_rate: 1000
     cuckoo:
         edge_bits: 15
         miners:
@@ -34,4 +33,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_compatibility_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_compatibility_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -9,14 +9,10 @@ sync:
     port: {{services.sync.port}}
     ping_interval: 5000
     single_outbound_per_group: false
-    resolver_backoff_times: [1000]  # Small compared to ping_interval, so when test adds container to network the node resolves peer hostname soon and starts syncing.
 
 http:
     external:
         port: {{services.ext_http.port}}
-    internal:
-        listen_address: 0.0.0.0
-        port: {{services.int_http.port}}
 
 keys:
     peer_password: {{key_password}}
@@ -25,19 +21,17 @@ keys:
 chain:
     persist: true
 
-mempool:
-    nonce_offset: 1000
-
 mining:
-    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+    beneficiary: {{config.beneficiary}}
+    beneficiary_reward_delay: 2
     autostart: true
     micro_block_cycle: 100
     expected_mine_rate: 1000
     cuckoo:
         edge_bits: 15
         miners:
-            - executable: mean15-generic
+            - executable: {{config.algorithm}}
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_genesis_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_genesis_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -13,9 +13,6 @@ sync:
 http:
     external:
         port: {{services.ext_http.port}}
-    internal:
-        listen_address: 0.0.0.0
-        port: {{services.int_http.port}}
 
 keys:
     peer_password: {{key_password}}
@@ -25,8 +22,9 @@ chain:
     persist: true
 
 mining:
-    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
-    autostart: {{mining.autostart}}
+    beneficiary: {{config.beneficiary}}
+    beneficiary_reward_delay: 2
+    autostart: true
     micro_block_cycle: 100
     expected_mine_rate: 1000
     cuckoo:
@@ -36,4 +34,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_mempool_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_mempool_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -7,18 +7,15 @@ peers: {{^peers}}[]{{/peers}}
 
 sync:
     port: {{services.sync.port}}
-    single_outbound_per_group: false
-    max_inbound: {{config.max_inbound}}
     ping_interval: 5000
+    single_outbound_per_group: false
+
+mempool:
+    invalid_tx_ttl: 3
 
 http:
     external:
         port: {{services.ext_http.port}}
-    internal:
-        listen_address: 0.0.0.0
-        port: {{services.int_http.port}}
-        debug_endpoints: true
-    debug: true
 
 keys:
     peer_password: {{key_password}}
@@ -28,9 +25,11 @@ chain:
     persist: true
 
 mining:
+    beneficiary: {{config.beneficiary}}
+    beneficiary_reward_delay: 2
     autostart: true
-    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     micro_block_cycle: 100
+    expected_mine_rate: 1000
     cuckoo:
         edge_bits: 15
         miners:
@@ -38,4 +37,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_names_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_names_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -12,9 +12,6 @@ sync:
 http:
     external:
         port: {{services.ext_http.port}}
-    internal:
-        listen_address: 0.0.0.0
-        port: {{services.int_http.port}}
 
 keys:
     peer_password: {{key_password}}
@@ -24,8 +21,11 @@ chain:
     persist: true
 
 mining:
-    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     autostart: true
+    beneficiary: {{config.beneficiary}}
+    beneficiary_reward_delay: 2
+    micro_block_cycle: 100
+    expected_mine_rate: 1000
     cuckoo:
         edge_bits: 15
         miners:
@@ -33,4 +33,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_oracles_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_oracles_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -7,15 +7,17 @@ peers: {{^peers}}[]{{/peers}}
 
 sync:
     port: {{services.sync.port}}
-    ping_interval: 5000
     single_outbound_per_group: false
-
-mempool:
-    invalid_tx_ttl: 3
 
 http:
     external:
         port: {{services.ext_http.port}}
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_http.port}}
+    endpoints:
+        debug: true
+        dev: true
 
 keys:
     peer_password: {{key_password}}
@@ -25,9 +27,9 @@ chain:
     persist: true
 
 mining:
+    autostart: true
     beneficiary: {{config.beneficiary}}
     beneficiary_reward_delay: 2
-    autostart: true
     micro_block_cycle: 100
     expected_mine_rate: 1000
     cuckoo:
@@ -37,4 +39,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_peers_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_peers_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -8,10 +8,17 @@ peers: {{^peers}}[]{{/peers}}
 sync:
     port: {{services.sync.port}}
     single_outbound_per_group: false
+    max_inbound: {{config.max_inbound}}
+    ping_interval: 5000
 
 http:
     external:
         port: {{services.ext_http.port}}
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_http.port}}
+        debug_endpoints: true
+    debug: true
 
 keys:
     peer_password: {{key_password}}
@@ -22,10 +29,8 @@ chain:
 
 mining:
     autostart: true
-    beneficiary: {{config.beneficiary}}
-    beneficiary_reward_delay: 2
+    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     micro_block_cycle: 100
-    expected_mine_rate: 1000
     cuckoo:
         edge_bits: 15
         miners:
@@ -33,4 +38,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_perf_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_perf_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -7,6 +7,7 @@ peers: {{^peers}}[]{{/peers}}
 
 sync:
     port: {{services.sync.port}}
+    ping_interval: 5000
     single_outbound_per_group: false
 
 http:
@@ -15,14 +16,6 @@ http:
     internal:
         listen_address: 0.0.0.0
         port: {{services.int_http.port}}
-    endpoints:
-        debug: true
-        dev: true
-
-websocket:
-    channel:
-        listen_address: 0.0.0.0
-        port: {{services.ext_ws.port}}
 
 keys:
     peer_password: {{key_password}}
@@ -32,9 +25,8 @@ chain:
     persist: true
 
 mining:
-    autostart: true
-    beneficiary: {{config.beneficiary}}
-    beneficiary_reward_delay: 2
+    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+    autostart: {{mining.autostart}}
     micro_block_cycle: 100
     expected_mine_rate: 1000
     cuckoo:
@@ -44,4 +36,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/aest_sync_SUITE.erl
+++ b/system_test/aest_sync_SUITE.erl
@@ -156,7 +156,7 @@ end_per_suite(_Config) -> ok.
 
 %% This is keypair of an account set in genesis config file
 %% (see https://github.com/aeternity/epoch/blob/master/data/aecore/.genesis/accounts_test.json),
-%% so beneficiary configuration in epoch.yaml (mining > beneficiary param) does not matter.
+%% so beneficiary configuration in aeternity.yaml (mining > beneficiary param) does not matter.
 patron() ->
     #{ pubkey => <<206,167,173,228,112,201,249,157,157,78,64,8,128,168,111,29,73,187,68,75,98,241,26,158,187,100,187,207,235,115,254,243>>,
        privkey => <<230,169,29,99,60,119,207,87,113,50,157,51,84,179,188,239,27,197,224,50,196,61,112,182,211,90,249,35,206,30,183,77,206,167,173,228,112,201,249,157,157,78,64,8,128,168,111,29,73,187,68,75,98,241,26,158,187,100,187,207,235,115,254,243>>

--- a/system_test/aest_sync_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_sync_SUITE_data/aeternity.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -9,10 +9,14 @@ sync:
     port: {{services.sync.port}}
     ping_interval: 5000
     single_outbound_per_group: false
+    resolver_backoff_times: [1000]  # Small compared to ping_interval, so when test adds container to network the node resolves peer hostname soon and starts syncing.
 
 http:
     external:
         port: {{services.ext_http.port}}
+    internal:
+        listen_address: 0.0.0.0
+        port: {{services.int_http.port}}
 
 keys:
     peer_password: {{key_password}}
@@ -21,17 +25,19 @@ keys:
 chain:
     persist: true
 
+mempool:
+    nonce_offset: 1000
+
 mining:
-    beneficiary: {{config.beneficiary}}
-    beneficiary_reward_delay: 2
+    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
     autostart: true
     micro_block_cycle: 100
     expected_mine_rate: 1000
     cuckoo:
         edge_bits: 15
         miners:
-            - executable: {{config.algorithm}}
+            - executable: mean15-generic
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}

--- a/system_test/helpers/aest_docker.erl
+++ b/system_test/helpers/aest_docker.erl
@@ -26,9 +26,9 @@
 
 %=== MACROS ====================================================================
 
--define(CONFIG_FILE_TEMPLATE, "epoch.yaml.mustache").
+-define(CONFIG_FILE_TEMPLATE, "aeternity.yaml.mustache").
 -define(EPOCH_OPS_BIN, "/home/aeternity/node/bin/epoch").
--define(EPOCH_CONFIG_FILE, "/home/aeternity/epoch.yaml").
+-define(AETERNITY_CONFIG_FILE, "/home/aeternity/aeternity.yaml").
 -define(EPOCH_LOG_FOLDER, "/home/aeternity/node/log").
 -define(EPOCH_KEYS_FOLDER, "/home/aeternity/node/keys").
 -define(EPOCH_GENESIS_FILE, "/home/aeternity/node/data/aecore/.genesis/accounts_test.json").
@@ -190,7 +190,7 @@ setup_node(Spec, BackendState) ->
     NetworkSpecs = maps:get(networks, Spec, ?DEFAULT_NETWORKS),
     [Network  | OtherNetworks] = setup_networks(NetworkSpecs, NodeState),
 
-    ConfigFileName = format("epoch_~s.yaml", [Name]),
+    ConfigFileName = format("aeternity_~s.yaml", [Name]),
     ConfigFilePath = filename:join([TempDir, "config", ConfigFileName]),
     TemplateFile = filename:join(DataDir, ?CONFIG_FILE_TEMPLATE),
     PeerVars = lists:map(fun (Addr) -> #{peer => Addr} end, Peers),
@@ -229,7 +229,7 @@ setup_node(Spec, BackendState) ->
         },
         mining => maps:merge(#{autostart => true}, maps:get(mining, Spec, #{}))
     },
-    Context = #{epoch_config => RootVars},
+    Context = #{aeternity_config => RootVars},
     {ok, ConfigString} = write_template(TemplateFile, ConfigFilePath, Context),
     Command =
         case MineRate of
@@ -264,12 +264,12 @@ setup_node(Spec, BackendState) ->
         image => Image,
         ulimits => AllUlimits,
         command => Command,
-        env => #{"EPOCH_CONFIG" => ?EPOCH_CONFIG_FILE,
+        env => #{"AETERNITY_CONFIG" => ?AETERNITY_CONFIG_FILE,
                  "ERL_CRASH_DUMP" => format("~s/erl_crash.dump", [?EPOCH_LOG_FOLDER])},
         labels => #{epoch_system_test => <<"true">>},
         volumes => [
             {rw, KeysDir, ?EPOCH_KEYS_FOLDER},
-            {ro, ConfigFilePath, ?EPOCH_CONFIG_FILE},
+            {ro, ConfigFilePath, ?AETERNITY_CONFIG_FILE},
             {rw, LogPath, ?EPOCH_LOG_FOLDER}] ++
             [ {ro, Genesis, ?EPOCH_GENESIS_FILE} || Genesis =/= undefined ],
         ports => PortMapping

--- a/system_test/only_local/aest_heavy_sync_SUITE.erl
+++ b/system_test/only_local/aest_heavy_sync_SUITE.erl
@@ -72,7 +72,7 @@ end_per_suite(_Config) -> ok.
 
 %% This is keypair of an account set in genesis config file
 %% (see https://github.com/aeternity/epoch/blob/master/data/aecore/.genesis/accounts_test.json),
-%% so beneficiary configuration in epoch.yaml (mining > beneficiary param) does not matter.
+%% so beneficiary configuration in aeternity.yaml (mining > beneficiary param) does not matter.
 patron() ->
     #{ pubkey => <<206,167,173,228,112,201,249,157,157,78,64,8,128,168,111,29,73,187,68,75,98,241,26,158,187,100,187,207,235,115,254,243>>,
        privkey => <<230,169,29,99,60,119,207,87,113,50,157,51,84,179,188,239,27,197,224,50,196,61,112,182,211,90,249,35,206,30,183,77,206,167,173,228,112,201,249,157,157,78,64,8,128,168,111,29,73,187,68,75,98,241,26,158,187,100,187,207,235,115,254,243>>

--- a/system_test/only_local/aest_heavy_sync_SUITE_data/epoch.yaml.mustache
+++ b/system_test/only_local/aest_heavy_sync_SUITE_data/epoch.yaml.mustache
@@ -1,4 +1,4 @@
-{{#epoch_config}}
+{{#aeternity_config}}
 ---
 peers: {{^peers}}[]{{/peers}}
 {{#peers}}
@@ -37,4 +37,4 @@ mining:
 
 fork_management:
     network_id: "ae_system_test"
-{{/epoch_config}}
+{{/aeternity_config}}


### PR DESCRIPTION
Corresponding infrastructure PR - https://github.com/aeternity/infrastructure/pull/229.

System discovery in the logs:
```
11:55:51.481 [info] Searching for config file aeternity.{json,yaml} in directory /Users/zp/.aeternity/aeternity
11:55:51.481 [info] Searching for config file aeternity.{json,yaml} in directory /Users/zp/src/aeternity/aeternity
11:55:51.481 [info] Searching for config file epoch.{json,yaml} in directory /Users/zp/.epoch/epoch
11:55:51.481 [info] Searching for config file epoch.{json,yaml} in directory /Users/zp/src/aeternity/aeternity
11:55:51.481 [info] No config file specified; using default settings
```

All ways of passing config tested locally.

System tests:
```
===> Running Common Test suites...
%%% aest_channels_SUITE ==> test_simple_same_node_channel: OK
%%% aest_channels_SUITE ==> test_simple_different_nodes_channel: OK
%%% aest_channels_SUITE ==> on_chain_channel: OK
%%% aest_commands_SUITE ==> epoch_commands: OK
%%% aest_compatibility_SUITE ==> test_mining_algorithms_compatibility: OK
%%% aest_genesis_SUITE ==> test_node_starts_with_30k_accounts: OK
%%% aest_mempool_SUITE ==> test_mempool_ttl_cleanup: OK
%%% aest_mempool_SUITE ==> test_mempool_bad_nonce_cleanup: OK
%%% aest_names_SUITE ==> test_name_registration: OK
%%% aest_names_SUITE ==> test_name_transfer: OK
%%% aest_oracles_SUITE ==> test_simple_same_node_query: OK
%%% aest_oracles_SUITE ==> test_simple_two_nodes_query: OK
%%% aest_oracles_SUITE ==> test_oracle_ttl_extension: OK
%%% aest_oracles_SUITE ==> test_pipelined_same_node_query: OK
%%% aest_oracles_SUITE ==> test_pipelined_two_nodes_query: OK
%%% aest_peers_SUITE ==> test_peer_discovery: OK
%%% aest_peers_SUITE ==> test_inbound_limitation: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_mine_and_export: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.mining_governed_rate: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.startup_speed: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.startup_speed_mining: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.sync_speed: OK
%%% aest_perf_SUITE ==> long_chain.long_chain_tests.stay_in_sync: OK
%%% aest_sync_SUITE ==> new_node_joins_network: OK
%%% aest_sync_SUITE ==> docker_keeps_data: OK
%%% aest_sync_SUITE ==> stop_and_continue_sync: OK
%%% aest_sync_SUITE ==> tx_pool_sync: OK
%%% aest_sync_SUITE ==> net_split_recovery: OK
%%% aest_sync_SUITE ==> net_split_mining_power: OK
%%% aest_sync_SUITE ==> abrupt_stop_new_node: SKIPPED
%%% aest_sync_SUITE ==> {tc_user_skip,database_restart_needs_fix}
%%% aest_sync_SUITE ==> abrupt_stop_mining_node: SKIPPED
%%% aest_sync_SUITE ==> {tc_user_skip,database_restart_needs_fix}
EXPERIMENTAL: Writing retry specification at /Users/zp/src/aeternity/aeternity/system_test/logs/retry.spec
              call rebar3 ct with '--retry' to re-run failing cases.
Skipped 2 (2, 0) tests. Passed 29 tests.
```