### PR TITLE
Speed up osx package builds pt 163453734

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,7 +517,10 @@ jobs:
           command: |
             brew update
             brew install libsodium
+            brew link libsoidium
             brew install file://`pwd`/deployment/homebrew/erlang.rb
+            brew link erlang
+            for erlang_dep in $(brew deps erlang); do brew link $erlang_dep; done
       - *save_macos_package_cache
       - *set_package_path
       - *build_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,12 +107,10 @@ references:
       paths:
         - "_build"
 
-  macos_package_cache_key: &macos_package_cache_key macos-package-cache-v1-{{ .Branch }}
+  macos_package_cache_key: &macos_package_cache_key macos-package-cache-v1
   restore_macos_package_cache: &restore_macos_package_cache
     restore_cache:
-      keys:
-        - *macos_package_cache_key
-        - macos-package-cache-v1-
+      key: *macos_package_cache_key
 
   save_macos_package_cache: &save_macos_package_cache
     save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,10 +107,12 @@ references:
       paths:
         - "_build"
 
-  macos_package_cache_key: &macos_package_cache_key macos-package-cache-v1-
+  macos_package_cache_key: &macos_package_cache_key macos-package-cache-v1-{{ .Branch }}
   restore_macos_package_cache: &restore_macos_package_cache
     restore_cache:
-      key: *macos_package_cache_key
+      keys:
+        - *macos_package_cache_key
+        - macos-package-cache-v1-
 
   save_macos_package_cache: &save_macos_package_cache
     save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,19 @@ references:
       paths:
         - "_build"
 
+  macos_package_cache_key: &macos_package_cache_key macos-package-cache-v1-
+  restore_macos_package_cache: &restore_macos_package_cache
+    restore_cache:
+      key: *macos_package_cache_key
+
+  save_macos_package_cache: &save_macos_package_cache
+    save_cache:
+      key: *macos_package_cache_key
+      paths:
+        - "/usr/local/Homebrew"
+        - "/usr/local/opt"
+        - "/usr/local/Cellar"
+
   packages_workspace: &packages_workspace /tmp/packages
   set_package_path: &set_package_path
     run:
@@ -498,12 +511,14 @@ jobs:
     working_directory: ~/aeternity
     steps:
       - checkout
+      - *restore_macos_package_cache
       - run:
           name: Install required tools
           command: |
             brew update
             brew install libsodium
             brew install file://`pwd`/deployment/homebrew/erlang.rb
+      - *save_macos_package_cache
       - *set_package_path
       - *build_package
       - *test_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,7 +517,7 @@ jobs:
           command: |
             brew update
             brew install libsodium
-            brew link libsoidium
+            brew link libsodium
             brew install file://`pwd`/deployment/homebrew/erlang.rb
             brew link erlang
             for erlang_dep in $(brew deps erlang); do brew link $erlang_dep; done


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163453734
Add circleci cache for homebrew install folders:
- restore cache takes ~ 30 secs to download and unarchive
- restored brew installs require to be relinked, which takes another ~20 secs
overall this decreases macos package build with ~ 3 mins
Other than that I don't know how to speed up this job more
https://circleci.com/gh/aeternity/aeternity/8645