### PR TITLE
Add procotol_vsn to SC fsm + codec

### DIFF
--- a/apps/aechannel/src/aesc_codec.erl
+++ b/apps/aechannel/src/aesc_codec.erl
@@ -1,9 +1,10 @@
 -module(aesc_codec).
 
--export([enc/2,
-         dec/1]).
+-export([enc/3,
+         dec/2]).
 
--export([max_inband_msg_size/0]).
+-export([max_inband_msg_size/0,
+         max_inband_msg_size/1]).
 
 -export_types([ch_open_msg/0,
                ch_accept_msg/0,
@@ -36,60 +37,61 @@
 -type amount()      :: i8bytes().
 -type pubkey()      :: bin32().
 -type error_code()  :: i2bytes().
+-type vsn()         :: 1 | 2.
 
 -define(PUBKEY_SIZE, 32).
 
-enc(?CH_OPEN      , Msg) -> enc_ch_open(Msg);
-enc(?CH_ACCEPT    , Msg) -> enc_ch_accept(Msg);
-enc(?CH_REESTABL  , Msg) -> enc_ch_reestabl(Msg);
-enc(?CH_REEST_ACK , Msg) -> enc_ch_reestabl_ack(Msg);
-enc(?FND_CREATED  , Msg) -> enc_fnd_created(Msg);
-enc(?FND_SIGNED   , Msg) -> enc_fnd_signed(Msg);
-enc(?FND_LOCKED   , Msg) -> enc_fnd_locked(Msg);
-enc(?UPDATE       , Msg) -> enc_update(Msg);
-enc(?UPDATE_ACK   , Msg) -> enc_update_ack(Msg);
-enc(?UPDATE_ERR   , Msg) -> enc_update_err(Msg);
-enc(?DEP_CREATED  , Msg) -> enc_dep_created(Msg);
-enc(?DEP_SIGNED   , Msg) -> enc_dep_signed(Msg);
-enc(?DEP_LOCKED   , Msg) -> enc_dep_locked(Msg);
-enc(?DEP_ERR      , Msg) -> enc_dep_err(Msg);
-enc(?WDRAW_CREATED, Msg) -> enc_wdraw_created(Msg);
-enc(?WDRAW_SIGNED , Msg) -> enc_wdraw_signed(Msg);
-enc(?WDRAW_LOCKED , Msg) -> enc_wdraw_locked(Msg);
-enc(?WDRAW_ERR    , Msg) -> enc_wdraw_err(Msg);
-enc(?ERROR        , Msg) -> enc_error(Msg);
-enc(?LEAVE        , Msg) -> enc_leave(Msg);
-enc(?LEAVE_ACK    , Msg) -> enc_leave_ack(Msg);
-enc(?SHUTDOWN     , Msg) -> enc_shutdown(Msg);
-enc(?SHUTDOWN_ACK , Msg) -> enc_shutdown_ack(Msg);
-enc(?INBAND_MSG   , Msg) -> enc_inband_msg(Msg).
+enc(?CH_OPEN      , Msg, V) -> enc_ch_open(Msg, V);
+enc(?CH_ACCEPT    , Msg, V) -> enc_ch_accept(Msg, V);
+enc(?CH_REESTABL  , Msg, V) -> enc_ch_reestabl(Msg, V);
+enc(?CH_REEST_ACK , Msg, V) -> enc_ch_reestabl_ack(Msg, V);
+enc(?FND_CREATED  , Msg, V) -> enc_fnd_created(Msg, V);
+enc(?FND_SIGNED   , Msg, V) -> enc_fnd_signed(Msg, V);
+enc(?FND_LOCKED   , Msg, V) -> enc_fnd_locked(Msg, V);
+enc(?UPDATE       , Msg, V) -> enc_update(Msg, V);
+enc(?UPDATE_ACK   , Msg, V) -> enc_update_ack(Msg, V);
+enc(?UPDATE_ERR   , Msg, V) -> enc_update_err(Msg, V);
+enc(?DEP_CREATED  , Msg, V) -> enc_dep_created(Msg, V);
+enc(?DEP_SIGNED   , Msg, V) -> enc_dep_signed(Msg, V);
+enc(?DEP_LOCKED   , Msg, V) -> enc_dep_locked(Msg, V);
+enc(?DEP_ERR      , Msg, V) -> enc_dep_err(Msg, V);
+enc(?WDRAW_CREATED, Msg, V) -> enc_wdraw_created(Msg, V);
+enc(?WDRAW_SIGNED , Msg, V) -> enc_wdraw_signed(Msg, V);
+enc(?WDRAW_LOCKED , Msg, V) -> enc_wdraw_locked(Msg, V);
+enc(?WDRAW_ERR    , Msg, V) -> enc_wdraw_err(Msg, V);
+enc(?ERROR        , Msg, V) -> enc_error(Msg, V);
+enc(?LEAVE        , Msg, V) -> enc_leave(Msg, V);
+enc(?LEAVE_ACK    , Msg, V) -> enc_leave_ack(Msg, V);
+enc(?SHUTDOWN     , Msg, V) -> enc_shutdown(Msg, V);
+enc(?SHUTDOWN_ACK , Msg, V) -> enc_shutdown_ack(Msg, V);
+enc(?INBAND_MSG   , Msg, V) -> enc_inband_msg(Msg, V).
 
 -define(c(C), C:1/unit:8).
 
-dec(<<?c(?ID_CH_OPEN)      , B/bytes>>) -> {?CH_OPEN     , dec_ch_open(B)};
-dec(<<?c(?ID_CH_ACCEPT)    , B/bytes>>) -> {?CH_ACCEPT   , dec_ch_accept(B)};
-dec(<<?c(?ID_CH_REESTABL)  , B/bytes>>) -> {?CH_REESTABL , dec_ch_reestabl(B)};
-dec(<<?c(?ID_CH_REEST_ACK) , B/bytes>>) -> {?CH_REEST_ACK, dec_ch_reest_ack(B)};
-dec(<<?c(?ID_FND_CREATED)  , B/bytes>>) -> {?FND_CREATED , dec_fnd_created(B)};
-dec(<<?c(?ID_FND_SIGNED)   , B/bytes>>) -> {?FND_SIGNED  , dec_fnd_signed(B)};
-dec(<<?c(?ID_FND_LOCKED)   , B/bytes>>) -> {?FND_LOCKED  , dec_fnd_locked(B)};
-dec(<<?c(?ID_UPDATE)       , B/bytes>>) -> {?UPDATE      , dec_update(B)};
-dec(<<?c(?ID_UPDATE_ACK)   , B/bytes>>) -> {?UPDATE_ACK  , dec_update_ack(B)};
-dec(<<?c(?ID_UPDATE_ERR)   , B/bytes>>) -> {?UPDATE_ERR  , dec_update_err(B)};
-dec(<<?c(?ID_DEP_CREATED)  , B/bytes>>) -> {?DEP_CREATED , dec_dep_created(B)};
-dec(<<?c(?ID_DEP_SIGNED)   , B/bytes>>) -> {?DEP_SIGNED  , dec_dep_signed(B)};
-dec(<<?c(?ID_DEP_LOCKED)   , B/bytes>>) -> {?DEP_LOCKED  , dec_dep_locked(B)};
-dec(<<?c(?ID_DEP_ERR)      , B/bytes>>) -> {?DEP_ERR     , dec_dep_err(B)};
-dec(<<?c(?ID_WDRAW_CREATED), B/bytes>>) -> {?WDRAW_CREATED, dec_wdraw_created(B)};
-dec(<<?c(?ID_WDRAW_SIGNED) , B/bytes>>) -> {?WDRAW_SIGNED, dec_wdraw_signed(B)};
-dec(<<?c(?ID_WDRAW_LOCKED) , B/bytes>>) -> {?WDRAW_LOCKED, dec_wdraw_locked(B)};
-dec(<<?c(?ID_WDRAW_ERR)    , B/bytes>>) -> {?WDRAW_ERR   , dec_wdraw_err(B)};
-dec(<<?c(?ID_ERROR)        , B/bytes>>) -> {?ERROR       , dec_error(B)};
-dec(<<?c(?ID_LEAVE)        , B/bytes>>) -> {?LEAVE       , dec_leave(B)};
-dec(<<?c(?ID_LEAVE_ACK)    , B/bytes>>) -> {?LEAVE_ACK   , dec_leave_ack(B)};
-dec(<<?c(?ID_SHUTDOWN)     , B/bytes>>) -> {?SHUTDOWN    , dec_shutdown(B)};
-dec(<<?c(?ID_SHUTDOWN_ACK) , B/bytes>>) -> {?SHUTDOWN_ACK, dec_shutdown_ack(B)};
-dec(<<?c(?ID_INBAND_MSG)   , B/bytes>>) -> {?INBAND_MSG  , dec_inband_msg(B)}.
+dec(<<?c(?ID_CH_OPEN)      , B/bytes>>, V) -> {?CH_OPEN     , dec_ch_open(B, V)};
+dec(<<?c(?ID_CH_ACCEPT)    , B/bytes>>, V) -> {?CH_ACCEPT   , dec_ch_accept(B, V)};
+dec(<<?c(?ID_CH_REESTABL)  , B/bytes>>, V) -> {?CH_REESTABL , dec_ch_reestabl(B, V)};
+dec(<<?c(?ID_CH_REEST_ACK) , B/bytes>>, V) -> {?CH_REEST_ACK, dec_ch_reest_ack(B, V)};
+dec(<<?c(?ID_FND_CREATED)  , B/bytes>>, V) -> {?FND_CREATED , dec_fnd_created(B, V)};
+dec(<<?c(?ID_FND_SIGNED)   , B/bytes>>, V) -> {?FND_SIGNED  , dec_fnd_signed(B, V)};
+dec(<<?c(?ID_FND_LOCKED)   , B/bytes>>, V) -> {?FND_LOCKED  , dec_fnd_locked(B, V)};
+dec(<<?c(?ID_UPDATE)       , B/bytes>>, V) -> {?UPDATE      , dec_update(B, V)};
+dec(<<?c(?ID_UPDATE_ACK)   , B/bytes>>, V) -> {?UPDATE_ACK  , dec_update_ack(B, V)};
+dec(<<?c(?ID_UPDATE_ERR)   , B/bytes>>, V) -> {?UPDATE_ERR  , dec_update_err(B, V)};
+dec(<<?c(?ID_DEP_CREATED)  , B/bytes>>, V) -> {?DEP_CREATED , dec_dep_created(B, V)};
+dec(<<?c(?ID_DEP_SIGNED)   , B/bytes>>, V) -> {?DEP_SIGNED  , dec_dep_signed(B, V)};
+dec(<<?c(?ID_DEP_LOCKED)   , B/bytes>>, V) -> {?DEP_LOCKED  , dec_dep_locked(B, V)};
+dec(<<?c(?ID_DEP_ERR)      , B/bytes>>, V) -> {?DEP_ERR     , dec_dep_err(B, V)};
+dec(<<?c(?ID_WDRAW_CREATED), B/bytes>>, V) -> {?WDRAW_CREATED, dec_wdraw_created(B, V)};
+dec(<<?c(?ID_WDRAW_SIGNED) , B/bytes>>, V) -> {?WDRAW_SIGNED, dec_wdraw_signed(B, V)};
+dec(<<?c(?ID_WDRAW_LOCKED) , B/bytes>>, V) -> {?WDRAW_LOCKED, dec_wdraw_locked(B, V)};
+dec(<<?c(?ID_WDRAW_ERR)    , B/bytes>>, V) -> {?WDRAW_ERR   , dec_wdraw_err(B, V)};
+dec(<<?c(?ID_ERROR)        , B/bytes>>, V) -> {?ERROR       , dec_error(B, V)};
+dec(<<?c(?ID_LEAVE)        , B/bytes>>, V) -> {?LEAVE       , dec_leave(B, V)};
+dec(<<?c(?ID_LEAVE_ACK)    , B/bytes>>, V) -> {?LEAVE_ACK   , dec_leave_ack(B, V)};
+dec(<<?c(?ID_SHUTDOWN)     , B/bytes>>, V) -> {?SHUTDOWN    , dec_shutdown(B, V)};
+dec(<<?c(?ID_SHUTDOWN_ACK) , B/bytes>>, V) -> {?SHUTDOWN_ACK, dec_shutdown_ack(B, V)};
+dec(<<?c(?ID_INBAND_MSG)   , B/bytes>>, V) -> {?INBAND_MSG  , dec_inband_msg(B, V)}.
 
 -type ch_open_msg() :: #{chain_hash           := hash()
                        , temporary_channel_id := chan_id()
@@ -100,7 +102,7 @@ dec(<<?c(?ID_INBAND_MSG)   , B/bytes>>) -> {?INBAND_MSG  , dec_inband_msg(B)}.
                        , channel_reserve      := amount()
                        , initiator            := pubkey()}.
 
--spec enc_ch_open(ch_open_msg()) -> binary().
+-spec enc_ch_open(ch_open_msg(), vsn()) -> binary().
 enc_ch_open(#{chain_hash := ChainHash
             , temporary_channel_id := ChanId
             , lock_period          := LockPeriod
@@ -108,7 +110,7 @@ enc_ch_open(#{chain_hash := ChainHash
             , initiator_amount     := InitiatorAmt
             , responder_amount     := ResponderAmt
             , channel_reserve      := ChanReserve
-            , initiator            := InitiatorPubkey}) ->
+            , initiator            := InitiatorPubkey}, _) ->
     << ?ID_CH_OPEN    :1 /unit:8
      , ChainHash      :32/binary
      , ChanId         :32/binary
