### PR TITLE
Script running the working property-based tests not requiring setup of a node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ quickcheck-system-test-dir:
 .PHONY: eqc
 eqc: | eqc/.git
 	## TODO Re-fetch repo if version not found in local repo.
-	( cd $@ && git reset --quiet --soft $(EQC_TEST_VERSION) && git stash --quiet --all; )
+	#( cd $@ && git reset --quiet --soft $(EQC_TEST_VERSION) && git stash --quiet --all; )
 
 eqc/.git:
 	git clone --quiet --no-checkout $(EQC_TEST_REPO) $(@D)

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ quickcheck-test: eqc
 	$(warning This target is known to fail.)
 	$(MAKE) quickcheck-test-dir EQC_DIR=$</aecore_eqc
 	$(MAKE) quickcheck-test-dir EQC_DIR=$</aeminer_eqc
-	$(MAKE) quickcheck-test-dir EQC_DIR=$</aesophia_eqc
+	#$(MAKE) quickcheck-test-dir EQC_DIR=$</aesophia_eqc
 	$(MAKE) quickcheck-test-dir EQC_DIR=$</aeutils_eqc
 
 .PHONY: quickcheck-integration-test

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -1517,6 +1517,7 @@ assert_contract_byte_code(ABIVersion, SerializedCode, CallData, S)
                 true ->
                     assert_contract_init_function(ABIVersion, CallData, TypeInfo);
                 false ->
+                    io:format("Vsn: ~p, Height: ~p~n", [Vsn, S#state.height]),
                     runtime_error(illegal_contract_compiler_version)
             end
     catch _:_ -> runtime_error(bad_sophia_code)

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
 %% `otp_patches/`.
 {minimum_otp_vsn, "20.1"}.
 
-{project_app_dirs, ["apps/*", "lib/*", "."]}.
+{project_app_dirs, ["apps/*"]}.
 
 {erl_opts, [debug_info, {parse_transform, lager_transform},
             {lager_extra_sinks, [epoch_mining,

--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,8 @@
 %% `otp_patches/`.
 {minimum_otp_vsn, "20.1"}.
 
+{project_app_dirs, ["apps/*", "lib/*", "."]}.
+
 {erl_opts, [debug_info, {parse_transform, lager_transform},
             {lager_extra_sinks, [epoch_mining,
                                  epoch_metrics, epoch_sync]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -210,7 +210,17 @@
                     {websocket_client, ".*", {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}}
                 ]},
                 {ct_opts, [{create_priv_dir, auto_per_tc}]}
-            ]}
+            ]},
+            %% In order to run QuickCheck tests, ensure that [`-include_lib`](http://erlang.org/doc/reference_manual/macros.html#file-inclusion) can find your copy of apps `eqc`, `pulse` and `pulse_otp`.
+            %% Sample alternatives:
+            %% * Export OS variable [`ERL_LIBS`](http://erlang.org/doc/man/code.html) e.g. `export ERL_LIBS="YOUR_EQC_DIR_PLACEHOLDER".
+            %% * Amend the code path via your [`~/.erlang` file](http://erlang.org/doc/man/erl.html) e.g. add in it:
+            %%     ```
+            %%     (fun(Dir, Vsn) -> [true = code:add_pathz(filename:join([Dir, A++"-"++Vsn, ebin])) || A <- ["eqc", "pulse", "pulse_otp"]], ok end)("YOUR_EQC_DIR_HERE, "YOUR_EQC_VERSION_HERE").
+            %%     ```
+            %%
+            %% TODO As `./rebar3` is 3.7.0+, consider handling QuickCheck as [vendored dependency](https://www.rebar3.org/docs/using-available-plugins#vendoring-dependencies).
+            {eqc, [{plugins, [{rebar3_eqc, "1.2.0"}]}, {eqc_opts, [{numtests, 500}]}]}
            ]
 }.
 


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/n/projects/2124891/stories/164548714

Please review https://github.com/Quviq/epoch-eqc/pull/6 first.

TODO:
* [ ] Identify if `txs_hardfork_eqc` is working (so to get `make quickcheck-test` passing locally with QuickCheck installed).
  * WIP PRs https://github.com/Quviq/epoch-eqc/pull/19 and https://github.com/Quviq/epoch-eqc/pull/18
* [ ] ~~Get https://github.com/Quviq/epoch-eqc/pull/6 merged first.~~ (obsolete)
* [ ] Update git remote (repo and commit) used to fetch scripts in makefile.
* [x] Delete [misplaced oracles tests](https://github.com/aeternity/aeternity/tree/d9521c3863395d3a74a4f38f06cc788095537611/apps/aeoracle/eqc).
  * See https://github.com/aeternity/aeternity/pull/2318