### PR TITLE
Fix running mining unit tests on their own

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ REBAR ?= ./rebar3
 EUNIT_VM_ARGS = $(CURDIR)/config/eunit.vm.args
 EUNIT_SYS_CONFIG = $(CURDIR)/config/eunit.sys.config
 EUNIT_TEST_FLAGS ?=
+EUNIT_REBAR_FLAGS ?=
 
 CT_TEST_FLAGS ?=
 ST_CT_FLAGS = --logdir system_test/logs
@@ -209,7 +210,7 @@ REVISION:
 
 eunit: KIND=test
 eunit: internal-build
-	@ERL_FLAGS="-args_file $(EUNIT_VM_ARGS) -config $(EUNIT_SYS_CONFIG)" ./rebar3 do eunit $(EUNIT_TEST_FLAGS)
+	@ERL_FLAGS="-args_file $(EUNIT_VM_ARGS) -config $(EUNIT_SYS_CONFIG)" ./rebar3 do eunit $(EUNIT_REBAR_FLAGS) $(EUNIT_TEST_FLAGS)
 
 eunit-roma: KIND=test
 eunit-roma: internal-build

--- a/apps/aecore/test/aec_metrics_test_utils.erl
+++ b/apps/aecore/test/aec_metrics_test_utils.erl
@@ -26,10 +26,10 @@ set_statsd_port_config(Dev, Cfg, CTConfig) ->
             case lists:keyfind(Dev, 1, PM) of
                 {_, Port} ->
                     insert_port_config(Port, Cfg);
-                _ ->
+                false ->
                     Cfg
             end;
-        _ ->
+        false ->
             Cfg
     end.
 

--- a/apps/aecore/test/aec_metrics_test_utils.erl
+++ b/apps/aecore/test/aec_metrics_test_utils.erl
@@ -17,6 +17,7 @@ make_port_map(Devs, Config) ->
     ct:log("Ports = ~p", [Ports]),
     PortMap = zip(Devs, Ports),
     ct:log("PortMap = ~p", [PortMap]),
+    false = lists:keyfind(logger_port_map, 1, Config),
     lists:keystore(logger_port_map, 1, Config,
                    {logger_port_map, PortMap}).
 

--- a/apps/aecore/test/aec_metrics_test_utils.erl
+++ b/apps/aecore/test/aec_metrics_test_utils.erl
@@ -1,7 +1,7 @@
 -module(aec_metrics_test_utils).
 
 -export([make_port_map/2,
-         set_statsd_port_config/3,
+         maybe_set_statsd_port_in_user_config/3,
          start_statsd_loggers/1,
          stop_statsd_loggers/0,
          fetch_data/0]).
@@ -20,7 +20,7 @@ make_port_map(Devs, Config) ->
     lists:keystore(logger_port_map, 1, Config,
                    {logger_port_map, PortMap}).
 
-set_statsd_port_config(Dev, Cfg, CTConfig) ->
+maybe_set_statsd_port_in_user_config(Dev, Cfg, CTConfig) ->
     case lists:keyfind(logger_port_map, 1, CTConfig) of
         {_, PM} ->
             case lists:keyfind(Dev, 1, PM) of