@@ -119,7 +121,7 @@ enc_ch_open(#{chain_hash := ChainHash
      , ChanReserve    :8 /unit:8
      , InitiatorPubkey:32/binary >>.
 
--spec dec_ch_open(binary()) -> ch_open_msg().
+-spec dec_ch_open(binary(), vsn()) -> ch_open_msg().
 dec_ch_open(<< ChainHash      :32/binary
              , ChanId         :32/binary
              , LockPeriod     :2 /unit:8
@@ -127,7 +129,7 @@ dec_ch_open(<< ChainHash      :32/binary
              , InitiatorAmt   :8 /unit:8
              , ResponderAmt   :8 /unit:8
              , ChanReserve    :8 /unit:8
-             , InitiatorPubkey:32/binary >>) ->
+             , InitiatorPubkey:32/binary >>, _) ->
     #{ chain_hash           => ChainHash
      , temporary_channel_id => ChanId
      , lock_period          => LockPeriod
@@ -146,14 +148,14 @@ dec_ch_open(<< ChainHash      :32/binary
                           , channel_reserve      := amount()
                           , responder            := pubkey()}.
 
--spec enc_ch_accept(ch_accept_msg()) -> binary().
+-spec enc_ch_accept(ch_accept_msg(), vsn()) -> binary().
 enc_ch_accept(#{ chain_hash           := ChainHash
                , temporary_channel_id := ChanId
                , minimum_depth        := MinDepth
                , initiator_amount     := InitiatorAmt
                , responder_amount     := ResponderAmt
                , channel_reserve      := ChanReserve
-               , responder            := Responder}) ->
+               , responder            := Responder}, _) ->
     << ?ID_CH_ACCEPT  :1 /unit:8
      , ChainHash      :32/binary
      , ChanId         :32/binary
