### PR TITLE
Add missing disk log close when renaming db

### DIFF
--- a/apps/aeutils/src/aeu_db.erl
+++ b/apps/aeutils/src/aeu_db.erl
@@ -126,6 +126,7 @@ change_latest_log(DbDir, FromNode, ToNode) ->
             ok = disk_log_open_file(LatestLogNewFile, ?LATEST_LOG_NEW),
             ok = write_changed_log_file(?LATEST_LOG, ?LATEST_LOG_NEW, FromNode, ToNode),
             ok = disk_log_sync(?LATEST_LOG_NEW),
+            ok = disk_log_close(?LATEST_LOG),
             ok = disk_log_close(?LATEST_LOG_NEW),
             ok = replace_file(LatestLogFile, LatestLogNewFile),
             ok;

--- a/docs/release-notes/RELEASE-NOTES-2.2.0.md
+++ b/docs/release-notes/RELEASE-NOTES-2.2.0.md
@@ -12,6 +12,7 @@ Regarding renaming, this release:
   * Example usage of the tool:
     * Using absolute path of database directory - `./bin/aeternity rename_db '/node/aeternity/node/my-old-db-path'`;
     * Using relative path of database directory (or when `chain` > `db_path` is not set in the config) - `./bin/aeternity rename_db data`;
+    * On Windows using absolute path of database directory - `.\usr\lib\aeternity\bin\aeternity.cmd rename_db C:\node\aeternity\node\my-old-db-path`;
     * If you are running a node using Docker (assuming you either don't have `db_path` set in your config, or it is set to `/home/aeternity/node/data`) - `docker run --entrypoint=/bin/bash -v ~/.aeternity/myaedb:/home/aeternity/node/data/mnesia -v ~/.aeternity/myaeternity.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml aeternity/aeternity -c "/home/aeternity/node/bin/aeternity rename_db /home/aeternity/node/data"`
   * Please use `rename_db` tool when your node is **not running**.
   * Note that, for some environments (e.g. Docker), the node may not be able  to start for the first time after database renaming. If that is the case, please retry to start a node, and the node should manage to start at the second attempt.


### PR DESCRIPTION
The missing close would result in an `eacces` error on win32 when trying to
replace files later in the procedure.