### PR TITLE
Log (debug) reason for invalid tx on external API

### DIFF
--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -432,10 +432,12 @@ handle_request_('PostTransaction', #{'Tx' := Tx}, _Context) ->
                         ok ->
                             Hash = aetx_sign:hash(SignedTx),
                             {200, [], #{<<"tx_hash">> => aehttp_api_encoder:encode(tx_hash, Hash)}};
-                        {error, _} ->
+                        {error, Reason} ->
+                            lager:debug("Invalid tx: ~p", [Reason]),
                             {400, [], #{reason => <<"Invalid tx">>}}
                     end;
                 {error, broken_tx} ->
+                    lager:debug("Broken tx", []),
                     {400, [], #{reason => <<"Invalid tx">>}}
             end;
         {error, _} ->

--- a/docs/release-notes/next/ext_api_log.md
+++ b/docs/release-notes/next/ext_api_log.md
@@ -1,0 +1,1 @@
+* Makes debug logging of failed external HTTP API `PostTransaction` requests more verbose.


### PR DESCRIPTION
I am used this locally for debugging tests amended in https://github.com/aeternity/aeternity/pull/2214 and it seems a reasonable addition to logs at debug level. The error reasons are not long.