@@ -163,14 +165,14 @@ enc_ch_accept(#{ chain_hash           := ChainHash
      , ChanReserve    :8 /unit:8
      , Responder      :32/binary >>.
 
--spec dec_ch_accept(binary()) -> ch_accept_msg().
+-spec dec_ch_accept(binary(), vsn()) -> ch_accept_msg().
 dec_ch_accept(<< ChainHash      :32/binary
                , ChanId         :32/binary
                , MinDepth       :4/unit:8
                , InitiatorAmt   :8 /unit:8
                , ResponderAmt   :8 /unit:8
                , ChanReserve    :8 /unit:8
-               , Responder      :32/binary >>) ->
+               , Responder      :32/binary >>, _) ->
     #{ chain_hash           => ChainHash
      , temporary_channel_id => ChanId
      , minimum_depth        => MinDepth
@@ -184,10 +186,10 @@ dec_ch_accept(<< ChainHash      :32/binary
                             , channel_id := chan_id()
                             , data := binary() }.
 
--spec enc_ch_reestabl(ch_reestabl_msg()) -> binary().
+-spec enc_ch_reestabl(ch_reestabl_msg(), vsn()) -> binary().
 enc_ch_reestabl(#{ chain_hash := ChainHash
                  , channel_id := ChanId
-                 , data       := Data }) ->
+                 , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_CH_REESTABL:1 /unit:8
      , ChainHash      :32/binary
