### PR TITLE
Support building on macOS with libs in custom locations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1027,6 +1027,8 @@ workflows:
             tags:
               only: *tag_regex
 
+      - osx_package_with_libs_flags: {}
+
       - deploy_integration:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,35 @@ references:
         fi
       when: on_fail
 
+  osx_package_steps: &osx_package_steps
+    - checkout
+    - *restore_macos_package_cache
+    - run:
+        name: Install required tools
+        command: |
+          brew update
+          brew install libsodium
+          brew link libsodium
+          brew install file://`pwd`/deployment/homebrew/erlang.rb
+          brew link erlang
+          for erlang_dep in $(brew deps erlang); do brew link $erlang_dep; done
+    - *save_macos_package_cache
+    - *set_package_path
+    - *build_package
+    - *test_package
+    - store_artifacts:
+        path: /tmp/package_tests/node1/log
+    - store_artifacts:
+        path: /tmp/package_tests/node2/log
+    - store_artifacts:
+        path: /tmp/package_tests/node3/log
+    - *store_package_artifacts
+    - persist_to_workspace:
+        root: *packages_workspace
+        paths:
+          - "*.tar.gz"
+    - *fail_notification
+
   docker_compose_build: &docker_compose_build
     run:
       name: Build latest docker image
@@ -575,34 +604,16 @@ jobs:
     macos:
       xcode: "10.0.0"
     working_directory: ~/aeternity
-    steps:
-      - checkout
-      - *restore_macos_package_cache
-      - run:
-          name: Install required tools
-          command: |
-            brew update
-            brew install libsodium
-            brew link libsodium
-            brew install file://`pwd`/deployment/homebrew/erlang.rb
-            brew link erlang
-            for erlang_dep in $(brew deps erlang); do brew link $erlang_dep; done
-      - *save_macos_package_cache
-      - *set_package_path
-      - *build_package
-      - *test_package
-      - store_artifacts:
-          path: /tmp/package_tests/node1/log
-      - store_artifacts:
-          path: /tmp/package_tests/node2/log
-      - store_artifacts:
-          path: /tmp/package_tests/node3/log
-      - *store_package_artifacts
-      - persist_to_workspace:
-          root: *packages_workspace
-          paths:
-            - "*.tar.gz"
-      - *fail_notification
+    steps: *osx_package_steps
+
+  osx_package_with_libs_flags:
+    environment:
+      - CFLAGS: ""
+      - LDFLAGS: ""
+    macos:
+      xcode: "10.0.0"
+    working_directory: ~/aeternity
+    steps: *osx_package_steps
 
   uat_tests:
     executor: builder_container_stable
@@ -1191,3 +1202,15 @@ workflows:
                 - master
     jobs:
       - docker_system_tests
+
+  seldom_checks:
+    triggers:
+      - schedule:
+          # run at midnight UTC
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - osx_package_with_libs_flags


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/165087263

This PR reproduces the failure. It does not address it yet.

If we want to support advanced users building the software on macOS - either Homebrew installing in a non-default path or (probably) nix-shell - we need to consider environment variables already set by the users, that are at least CFLAGS and LDFLAGS. If we do not, then we need to make it clear that we do not support building the software in such configuration.