### PR TITLE
PT-163553535 Testing old vm version(s) (and compiler(s))

### DIFF
--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -506,19 +506,25 @@ aens_call_revoke(Data, #chain{api = API, state = State} = Chain) ->
 %% ------------------------------------------------------------------
 %% Crypto operations.
 %% ------------------------------------------------------------------
-crypto_call(Gas, ?PRIM_CALL_CRYPTO_ECVERIFY, _Value, Data, State) ->
+crypto_call(Gas, Op, _Value, Data, State) ->
+    case {aevm_eeevm_state:vm_version(State), Op} of
+        {?VM_AEVM_SOPHIA_1, _} -> {error, out_of_gas};
+        {?VM_AEVM_SOPHIA_2, _} -> crypto_call(Gas, Op, Data, State)
+    end.
+
+crypto_call(Gas, ?PRIM_CALL_CRYPTO_ECVERIFY, Data, State) ->
     crypto_call_ecverify(Gas, Data, State);
-crypto_call(Gas, ?PRIM_CALL_CRYPTO_SHA3, _Value, Data, State) ->
+crypto_call(Gas, ?PRIM_CALL_CRYPTO_SHA3, Data, State) ->
     crypto_call_generic_hash(?PRIM_CALL_CRYPTO_SHA3, Gas, Data, State);
-crypto_call(Gas, ?PRIM_CALL_CRYPTO_SHA256, _Value, Data, State) ->
+crypto_call(Gas, ?PRIM_CALL_CRYPTO_SHA256, Data, State) ->
     crypto_call_generic_hash(?PRIM_CALL_CRYPTO_SHA256, Gas, Data, State);
-crypto_call(Gas, ?PRIM_CALL_CRYPTO_BLAKE2B, _Value, Data, State) ->
+crypto_call(Gas, ?PRIM_CALL_CRYPTO_BLAKE2B, Data, State) ->
     crypto_call_generic_hash(?PRIM_CALL_CRYPTO_BLAKE2B, Gas, Data, State);
-crypto_call(_Gas, ?PRIM_CALL_CRYPTO_SHA256_STRING, _Value, Data, State) ->
+crypto_call(_Gas, ?PRIM_CALL_CRYPTO_SHA256_STRING, Data, State) ->
     crypto_call_string_hash(?PRIM_CALL_CRYPTO_SHA256_STRING, Data, State);
-crypto_call(_Gas, ?PRIM_CALL_CRYPTO_BLAKE2B_STRING, _Value, Data, State) ->
+crypto_call(_Gas, ?PRIM_CALL_CRYPTO_BLAKE2B_STRING, Data, State) ->
     crypto_call_string_hash(?PRIM_CALL_CRYPTO_BLAKE2B_STRING, Data, State);
-crypto_call(_, _, _, _, _) ->
+crypto_call(_, _, _, _) ->
     {error, out_of_gas}.
 
 crypto_call_ecverify(_Gas, Data, State) ->

--- a/rebar.config
+++ b/rebar.config
@@ -170,7 +170,7 @@
                             {ref, "a4fb3db"}}},
                             {ephemeral, "2.0.4"}
                            ]},
-                    {pre_hooks, [{ct, "scripts/standalone_compiler.sh"}]}
+                    {pre_hooks, [{ct, "sh ./scripts/standalone_compiler.sh"}]}
                    ]},
             {prod, [{relx, [{dev_mode, false},
                             {include_erts, true},

--- a/rebar.config
+++ b/rebar.config
@@ -167,8 +167,10 @@
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, ".*", {git,
                             "git://github.com/aeternity/websocket_client",
-                            {ref, "a4fb3db"}}}
-                           ]}
+                            {ref, "a4fb3db"}}},
+                            {ephemeral, "2.0.4"}
+                           ]},
+                    {pre_hooks, [{ct, "scripts/standalone_compiler.sh"}]}
                    ]},
             {prod, [{relx, [{dev_mode, false},
                             {include_erts, true},

--- a/rebar.config
+++ b/rebar.config
@@ -170,7 +170,10 @@
                             {ref, "a4fb3db"}}},
                             {ephemeral, "2.0.4"}
                            ]},
-                    {pre_hooks, [{ct, "sh ./scripts/standalone_compiler.sh"}]}
+                    {pre_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
+                                  ct, "scripts/standalone_compiler.sh"},
+                                 {"win32", ct, "sh ./scripts/standalone_compiler.sh"}
+                                ]}
                    ]},
             {prod, [{relx, [{dev_mode, false},
                             {include_erts, true},

--- a/scripts/standalone_compiler.sh
+++ b/scripts/standalone_compiler.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+MD5="d40bf7e90120eedd6ea04aa897c34a1c"
+DST="_build/test/lib/aecontract/test/bin"
+SRC="https://github.com/aeternity/aesophia/releases/download/roma-v1/aesophia"
+
+function check() {
+    if [ -e ${DST}/aesophia ]; then
+        if [ ! -x ${DST}/aesophia ]; then
+            chmod +x ${DST}/aesophia
+        fi
+        MD5X=`openssl md5 ${DST}/aesophia | cut -d' ' -f2`
+        if [ ${MD5} = ${MD5X} ]; then
+            echo "All is good, standalone compiler in place"
+            exit 0
+        fi
+    fi
+}
+
+check
+
+echo "Installing standalone ROMA compiler"
+
+if [ ! -e ${DST} ]; then
+    mkdir -p ${DST}
+fi
+
+curl -s -L ${SRC} -o ${DST}/aesophia
+
+if [ $? -gt 0 ]; then
+    echo "ERROR: failed to fetch ${SRC}"
+    exit 1
+fi
+
+check
+
+echo "ERROR: Wrong MD5 for ${DST}"
+exit 1

--- a/scripts/standalone_compiler.sh
+++ b/scripts/standalone_compiler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MD5="d40bf7e90120eedd6ea04aa897c34a1c"
 DST="_build/test/lib/aecontract/test/bin"


### PR DESCRIPTION
This is a first step towards better testing. It will run `aecontract_SUITE` with different combinations of VM and compiler. For most of the functionality the VM and the compiler behaves the same for ROMA and MINERVA so most test cases are fairly boring/unnecessary to re-run though.

The macro `?assertMatchVM` is used where the test is behaving differently between VM:s (look for these, they mark _interesting_ tests). Similarily `skipRest` is used when a test can't be compiled with the old compiler...

To achieve this there is a bash script that fetches a standalone Sophia compiler for ROMA and uses it when appropriate. @tolbrino promised to check the script for Windows feasibility...

Thoughts on the approach, and also whether we should remove some tests from the duplicated running?!