--- a/apps/aecore/test/aec_metrics_test_utils.erl
+++ b/apps/aecore/test/aec_metrics_test_utils.erl
@@ -1,6 +1,7 @@
 -module(aec_metrics_test_utils).
 
 -export([make_port_map/2,
+         port_map/1,
          maybe_set_statsd_port_in_user_config/3,
          start_statsd_loggers/1,
          stop_statsd_loggers/0,
@@ -20,6 +21,10 @@ make_port_map(Devs, Config) ->
     false = lists:keyfind(logger_port_map, 1, Config),
     lists:keystore(logger_port_map, 1, Config,
                    {logger_port_map, PortMap}).
+
+port_map(Config) ->
+    {_, PortMap} = lists:keyfind(logger_port_map, 1, Config),
+    PortMap.
 
 maybe_set_statsd_port_in_user_config(Dev, Cfg, CTConfig) ->
     case lists:keyfind(logger_port_map, 1, CTConfig) of
@@ -43,40 +48,29 @@ insert_port_config(Port, Cfg) ->
             Cfg#{<<"metrics">> => #{<<"port">> => Port}}
     end.
 
-start_statsd_loggers(Config) ->
-    {_, PortMap} = lists:keyfind(logger_port_map, 1, Config),
+start_statsd_loggers(PortMap) ->
     ct:log("PortMap = ~p", [PortMap]),
-    Loggers0 = proplists:get_value(loggers, Config, []),
-    ct:log("Loggers0 = ~p", [Loggers0]),
-    Loggers1 = lists:foldl(
-                 fun({Id, Port}, Acc) ->
-                         start_statsd_logger_(Id, Port, Acc)
-                 end, Loggers0, PortMap),
+    [] = loggers(),
+    Loggers1 = lists:map(
+                 fun({Id, Port}) ->
+                         start_statsd_logger_(Id, Port)
+                 end, PortMap),
     ct:log("Loggers1 = ~p", [Loggers1]),
-    lists:keystore(loggers, 1, Config, {loggers, Loggers1}).
+    ok.
 
-start_statsd_logger_(Id, Port, Loggers) ->
-    case lists:keyfind(Id, 1, Loggers) of
-        {_, Info} ->
-            case lists:keyfind(port, 1, Info) of
-                {_, Port} -> Loggers;
-                {_, OldPort} ->
-                    error({logger_on_different_port, [{id, Id},
-                                                      {old_port, OldPort},
-                                                      {new_port, Port}]})
-            end;
-        false ->
-            application:ensure_all_started(exometer_core),
-            {ok, Pid} = exometer_report_logger:new([{id, Id},
-                                                    {input, [{mode, udp},
-                                                             {port, Port}]},
-                                                    {output, [{mode, ets}]}]),
-            [{Id, [{port, Port},
-                   {pid, Pid}]} | Loggers]
-    end.
+start_statsd_logger_(Id, Port) ->
+    {ok, Pid} = exometer_report_logger:new([{id, Id},
+                                            {input, [{mode, udp},
+                                                     {port, Port}]},
+                                            {output, [{mode, ets}]}]),
+    {Id, [{port, Port},
+          {pid, Pid}]}.
+
+loggers() ->
+    supervisor:which_children(exometer_report_logger_sup).
 
 stop_statsd_loggers() ->
-    Children = supervisor:which_children(exometer_report_logger_sup),
+    Children = loggers(),
     ct:log("Logger Children = ~p", [Children]),
     [ok = stop_logger(C) || C <- Children],
     ok.

--- a/apps/aecore/test/aec_metrics_test_utils.erl
+++ b/apps/aecore/test/aec_metrics_test_utils.erl
@@ -3,7 +3,7 @@
 -export([make_port_map/2,
          set_statsd_port_config/3,
          start_statsd_loggers/1,
-         stop_statsd_loggers/1,
+         stop_statsd_loggers/0,
          fetch_data/0]).
 
 make_port_map(Devs, Config) ->
@@ -83,7 +83,7 @@ start_statsd_logger_(Id, Port, Loggers) ->
                    {pid, Pid}]} | Loggers]
     end.
 
-stop_statsd_loggers(_Config) ->
+stop_statsd_loggers() ->
     Children = supervisor:which_children(exometer_report_logger_sup),
     ct:log("Logger Children = ~p", [Children]),
     [ok = stop_logger(C) || C <- Children],

--- a/apps/aecore/test/aec_metrics_test_utils.erl
+++ b/apps/aecore/test/aec_metrics_test_utils.erl
@@ -42,17 +42,8 @@ insert_port_config(Port, Cfg) ->
             Cfg#{<<"metrics">> => #{<<"port">> => Port}}
     end.
 
-start_statsd_loggers(Config0) ->
-    Devs = proplists:get_value(devs, Config0, []),
-    {PortMap, Config} = case lists:keyfind(logger_port_map, 1, Config0) of
-                            false ->
-                                NewConfig = make_port_map(Devs, Config0),
-                                {_, PM} = lists:keyfind(
-                                            logger_port_map, 1, NewConfig),
-                                {PM, NewConfig};
-                            {_, PM} ->
-                                {PM, Config0}
-                        end,
+start_statsd_loggers(Config) ->
+    {_, PortMap} = lists:keyfind(logger_port_map, 1, Config),
     ct:log("PortMap = ~p", [PortMap]),
     Loggers0 = proplists:get_value(loggers, Config, []),
     ct:log("Loggers0 = ~p", [Loggers0]),

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -7,7 +7,10 @@
 
 -module(aec_test_utils).
 