@@ -195,11 +197,11 @@ enc_ch_reestabl(#{ chain_hash := ChainHash
      , Length         :2 /unit:8
      , Data           :Length/bytes>>.
 
--spec dec_ch_reestabl(binary()) -> ch_reestabl_msg().
+-spec dec_ch_reestabl(binary(), vsn()) -> ch_reestabl_msg().
 dec_ch_reestabl(<< ChainHash:32/binary
                  , ChanId   :32/binary
                  , Length   :2 /unit:8
-                 , Data/binary >>) ->
+                 , Data/binary >>, _) ->
     Length = byte_size(Data),
     #{ chain_hash => ChainHash
      , channel_id => ChanId
@@ -210,10 +212,10 @@ dec_ch_reestabl(<< ChainHash:32/binary
                                 , channel_id := chan_id()
                                 , data := binary() }.
 
--spec enc_ch_reestabl_ack(ch_reestabl_ack_msg()) -> binary().
+-spec enc_ch_reestabl_ack(ch_reestabl_ack_msg(), vsn()) -> binary().
 enc_ch_reestabl_ack(#{ chain_hash := ChainHash
                      , channel_id := ChanId
-                     , data       := Data }) ->
+                     , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_CH_REEST_ACK:1 /unit:8
      , ChainHash       :32/binary
@@ -221,11 +223,11 @@ enc_ch_reestabl_ack(#{ chain_hash := ChainHash
      , Length          :2 /unit:8
      , Data            :Length/bytes>>.
 
--spec dec_ch_reest_ack(binary()) -> ch_reestabl_ack_msg().
+-spec dec_ch_reest_ack(binary(), vsn()) -> ch_reestabl_ack_msg().
 dec_ch_reest_ack(<< ChainHash:32/binary
                   , ChanId   :32/binary
                   , Length   :2 /unit:8
-                  , Data/binary >>) ->
+                  , Data/binary >>, _) ->
     Length = byte_size(Data),
     #{ chain_hash => ChainHash
      , channel_id => ChanId
@@ -235,19 +237,19 @@ dec_ch_reest_ack(<< ChainHash:32/binary
 -type fnd_created_msg() :: #{ temporary_channel_id := chan_id()
                             , data                 := binary()}.
 
--spec enc_fnd_created(fnd_created_msg()) -> binary().
+-spec enc_fnd_created(fnd_created_msg(), vsn()) -> binary().
 enc_fnd_created(#{ temporary_channel_id := ChanId
-                 , data                 := Data }) ->
+                 , data                 := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_FND_CREATED:1 /unit:8
      , ChanId         :32/binary
      , Length         :2 /unit:8
      , Data           :Length/bytes >>.
 
