### PR TITLE
Revisit StateChannel timeouts

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -280,8 +280,7 @@ timer_subst(mutual_closing          ) -> accept;
 timer_subst(channel_closing         ) -> idle.
 
 default_timeouts() ->
-    #{ open           => 120000
-     , accept         => 120000
+    #{ accept         => 120000
      , funding_create => 120000
      , funding_sign   => 120000
      , funding_lock   => 360000

--- a/docs/release-notes/next/revisit_sc_timeouts.md
+++ b/docs/release-notes/next/revisit_sc_timeouts.md
@@ -1,0 +1,1 @@
+* Unifies State Channel's WebSocket API timeouts: `open` fallbacks to `idle`


### PR DESCRIPTION
Inspired by aeternity/protocol#330.
This PR aims at providing a more homogeneous approach regarding timeouts.

This implementation aims making all states where the channel is waiting for a new update, use the same `idle` timeout. This will change the default value for `open` from 12000 ms to 600000 ms but since those are defaults, I don't consider it an API breaking change.

Another approach with keeping the `timeout_open` option will be removing [this line](https://github.com/aeternity/aeternity/compare/revisit_sc_timeouts?expand=1#diff-d4455bfb4a5f76a7c3e0cc75b6abd537R262) as it is misleading (we always will have a default `open` value, this will never match). This will keep the old timeout and provide a specific setting just for `open` state.

If you think the latter approash shall be taken instead, please comment.