--export([ mock_time/0
+-export([ running_apps/0
+        , loaded_apps/0
+        , restore_stopped_and_unloaded_apps/2
+        , mock_time/0
         , unmock_time/0
         , mock_difficulty_as_target/0
         , unmock_difficulty_as_target/0
@@ -70,6 +73,21 @@
 -endif.
 
 -define(GENESIS_ACCOUNTS, [{<<"_________my_public_key__________">>, 100}]).
+
+running_apps() ->
+    lists:map(fun({A,_,_}) -> A end, application:which_applications()).
+
+loaded_apps() ->
+    lists:map(fun({A,_,_}) -> A end, application:loaded_applications()).
+
+restore_stopped_and_unloaded_apps(OldRunningApps, OldLoadedApps) ->
+    BadRunningApps = running_apps() -- OldRunningApps,
+    lists:foreach(fun(A) -> ok = application:stop(A) end, BadRunningApps),
+    BadLoadedApps = loaded_apps() -- OldLoadedApps,
+    lists:foreach(fun(A) -> ok = application:unload(A) end, BadLoadedApps),
+    OldRunningApps = running_apps(),
+    OldLoadedApps = loaded_apps(),
+    ok.
 
 genesis_accounts() ->
   ?GENESIS_ACCOUNTS.

--- a/apps/aecore/test/aecore_app_tests.erl
+++ b/apps/aecore/test/aecore_app_tests.erl
@@ -1,27 +1,30 @@
 -module(aecore_app_tests).
 
+-import(aec_test_utils, [running_apps/0, loaded_apps/0, restore_stopped_and_unloaded_apps/2]).
+
 -include_lib("eunit/include/eunit.hrl").
 -include("blocks.hrl").
 
 persisted_valid_gen_block_test_() ->
     {foreach,
      fun() ->
+             InitialApps = {running_apps(), loaded_apps()},
              meck:new(aec_db, [passthrough]),
              meck:expect(aec_db, load_database, 0, ok),
              meck:new(aecore_sup, [passthrough]),
              meck:expect(aecore_sup, start_link, 0, {ok, pid}),
              meck:new(aec_jobs_queues, [passthrough]),
              meck:expect(aec_jobs_queues, start, 0, ok),
-             lager:start(),
-             ok
+             ok = lager:start(),
+             InitialApps
      end,
-     fun(ok) ->
+     fun({OldRunningApps, OldLoadedApps}) ->
              ok = application:stop(lager),
-             ok = application:stop(mnesia),
              meck:unload(aec_jobs_queues),
              meck:unload(aecore_sup),
-             meck:unload(aec_db)
-     end,
+             meck:unload(aec_db),
+             ok = restore_stopped_and_unloaded_apps(OldRunningApps, OldLoadedApps)
+end,
      [{"Check persisted genesis block",
        fun() ->
             meck:expect(aec_db, persisted_valid_genesis_block, 0, false),
@@ -33,4 +36,3 @@ persisted_valid_gen_block_test_() ->
             ok
        end}
      ]}.
-

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -139,7 +139,7 @@ create_config(Node, CTConfig, CustomConfig, Options) ->
     EpochCfgPath = epoch_config_dir(Node, CTConfig),
     ok = filelib:ensure_dir(EpochCfgPath),
     MergedCfg = maps_merge(default_config(Node, CTConfig), CustomConfig),
-    MergedCfg1 = aec_metrics_test_utils:set_statsd_port_config(
+    MergedCfg1 = aec_metrics_test_utils:maybe_set_statsd_port_in_user_config(
                    Node, MergedCfg, CTConfig),
     Config = config_apply_options(Node, MergedCfg1, Options),
     write_keys(Node, Config),

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -171,7 +171,7 @@ init_per_group(_Group, Config) ->
 end_per_group(Group, Config) when Group =:= one_blocked;
                                    Group =:= large_msgs ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
-    aec_metrics_test_utils:stop_statsd_loggers(Config),
+    ok = aec_metrics_test_utils:stop_statsd_loggers(Config),
     stop_devs(Config),
     %% reset dev1 config to no longer block any peers.
     Config1 = config({devs, [dev1]}, Config),
@@ -182,12 +182,12 @@ end_per_group(Group, Config) when Group =:= one_blocked;
                                      [{add_peers, true}]);
 end_per_group(mempool_sync, Config) ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
-    aec_metrics_test_utils:stop_statsd_loggers(Config),
+    ok = aec_metrics_test_utils:stop_statsd_loggers(Config),
     Devs = proplists:get_value(devs, Config, []),
     stop_devs([dev3 | Devs], Config);
 end_per_group(_, Config) ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
-    aec_metrics_test_utils:stop_statsd_loggers(Config),
+    ok = aec_metrics_test_utils:stop_statsd_loggers(Config),
     stop_devs(Config).
 
 stop_devs(Config) ->

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -179,16 +179,19 @@ end_per_group(Group, Config) when Group =:= one_blocked;
     EpochCfg = aecore_suite_utils:epoch_config(Dev1, Config),
     aecore_suite_utils:create_config(Dev1, Config,
                                      maps:without([<<"blocked_peers">>], EpochCfg),
-                                     [{add_peers, true}]);
+                                     [{add_peers, true}]),
+    ok;
 end_per_group(mempool_sync, Config) ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
     ok = aec_metrics_test_utils:stop_statsd_loggers(),
     Devs = proplists:get_value(devs, Config, []),
-    stop_devs([dev3 | Devs], Config);
+    stop_devs([dev3 | Devs], Config),
+    ok;
 end_per_group(_, Config) ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
     ok = aec_metrics_test_utils:stop_statsd_loggers(),
-    stop_devs(Config).
+    stop_devs(Config),
+    ok.
 
 stop_devs(Config) ->
     Devs = proplists:get_value(devs, Config, []),

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -171,7 +171,7 @@ init_per_group(_Group, Config) ->
 end_per_group(Group, Config) when Group =:= one_blocked;
                                    Group =:= large_msgs ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
-    ok = aec_metrics_test_utils:stop_statsd_loggers(Config),
+    ok = aec_metrics_test_utils:stop_statsd_loggers(),
     stop_devs(Config),
     %% reset dev1 config to no longer block any peers.
     Config1 = config({devs, [dev1]}, Config),
@@ -182,12 +182,12 @@ end_per_group(Group, Config) when Group =:= one_blocked;
                                      [{add_peers, true}]);
 end_per_group(mempool_sync, Config) ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
-    ok = aec_metrics_test_utils:stop_statsd_loggers(Config),
+    ok = aec_metrics_test_utils:stop_statsd_loggers(),
     Devs = proplists:get_value(devs, Config, []),
     stop_devs([dev3 | Devs], Config);
 end_per_group(_, Config) ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
-    ok = aec_metrics_test_utils:stop_statsd_loggers(Config),
+    ok = aec_metrics_test_utils:stop_statsd_loggers(),
     stop_devs(Config).
 
 stop_devs(Config) ->

--- a/config/eunit.sys.config
+++ b/config/eunit.sys.config
@@ -1,4 +1,9 @@
 [
+  {kernel,
+    [
+      {error_logger, silent}
+    ]
+  },
 
   {lager, [
       {error_logger_flush_queue, false},

--- a/config/eunit.sys.config
+++ b/config/eunit.sys.config
@@ -3,7 +3,6 @@
   {lager, [
       {error_logger_flush_queue, false},
       {handlers, [
-          {lager_console_backend, [{level, debug}]}
       ]},
       {extra_sinks, [
            {epoch_mining_lager_event, [
@@ -20,7 +19,6 @@
            ]},
            {epoch_sync_lager_event, [
              {handlers, [
-                {lager_console_backend, [{level, info}]}
              ]}
            ]}
       ]}


### PR DESCRIPTION
Delivers https://www.pivotaltracker.com/story/show/164698259

This PR aims at showing that now eunit test of aec_mining module fails, thanks to setup app env not leaked any longer.

TODO:
* [x] Re-check manually re-running `make eunit` (rather than specific eunit test module)