--spec dec_fnd_created(binary()) -> fnd_created_msg().
+-spec dec_fnd_created(binary(), vsn()) -> fnd_created_msg().
 dec_fnd_created(<< ChanId:32/binary
                  , Length:2/unit:8
-                 , Data/binary >>) ->
+                 , Data/binary >>, _) ->
     Length = byte_size(Data),
     #{ temporary_channel_id => ChanId
      , data                 => Data}.
@@ -255,19 +257,19 @@ dec_fnd_created(<< ChanId:32/binary
 -type fnd_signed_msg() :: #{ temporary_channel_id := chan_id()
                            , data                 := binary()}.
 
--spec enc_fnd_signed(fnd_signed_msg()) -> binary().
+-spec enc_fnd_signed(fnd_signed_msg(), vsn()) -> binary().
 enc_fnd_signed(#{temporary_channel_id := ChanId,
-                 data                 := Data}) ->
+                 data                 := Data}, _) ->
     Length = byte_size(Data),
     << ?ID_FND_SIGNED:1 /unit:8
      , ChanId        :32/binary
      , Length        :2 /unit:8
      , Data          :Length/bytes >>.
 
--spec dec_fnd_signed(binary()) -> fnd_signed_msg().
+-spec dec_fnd_signed(binary(), vsn()) -> fnd_signed_msg().
 dec_fnd_signed(<< ChanId:32/binary
                 , Length:2/unit:8
-                , Data/binary >>) ->
+                , Data/binary >>, _) ->
     Length = byte_size(Data),
     #{ temporary_channel_id => ChanId
      , data                 => Data}.
@@ -275,53 +277,53 @@ dec_fnd_signed(<< ChanId:32/binary
 -type fnd_locked_msg() :: #{ temporary_channel_id := chan_id()
                            , channel_id           := chan_id()}.
 
--spec enc_fnd_locked(fnd_locked_msg()) -> binary().
+-spec enc_fnd_locked(fnd_locked_msg(), vsn()) -> binary().
 enc_fnd_locked(#{ temporary_channel_id := ChanId
-                , channel_id           := OnChainId }) ->
+                , channel_id           := OnChainId }, _) ->
     << ?ID_FND_LOCKED:1 /unit:8
      , ChanId        :32/binary
      , OnChainId     :32/binary >>.
 
--spec dec_fnd_locked(binary()) -> fnd_locked_msg().
+-spec dec_fnd_locked(binary(), vsn()) -> fnd_locked_msg().
 dec_fnd_locked(<< ChanId:32/binary
-                , OnChainId:32/binary >>) ->
+                , OnChainId:32/binary >>, _) ->
     #{ temporary_channel_id => ChanId
      , channel_id           => OnChainId }.
 
 -type update_msg() :: #{ channel_id := chan_id()
                        , data       := binary()}.
--spec enc_update(update_msg()) -> binary().
+-spec enc_update(update_msg(), vsn()) -> binary().
 enc_update(#{ channel_id := ChanId
-            , data   := Data }) ->
+            , data   := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_UPDATE:1 /unit:8
      , ChanId    :32/binary
      , Length    :2 /unit:8
      , Data      :Length/bytes >>.
 
--spec dec_update(binary()) -> update_msg().
+-spec dec_update(binary(), vsn()) -> update_msg().
 dec_update(<< ChanId:32/binary
             , Length:2 /unit:8
-            , Data/bytes >>) ->
+            , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data   => Data }.
 
 -type update_ack_msg() :: #{ channel_id := chan_id()
                            , data       := binary()}.
--spec enc_update_ack(update_ack_msg()) -> binary().
+-spec enc_update_ack(update_ack_msg(), vsn()) -> binary().
 enc_update_ack(#{ channel_id := ChanId
-                , data       := Data }) ->
+                , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_UPDATE_ACK:1 /unit:8
      , ChanId        :32/binary
      , Length        :2 /unit:8
      , Data          :Length/bytes >>.
 
--spec dec_update_ack(binary()) -> update_ack_msg().
+-spec dec_update_ack(binary(), vsn()) -> update_ack_msg().
 dec_update_ack(<< ChanId:32/binary
                 , Length:2 /unit:8
-                , Data/bytes >>) ->
+                , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data   => Data }.
@@ -330,19 +332,19 @@ dec_update_ack(<< ChanId:32/binary
                            , round      := non_neg_integer()
                            , error_code := error_code() }.
 
--spec enc_update_err(update_err_msg()) -> binary().
+-spec enc_update_err(update_err_msg(), vsn()) -> binary().
 enc_update_err(#{ channel_id := ChanId
                 , round      := Round
-                , error_code := ErrCode }) ->
+                , error_code := ErrCode }, _) ->
     << ?ID_UPDATE_ERR:1 /unit:8
      , ChanId        :32/binary
      , Round         :4 /unit:8
      , ErrCode       :2 /unit:8 >>.
 
