### PR TITLE
Provide more info in top_changed event (Fixes #165176101)

### DIFF
--- a/apps/aecore/src/aec_block_generator.erl
+++ b/apps/aecore/src/aec_block_generator.erl
@@ -172,7 +172,7 @@ add_new_tx(S = #state{ worker = Worker }, Tx) ->
         {_WPid, _WRef} -> S#state{ new_txs = [Tx | S#state.new_txs] }
     end.
 
-preempt_generation(S, NewTop) ->
+preempt_generation(S, #{ block_hash := NewTop }) ->
     S1 = stop_worker(S),
     start_worker_block(S1, NewTop).
 

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -646,10 +646,14 @@ preempt_if_new_top(#state{ top_block_hash = OldHash,
             BlockType = aec_blocks:type(NewBlock),
             ok = aec_tx_pool:top_change(BlockType, OldHash, NewHash),
 
-            aec_events:publish(top_changed, NewHash),
+            Hdr = aec_blocks:to_header(NewBlock),
+            Height = aec_headers:height(Hdr),
+            aec_events:publish(top_changed, #{ block_hash => NewHash
+                                             , block_type => BlockType
+                                             , prev_hash  => aec_headers:prev_hash(Hdr)
+                                             , height     => Height }),
             maybe_publish_top(Origin, NewBlock),
-            aec_metrics:try_update([ae,epoch,aecore,chain,height],
-                                   aec_blocks:height(NewBlock)),
+            aec_metrics:try_update([ae,epoch,aecore,chain,height], Height),
             State1 = State#state{top_block_hash = NewHash},
             KeyHash = aec_blocks:prev_key_hash(NewBlock),
             %% A new micro block from the same generation should

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -603,7 +603,10 @@ expect_top_event_hashes([],_AllowMissing) ->
     ok;
 expect_top_event_hashes(Expected, AllowMissing) ->
     receive
-        {gproc_ps_event, top_changed, #{info := Hash}} ->
+        {gproc_ps_event, top_changed, #{info := #{ block_hash := Hash
+                                                 , block_type := _
+                                                 , prev_hash  := _
+                                                 , height     := _ }}} ->
             NewExpected = Expected -- [Hash],
             case lists:member(Hash, Expected) of
                 true  -> expect_top_event_hashes(NewExpected, AllowMissing);


### PR DESCRIPTION
The top_changed event used to only convey the block hash, but not
least the state channel chain watcher also needs the prev_hash and
the height in order to assess a new top block without digging into
the chain. Addresses #165176101.