### PR TITLE
Deprecate log field of contract object in API

### DIFF
--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -4038,7 +4038,8 @@
           "maximum" : 65535
         },
         "log" : {
-          "type" : "string"
+          "type" : "string",
+          "description" : "DEPRECATED"
         },
         "active" : {
           "type" : "boolean"

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -3084,6 +3084,7 @@ definitions:
         minimum: 0
         maximum: 65535
       log:
+        description: 'DEPRECATED'
         type: string
       active:
         type: boolean

--- a/docs/release-notes/next/PT-164539296-deprecate-contract-log.md
+++ b/docs/release-notes/next/PT-164539296-deprecate-contract-log.md
@@ -1,0 +1,1 @@
+* Deprecates the `log` field in the contract object in the user HTTP API.


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/164539296