### PR TITLE
PT-164805105 Re-check nonce of transactions in the mempool

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -73,6 +73,7 @@
          terminate/2, code_change/3]).
 
 -export_type([ dbs/0
+             , origins_cache/0
              , pool_db/0
              , pool_db_key/0
              , tx_hash/0]).

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -47,7 +47,8 @@
         ]).
 
 %% exports used by GC (should perhaps be in a common lib module)
--export([ origins_cache/0
+-export([ dbs_/0
+        , origins_cache/0
         , origins_cache_max_size/0
         , pool_db/0
         , pool_db_nonce/0
@@ -266,6 +267,10 @@ dbs() ->
 
 raw_delete(#dbs{} = Dbs, Key) ->
     pool_db_raw_delete(Dbs, Key).
+
+-spec dbs_() -> dbs().
+dbs_() ->
+    #dbs{}.
 
 -spec gc_db(dbs()) -> pool_db().
 gc_db(#dbs{gc_db = GcDb}) ->

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -558,7 +558,7 @@ pool_db_open(DbName, ExtraOpts) ->
 origins_cache_open(Name) ->
     ets:new(Name, [set, public, named_table]).
 
--spec pool_db_peek(pool_db(), MaxNumber::pos_integer() | infinity,
+-spec pool_db_peek(dbs(), MaxNumber::pos_integer() | infinity,
                    aec_keys:pubkey() | all, non_neg_integer() | all) ->
                           [pool_db_value()].
 pool_db_peek(_, 0, _, _) -> [];

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -48,6 +48,7 @@
 
 %% exports used by GC (should perhaps be in a common lib module)
 -export([ dbs_/0
+        , gc_db/1
         , origins_cache/0
         , origins_cache_max_size/0
         , pool_db/0
@@ -56,7 +57,6 @@
         , pool_db_gc/0
         , pool_db_peek/4
         , raw_delete/2
-        , gc_db/1
         ]).
 
 -include("aec_tx_pool.hrl").

--- a/apps/aecore/src/aec_tx_pool_gc.erl
+++ b/apps/aecore/src/aec_tx_pool_gc.erl
@@ -1,17 +1,33 @@
+%%%=============================================================================
+%%% @copyright (C) 2019, Aeternity Anstalt
+%%% @doc
+%%%    Garbage collection of mempool transactions
+%%% @end
+%%%=============================================================================
+
 -module(aec_tx_pool_gc).
+
 -behaviour(gen_server).
 
--export([
-          start_link/0
-        , stop/0
-        , gc/2
+%% API
+-export([ add_hash/4
+        , add_to_origins_cache/3
+        , adjust_ttl/2
         , delete_hash/2
-        , add_hash/4
-        , adjust_ttl/1
+        , gc/2
         ]).
 
--export([
-          init/1
+-ifdef(TEST).
+-export([ origins_cache_init/0
+        , origins_cache_gc/0
+        , stop/0]).
+-endif.
+
+%% gen_server API
+-export([ start_link/0]).
+
+%% gen_server callbacks
+-export([ init/1
         , handle_call/3
         , handle_cast/2
         , handle_info/2
@@ -23,6 +39,10 @@
 
 -import(aeu_debug, [pp/1]).
 
+%%%===================================================================
+%%% Types
+%%%===================================================================
+
 -export_type([pool_db_gc_key/0]).
 
 -type pool_db() :: atom().
@@ -30,36 +50,93 @@
 
 -define(SERVER, ?MODULE).
 
--record(st, { gc_db = aec_tx_pool:pool_db_gc() :: pool_db() }).
+-record(state, {origins_cache :: aec_tx_pool:origins_cache(),
+                dbs :: aec_tx_pool:dbs()}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec add_hash(aec_tx_pool:pool_db(), pool_db_gc_key(),
+               aec_tx_pool:pool_db_key(), aetx:tx_ttl()) -> integer().
+add_hash(MempoolGC, TxHash, Key, TTL) ->
+    %% Use update_counter with a threshold to do the compare and maybe update
+    %% efficiently.
+    ets:update_counter(MempoolGC, TxHash, {#tx.ttl, 0, TTL, TTL},
+                       #tx{hash = TxHash, ttl = TTL, key = Key}).
+
+-spec adjust_ttl(integer(), aec_tx_pool:dbs()) -> ok.
+adjust_ttl(Diff, Dbs) ->
+    gen_server:cast(?SERVER, {adjust_ttl, Diff, Dbs}).
+
+delete_hash(MempoolGC, TxHash) ->
+    ets:delete(MempoolGC, TxHash).
+
+-spec gc(aec_blocks:height(), aec_tx_pool:dbs()) -> ok.
+gc(Height, Dbs) ->
+    gen_server:cast(?SERVER, {garbage_collect, Height, Dbs}).
+
+-spec add_to_origins_cache(aec_tx_pool:origins_cache(), aec_keys:pubkey(),
+                           non_neg_integer()) -> ok.
+add_to_origins_cache(OriginsCache, Origin, Nonce) ->
+    gen_server:cast(?SERVER, {add_to_origins_cache, OriginsCache, Origin, Nonce}).
+
+-ifdef(TEST).
+origins_cache_init() ->
+    gen_server:call(?SERVER, origins_cache_init).
+
+origins_cache_gc() ->
+    gen_server:call(?SERVER, origins_cache_gc).
+
+stop() ->
+    gen_server:stop(?SERVER).
+-endif.
+
+%%%===================================================================
+%%% Gen server API
 
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
-stop() ->
-    gen_server:stop(?SERVER).
-
-gc(Height, Dbs) ->
-    gen_server:cast(?SERVER, {garbage_collect, Height, Dbs}).
-
-adjust_ttl(Diff) ->
-    gen_server:cast(?SERVER, {adjust_ttl, Diff}).
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
 
 init([]) ->
-    {ok, #st{ gc_db = aec_tx_pool:pool_db_gc()}}.
+    ok = start_origins_cache_gc(),
+    {ok, #state{}}.
 
+handle_call(origins_cache_init, _From, _S) ->
+    S = init_state(),
+    {reply, ok, S};
+handle_call(origins_cache_gc, _From, S) ->
+    ok = origins_cache_gc(S),
+    {reply, ok, S};
 handle_call(_Req, _From, S) ->
     {reply, {error, unknown_request}, S}.
 
-handle_cast({garbage_collect, Height, Dbs}, S) ->
-    do_gc(Height, Dbs, S),
-    {noreply, S};
-handle_cast({adjust_ttl, Diff}, #st{gc_db = GCDb} = S) ->
+handle_cast({adjust_ttl, Diff, Dbs}, S) ->
+    GCDb = aec_tx_pool:gc_db(Dbs),
     do_adjust_ttl(GCDb, Diff),
+    {noreply, S};
+handle_cast({garbage_collect, Height, Dbs}, S) ->
+    ok = do_gc(Height, Dbs),
+    {noreply, S};
+handle_cast({add_to_origins_cache, OriginsCache, Origin, Nonce}, S) ->
+    ok = do_add_to_origins_cache(OriginsCache, Origin, Nonce),
     {noreply, S};
 handle_cast(Msg, S) ->
     lager:warning("Ignoring unknown cast message: ~p", [Msg]),
     {noreply, S}.
 
+handle_info(init_origins_cache_gc, _S) ->
+    S = init_state(),
+    erlang:send_after(30000, self(), origins_cache_gc),
+    {noreply, S};
+handle_info(origins_cache_gc, #state{} = S) ->
+    ok = origins_cache_gc(S),
+    erlang:send_after(30000, self(), origins_cache_gc),
+    {noreply, S};
 handle_info(Info, S) ->
     lager:debug("Ignoring unknown info: ~p", [Info]),
     {noreply, S}.
@@ -70,17 +147,30 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, S, _Extra) ->
     {ok, S}.
 
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
 
-do_gc(Height, Dbs, State = #st{ gc_db = GCDb }) ->
+do_adjust_ttl(GCDb, Diff) ->
+    do_adjust_ttl(GCDb, ets:first(GCDb), Diff).
+
+do_adjust_ttl(_GCDb, '$end_of_table', _Diff) ->
+    ok;
+do_adjust_ttl(GCDb, TxHash, Diff) ->
+    ets:update_counter(GCDb, TxHash, {#tx.ttl, -Diff}),
+    do_adjust_ttl(GCDb, ets:next(GCDb, TxHash), Diff).
+
+do_gc(Height, Dbs) ->
+    GCDb = aec_tx_pool:gc_db(Dbs),
     GCTxs = ets:select(
               GCDb, [{ #tx{hash = '$1', ttl = '$2', key = '$3', _ = '_'},
                        [{'=<', '$2', Height}],
                        [{{'$1', '$3'}}] }]),
-    do_gc_(GCTxs, Dbs, State).
+    do_gc_(GCTxs, Dbs, GCDb).
 
-do_gc_([], _Dbs, S) ->
-    S;
-do_gc_([{TxHash, Key} | TxHashes], Dbs, S = #st{ gc_db = GCDb }) ->
+do_gc_([], _Dbs, _GCDb) ->
+    ok;
+do_gc_([{TxHash, Key} | TxHashes], Dbs, GCDb) ->
     case aec_db:gc_tx(TxHash) of
         ok ->
             aec_tx_pool:raw_delete(Dbs, Key),
@@ -95,24 +185,118 @@ do_gc_([{TxHash, Key} | TxHashes], Dbs, S = #st{ gc_db = GCDb }) ->
                        [pp(BlockHash), pp(TxHash)]),
             ok
     end,
-    do_gc_(TxHashes, Dbs, S).
+    do_gc_(TxHashes, Dbs, GCDb).
 
--spec delete_hash(pool_db(), pool_db_gc_key()) -> true.
-delete_hash(MempoolGC, TxHash) ->
-    Res = ets:delete(MempoolGC, TxHash),
-    Res.
+%%===================================================================
+%% Origins cache
+%%
+%% Origins/accounts cache keeps track of {origin, nonce} pairs which
+%% have been added to the chain. This allows earlier
+%% garbage collection of potentially hanging transactions from
+%% the same origin/account, but with nonce that will block them
+%% from ever getting into the chain.
+%% E.g. if a transaction from sender X with nonce Y made it into the
+%% chain, all pending transactions from X with nonce =< Y can
+%% be removed from the mempool.
 
-add_hash(MempoolGC, TxHash, Key, TTL) ->
-    %% Use update_counter with a threshold to do the compare and maybe update
-    %% efficiently.
-    ets:update_counter(MempoolGC, TxHash, {#tx.ttl, 0, TTL, TTL},
-                       #tx{hash = TxHash, ttl = TTL, key = Key}).
+-ifdef(TEST).
+start_origins_cache_gc() ->
+    ok.
+-else.
+start_origins_cache_gc() ->
+    erlang:send_after(30000 + rand:uniform(10000), self(), init_origins_cache_gc),
+    ok.
+-endif.
 
-do_adjust_ttl(GCDb, Diff) ->
-    do_adjust_ttl(GCDb, ets:first(GCDb), Diff).
+do_add_to_origins_cache(OriginsCache, Origin, Nonce) ->
+    case ets:info(OriginsCache, size) < aec_tx_pool:origins_cache_max_size() of
+        true ->
+            case ets:lookup(OriginsCache, Origin) of
+                [] ->
+                    true = ets:insert(OriginsCache, {Origin, Nonce}),
+                    ok;
+                [{Origin, N}] ->
+                    %% Always keep the highest included nonce in cache
+                    case Nonce > N of
+                        true ->
+                            true = ets:insert(OriginsCache, {Origin, Nonce}),
+                            ok;
+                        false -> ok
+                    end
+            end;
+        false -> ok
+    end.
 
-do_adjust_ttl(_GCDb, '$end_of_table', _Diff) ->
+origins_cache_gc(#state{origins_cache = OriginsCache, dbs = Dbs}) ->
+    EntriesToProcess = 100,
+    case origins_cache_get(OriginsCache, EntriesToProcess) of
+        [] -> ok;
+        CacheEntries ->
+            case aec_chain:get_block_state(aec_chain:top_block_hash()) of
+                error ->
+                    lager:info("Error trying to get top block state");
+                {ok, Trees} ->
+                    AccountsTree = aec_trees:accounts(Trees),
+                    origins_cache_gc(CacheEntries, AccountsTree, OriginsCache, Dbs)
+            end
+    end.
+
+origins_cache_get(OriginsCache, Size) ->
+    Pat = [{ '_', [], ['$_'] }],
+    case ets:select(OriginsCache, Pat, Size) of
+        '$end_of_table'  -> [];
+        {Entries, _Cont} -> Entries
+    end.
+
+origins_cache_gc([], _AccountsTree, _OriginsCache, _Dbs) ->
     ok;
-do_adjust_ttl(GCDb, TxHash, Diff) ->
-    ets:update_counter(GCDb, TxHash, {#tx.ttl, -Diff}),
-    do_adjust_ttl(GCDb, ets:next(GCDb, TxHash), Diff).
+origins_cache_gc([{Origin, Nonce} | Rest], AccountsTree, OriginsCache, Dbs) ->
+    case aec_tx_pool:pool_db_peek(Dbs, 50, Origin, Nonce) of
+        [] ->
+            %% No hanging stale transactions, remove Origin from cache
+            true = ets:delete(Origin, OriginsCache);
+        SignedTxs ->
+            %% Origin cache information may be stale.
+            %% Re-check transactions, based on the account nonce from
+            %% accounts state tree.
+            case get_account(Origin, {account_trees, AccountsTree}) of
+                none -> ok;
+                {value, Account} ->
+                    AccountNonce = aec_accounts:nonce(Account),
+                    SignedTxsForGc = filter_txs_by_account_nonce(SignedTxs, AccountNonce),
+                    remove_txs_from_dbs(SignedTxsForGc, Dbs)
+            end
+    end,
+    origins_cache_gc(Rest, AccountsTree, OriginsCache, Dbs).
+
+filter_txs_by_account_nonce(SignedTxs, AccountNonce) ->
+    lists:filter(fun(SignedTx) ->
+                         Tx = aetx_sign:tx(SignedTx),
+                         aetx:nonce(Tx) =< AccountNonce
+                 end, SignedTxs).
+
+remove_txs_from_dbs([], _Dbs) ->
+    ok;
+remove_txs_from_dbs([SignedTx | Rest], Dbs) ->
+    TxHash = aetx_sign:hash(SignedTx),
+    case aec_db:gc_tx(TxHash) of
+        ok ->
+            aec_tx_pool:raw_delete(Dbs, aec_tx_pool:pool_db_key(SignedTx)),
+            delete_hash(aec_tx_pool:gc_db(Dbs), TxHash);
+        {error, Reason} ->
+            lager:debug("TX Origin-based garbage collect of ~p failed: ~p",
+                        [pp(TxHash), Reason])
+    end,
+    remove_txs_from_dbs(Rest, Dbs).
+
+init_state() ->
+    %% Should dbs and origins cache be shared between aec_tx_pool and aec_tx_pool_gc?
+    Dbs = aec_tx_pool:dbs(),
+    OriginsCache = aec_tx_pool:origins_cache(),
+    #state{dbs = Dbs, origins_cache = OriginsCache}.
+
+%% This can be moved to common lib shared with aec_tx_pool
+get_account(AccountKey, {account_trees, AccountsTrees}) ->
+    aec_accounts_trees:lookup(AccountKey, AccountsTrees);
+get_account(AccountKey, {block_hash, BlockHash}) ->
+    aec_chain:get_account_at_hash(AccountKey, BlockHash).

--- a/apps/aecore/src/aec_tx_pool_gc.erl
+++ b/apps/aecore/src/aec_tx_pool_gc.erl
@@ -245,7 +245,7 @@ origins_cache_get(OriginsCache, Size) ->
 origins_cache_gc([], _AccountsTree, _OriginsCache, _Dbs) ->
     ok;
 origins_cache_gc([{Origin, Nonce} | Rest], AccountsTree, OriginsCache, Dbs) ->
-    case aec_tx_pool:pool_db_peek(aec_tx_pool:pool_db(), ?OC_TXS_PER_ORIGIN_COUNT, Origin, Nonce) of
+    case aec_tx_pool:pool_db_peek(Dbs, ?OC_TXS_PER_ORIGIN_COUNT, Origin, Nonce) of
         [] ->
             %% No hanging stale transactions, remove Origin from cache
             true = ets:delete(Origin, OriginsCache);

--- a/apps/aecore/src/aec_tx_pool_gc.erl
+++ b/apps/aecore/src/aec_tx_pool_gc.erl
@@ -248,7 +248,7 @@ origins_cache_gc([{Origin, Nonce} | Rest], AccountsTree, OriginsCache, Dbs) ->
     case aec_tx_pool:pool_db_peek(Dbs, ?OC_TXS_PER_ORIGIN_COUNT, Origin, Nonce) of
         [] ->
             %% No hanging stale transactions, remove Origin from cache
-            true = ets:delete(Origin, OriginsCache);
+            true = ets:delete(OriginsCache, Origin);
         SignedTxs ->
             %% Origin cache information may be stale.
             %% Re-check transactions, based on the account nonce from

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -26,6 +26,7 @@ tx_pool_test_() ->
              aec_test_utils:mock_block_target_validation(), %% Mocks aec_governance.
              {ok, _} = aec_tx_pool_gc:start_link(),
              {ok, _} = aec_tx_pool:start_link(),
+             ok = aec_tx_pool_gc:origins_cache_init(),
              %% Start `aec_keys` merely for generating realistic test
              %% signed txs - as a node would do.
              ets:new(?TAB, [public, ordered_set, named_table]),
@@ -791,7 +792,7 @@ tx_pool_test_() ->
                ?assertMatch({ok, [_, _, _, _, _]}, aec_tx_pool:peek(infinity)),
 
                %% GC removes stale transactions with nonce lower than 4
-               ok = aec_tx_pool:origins_cache_gc(),
+               ok = aec_tx_pool_gc:origins_cache_gc(),
 
                %% Only transactions with nonce=4 are not GCed
                ?assertMatch({ok, [STx42, STx41]}, aec_tx_pool:peek(infinity))

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -26,7 +26,6 @@ tx_pool_test_() ->
              aec_test_utils:mock_block_target_validation(), %% Mocks aec_governance.
              {ok, _} = aec_tx_pool_gc:start_link(),
              {ok, _} = aec_tx_pool:start_link(),
-             ok = aec_tx_pool_gc:origins_cache_init(),
              %% Start `aec_keys` merely for generating realistic test
              %% signed txs - as a node would do.
              ets:new(?TAB, [public, ordered_set, named_table]),


### PR DESCRIPTION
Introduce additional garbage collection of transactions, based on the
`{origin, nonce}` pair cache of transactions that were accepted into the chain.