### PR TITLE
Chain shapshot job in ci failed pt 164002607

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ references:
       command: |
         export BACKUP_SUFFIX=${BACKUP_ENV:?}_db_backup_$(date +%s)
         cd /infrastructure && make mnesia_backup
-      no_output_timeout: 20m
+      no_output_timeout: 30m
 
   upload_package: &upload_package
     steps:
@@ -954,11 +954,6 @@ workflows:
               ignore: /.*/
             tags:
               only: *stable_tag_regex
-
-      - main_chain_snapshot:
-          filters:
-            branches:
-              only: Chain-shapshot-job-in-CI-failed-PT-164002607
 
   chain_snapshots:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,7 @@ references:
       command: |
         export BACKUP_SUFFIX=${BACKUP_ENV:?}_db_backup_$(date +%s)
         cd /infrastructure && make mnesia_backup
+      no_output_timeout: 20m
 
   upload_package: &upload_package
     steps:
@@ -953,6 +954,11 @@ workflows:
               ignore: /.*/
             tags:
               only: *stable_tag_regex
+
+      - main_chain_snapshot:
+          filters:
+            branches:
+              only: Chain-shapshot-job-in-CI-failed-PT-164002607
 
   chain_snapshots:
     triggers:


### PR DESCRIPTION
Re https://www.pivotaltracker.com/story/show/164002607
Mnesia backup needs about 17min now - https://circleci.com/gh/aeternity/aeternity/7921 ,
so increase default job timeout to 30 min.
Other tasks like comress, donwload in this job also need more time ( > 5 min)
During backup there was no increase in CPU or mem usage