--spec dec_update_err(binary()) -> update_err_msg().
+-spec dec_update_err(binary(), vsn()) -> update_err_msg().
 dec_update_err(<< ChanId :32/binary
                 , Round  :4/unit:8
-                , ErrCode:2/unit:8 >>) ->
+                , ErrCode:2/unit:8 >>, _) ->
     #{ channel_id => ChanId
      , round      => Round
      , error_code => ErrCode }.
@@ -350,53 +352,53 @@ dec_update_err(<< ChanId :32/binary
 -type deposit_msg() :: #{ channel_id := chan_id()
                         , data       := binary()}.
 
--spec enc_dep_created(deposit_msg()) -> binary().
+-spec enc_dep_created(deposit_msg(), vsn()) -> binary().
 enc_dep_created(#{ channel_id := ChanId
-                 , data       := Data }) ->
+                 , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_DEP_CREATED:1 /unit:8
      , ChanId         :32/binary
      , Length         :2 /unit:8
      , Data/bytes >>.
 
--spec dec_dep_created(binary()) -> deposit_msg().
+-spec dec_dep_created(binary(), vsn()) -> deposit_msg().
 dec_dep_created(<< ChanId:32/binary
                  , Length:2 /unit:8
-                 , Data/bytes >>) ->
+                 , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
 
--spec enc_dep_signed(deposit_msg()) -> binary().
+-spec enc_dep_signed(deposit_msg(), vsn()) -> binary().
 enc_dep_signed(#{ channel_id := ChanId
-                , data       := Data }) ->
+                , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_DEP_SIGNED:1 /unit:8
      , ChanId        :32/binary
      , Length        :2 /unit:8
      , Data/bytes >>.
 
--spec dec_dep_signed(binary()) -> deposit_msg().
+-spec dec_dep_signed(binary(), vsn()) -> deposit_msg().
 dec_dep_signed(<< ChanId:32/binary
                 , Length:2 /unit:8
-                , Data/bytes >>) ->
+                , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
 
--spec enc_dep_locked(deposit_msg()) -> binary().
+-spec enc_dep_locked(deposit_msg(), vsn()) -> binary().
 enc_dep_locked(#{ channel_id := ChanId
-                , data       := Data }) ->
+                , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_DEP_LOCKED:1 /unit:8
      , ChanId        :32/binary
      , Length        :2 /unit:8
      , Data/bytes >>.
 
--spec dec_dep_locked(binary()) -> deposit_msg().
+-spec dec_dep_locked(binary(), vsn()) -> deposit_msg().
 dec_dep_locked(<< ChanId:32/binary
                 , Length:2 /unit:8
-                , Data/bytes >>) ->
+                , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
@@ -405,19 +407,19 @@ dec_dep_locked(<< ChanId:32/binary
                         , round      := non_neg_integer()
                         , error_code := error_code() }.
 
--spec enc_dep_err(dep_err_msg()) -> binary().
+-spec enc_dep_err(dep_err_msg(), vsn()) -> binary().
 enc_dep_err(#{ channel_id := ChanId
              , round      := Round
-             , error_code := ErrCode }) ->
+             , error_code := ErrCode }, _) ->
     << ?ID_DEP_ERR:1 /unit:8
      , ChanId        :32/binary
      , Round         :4 /unit:8
      , ErrCode       :2 /unit:8 >>.
 
--spec dec_dep_err(binary()) -> dep_err_msg().
+-spec dec_dep_err(binary(), vsn()) -> dep_err_msg().
 dec_dep_err(<< ChanId :32/binary
              , Round  :4 /unit:8
-             , ErrCode:2 /unit:8 >>) ->
+             , ErrCode:2 /unit:8 >>, _) ->
     #{ channel_id => ChanId
      , round      => Round
      , error_code => ErrCode }.
@@ -425,53 +427,53 @@ dec_dep_err(<< ChanId :32/binary
 -type withdrawal_msg() :: #{ channel_id := chan_id()
                            , data       := binary()}.
 
--spec enc_wdraw_created(withdrawal_msg()) -> binary().
+-spec enc_wdraw_created(withdrawal_msg(), vsn()) -> binary().
 enc_wdraw_created(#{ channel_id := ChanId
-                   , data       := Data }) ->
+                   , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_WDRAW_CREATED:1 /unit:8
      , ChanId           :32/binary
      , Length           :2 /unit:8
      , Data/bytes >>.
 
--spec dec_wdraw_created(binary()) -> withdrawal_msg().
+-spec dec_wdraw_created(binary(), vsn()) -> withdrawal_msg().
 dec_wdraw_created(<< ChanId:32/binary
                    , Length:2 /unit:8
-                   , Data/bytes >>) ->
+                   , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
 
