### PR TITLE
Plant test suite re DB

### DIFF
--- a/system_test/aest_db_SUITE.erl
+++ b/system_test/aest_db_SUITE.erl
@@ -1,0 +1,74 @@
+-module(aest_db_SUITE).
+
+%=== EXPORTS ===================================================================
+
+% Common Test exports
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+-export([end_per_suite/1]).
+
+% Test cases
+-export([
+    node_can_reuse_db_of_other_node/1
+]).
+
+%=== INCLUDES ==================================================================
+
+-include_lib("stdlib/include/assert.hrl").
+
+%=== MACROS ====================================================================
+
+-define(STARTUP_TIMEOUT, 20000).
+-define(MINING_TIMEOUT,   3000).
+-define(GRACEFUL_STOP_TIMEOUT, 60000).
+
+%=== COMMON TEST FUNCTIONS =====================================================
+
+all() -> [
+    node_can_reuse_db_of_other_node
+].
+
+init_per_suite(Config) ->
+    Config.
+
+init_per_testcase(_TC, Config) ->
+    aest_nodes:ct_setup(Config).
+
+end_per_testcase(_TC, Config) ->
+    aest_nodes:ct_cleanup(Config).
+
+end_per_suite(_Config) -> ok.
+
+%=== TEST CASES ================================================================
+
+node_can_reuse_db_of_other_node(Cfg) ->
+    DbHostPath = node_db_host_path(node1, Cfg),
+    N1 = node_spec(node1, DbHostPath),
+    N2 = node_spec(node2, DbHostPath),
+    aest_nodes:setup_nodes([N1, N2], Cfg),
+    aest_nodes:start_node(node1, Cfg),
+    aest_nodes:wait_for_value({height, 0}, [node1], ?STARTUP_TIMEOUT, Cfg),
+    TargetHeight = 3,
+    aest_nodes:wait_for_value({height, TargetHeight}, [node1], TargetHeight * ?MINING_TIMEOUT, Cfg),
+    #{hash := BlockHash} = aest_nodes:get_block(node1, TargetHeight),
+    aest_nodes:stop_node(node1, ?GRACEFUL_STOP_TIMEOUT, Cfg),
+    aest_nodes:start_node(node2, Cfg),
+    aest_nodes:wait_for_value({height, 0}, [node2], ?STARTUP_TIMEOUT, Cfg),
+    aest_nodes:wait_for_value({height, TargetHeight}, [node2], ?STARTUP_TIMEOUT, Cfg),
+    ?assertMatch({ok, 200, _}, aest_nodes:request(node2, 'GetKeyBlockByHash', #{hash => BlockHash})),
+    ok.
+
+%=== INTERNAL FUNCTIONS ========================================================
+
+node_db_host_path(NodeName, Config) ->
+    {priv_dir, PrivDir} = proplists:lookup(priv_dir, Config),
+    filename:join(PrivDir, format("~s_db", [NodeName])).
+
+format(Fmt, Args) ->
+    iolist_to_binary(io_lib:format(Fmt, Args)).
+
+node_spec(Name, DbHostPath) ->
+    DbGuestPath = "/home/aeternity/node/data/mnesia",
+    aest_nodes:spec(Name, [], #{source  => {pull, "aeternity/aeternity:local"}, db_path => {DbHostPath, DbGuestPath}}).

--- a/system_test/aest_db_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/aest_db_SUITE_data/aeternity.yaml.mustache
@@ -1,0 +1,23 @@
+{{#aeternity_config}}
+---
+peers: []
+
+http:
+    external:
+        port: {{services.ext_http.port}}
+
+chain:
+    persist: true
+
+mining:
+    beneficiary: "ak_2VoAhMd7tVJrDYM5vPJwFRjueZyirDJumVJNeBWL9j1eNTHsRx"
+    autostart: true
+    expected_mine_rate: 1000
+    cuckoo:
+        edge_bits: 15
+        miners:
+            - executable: mean15-generic
+
+fork_management:
+    network_id: "ae_system_test"
+{{/aeternity_config}}


### PR DESCRIPTION
As part of https://www.pivotaltracker.com/story/show/163423623 I am planting tests for handling DB migration following change of node name inside DB. This PR is a **RFC for where to place such tests**. It contains a basic test that is meant to pass without code changes, so it can be considered an increase in test coverage for the codebase and Dockerfile.

[Here](https://circleci.com/workflow-run/34c835fa-1296-4550-b242-5d334010474b) is CI workflow with the new test suite (temporarily) enabled in the system smoke test job.