### PR TITLE
Revert "Fix wrong UAT seed node peer addresses"

### DIFF
--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -2,7 +2,7 @@
 # Pre-configured addresses of epoch nodes to contact. If not set TestNet seed peers will be used.
 peers:
     # TestNet seed peers
-    - "aenode://pp_2ssMqRVVRP7Dcy6QHhjSdhfgi9rm3TKPVsmRB8VMr4HSwKm1Yf@52.10.46.160:3015" # us-west-2
+    - "aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015" # us-west-2
     - "aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015" # eu-central-1
     - "aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015" # ap-southeast-1
     - "aenode://pp_2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3015" # eu-east

--- a/apps/aeutils/test/data/epoch_no_newline.yaml
+++ b/apps/aeutils/test/data/epoch_no_newline.yaml
@@ -2,7 +2,7 @@
 # Pre-configured addresses of epoch nodes to contact. If not set TestNet seed peers will be used.
 peers:
     # TestNet seed peers
-    - "aenode://pp_2ssMqRVVRP7Dcy6QHhjSdhfgi9rm3TKPVsmRB8VMr4HSwKm1Yf@52.10.46.160:3015" # us-west-2
+    - "aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015" # us-west-2
     - "aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015" # eu-central-1
     - "aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015" # ap-southeast-1
     - "aenode://pp_2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3015" # eu-east

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -115,10 +115,10 @@ The minimal configuration to join the testnet needs a list of seed peers and net
 ---
 peers:
     # UAT
-    - aenode://pp_2ssMqRVVRP7Dcy6QHhjSdhfgi9rm3TKPVsmRB8VMr4HSwKm1Yf@52.10.46.160:3015
+    - aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
     - aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
     - aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
-    - aenode://pp_21A4HvJu1AuMV5njfEqLoR6JkKTWDyuirXZUZP2JND2RbQ1kBE@13.53.161.215:3015
+    - aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
 fork_management:
     network_id: ae_uat

--- a/docs/release-notes/RELEASE-NOTES-1.5.0.md
+++ b/docs/release-notes/RELEASE-NOTES-1.5.0.md
@@ -84,10 +84,10 @@ For running a node as part of the testnet by using the Docker image, please cons
 
 In order to join testnet reconfigure seed nodes in the release package:
 
-* aenode://pp_2ssMqRVVRP7Dcy6QHhjSdhfgi9rm3TKPVsmRB8VMr4HSwKm1Yf@52.10.46.160:3015
+* aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
 * aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
-* aenode://pp_21A4HvJu1AuMV5njfEqLoR6JkKTWDyuirXZUZP2JND2RbQ1kBE@13.53.161.215:3015
+* aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
 ### Inspect the testnet
 


### PR DESCRIPTION
Reverts aeternity/aeternity#2135

It turns out that the correct peer keys was not used because of wrong config file name used during the deploys. https://github.com/aeternity/infrastructure/commit/3a7b50a54ace14e1182ad8a732a9d6179409cda5 as merged too early.

It's reverted in https://github.com/aeternity/infrastructure/pull/254