--spec enc_wdraw_signed(withdrawal_msg()) -> binary().
+-spec enc_wdraw_signed(withdrawal_msg(), vsn()) -> binary().
 enc_wdraw_signed(#{ channel_id := ChanId
-                  , data       := Data }) ->
+                  , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_WDRAW_SIGNED:1 /unit:8
      , ChanId          :32/binary
      , Length          :2 /unit:8
      , Data/bytes >>.
 
--spec dec_wdraw_signed(binary()) -> withdrawal_msg().
+-spec dec_wdraw_signed(binary(), vsn()) -> withdrawal_msg().
 dec_wdraw_signed(<< ChanId:32/binary
                    , Length:2 /unit:8
-                   , Data/bytes >>) ->
+                   , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
 
--spec enc_wdraw_locked(withdrawal_msg()) -> binary().
+-spec enc_wdraw_locked(withdrawal_msg(), vsn()) -> binary().
 enc_wdraw_locked(#{ channel_id := ChanId
-                  , data       := Data }) ->
+                  , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_WDRAW_LOCKED:1 /unit:8
      , ChanId          :32/binary
      , Length          :2 /unit:8
      , Data/bytes >>.
 
--spec dec_wdraw_locked(binary()) -> withdrawal_msg().
+-spec dec_wdraw_locked(binary(), vsn()) -> withdrawal_msg().
 dec_wdraw_locked(<< ChanId:32/binary
                   , Length:2 /unit:8
-                  , Data/bytes >>) ->
+                  , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
@@ -480,19 +482,19 @@ dec_wdraw_locked(<< ChanId:32/binary
                           , round      := non_neg_integer()
                           , error_code := error_code() }.
 
--spec enc_wdraw_err(wdraw_err_msg()) -> binary().
+-spec enc_wdraw_err(wdraw_err_msg(), vsn()) -> binary().
 enc_wdraw_err(#{ channel_id := ChanId
                , round      := Round
-               , error_code := ErrCode }) ->
+               , error_code := ErrCode }, _) ->
     << ?ID_WDRAW_ERR:1 /unit:8
      , ChanId       :32/binary
      , Round        :4 /unit:8
      , ErrCode      :2 /unit:8 >>.
 
--spec dec_wdraw_err(binary()) -> wdraw_err_msg().
+-spec dec_wdraw_err(binary(), vsn()) -> wdraw_err_msg().
 dec_wdraw_err(<< ChanId :32/binary
                , Round  :4 /unit:8
-               , ErrCode:2 /unit:8 >>) ->
+               , ErrCode:2 /unit:8 >>, _) ->
     #{ channel_id => ChanId
      , round      => Round
      , error_code => ErrCode }.
@@ -500,61 +502,61 @@ dec_wdraw_err(<< ChanId :32/binary
 -type error_msg() :: #{ channel_id := chan_id()
                       , data       := binary() }.
 
--spec enc_error(error_msg()) -> binary().
+-spec enc_error(error_msg(), vsn()) -> binary().
 enc_error(#{ channel_id := ChanId
-           , data       := Data }) ->
+           , data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_ERROR :1 /unit:8
      , ChanId    :32/binary
      , Length    :2 /unit:8
      , Data      :Length/bytes >>.
 
--spec dec_error(binary()) -> error_msg().
+-spec dec_error(binary(), vsn()) -> error_msg().
 dec_error(<< ChanId:32/binary
            , Length:2 /unit:8
-           , Data/bytes >>) ->
+           , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
 
 -type leave_msg() :: #{channel_id := chan_id()}.
 
--spec enc_leave(leave_msg()) -> binary().
-enc_leave(#{channel_id := ChanId}) ->
+-spec enc_leave(leave_msg(), vsn()) -> binary().
+enc_leave(#{channel_id := ChanId}, _) ->
     << ?ID_LEAVE:1 /unit:8
      , ChanId   :32/binary >>.
 
--spec dec_leave(binary()) -> leave_msg().
-dec_leave(<< ChanId:32/binary >>) ->
+-spec dec_leave(binary(), vsn()) -> leave_msg().
+dec_leave(<< ChanId:32/binary >>, _) ->
     #{ channel_id => ChanId }.
 
 -type leave_ack_msg() :: #{channel_id := chan_id()}.
 
--spec enc_leave_ack(leave_ack_msg()) -> binary().
-enc_leave_ack(#{channel_id := ChanId}) ->
+-spec enc_leave_ack(leave_ack_msg(), vsn()) -> binary().
+enc_leave_ack(#{channel_id := ChanId}, _) ->
     << ?ID_LEAVE_ACK:1 /unit:8
      , ChanId       :32/binary >>.
 
--spec dec_leave_ack(binary()) -> leave_ack_msg().
-dec_leave_ack(<< ChanId:32/binary >>) ->
+-spec dec_leave_ack(binary(), vsn()) -> leave_ack_msg().
+dec_leave_ack(<< ChanId:32/binary >>, _) ->
     #{ channel_id => ChanId }.
 
 -type shutdown_msg() :: #{channel_id := chan_id(),
                           data       := binary() }.
 
--spec enc_shutdown(shutdown_msg()) -> binary().
+-spec enc_shutdown(shutdown_msg(), vsn()) -> binary().
 enc_shutdown(#{channel_id := ChanId,
-               data       := Data }) ->
+               data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_SHUTDOWN:1 /unit:8
      , ChanId      :32/binary
      , Length      :2 /unit:8
      , Data        :Length/bytes >>.
 
--spec dec_shutdown(binary()) -> shutdown_msg().
+-spec dec_shutdown(binary(), vsn()) -> shutdown_msg().
 dec_shutdown(<< ChanId:32/binary
               , Length:2 /unit:8
-              , Data/bytes >>) ->
+              , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
@@ -562,19 +564,19 @@ dec_shutdown(<< ChanId:32/binary
 -type shutdown_ack_msg() :: #{channel_id := chan_id(),
                               data       := binary() }.
 
--spec enc_shutdown_ack(shutdown_ack_msg()) -> binary().
+-spec enc_shutdown_ack(shutdown_ack_msg(), vsn()) -> binary().
 enc_shutdown_ack(#{channel_id := ChanId,
-                   data       := Data }) ->
+                   data       := Data }, _) ->
     Length = byte_size(Data),
     << ?ID_SHUTDOWN_ACK:1 /unit:8
      , ChanId          :32/binary
      , Length          :2 /unit:8
      , Data            :Length/bytes >>.
 
