### PR TITLE
Set MINERVA hard fork height for ae_uat

### DIFF
--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -73,7 +73,7 @@ protocols_from_network_id(<<"ae_mainnet">>) ->
      };
 protocols_from_network_id(<<"ae_uat">>) ->
     #{ ?ROMA_PROTOCOL_VSN     => 0
-     %%, ?MINERVA_PROTOCOL_VSN  => Not yet decided
+     , ?MINERVA_PROTOCOL_VSN  => 40900
      };
 protocols_from_network_id(<<"local_roma_testnet">>) ->
     #{ ?ROMA_PROTOCOL_VSN     => 0

--- a/docs/release-notes/next-minerva/PT-163899406-testnet_hardfork_height.md
+++ b/docs/release-notes/next-minerva/PT-163899406-testnet_hardfork_height.md
@@ -1,0 +1,1 @@
+* Sets the MINERVA testnet (UAT) hard fork height to block 40900


### PR DESCRIPTION
At 13:00 CET Thursday 14th - UAT was at 37660. The block interval is fairly stable at 3 minutes per block so by setting the Fork height at 40000 we should reach the fork height around 10:00 CET on Tuesday, 19th...