### PR TITLE
Fix Swagger endpoints warning for OTP 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -84,7 +84,7 @@
                {ref, "c818ddc"}}}
        ]}.
 
-{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "4cdc9e0ad0b68501fc9fba8ac0712e46c1f8541e"}}},
+{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "dc74df712fbe021298b7d0d442890483d791f334"}}},
            {rebar_aecuckooprebuilt_dep, {git, "https://github.com/aeternity/rebar3-cuckoo-prebuilt-plugin.git", {ref, "2b2f3b3cf969ee91ba41d8351f3808530a8bf28e"}}}
           ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -84,7 +84,7 @@
                {ref, "c818ddc"}}}
        ]}.
 
-{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "dc74df712fbe021298b7d0d442890483d791f334"}}},
+{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "ac38525ba55e8eefc00fb4fc0ec697ec3b2c26cf"}}},
            {rebar_aecuckooprebuilt_dep, {git, "https://github.com/aeternity/rebar3-cuckoo-prebuilt-plugin.git", {ref, "2b2f3b3cf969ee91ba41d8351f3808530a8bf28e"}}}
           ]}.
 


### PR DESCRIPTION
In scope of easing reviewing PRs by using recent OTP.

Depends on https://github.com/aeternity/swagger_endpoints/pull/7