--spec dec_shutdown_ack(binary()) -> shutdown_ack_msg().
+-spec dec_shutdown_ack(binary(), vsn()) -> shutdown_ack_msg().
 dec_shutdown_ack(<< ChanId:32/binary
                   , Length:2 /unit:8
-                  , Data/bytes >>) ->
+                  , Data/bytes >>, _) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
      , data       => Data }.
@@ -584,20 +586,26 @@ dec_shutdown_ack(<< ChanId:32/binary
                         to         := binary(),
                         info       := binary()}.
 
-max_inband_msg_size() -> 65000.
-inband_msg_bytes() -> 2.
+max_inband_msg_size() ->
+    max_inband_msg_size(2).
+
+max_inband_msg_size(1) -> 16#ff;
+max_inband_msg_size(2) -> 65000.
+
+inband_msg_bytes(1) -> 1;
+inband_msg_bytes(2) -> 2.
 
 
--spec enc_inband_msg(inband_msg()) -> binary().
+-spec enc_inband_msg(inband_msg(), vsn()) -> binary().
 enc_inband_msg(#{ channel_id := ChanId
                 , from       := From
                 , to         := To
-                , info       := Info }) ->
+                , info       := Info }, V) ->
     assert_max_length(?PUBKEY_SIZE, byte_size(From), from),
     assert_max_length(?PUBKEY_SIZE, byte_size(To), to),
     Length = byte_size(Info),
     assert_max_length(max_inband_msg_size(), Length, msg),
-    Bytes = inband_msg_bytes(),
+    Bytes = inband_msg_bytes(V),
     << ?ID_INBAND_MSG:1 /unit:8
      , ChanId        :32/binary
      , From          :?PUBKEY_SIZE/binary
@@ -605,11 +613,12 @@ enc_inband_msg(#{ channel_id := ChanId
      , Length        :Bytes /unit:8
      , Info          :Length/bytes >>.
 
+-spec dec_inband_msg(binary(), vsn()) -> inband_msg().
 dec_inband_msg(<< ChanId:32/binary
                 , From  :?PUBKEY_SIZE/binary
                 , To    :?PUBKEY_SIZE/binary
-                , Rest/binary >>) ->
-    Bytes = inband_msg_bytes(),
+                , Rest/binary >>, V) ->
+    Bytes = inband_msg_bytes(V),
     <<Length:Bytes/unit:8, Info/binary>> = Rest,
     Length = byte_size(Info),
     #{ channel_id => ChanId

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -272,6 +272,7 @@ read_channel_options(Params) ->
          Read(<<"responder_amount">>, responder_amount, #{type => integer}),
          Read(<<"channel_reserve">>, channel_reserve, #{type => integer}),
          Read(<<"ttl">>, ttl, #{type => integer, mandatory => false}),
+         Read(<<"protocol_vsn">>, protocol_vsn, #{type => integer, mandatory => false}),
          Put(noise, [{noise, <<"Noise_NN_25519_ChaChaPoly_BLAKE2b">>}])
         ] ++ lists:map(ReadTimeout, aesc_fsm:timeouts() ++ [awaiting_open,
                                                             initialized])


### PR DESCRIPTION
See [PT #164238122](https://www.pivotaltracker.com/story/show/164238122)

Currently, tests have been added to `aesc_fsm_SUITE` verifying that `protocol_vsn` defaults to `1` (the old version), and that message size limits are respected.

Note that there is no way to verify that both sides use the same version. The `protocol_vsn` option would need to be included in the `channel_open` and `channel_accept` messages for this.