### PR TITLE
Pt 160843011 onchain transactions and serializations

### DIFF
--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -19,7 +19,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -142,8 +142,8 @@ serialize(#channel_close_mutual_tx{channel_id             = ChannelId,
                                    responder_amount_final = ResponderAmount,
                                    ttl                    = TTL,
                                    fee                    = Fee,
-                                   nonce                  = Nonce}) ->
-    {version(),
+                                   nonce                  = Nonce} = Tx) ->
+    {version(Tx),
      [ {channel_id              , ChannelId}
      , {from_id                 , FromId}
      , {initiator_amount_final  , InitiatorAmount}
@@ -205,12 +205,8 @@ initiator_amount_final(#channel_close_mutual_tx{initiator_amount_final  = Amount
 responder_amount_final(#channel_close_mutual_tx{responder_amount_final  = Amount}) ->
     Amount.
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_CLOSE_MUTUAL_TX_VSN.
 
 %%%===================================================================

--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -24,6 +24,7 @@
          serialize/1,
          deserialize/2,
          for_client/1,
+         valid_at_protocol/2,
          initiator_amount_final/1,
          responder_amount_final/1
         ]).
@@ -208,6 +209,10 @@ responder_amount_final(#channel_close_mutual_tx{responder_amount_final  = Amount
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_CLOSE_MUTUAL_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 %%%===================================================================
 %%% Test setters 

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -23,7 +23,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %%%===================================================================
@@ -197,4 +198,8 @@ serialization_template(?CHANNEL_CLOSE_SOLO_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_CLOSE_SOLO_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -19,7 +19,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -138,8 +138,8 @@ serialize(#channel_close_solo_tx{channel_id = ChannelId,
                                  poi        = PoI,
                                  ttl        = TTL,
                                  fee        = Fee,
-                                 nonce      = Nonce}) ->
-    {version(),
+                                 nonce      = Nonce} = Tx) ->
+    {version(Tx),
      [ {channel_id, ChannelId}
      , {from_id   , FromId}
      , {payload   , Payload}
@@ -194,11 +194,7 @@ serialization_template(?CHANNEL_CLOSE_SOLO_TX_VSN) ->
     , {nonce     , int}
     ].
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_CLOSE_SOLO_TX_VSN.
 

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -20,7 +20,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -170,8 +170,8 @@ serialize(#channel_create_tx{initiator_id       = InitiatorId,
                              fee                = Fee,
                              delegate_ids       = DelegateIds,
                              state_hash         = StateHash,
-                             nonce              = Nonce}) ->
-    {version(),
+                             nonce              = Nonce} = Tx) ->
+    {version(Tx),
      [ {initiator_id      , InitiatorId}
      , {initiator_amount  , InitiatorAmount}
      , {responder_id      , ResponderId}
@@ -314,12 +314,8 @@ delegate_ids(#channel_create_tx{delegate_ids = DelegateIds}) ->
 delegate_pubkeys(#channel_create_tx{delegate_ids = DelegateIds}) ->
     [aeser_id:specialize(D, account) || D <- DelegateIds].
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_CREATE_TX_VSN.
 
 %%%===================================================================

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -24,7 +24,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Getters
@@ -317,6 +318,10 @@ delegate_pubkeys(#channel_create_tx{delegate_ids = DelegateIds}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_CREATE_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 %%%===================================================================
 %%% Test setters 

--- a/apps/aechannel/src/aesc_create_tx.erl
+++ b/apps/aechannel/src/aesc_create_tx.erl
@@ -51,11 +51,14 @@
 -ifdef(TEST).
 -export([set_state_hash/2]).
 -endif.
+
+-include_lib("aecontract/include/hard_forks.hrl").
 %%%===================================================================
 %%% Types
 %%%===================================================================
 
--define(CHANNEL_CREATE_TX_VSN, 1).
+-define(INITIAL_VSN, 1).
+-define(PINNED_BLOCK_VSN, 2).
 -define(CHANNEL_CREATE_TX_TYPE, channel_create_tx).
 
 -type vsn() :: non_neg_integer().
@@ -71,7 +74,8 @@
           fee                :: non_neg_integer(),
           delegate_ids       :: [aeser_id:id()],
           state_hash         :: binary(),
-          nonce              :: non_neg_integer()
+          nonce              :: non_neg_integer(),
+          block_hash         :: aesc_pinned_block:hash()
          }).
 
 -opaque tx() :: #channel_create_tx{}.
@@ -99,6 +103,7 @@ new(#{initiator_id       := InitiatorId,
     lists:foreach(fun(D) -> account = aeser_id:specialize_type(D) end, DelegateIds),
     account = aeser_id:specialize_type(InitiatorId),
     account = aeser_id:specialize_type(ResponderId),
+    BlockHash = maps:get(block_hash, Args, aesc_pinned_block:no_hash()),
     Tx = #channel_create_tx{initiator_id       = InitiatorId,
                             responder_id       = ResponderId,
                             initiator_amount   = InitiatorAmount,
@@ -109,7 +114,8 @@ new(#{initiator_id       := InitiatorId,
                             fee                = Fee,
                             delegate_ids       = DelegateIds,
                             state_hash         = StateHash,
-                            nonce              = Nonce},
+                            nonce              = Nonce,
+                            block_hash         = BlockHash},
     {ok, aetx:new(?MODULE, Tx)}.
 
 type() ->
@@ -171,23 +177,42 @@ serialize(#channel_create_tx{initiator_id       = InitiatorId,
                              fee                = Fee,
                              delegate_ids       = DelegateIds,
                              state_hash         = StateHash,
-                             nonce              = Nonce} = Tx) ->
-    {version(Tx),
-     [ {initiator_id      , InitiatorId}
-     , {initiator_amount  , InitiatorAmount}
-     , {responder_id      , ResponderId}
-     , {responder_amount  , ResponderAmount}
-     , {channel_reserve   , ChannelReserve}
-     , {lock_period       , LockPeriod}
-     , {ttl               , TTL}
-     , {fee               , Fee}
-     , {delegate_ids      , DelegateIds}
-     , {state_hash        , StateHash}
-     , {nonce             , Nonce}
-     ]}.
+                             nonce              = Nonce,
+                             block_hash         = BlockHash} = Tx) ->
+    case version(Tx) of
+        ?INITIAL_VSN ->
+            {?INITIAL_VSN,
+            [ {initiator_id      , InitiatorId}
+            , {initiator_amount  , InitiatorAmount}
+            , {responder_id      , ResponderId}
+            , {responder_amount  , ResponderAmount}
+            , {channel_reserve   , ChannelReserve}
+            , {lock_period       , LockPeriod}
+            , {ttl               , TTL}
+            , {fee               , Fee}
+            , {delegate_ids      , DelegateIds}
+            , {state_hash        , StateHash}
+            , {nonce             , Nonce}
+            ]};
+        ?PINNED_BLOCK_VSN ->
+            {?PINNED_BLOCK_VSN,
+            [ {initiator_id      , InitiatorId}
+            , {initiator_amount  , InitiatorAmount}
+            , {responder_id      , ResponderId}
+            , {responder_amount  , ResponderAmount}
+            , {channel_reserve   , ChannelReserve}
+            , {lock_period       , LockPeriod}
+            , {ttl               , TTL}
+            , {fee               , Fee}
+            , {delegate_ids      , DelegateIds}
+            , {state_hash        , StateHash}
+            , {nonce             , Nonce}
+            , {block_hash        , aesc_pinned_block:serialize(BlockHash)}
+            ]}
+    end.
 
 -spec deserialize(vsn(), list()) -> tx().
-deserialize(?CHANNEL_CREATE_TX_VSN,
+deserialize(?INITIAL_VSN,
             [ {initiator_id      , InitiatorId}
             , {initiator_amount  , InitiatorAmount}
             , {responder_id      , ResponderId}
@@ -213,7 +238,37 @@ deserialize(?CHANNEL_CREATE_TX_VSN,
                        fee                = Fee,
                        delegate_ids       = DelegateIds,
                        state_hash         = StateHash,
-                       nonce              = Nonce}.
+                       nonce              = Nonce,
+                       block_hash         = aesc_pinned_block:no_hash()};
+deserialize(?PINNED_BLOCK_VSN,
+            [ {initiator_id      , InitiatorId}
+            , {initiator_amount  , InitiatorAmount}
+            , {responder_id      , ResponderId}
+            , {responder_amount  , ResponderAmount}
+            , {channel_reserve   , ChannelReserve}
+            , {lock_period       , LockPeriod}
+            , {ttl               , TTL}
+            , {fee               , Fee}
+            , {delegate_ids      , DelegateIds}
+            , {state_hash        , StateHash}
+            , {nonce             , Nonce}
+            , {block_hash        , BlockHash}]) ->
+    account = aeser_id:specialize_type(InitiatorId),
+    account = aeser_id:specialize_type(ResponderId),
+    [account = aeser_id:specialize_type(D) || D <- DelegateIds],
+    true = aesc_utils:check_state_hash_size(StateHash),
+    #channel_create_tx{initiator_id       = InitiatorId,
+                       initiator_amount   = InitiatorAmount,
+                       responder_id       = ResponderId,
+                       responder_amount   = ResponderAmount,
+                       channel_reserve    = ChannelReserve,
+                       lock_period        = LockPeriod,
+                       ttl                = TTL,
+                       fee                = Fee,
+                       delegate_ids       = DelegateIds,
+                       state_hash         = StateHash,
+                       nonce              = Nonce,
+                       block_hash         = aesc_pinned_block:deserialize(BlockHash)}.
 
 -spec for_client(tx()) -> map().
 for_client(#channel_create_tx{initiator_id       = InitiatorId,
@@ -226,7 +281,8 @@ for_client(#channel_create_tx{initiator_id       = InitiatorId,
                               ttl                = TTL,
                               delegate_ids       = DelegateIds,
                               state_hash         = StateHash,
-                              fee                = Fee}) ->
+                              fee                = Fee,
+                              block_hash         = BlockHash}) ->
     #{<<"initiator_id">>       => aeser_api_encoder:encode(id_hash, InitiatorId),
       <<"initiator_amount">>   => InitiatorAmount,
       <<"responder_id">>       => aeser_api_encoder:encode(id_hash, ResponderId),
@@ -238,8 +294,9 @@ for_client(#channel_create_tx{initiator_id       = InitiatorId,
       <<"delegate_ids">>       => [aeser_api_encoder:encode(id_hash, D) || D <- DelegateIds],
       <<"state_hash">>         => aeser_api_encoder:encode(state, StateHash),
       <<"fee">>                => Fee}.
+      %<<"block_hash">>         => aesc_pinned_block:serialize_for_client(BlockHash), TODO
 
-serialization_template(?CHANNEL_CREATE_TX_VSN) ->
+serialization_template(?INITIAL_VSN) ->
     [ {initiator_id      , id}
     , {initiator_amount  , int}
     , {responder_id      , id}
@@ -251,6 +308,20 @@ serialization_template(?CHANNEL_CREATE_TX_VSN) ->
     , {delegate_ids      , [id]}
     , {state_hash        , binary}
     , {nonce             , int}
+    ];
+serialization_template(?PINNED_BLOCK_VSN) ->
+    [ {initiator_id      , id}
+    , {initiator_amount  , int}
+    , {responder_id      , id}
+    , {responder_amount  , int}
+    , {channel_reserve   , int}
+    , {lock_period       , int}
+    , {ttl               , int}
+    , {fee               , int}
+    , {delegate_ids      , [id]}
+    , {state_hash        , binary}
+    , {nonce             , int}
+    , {block_hash        , binary}
     ].
 
 %%%===================================================================
@@ -316,12 +387,22 @@ delegate_pubkeys(#channel_create_tx{delegate_ids = DelegateIds}) ->
     [aeser_id:specialize(D, account) || D <- DelegateIds].
 
 -spec version(tx()) -> non_neg_integer().
-version(_) ->
-    ?CHANNEL_CREATE_TX_VSN.
+version(#channel_create_tx{block_hash = BlockHash}) ->
+    case BlockHash =:= aesc_pinned_block:no_hash() of
+        true ->
+            ?INITIAL_VSN;
+        false ->
+            ?PINNED_BLOCK_VSN
+    end.
+
 
 -spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
-valid_at_protocol(_, _) ->
-    true.
+valid_at_protocol(Protocol, Tx) ->
+    case version(Tx) of
+        ?INITIAL_VSN -> true;
+        ?PINNED_BLOCK_VSN when Protocol =:= ?FORTUNA_PROTOCOL_VSN -> true;
+        _ -> false
+    end.
 
 %%%===================================================================
 %%% Test setters 

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -21,7 +21,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -171,8 +171,8 @@ serialize(#channel_deposit_tx{channel_id  = ChannelId,
                               fee         = Fee,
                               state_hash  = StateHash,
                               round       = Round,
-                              nonce       = Nonce}) ->
-    {version(),
+                              nonce       = Nonce} = Tx) ->
+    {version(Tx),
      [ {channel_id  , ChannelId}
      , {from_id     , FromId}
      , {amount      , Amount}
@@ -242,12 +242,8 @@ updates(#channel_deposit_tx{from_id = FromId, amount = Amount}) ->
 round(#channel_deposit_tx{round = Round}) ->
     Round.
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_DEPOSIT_TX_VSN.
 
 %%%===================================================================

--- a/apps/aechannel/src/aesc_deposit_tx.erl
+++ b/apps/aechannel/src/aesc_deposit_tx.erl
@@ -25,7 +25,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 % aesc_signable_transaction callbacks
@@ -245,6 +246,10 @@ round(#channel_deposit_tx{round = Round}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_DEPOSIT_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 %%%===================================================================
 %%% Test setters 

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -352,7 +352,7 @@ valid_at_protocol(Protocol, #channel_force_progress_tx{payload = Payload} = Tx) 
     CorrectTxVsn =
         case version(Tx) of
             ?INITIAL_VSN -> true;
-            ?PINNED_BLOCK_VSN when Protocol =:= ?FORTUNA_PROTOCOL_VSN -> true;
+            ?PINNED_BLOCK_VSN when Protocol >= ?FORTUNA_PROTOCOL_VSN -> true;
             _ -> false
         end,
     CorrectPayloadVsn =

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -274,6 +274,11 @@ version(_) ->
     ?CHANNEL_FORCE_PROGRESS_TX_VSN.
 
 -spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
-valid_at_protocol(_, _) ->
-    true.
+valid_at_protocol(Protocol, #channel_force_progress_tx{payload = Payload}) ->
+    case aesc_utils:deserialize_payload(Payload) of
+        {error, _} -> false;
+        {ok, last_onchain} -> true; %% already on-chain
+        {ok, _SignedTx, OffChainTx} ->
+            aesc_offchain_tx:valid_at_protocol(Protocol, OffChainTx)
+    end.
 

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -20,7 +20,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -170,8 +170,8 @@ serialize(#channel_force_progress_tx{channel_id     = ChannelId,
                                      offchain_trees = OffChainTrees,
                                      ttl            = TTL,
                                      fee            = Fee,
-                                     nonce          = Nonce}) ->
-    {version(),
+                                     nonce          = Nonce} = Tx) ->
+    {version(Tx),
      [ {channel_id    , ChannelId}
      , {from_id       , FromId}
      , {payload       , Payload}
@@ -268,11 +268,7 @@ round(#channel_force_progress_tx{round = Round}) ->
 state_hash(#channel_force_progress_tx{state_hash = StateHash}) ->
     StateHash.
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_FORCE_PROGRESS_TX_VSN.
 

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -24,7 +24,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 -export([gas_price/1]).
@@ -271,4 +272,8 @@ state_hash(#channel_force_progress_tx{state_hash = StateHash}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_FORCE_PROGRESS_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -286,8 +286,8 @@ for_client(#channel_force_progress_tx{payload       = Payload,
                                                 aec_trees:serialize_to_binary(OffChainTrees)),
       <<"ttl">>           => TTL,
       <<"fee">>           => Fee,
+      <<"block_hash">>    => aesc_pinned_block:serialize_for_client(BlockHash),
       <<"nonce">>         => Nonce}.
-      %<<"block_hash">>         => aesc_pinned_block:serialize_for_client(BlockHash), TODO
 
 serialization_template(?INITIAL_VSN) ->
     [ {channel_id     , id}

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -266,7 +266,7 @@ version(#channel_offchain_tx{block_hash = BlockHash}) ->
 valid_at_protocol(Protocol, Tx) ->
     case version(Tx) of
         ?INITIAL_VSN -> true;
-        ?PINNED_BLOCK_VSN when Protocol =:= ?FORTUNA_PROTOCOL_VSN -> true;
+        ?PINNED_BLOCK_VSN when Protocol >= ?FORTUNA_PROTOCOL_VSN -> true;
         _ -> false
     end.
 

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -18,7 +18,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 % aesc_signable_transaction callbacks
@@ -37,6 +38,8 @@
          set_round/2,
          set_state_hash/2]).
 -endif.
+
+-include_lib("aecontract/include/hard_forks.hrl").
 %%%===================================================================
 %%% Types
 %%%===================================================================
@@ -251,6 +254,14 @@ version(#channel_offchain_tx{block_hash = ?NO_PINNED_BLOCK}) ->
     ?INITIAL_VSN;
 version(#channel_offchain_tx{}) ->
     ?PINNED_BLOCK_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(Protocol, Tx) ->
+    case version(Tx) of
+        ?INITIAL_VSN -> true;
+        ?PINNED_BLOCK_VSN when Protocol =:= ?FORTUNA_PROTOCOL_VSN -> true;
+        _ -> false
+    end.
 
 %%%===================================================================
 %%% Test setters 

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -186,6 +186,11 @@ deserialize(?PINNED_BLOCK_VSN,
        round              = Round,
        block_hash         = aesc_pinned_block:deserialize(BlockHash)}.
 
+%% off-chain transactions are included on-chain as a serialized payload
+%% in a force progress transactions thus the callback
+%% aesc_offchain_tx:for_client/1 is never executed for an off-chain tx
+%% via HTTP API, but it might be used by State Channel's WebSocket API
+%% Note: not documented in swagger.yaml
 -spec for_client(tx()) -> map().
 for_client(#channel_offchain_tx{
               updates            = Updates,
@@ -196,7 +201,7 @@ for_client(#channel_offchain_tx{
     #{<<"channel_id">>         => aeser_api_encoder:encode(id_hash, ChannelId),
       <<"round">>              => Round,
       <<"updates">>            => [aesc_offchain_update:for_client(D) || D <- Updates],
-      %<<"block_hash">>         => aesc_pinned_block:serialize_for_client(BlockHash), TODO
+      <<"block_hash">>         => aesc_pinned_block:serialize_for_client(BlockHash),
       <<"state_hash">>         => aeser_api_encoder:encode(state, StateHash)}.
 
 serialization_template(?INITIAL_VSN) ->

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -1,7 +1,7 @@
 -module(aesc_offchain_tx).
 
--behaviour(aetx).
--behaviour(aesc_signable_transaction).
+-behavior(aetx).
+-behavior(aesc_signable_transaction).
 
 %% Behavior API
 -export([new/1,
@@ -14,7 +14,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -41,17 +41,22 @@
 %%% Types
 %%%===================================================================
 
--define(CHANNEL_OFFCHAIN_TX_VSN, 1).
+-define(INITIAL_VSN, 1).
+-define(PINNED_BLOCK_VSN, 2).
+
 -define(CHANNEL_OFFCHAIN_TX_TYPE, channel_offchain_tx).
 -define(CHANNEL_OFFCHAIN_TX_FEE, 0).   % off-chain
+-define(NO_PINNED_BLOCK, <<>>).
 
 -type vsn() :: non_neg_integer().
+-type pinned_block_hash() :: ?NO_PINNED_BLOCK | aec_blocks:block_header_hash().
 
 -record(channel_offchain_tx, {
           channel_id         :: aeser_id:id(),
           updates            :: [aesc_offchain_update:update()],
           state_hash         :: binary(),
-          round              :: non_neg_integer()
+          round              :: non_neg_integer(),
+          block_hash         :: pinned_block_hash()
          }).
 
 -opaque tx() :: #channel_offchain_tx{}.
@@ -66,13 +71,15 @@
 new(#{channel_id         := ChannelId,
       state_hash         := StateHash,
       updates            := Updates,
-      round              := Round}) ->
+      round              := Round} = Opts) ->
     channel = aeser_id:specialize_type(ChannelId),
+    BlockHash = maps:get(block_hash, Opts, ?NO_PINNED_BLOCK),
     Tx = #channel_offchain_tx{
             channel_id         = ChannelId,
             updates            = Updates,
             state_hash         = StateHash,
-            round              = Round},
+            round              = Round,
+            block_hash         = BlockHash},
     {ok, aetx:new(?MODULE, Tx)}.
 
 type() ->
@@ -128,17 +135,29 @@ serialize(#channel_offchain_tx{
              channel_id         = ChannelId,
              updates            = Updates0,
              state_hash         = StateHash,
-             round              = Round}) ->
+             round              = Round,
+             block_hash         = BlockHash} = Tx) ->
     Updates = [aesc_offchain_update:serialize(U) || U <- Updates0],
-    {version(),
-     [ {channel_id        , ChannelId}
-     , {round             , Round}
-     , {updates           , Updates}
-     , {state_hash        , StateHash}
-     ]}.
+    case version(Tx) of
+        ?INITIAL_VSN ->
+            {?INITIAL_VSN,
+            [ {channel_id        , ChannelId}
+            , {round             , Round}
+            , {updates           , Updates}
+            , {state_hash        , StateHash}
+            ]};
+        ?PINNED_BLOCK_VSN ->
+            {?PINNED_BLOCK_VSN,
+            [ {channel_id        , ChannelId}
+            , {round             , Round}
+            , {updates           , Updates}
+            , {state_hash        , StateHash}
+            , {block_hash        , BlockHash}
+            ]}
+    end.
 
 -spec deserialize(vsn(), list()) -> tx().
-deserialize(?CHANNEL_OFFCHAIN_TX_VSN,
+deserialize(?INITIAL_VSN,
             [ {channel_id        , ChannelId}
             , {round             , Round}
             , {updates           , Updates0}
@@ -149,24 +168,47 @@ deserialize(?CHANNEL_OFFCHAIN_TX_VSN,
        channel_id         = ChannelId,
        updates            = Updates,
        state_hash         = StateHash,
-       round              = Round}.
+       round              = Round,
+       block_hash         = ?NO_PINNED_BLOCK};
+deserialize(?PINNED_BLOCK_VSN,
+            [ {channel_id        , ChannelId}
+            , {round             , Round}
+            , {updates           , Updates0}
+            , {state_hash        , StateHash}
+            , {block_hash        , BlockHash}]) ->
+    channel = aeser_id:specialize_type(ChannelId),
+    Updates = [aesc_offchain_update:deserialize(U) || U <- Updates0],
+    #channel_offchain_tx{
+       channel_id         = ChannelId,
+       updates            = Updates,
+       state_hash         = StateHash,
+       round              = Round,
+       block_hash         = BlockHash}.
 
 -spec for_client(tx()) -> map().
 for_client(#channel_offchain_tx{
               updates            = Updates,
               state_hash         = StateHash,
               channel_id         = ChannelId,
-              round              = Round}) ->
+              round              = Round,
+              block_hash         = BlockHash}) ->
     #{<<"channel_id">>         => aeser_api_encoder:encode(id_hash, ChannelId),
       <<"round">>              => Round,
       <<"updates">>            => [aesc_offchain_update:for_client(D) || D <- Updates],
       <<"state_hash">>         => aeser_api_encoder:encode(state, StateHash)}.
 
-serialization_template(?CHANNEL_OFFCHAIN_TX_VSN) ->
+serialization_template(?INITIAL_VSN) ->
     [ {channel_id        , id}
     , {round             , int}
     , {updates           , [binary]}
     , {state_hash        , binary}
+    ];
+serialization_template(?PINNED_BLOCK_VSN) ->
+    [ {channel_id        , id}
+    , {round             , int}
+    , {updates           , [binary]}
+    , {state_hash        , binary}
+    , {block_hash        , binary}
     ].
 
 %%%===================================================================
@@ -205,13 +247,10 @@ set_value(#channel_offchain_tx{} = Tx, state_hash, Hash) when
   is_binary(Hash) ->
     Tx#channel_offchain_tx{state_hash=Hash}.
 
-
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
-version() ->
-    ?CHANNEL_OFFCHAIN_TX_VSN.
+version(#channel_offchain_tx{block_hash = ?NO_PINNED_BLOCK}) ->
+    ?INITIAL_VSN;
+version(#channel_offchain_tx{}) ->
+    ?PINNED_BLOCK_VSN.
 
 %%%===================================================================
 %%% Test setters 

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -2,19 +2,50 @@
 
 -define(UPDATE_VSN, 1).
 
--define(OP_TRANSFER,        0).
--define(OP_WITHDRAW,        1).
--define(OP_DEPOSIT ,        2).
--define(OP_CREATE_CONTRACT, 3).
--define(OP_CALL_CONTRACT,   4).
+-record(transfer, {
+          from_id      :: aeser_id:id(),
+          to_id        :: aeser_id:id(),
+          amount       :: non_neg_integer()
+         }).
 
--opaque update() :: {?OP_TRANSFER, aeser_id:id(), aeser_id:id(), non_neg_integer()}
-        | {?OP_WITHDRAW | ?OP_DEPOSIT, aeser_id:id(), non_neg_integer()}
-        | {?OP_CREATE_CONTRACT, aeser_id:id(), aect_contracts:vm_version(), aect_contracts:abi_version(),
-           binary(), non_neg_integer(), binary()}
-        | {?OP_CALL_CONTRACT, aeser_id:id(), aeser_id:id(), aect_contracts:abi_version(),
-           non_neg_integer(), aect_call:call(), [non_neg_integer()],
-           non_neg_integer(), non_neg_integer()}.
+-record(withdraw, {
+          to_id        :: aeser_id:id(),
+          amount       :: non_neg_integer()
+         }).
+
+-record(deposit, {
+          from_id      :: aeser_id:id(),
+          amount       :: non_neg_integer()
+         }).
+
+-record(create_contract, {
+          owner_id     :: aeser_id:id(),
+          vm_version   :: aect_contracts:vm_version(),
+          abi_version  :: aect_contracts:abi_version(),
+          code         :: binary(),
+          deposit      :: non_neg_integer(),
+          call_data    :: binary()
+         }).
+
+-record(call_contract, {
+          caller_id    :: aeser_id:id(),
+          contract_id  :: aeser_id:id(),
+          abi_version  :: aect_contracts:abi_version(),
+          amount       :: non_neg_integer(),
+          call_data    :: binary(),
+          call_stack   :: [non_neg_integer()],
+          gas_price    :: non_neg_integer(),
+          gas          :: non_neg_integer()
+         }).
+
+-opaque update() :: #transfer{}
+                  | #withdraw{}
+                  | #deposit{}
+                  | #create_contract{}
+                  | #call_contract{}.
+
+-type update_type() :: transfer | withdraw | deposit | create_contract |
+                       call_contract.
 
 -export_type([update/0]).
 
@@ -43,24 +74,30 @@
 op_transfer(From, To, Amount) ->
     account = aeser_id:specialize_type(From),
     account = aeser_id:specialize_type(To),
-    {?OP_TRANSFER, From, To, Amount}.
+    #transfer{from_id = From,
+              to_id   = To,
+              amount  = Amount}.
 
 -spec op_deposit(aeser_id:id(), non_neg_integer()) -> update().
-op_deposit(Acct, Amount) ->
-    account = aeser_id:specialize_type(Acct),
-    {?OP_DEPOSIT, Acct, Amount}.
+op_deposit(FromId, Amount) ->
+    account = aeser_id:specialize_type(FromId),
+    #deposit{from_id = FromId, amount = Amount}.
 
 -spec op_withdraw(aeser_id:id(), non_neg_integer()) -> update().
-op_withdraw(Acct, Amount) ->
-    account = aeser_id:specialize_type(Acct),
-    {?OP_WITHDRAW, Acct, Amount}.
+op_withdraw(ToId, Amount) ->
+    account = aeser_id:specialize_type(ToId),
+    #withdraw{to_id = ToId, amount = Amount}.
 
 -spec op_new_contract(aeser_id:id(), aect_contracts:vm_version(), aect_contracts:abi_version(),
            binary(), non_neg_integer(), binary()) -> update().
 op_new_contract(OwnerId, VmVersion, ABIVersion, Code, Deposit, CallData) ->
     account = aeser_id:specialize_type(OwnerId),
-    {?OP_CREATE_CONTRACT, OwnerId, VmVersion, ABIVersion, Code, Deposit, CallData}.
-
+    #create_contract{owner_id    = OwnerId,
+                     vm_version  = VmVersion,
+                     abi_version = ABIVersion,
+                     code        = Code,
+                     deposit     = Deposit,
+                     call_data   = CallData}.
 
 -spec op_call_contract(aeser_id:id(), aeser_id:id(), aect_contracts:abi_version(),
                        non_neg_integer(), Call, [non_neg_integer()]) -> update()
@@ -77,26 +114,34 @@ op_call_contract(CallerId, ContractId, ABIVersion, Amount, CallData, CallStack,
                  GasPrice, Gas) ->
     account = aeser_id:specialize_type(CallerId),
     contract = aeser_id:specialize_type(ContractId),
-    {?OP_CALL_CONTRACT, CallerId, ContractId, ABIVersion, Amount, CallData,
-     CallStack, GasPrice, Gas}.
+    #call_contract{caller_id = CallerId,
+                   contract_id = ContractId,
+                   abi_version = ABIVersion,
+                   amount = Amount,
+                   call_data = CallData,
+                   call_stack = CallStack,
+                   gas_price = GasPrice,
+                   gas = Gas}.
 
 -spec apply_on_trees(aesc_offchain_update:update(), aec_trees:trees(),
                      aec_trees:trees(), aetx_env:env(),
                      non_neg_integer(), non_neg_integer()) -> aec_trees:trees().
 apply_on_trees(Update, Trees0, OnChainTrees, OnChainEnv, Round, Reserve) ->
     case Update of
-        {?OP_TRANSFER, FromId, ToId, Amount} ->
+        #transfer{from_id = FromId, to_id = ToId, amount = Amount} ->
             From = account_pubkey(FromId),
             To = account_pubkey(ToId),
             Trees = remove_tokens(From, Amount, Trees0, Reserve),
             add_tokens(To, Amount, Trees);
-        {?OP_DEPOSIT, ToId, Amount} ->
-            To = account_pubkey(ToId),
-            add_tokens(To, Amount, Trees0);
-        {?OP_WITHDRAW, FromId, Amount} ->
+        #deposit{from_id = FromId, amount = Amount} ->
             From = account_pubkey(FromId),
-            remove_tokens(From, Amount, Trees0, Reserve);
-        {?OP_CREATE_CONTRACT, OwnerId, VmVersion, ABIVersion, Code, Deposit, CallData} ->
+            add_tokens(From, Amount, Trees0);
+        #withdraw{to_id = ToId, amount = Amount} ->
+            To = account_pubkey(ToId),
+            remove_tokens(To, Amount, Trees0, Reserve);
+        #create_contract{owner_id = OwnerId, vm_version  = VmVersion,
+                         abi_version = ABIVersion, code = Code,
+                         deposit = Deposit, call_data   = CallData} ->
             Owner = account_pubkey(OwnerId),
             {ContractId, _Contract, Trees1} =
                 aect_channel_contract:new(Owner, Round, #{vm => VmVersion, abi => ABIVersion},
@@ -108,8 +153,10 @@ apply_on_trees(Update, Trees0, OnChainTrees, OnChainEnv, Round, Reserve) ->
             Call = aect_call:new(OwnerId, Round, ContractId, Round, 0),
             _Trees = aect_channel_contract:run_new(ContractPubKey, Call, CallData, Trees4,
                                                   OnChainTrees, OnChainEnv);
-        {?OP_CALL_CONTRACT, CallerId, ContractId, ABIVersion, Amount, CallData,
-         CallStack, GasPrice, Gas} ->
+        #call_contract{caller_id = CallerId, contract_id = ContractId,
+                       abi_version = ABIVersion, amount = Amount,
+                       call_data = CallData, call_stack = CallStack,
+                       gas_price = GasPrice, gas = Gas} ->
             Caller = account_pubkey(CallerId),
             ContractPubKey = contract_pubkey(ContractId),
             Trees1 = remove_tokens(Caller, Amount, Trees0, Reserve),
@@ -123,20 +170,22 @@ apply_on_trees(Update, Trees0, OnChainTrees, OnChainEnv, Round, Reserve) ->
     end.
 
 -spec for_client(update()) -> map().
-for_client({?OP_TRANSFER, From, To, Amount}) ->
+for_client(#transfer{from_id = FromId, to_id = ToId, amount = Amount}) ->
     #{<<"op">> => <<"OffChainTransfer">>, % swagger name
-      <<"from">> => aeser_api_encoder:encode(id_hash, From),
-      <<"to">> => aeser_api_encoder:encode(id_hash, To),
+      <<"from">> => aeser_api_encoder:encode(id_hash, FromId),
+      <<"to">> => aeser_api_encoder:encode(id_hash, ToId),
       <<"am">>   => Amount};
-for_client({?OP_WITHDRAW, To, Amount}) ->
+for_client(#withdraw{to_id = ToId, amount = Amount}) ->
     #{<<"op">> => <<"OffChainWithdrawal">>, % swagger name
-      <<"to">> => aeser_api_encoder:encode(id_hash, To),
+      <<"to">> => aeser_api_encoder:encode(id_hash, ToId),
       <<"am">>   => Amount};
-for_client({?OP_DEPOSIT, From, Amount}) ->
+for_client(#deposit{from_id = FromId, amount = Amount}) ->
     #{<<"op">> => <<"OffChainDeposit">>, % swagger name
-      <<"from">> => aeser_api_encoder:encode(id_hash, From),
+      <<"from">> => aeser_api_encoder:encode(id_hash, FromId),
       <<"am">>   => Amount};
-for_client({?OP_CREATE_CONTRACT, OwnerId, VmVersion, ABIVersion, Code, Deposit, CallData}) ->
+for_client(#create_contract{owner_id = OwnerId, vm_version  = VmVersion,
+                         abi_version = ABIVersion, code = Code,
+                         deposit = Deposit, call_data   = CallData}) ->
     #{<<"op">>          => <<"OffChainNewContract">>, % swagger name
       <<"owner">>       => aeser_api_encoder:encode(id_hash, OwnerId),
       <<"vm_version">>  => VmVersion,
@@ -144,8 +193,10 @@ for_client({?OP_CREATE_CONTRACT, OwnerId, VmVersion, ABIVersion, Code, Deposit, 
       <<"code">>        => Code,
       <<"deposit">>     => Deposit,
       <<"call_data">>   => aeser_api_encoder:encode(contract_bytearray, CallData)};
-for_client({?OP_CALL_CONTRACT, CallerId, ContractId, ABIVersion, Amount,
-            CallData, CallStack, GasPrice, Gas}) ->
+for_client(#call_contract{caller_id = CallerId, contract_id = ContractId,
+                          abi_version = ABIVersion, amount = Amount,
+                           call_data = CallData, call_stack = CallStack,
+                          gas_price = GasPrice, gas = Gas}) ->
     #{<<"op">>          => <<"OffChainCallContract">>, % swagger name
       <<"caller">>      => aeser_api_encoder:encode(id_hash, CallerId),
       <<"contract">>    => aeser_api_encoder:encode(id_hash, ContractId),
@@ -160,7 +211,7 @@ for_client({?OP_CALL_CONTRACT, CallerId, ContractId, ABIVersion, Amount,
 serialize(Update) ->
     Fields = update2fields(Update),
     Vsn = ?UPDATE_VSN,
-    UpdateType = element(1, Update),
+    UpdateType = record_to_update_type(Update),
     aeser_chain_objects:serialize(
       ut2type(UpdateType),
       Vsn,
@@ -176,24 +227,28 @@ deserialize(Bin) ->
     Fields = aeserialization:decode_fields(Template, RawFields),
     fields2update(UpdateType, Fields).
 
-update2fields({?OP_TRANSFER, From, To, Amount}) ->
-    [ {from,    From},
-      {to,      To},
+update2fields(#transfer{from_id = FromId, to_id = ToId, amount = Amount}) ->
+    [ {from,    FromId},
+      {to,      ToId},
       {amount,  Amount}];
-update2fields({?OP_DEPOSIT, From, Amount}) ->
-    [ {from,    From},
+update2fields(#deposit{from_id = FromId, amount = Amount}) ->
+    [ {from,    FromId},
       {amount,  Amount}];
-update2fields({?OP_WITHDRAW, To, Amount}) ->
-    [ {to,      To},
+update2fields(#withdraw{to_id = ToId, amount = Amount}) ->
+    [ {to,      ToId},
       {amount,  Amount}];
-update2fields({?OP_CREATE_CONTRACT, OwnerId, VmVersion, ABIVersion, Code, Deposit, CallData}) ->
+update2fields(#create_contract{owner_id = OwnerId, vm_version  = VmVersion,
+                               abi_version = ABIVersion, code = Code,
+                               deposit = Deposit, call_data   = CallData}) ->
     [ {owner, OwnerId},
       {ct_version, aect_contracts:pack_vm_abi(#{vm => VmVersion, abi => ABIVersion})},
       {code, Code},
       {deposit, Deposit},
       {call_data, CallData}];
-update2fields({?OP_CALL_CONTRACT, CallerId, ContractId, ABIVersion, Amount,
-               CallData, CallStack, GasPrice, Gas}) ->
+update2fields(#call_contract{caller_id = CallerId, contract_id = ContractId,
+                             abi_version = ABIVersion, amount = Amount,
+                             call_data = CallData, call_stack = CallStack,
+                             gas_price = GasPrice, gas = Gas}) ->
     [ {caller, CallerId},
       {contract, ContractId},
       {abi_version, ABIVersion},
@@ -203,63 +258,67 @@ update2fields({?OP_CALL_CONTRACT, CallerId, ContractId, ABIVersion, Amount,
       {call_data, CallData},
       {call_stack, CallStack}].
 
-fields2update(?OP_TRANSFER, [{from,   From},
-                             {to,     To},
-                             {amount, Amount}]) ->
+-spec fields2update(update_type(), list()) -> update().
+fields2update(transfer, [{from,   From},
+                         {to,     To},
+                         {amount, Amount}]) ->
     op_transfer(From, To, Amount);
-fields2update(?OP_DEPOSIT, [{from,   From},
-                            {amount, Amount}]) ->
+fields2update(deposit, [{from,   From},
+                        {amount, Amount}]) ->
     op_deposit(From, Amount);
-fields2update(?OP_WITHDRAW, [{to,    To},
-                            {amount, Amount}]) ->
+fields2update(withdraw, [{to,    To},
+                         {amount, Amount}]) ->
     op_withdraw(To, Amount);
-fields2update(?OP_CREATE_CONTRACT, [{owner, OwnerId},
-                                    {ct_version, CTVersion},
-                                    {code, Code},
-                                    {deposit, Deposit},
-                                    {call_data, CallData}]) ->
+fields2update(create_contract, [{owner, OwnerId},
+                                {ct_version, CTVersion},
+                                {code, Code},
+                                {deposit, Deposit},
+                                {call_data, CallData}]) ->
     #{vm := VmVersion, abi := ABIVersion} = aect_contracts:split_vm_abi(CTVersion),
     op_new_contract(OwnerId, VmVersion, ABIVersion, Code, Deposit, CallData);
-fields2update(?OP_CALL_CONTRACT, [ {caller, CallerId},
-                                    {contract, ContractId},
-                                    {abi_version, ABIVersion},
-                                    {amount, Amount},
-                                    {gas, Gas},
-                                    {gas_price, GasPrice},
-                                    {call_data, CallData},
-                                    {call_stack, CallStack}]) ->
+fields2update(call_contract, [ {caller, CallerId},
+                               {contract, ContractId},
+                               {abi_version, ABIVersion},
+                               {amount, Amount},
+                               {gas, Gas},
+                               {gas_price, GasPrice},
+                               {call_data, CallData},
+                               {call_stack, CallStack}]) ->
     op_call_contract(CallerId, ContractId, ABIVersion, Amount, CallData,
                      CallStack, GasPrice, Gas).
 
-ut2type(?OP_TRANSFER)         -> channel_offchain_update_transfer;
-ut2type(?OP_DEPOSIT)          -> channel_offchain_update_deposit;
-ut2type(?OP_WITHDRAW)         -> channel_offchain_update_withdraw;
-ut2type(?OP_CREATE_CONTRACT)  -> channel_offchain_update_create_contract;
-ut2type(?OP_CALL_CONTRACT)    -> channel_offchain_update_call_contract.
+-spec ut2type(update_type())  -> atom().
+ut2type(transfer)             -> channel_offchain_update_transfer;
+ut2type(deposit)              -> channel_offchain_update_deposit;
+ut2type(withdraw)             -> channel_offchain_update_withdraw;
+ut2type(create_contract)      -> channel_offchain_update_create_contract;
+ut2type(call_contract)        -> channel_offchain_update_call_contract.
 
-type2ut(channel_offchain_update_transfer)         -> ?OP_TRANSFER;
-type2ut(channel_offchain_update_deposit)          -> ?OP_DEPOSIT;
-type2ut(channel_offchain_update_withdraw)         -> ?OP_WITHDRAW;
-type2ut(channel_offchain_update_create_contract)  -> ?OP_CREATE_CONTRACT;
-type2ut(channel_offchain_update_call_contract)    -> ?OP_CALL_CONTRACT.
+-spec type2ut(atom()) -> update_type().
+type2ut(channel_offchain_update_transfer)         -> transfer;
+type2ut(channel_offchain_update_deposit)          -> deposit;
+type2ut(channel_offchain_update_withdraw)         -> withdraw;
+type2ut(channel_offchain_update_create_contract)  -> create_contract;
+type2ut(channel_offchain_update_call_contract)    -> call_contract.
 
-update_serialization_template(?UPDATE_VSN, ?OP_TRANSFER) ->
+-spec update_serialization_template(non_neg_integer(), update_type()) -> list().
+update_serialization_template(?UPDATE_VSN, transfer) ->
     [ {from,    id},
       {to,      id},
       {amount,  int}];
-update_serialization_template(?UPDATE_VSN, ?OP_DEPOSIT) ->
+update_serialization_template(?UPDATE_VSN, deposit) ->
     [ {from,    id},
       {amount,  int}];
-update_serialization_template(?UPDATE_VSN, ?OP_WITHDRAW) ->
+update_serialization_template(?UPDATE_VSN, withdraw) ->
     [ {to,      id},
       {amount,  int}];
-update_serialization_template(?UPDATE_VSN, ?OP_CREATE_CONTRACT) ->
+update_serialization_template(?UPDATE_VSN, create_contract) ->
     [ {owner,       id},
       {ct_version,  int},
       {code,        binary},
       {deposit,     int},
       {call_data,   binary}];
-update_serialization_template(?UPDATE_VSN, ?OP_CALL_CONTRACT) ->
+update_serialization_template(?UPDATE_VSN, call_contract) ->
     [ {caller,      id},
       {contract,    id},
       {abi_version, int},
@@ -268,6 +327,13 @@ update_serialization_template(?UPDATE_VSN, ?OP_CALL_CONTRACT) ->
       {gas_price,   int},
       {call_data,   binary},
       {call_stack,  [int]}].
+
+-spec record_to_update_type(update()) -> update_type().
+record_to_update_type(#transfer{})        -> transfer;
+record_to_update_type(#deposit{})         -> deposit;
+record_to_update_type(#withdraw{})        -> withdraw;
+record_to_update_type(#create_contract{}) -> create_contract;
+record_to_update_type(#call_contract{})   -> call_contract.
 
 check_min_amt(Amt, Reserve) ->
     if Amt < Reserve ->
@@ -308,19 +374,19 @@ contract_pubkey(Id) ->
     aeser_id:specialize(Id, contract).
 
 -spec extract_caller(update()) -> aec_keys:pubkey().
-extract_caller({?OP_CALL_CONTRACT, CallerId, _, _, _, _, _, _, _}) ->
+extract_caller(#call_contract{caller_id = CallerId}) ->
     account_pubkey(CallerId);
-extract_caller({?OP_CREATE_CONTRACT, OwnerId, _, _, _, _, _}) ->
+extract_caller(#create_contract{owner_id = OwnerId}) ->
     account_pubkey(OwnerId).
 
 -spec is_call(update()) -> boolean().
-is_call({?OP_CALL_CONTRACT, _, _, _, _, _, _, _, _}) ->
+is_call(#call_contract{}) ->
       true;
 is_call(_) ->
       false.
 
 -spec is_contract_create(update()) -> boolean().
-is_contract_create({?OP_CREATE_CONTRACT, _, _, _, _, _, _}) ->
+is_contract_create(#create_contract{}) ->
       true;
 is_contract_create(_) ->
       false.
@@ -329,27 +395,27 @@ is_contract_create(_) ->
                                                      | not_call.
 extract_call(Update) ->
     case Update of
-        {?OP_CALL_CONTRACT, CallerId, ContractId, _, _, _, _, _, _} ->
+        #call_contract{caller_id = CallerId, contract_id = ContractId} ->
             {contract_pubkey(ContractId), account_pubkey(CallerId)};
         _ -> not_call
     end.
 
 -spec extract_contract_pubkey(update()) -> aect_contracts:pubkey().
-extract_contract_pubkey({?OP_CALL_CONTRACT, _, Contract, _, _, _, _, _, _}) ->
-    contract_pubkey(Contract).
+extract_contract_pubkey(#call_contract{contract_id = ContractId}) ->
+    contract_pubkey(ContractId).
 
 -spec extract_amounts(update()) -> {non_neg_integer(),
                                     non_neg_integer(),
                                     non_neg_integer()} | not_call.
 extract_amounts(Update) ->
     case Update of
-        {?OP_CALL_CONTRACT, _, _, _, Amount, _, _, GasPrice, Gas} ->
+        #call_contract{amount = Amount, gas_price = GasPrice, gas = Gas}->
             {Amount, GasPrice, Gas};
         _ -> not_call
     end.
 
 -spec extract_abi_version(update()) -> aect_contracts:abi_version().
-extract_abi_version({?OP_CALL_CONTRACT, _, _, ABIVersion, _, _, _, _, _}) ->
+extract_abi_version(#call_contract{abi_version = ABIVersion}) ->
     ABIVersion.
 
 update_error(Err) ->

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -3,30 +3,30 @@
 -define(INITIAL_VSN, 1).
 -define(PINNED_BLOCKHASH_VSN, 2).
 
--define(TOP_BLOCK, <<>>).
+-define(NO_BLOCK, <<>>).
 
--type(pinned_block_hash() :: aec_blocks:block_header_hash() | ?TOP_BLOCK).
+-type(pinned_block_hash() :: aec_blocks:block_header_hash() | ?NO_BLOCK).
 
 -record(transfer, {
           from_id                 :: aeser_id:id(),
           to_id                   :: aeser_id:id(),
           amount                  :: non_neg_integer(),
-          vsn = ?PINNED_BLOCKHASH_VSN      :: non_neg_integer(),
-          block_hash = ?TOP_BLOCK :: pinned_block_hash() 
+          vsn = ?INITIAL_VSN      :: non_neg_integer(),
+          block_hash = ?NO_BLOCK  :: pinned_block_hash() 
          }).
 
 -record(withdraw, {
           to_id                   :: aeser_id:id(),
           amount                  :: non_neg_integer(),
-          vsn = ?PINNED_BLOCKHASH_VSN      :: non_neg_integer(),
-          block_hash = ?TOP_BLOCK :: pinned_block_hash() 
+          vsn = ?INITIAL_VSN      :: non_neg_integer(),
+          block_hash = ?NO_BLOCK  :: pinned_block_hash() 
          }).
 
 -record(deposit, {
           from_id                 :: aeser_id:id(),
           amount                  :: non_neg_integer(),
-          vsn = ?PINNED_BLOCKHASH_VSN      :: non_neg_integer(),
-          block_hash = ?TOP_BLOCK :: pinned_block_hash() 
+          vsn = ?INITIAL_VSN      :: non_neg_integer(),
+          block_hash = ?NO_BLOCK  :: pinned_block_hash() 
          }).
 
 -record(create_contract, {
@@ -36,8 +36,8 @@
           code                    :: binary(),
           deposit                 :: non_neg_integer(),
           call_data               :: binary(),
-          vsn = ?PINNED_BLOCKHASH_VSN      :: non_neg_integer(),
-          block_hash = ?TOP_BLOCK :: pinned_block_hash() 
+          vsn = ?INITIAL_VSN      :: non_neg_integer(),
+          block_hash = ?NO_BLOCK  :: pinned_block_hash()
          }).
 
 -record(call_contract, {
@@ -49,8 +49,8 @@
           call_stack              :: [non_neg_integer()],
           gas_price               :: non_neg_integer(),
           gas                     :: non_neg_integer(),
-          vsn = ?PINNED_BLOCKHASH_VSN      :: non_neg_integer(),
-          block_hash = ?TOP_BLOCK :: pinned_block_hash() 
+          vsn = ?INITIAL_VSN      :: non_neg_integer(),
+          block_hash = ?NO_BLOCK  :: pinned_block_hash() 
          }).
 
 -opaque update() :: #transfer{}
@@ -62,7 +62,8 @@
 -type update_type() :: transfer | withdraw | deposit | create_contract |
                        call_contract.
 
--export_type([update/0]).
+-export_type([update/0,
+              pinned_block_hash/0]).
 
 -export([ op_transfer/3
         , op_deposit/2
@@ -83,7 +84,9 @@
          extract_caller/1,
          extract_contract_pubkey/1,
          extract_amounts/1,
-         extract_abi_version/1]).
+         extract_abi_version/1,
+         no_pinned_block/0
+         ]).
 
 -spec op_transfer(aeser_id:id(), aeser_id:id(), non_neg_integer()) -> update().
 op_transfer(From, To, Amount) ->
@@ -289,7 +292,7 @@ fields2update(Vsn, Type, Fields0) ->
     Fields =
         case Vsn of
             ?INITIAL_VSN -> Fields0 ++ [{vsn, Vsn},
-                                        {block_hash, ?TOP_BLOCK}];
+                                        {block_hash, ?NO_BLOCK}];
             ?PINNED_BLOCKHASH_VSN -> Fields0
         end,
     fields2update(Type, Fields).
@@ -469,6 +472,9 @@ extract_amounts(Update) ->
 -spec extract_abi_version(update()) -> aect_contracts:abi_version().
 extract_abi_version(#call_contract{abi_version = ABIVersion}) ->
     ABIVersion.
+
+-spec no_pinned_block() -> pinned_block_hash().
+no_pinned_block() -> ?NO_BLOCK.
 
 update_error(Err) ->
     error({off_chain_update_error, Err}).

--- a/apps/aechannel/src/aesc_pinned_block.erl
+++ b/apps/aechannel/src/aesc_pinned_block.erl
@@ -58,7 +58,7 @@ deserialize(Bin) ->
 
 serialization_template(?VSN) ->
     [{hash, binary},
-     {type, integer}].
+     {type, int}].
 
 type_to_int(key)   -> ?KEYBLOCK;
 type_to_int(micro) -> ?MICROBLOCK.

--- a/apps/aechannel/src/aesc_pinned_block.erl
+++ b/apps/aechannel/src/aesc_pinned_block.erl
@@ -24,7 +24,7 @@
 
 -define(VSN, 1).
 -define(NO_PINNED_BLOCK, <<>>).
--define(BINATY_NO_PINNED_BLOCK, <<>>).
+-define(BINARY_NO_PINNED_BLOCK, <<>>).
 -opaque hash() :: ?NO_PINNED_BLOCK | #pinned{}.
 -export_type([hash/0]).
 
@@ -37,7 +37,7 @@ block_hash(BH, Type) when Type =:= key;
     #pinned{hash = BH, type = Type}.
 
 -spec serialize(hash()) -> binary().
-serialize(?NO_PINNED_BLOCK) -> ?BINATY_NO_PINNED_BLOCK;
+serialize(?NO_PINNED_BLOCK) -> ?BINARY_NO_PINNED_BLOCK;
 serialize(#pinned{hash = BH, type = Type}) ->
     Vsn = ?VSN,
     aeser_chain_objects:serialize(
@@ -48,7 +48,7 @@ serialize(#pinned{hash = BH, type = Type}) ->
        {type, type_to_int(Type)}]).
 
 -spec deserialize(binary()) -> hash().
-deserialize(?BINATY_NO_PINNED_BLOCK) -> ?NO_PINNED_BLOCK;
+deserialize(?BINARY_NO_PINNED_BLOCK) -> ?NO_PINNED_BLOCK;
 deserialize(Bin) ->
     {pinned_block, ?VSN, RawFields} =
         aeser_chain_objects:deserialize_type_and_vsn(Bin),

--- a/apps/aechannel/src/aesc_pinned_block.erl
+++ b/apps/aechannel/src/aesc_pinned_block.erl
@@ -1,0 +1,31 @@
+%%%=============================================================================
+%%% @copyright 2019, Aeternity Anstalt
+%%% @doc
+%%%   Module defining State Channel's pinned block hash. It sets the on-chain
+%%%   environment the updates - either off-chain of force progress are
+%%%   executed
+%%% @end
+%%%=============================================================================
+-module(aesc_pinned_block).
+
+-export([ no_hash/0
+        , block_hash/1
+        , serialize/1
+        , deserialize/1
+        %, serialize_for_client/1 TODO: expose key and micro hash serialization
+        ]).
+
+-define(NO_PINNED_BLOCK, <<>>).
+-opaque hash() :: ?NO_PINNED_BLOCK | aec_blocks:block_header_hash().
+-export_type([hash/0]).
+
+-spec no_hash() -> hash().
+no_hash() -> ?NO_PINNED_BLOCK.
+
+-spec block_hash(aec_blocks:block_header_hash()) -> hash().
+block_hash(BH) -> BH.
+
+serialize(BH) -> BH.
+
+deserialize(BH) -> BH.
+

--- a/apps/aechannel/src/aesc_pinned_block.erl
+++ b/apps/aechannel/src/aesc_pinned_block.erl
@@ -9,23 +9,70 @@
 -module(aesc_pinned_block).
 
 -export([ no_hash/0
-        , block_hash/1
+        , block_hash/2
         , serialize/1
         , deserialize/1
-        %, serialize_for_client/1 TODO: expose key and micro hash serialization
+        , serialize_for_client/1
         ]).
 
+-define(KEYBLOCK,   1).
+-define(MICROBLOCK, 2).
+-record(pinned, {
+          hash :: aec_blocks:block_header_hash(),
+          type :: key | micro 
+         }).
+
+-define(VSN, 1).
 -define(NO_PINNED_BLOCK, <<>>).
--opaque hash() :: ?NO_PINNED_BLOCK | aec_blocks:block_header_hash().
+-define(BINATY_NO_PINNED_BLOCK, <<>>).
+-opaque hash() :: ?NO_PINNED_BLOCK | #pinned{}.
 -export_type([hash/0]).
 
 -spec no_hash() -> hash().
 no_hash() -> ?NO_PINNED_BLOCK.
 
--spec block_hash(aec_blocks:block_header_hash()) -> hash().
-block_hash(BH) -> BH.
+-spec block_hash(aec_blocks:block_header_hash(), key | micro) -> hash().
+block_hash(BH, Type) when Type =:= key;
+                          Type =:= micro ->
+    #pinned{hash = BH, type = Type}.
 
-serialize(BH) -> BH.
+-spec serialize(hash()) -> binary().
+serialize(?NO_PINNED_BLOCK) -> ?BINATY_NO_PINNED_BLOCK;
+serialize(#pinned{hash = BH, type = Type}) ->
+    Vsn = ?VSN,
+    aeser_chain_objects:serialize(
+      pinned_block,
+      Vsn,
+      serialization_template(Vsn),
+      [{hash, BH},
+       {type, type_to_int(Type)}]).
 
-deserialize(BH) -> BH.
+-spec deserialize(binary()) -> hash().
+deserialize(?BINATY_NO_PINNED_BLOCK) -> ?NO_PINNED_BLOCK;
+deserialize(Bin) ->
+    {pinned_block, ?VSN, RawFields} =
+        aeser_chain_objects:deserialize_type_and_vsn(Bin),
+    [{hash, BH}, {type, Type}]
+        = aeserialization:decode_fields(serialization_template(?VSN), RawFields),
+    #pinned{hash = BH, type = int_to_type(Type)}.
+
+serialization_template(?VSN) ->
+    [{hash, binary},
+     {type, integer}].
+
+type_to_int(key)   -> ?KEYBLOCK;
+type_to_int(micro) -> ?MICROBLOCK.
+
+int_to_type(?KEYBLOCK)   -> key;
+int_to_type(?MICROBLOCK) -> micro.
+
+-spec serialize_for_client(hash()) -> binary().
+serialize_for_client(?NO_PINNED_BLOCK) -> <<>>;
+serialize_for_client(#pinned{hash = BH, type = Type}) ->
+    AESERType =
+        case Type of
+            key -> key_block_hash;
+            micro -> micro_block_hash
+        end,
+    aeser_api_encoder:encode(AESERType, BH).
 

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -23,7 +23,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %%%===================================================================
@@ -191,3 +192,8 @@ serialization_template(?CHANNEL_SETTLE_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_SETTLE_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
+

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -19,7 +19,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -131,8 +131,8 @@ serialize(#channel_settle_tx{channel_id             = ChannelId,
                              responder_amount_final = ResponderAmount,
                              ttl                    = TTL,
                              fee                    = Fee,
-                             nonce                  = Nonce}) ->
-    {version(),
+                             nonce                  = Nonce} = Tx) ->
+    {version(Tx),
     [ {channel_id             , ChannelId}
     , {from_id                , FromId}
     , {initiator_amount_final , InitiatorAmount}
@@ -188,10 +188,6 @@ serialization_template(?CHANNEL_SETTLE_TX_VSN) ->
     , {nonce                  , int}
     ].
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_SETTLE_TX_VSN.

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -19,7 +19,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -139,8 +139,8 @@ serialize(#channel_slash_tx{channel_id = ChannelId,
                             poi        = PoI,
                             ttl        = TTL,
                             fee        = Fee,
-                            nonce      = Nonce}) ->
-    {version(),
+                            nonce      = Nonce} = Tx) ->
+    {version(Tx),
      [ {channel_id, ChannelId}
      , {from_id   , FromId}
      , {payload   , Payload}
@@ -195,10 +195,6 @@ serialization_template(?CHANNEL_SLASH_TX_VSN) ->
     , {nonce     , int}
     ].
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_SLASH_TX_VSN.

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -23,7 +23,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %%%===================================================================
@@ -198,3 +199,8 @@ serialization_template(?CHANNEL_SLASH_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_SLASH_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
+

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -19,7 +19,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -130,8 +130,8 @@ serialize(#channel_snapshot_solo_tx{channel_id = ChannelId,
                                     payload    = Payload,
                                     ttl        = TTL,
                                     fee        = Fee,
-                                    nonce      = Nonce}) ->
-    {version(),
+                                    nonce      = Nonce} = Tx) ->
+    {version(Tx),
      [ {channel_id, ChannelId}
      , {from_id   , FromId}
      , {payload   , Payload}
@@ -180,11 +180,7 @@ serialization_template(?CHANNEL_SNAPSHOT_SOLO_TX_VSN) ->
     , {nonce     , int}
     ].
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_SNAPSHOT_SOLO_TX_VSN.
 

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -23,7 +23,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %%%===================================================================
@@ -183,4 +184,8 @@ serialization_template(?CHANNEL_SNAPSHOT_SOLO_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_SNAPSHOT_SOLO_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -21,7 +21,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -167,8 +167,8 @@ serialize(#channel_withdraw_tx{channel_id = ChannelId,
                                fee        = Fee,
                                state_hash = StateHash,
                                round      = Round,
-                               nonce      = Nonce}) ->
-    {version(),
+                               nonce      = Nonce} = Tx) ->
+    {version(Tx),
      [ {channel_id , ChannelId}
      , {to_id      , ToId}
      , {amount     , Amount}
@@ -238,12 +238,8 @@ updates(#channel_withdraw_tx{to_id = ToId, amount = Amount}) ->
 round(#channel_withdraw_tx{round = Round}) ->
     Round.
 
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CHANNEL_WITHDRAW_TX_VSN.
 
 %%%===================================================================

--- a/apps/aechannel/src/aesc_withdraw_tx.erl
+++ b/apps/aechannel/src/aesc_withdraw_tx.erl
@@ -25,7 +25,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 % aesc_signable_transaction callbacks
@@ -241,6 +242,10 @@ round(#channel_withdraw_tx{round = Round}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CHANNEL_WITHDRAW_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 %%%===================================================================
 %%% Test setters 

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -61,9 +61,6 @@
 -define(LONG_TIMEOUT, 60000).
 -define(PORT, 9325).
 
--define(OP_TRANSFER, 0).
--define(OP_WITHDRAW, 1).
--define(OP_DEPOSIT , 2).
 -define(BOGUS_PUBKEY, <<12345:32/unit:8>>).
 -define(BOGUS_PRIVKEY, <<12345:64/unit:8>>).
 
@@ -1704,7 +1701,7 @@ if_debug(_, _, Y) -> Y.
 
 apply_updates([], R) ->
     R;
-apply_updates([{?OP_TRANSFER, FromId, ToId, Amount} | T], R) ->
+apply_updates([{transfer, FromId, ToId, Amount} | T], R) -> %TODO:FIX THIS
     From = aeser_id:specialize(FromId, account),
     To = aeser_id:specialize(ToId, account),
     #{ initiator_amount := IAmt0

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -25,7 +25,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 -export([process_call_from_contract/3]).
@@ -307,6 +308,10 @@ serialization_template(?CONTRACT_CALL_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CONTRACT_CALL_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 for_client(#contract_call_tx{caller_id   = CallerId,
                              nonce       = Nonce,

--- a/apps/aecontract/src/aect_call_tx.erl
+++ b/apps/aecontract/src/aect_call_tx.erl
@@ -21,7 +21,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -248,11 +248,11 @@ serialize(#contract_call_tx{caller_id   = CallerId,
                             amount      = Amount,
                             gas         = Gas,
                             gas_price   = GasPrice,
-                            call_data   = CallData}) ->
+                            call_data   = CallData} = Tx) ->
     %% Note that the call_stack is not serialized. This is ok since we don't
     %% serialize transactions originating from contract execution, and for
     %% top-level transactions the call_stack is always empty.
-    {version(),
+    {version(Tx),
      [ {caller_id, CallerId}
      , {nonce, Nonce}
      , {contract_id, ContractId}
@@ -304,8 +304,8 @@ serialization_template(?CONTRACT_CALL_TX_VSN) ->
     , {call_data, binary}
     ].
 
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CONTRACT_CALL_TX_VSN.
 
 for_client(#contract_call_tx{caller_id   = CallerId,

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -25,7 +25,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Additional getters
@@ -310,10 +311,11 @@ for_client(#contract_create_tx{ owner_id    = OwnerId,
       <<"gas_price">>   => GasPrice,
       <<"call_data">>   => aeser_api_encoder:encode(contract_bytearray, CallData)}.
 
-%%%===================================================================
-%%% Internal functions
-
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?CONTRACT_CREATE_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aecontract/src/aect_create_tx.erl
+++ b/apps/aecontract/src/aect_create_tx.erl
@@ -21,7 +21,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -232,8 +232,8 @@ serialize(#contract_create_tx{owner_id   = OwnerId,
                               amount     = Amount,
                               gas        = Gas,
                               gas_price  = GasPrice,
-                              call_data  = CallData}) ->
-    {version(),
+                              call_data  = CallData} = Tx) ->
+    {version(Tx),
      [ {owner_id, OwnerId}
      , {nonce, Nonce}
      , {code, Code}
@@ -313,7 +313,7 @@ for_client(#contract_create_tx{ owner_id    = OwnerId,
 %%%===================================================================
 %%% Internal functions
 
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?CONTRACT_CREATE_TX_VSN.
 

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -23,7 +23,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 -export([payload/1]).
@@ -216,4 +217,8 @@ for_client(#spend_tx{sender_id    = SenderId,
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?SPEND_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -19,7 +19,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -153,8 +153,8 @@ serialize(#spend_tx{sender_id    = SenderId,
                     fee          = Fee,
                     ttl          = TTL,
                     nonce        = Nonce,
-                    payload      = Payload}) ->
-    {version(),
+                    payload      = Payload} = Tx) ->
+    {version(Tx),
      [ {sender_id, SenderId}
      , {recipient_id, RecipientId}
      , {amount, Amount}
@@ -213,7 +213,7 @@ for_client(#spend_tx{sender_id    = SenderId,
       <<"nonce">>        => Nonce,
       <<"payload">>      => Payload}.
 
-%% Internals
-
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?SPEND_TX_VSN.
+

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -3381,6 +3381,10 @@
           "description" : "Channel's next state_hash",
           "$ref" : "#/definitions/EncodedHash"
         },
+        "block_hash" : {
+          "description" : "The block hash the forced progress used as an on-chain environment",
+          "$ref" : "#/definitions/EncodedHash"
+        },
         "ttl" : {
           "type" : "integer",
           "format" : "int64",

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -20,7 +20,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -121,8 +121,8 @@ serialize(#ns_claim_tx{account_id = AccountId,
                        name       = Name,
                        name_salt  = NameSalt,
                        fee        = Fee,
-                       ttl        = TTL}) ->
-    {version(),
+                       ttl        = TTL} = Tx) ->
+    {version(Tx),
      [ {account_id, AccountId}
      , {nonce, None}
      , {name, Name}
@@ -193,6 +193,7 @@ name_salt(#ns_claim_tx{name_salt = NameSalt}) ->
 account_pubkey(#ns_claim_tx{account_id = AccountId}) ->
     aeser_id:specialize(AccountId, account).
 
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?NAME_CLAIM_TX_VSN.
 

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -24,7 +24,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Getters
@@ -196,4 +197,8 @@ account_pubkey(#ns_claim_tx{account_id = AccountId}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?NAME_CLAIM_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -24,7 +24,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Getters
@@ -188,4 +189,8 @@ commitment_hash(#ns_preclaim_tx{commitment_id = CommitmentId}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?NAME_PRECLAIM_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aens/src/aens_preclaim_tx.erl
+++ b/apps/aens/src/aens_preclaim_tx.erl
@@ -20,7 +20,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -119,8 +119,8 @@ serialize(#ns_preclaim_tx{account_id    = AccountId,
                           nonce         = Nonce,
                           commitment_id = CommitmentId,
                           fee           = Fee,
-                          ttl           = TTL}) ->
-    {version(),
+                          ttl           = TTL} = Tx) ->
+    {version(Tx),
      [ {account_id, AccountId}
      , {nonce, Nonce}
      , {commitment_id, CommitmentId}
@@ -185,6 +185,7 @@ account_pubkey(#ns_preclaim_tx{account_id = AccountId}) ->
 commitment_hash(#ns_preclaim_tx{commitment_id = CommitmentId}) ->
     aeser_id:specialize(CommitmentId, commitment).
 
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?NAME_PRECLAIM_TX_VSN.
 

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -19,7 +19,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -120,8 +120,8 @@ serialize(#ns_revoke_tx{account_id = AccountId,
                         nonce      = Nonce,
                         name_id    = NameId,
                         fee        = Fee,
-                        ttl        = TTL}) ->
-    {version(),
+                        ttl        = TTL} = Tx) ->
+    {version(Tx),
      [ {account_id, AccountId}
      , {nonce, Nonce}
      , {name_id, NameId}
@@ -174,6 +174,7 @@ account_pubkey(#ns_revoke_tx{account_id = AccountId}) ->
 name_hash(#ns_revoke_tx{name_id = NameId}) ->
     aeser_id:specialize(NameId, name).
 
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?NAME_REVOKE_TX_VSN.
 

--- a/apps/aens/src/aens_revoke_tx.erl
+++ b/apps/aens/src/aens_revoke_tx.erl
@@ -23,7 +23,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 -export([account_id/1,
@@ -177,4 +178,8 @@ name_hash(#ns_revoke_tx{name_id = NameId}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?NAME_REVOKE_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -20,7 +20,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -136,8 +136,8 @@ serialize(#ns_transfer_tx{account_id   = AccountId,
                           name_id      = NameId,
                           recipient_id = RecipientId,
                           fee          = Fee,
-                          ttl          = TTL}) ->
-    {version(),
+                          ttl          = TTL} = Tx) ->
+    {version(Tx),
      [ {account_id, AccountId}
      , {nonce, Nonce}
      , {name_id, NameId}
@@ -214,5 +214,6 @@ recipient_id(#ns_transfer_tx{recipient_id = RecipientId}) ->
 %%% Internal functions
 %%%===================================================================
 
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?NAME_TRANSFER_TX_VSN.

--- a/apps/aens/src/aens_transfer_tx.erl
+++ b/apps/aens/src/aens_transfer_tx.erl
@@ -24,7 +24,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 -export([account_id/1,
@@ -217,3 +218,8 @@ recipient_id(#ns_transfer_tx{recipient_id = RecipientId}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?NAME_TRANSFER_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
+

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -24,7 +24,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Getters
@@ -224,3 +225,8 @@ name_hash(#ns_update_tx{name_id = NameId}) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?NAME_UPDATE_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
+

--- a/apps/aens/src/aens_update_tx.erl
+++ b/apps/aens/src/aens_update_tx.erl
@@ -20,7 +20,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -133,8 +133,8 @@ serialize(#ns_update_tx{account_id = AccountId,
                         pointers   = Pointers,
                         client_ttl = ClientTTL,
                         fee        = Fee,
-                        ttl        = TTL}) ->
-    {version(),
+                        ttl        = TTL} = Tx) ->
+    {version(Tx),
      [ {account_id, AccountId}
      , {nonce, Nonce}
      , {name_id, NameId}
@@ -221,5 +221,6 @@ account_pubkey(#ns_update_tx{account_id = AccountId}) ->
 name_hash(#ns_update_tx{name_id = NameId}) ->
     aeser_id:specialize(NameId, name).
 
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?NAME_UPDATE_TX_VSN.

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -21,7 +21,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialize/1,
          serialization_template/1,
          deserialize/2,
@@ -120,8 +120,8 @@ serialize(#oracle_extend_tx{oracle_id  = OracleId,
                             nonce      = Nonce,
                             oracle_ttl = {?ttl_delta_atom, TTLValue},
                             fee        = Fee,
-                            ttl        = TTL}) ->
-    {version(),
+                            ttl        = TTL} = Tx) ->
+    {version(Tx),
     [ {oracle_id, OracleId}
     , {nonce, Nonce}
     , {oracle_ttl_type, ?ttl_delta_int}
@@ -153,8 +153,8 @@ serialization_template(?ORACLE_EXTEND_TX_VSN) ->
     , {ttl, int}
     ].
 
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?ORACLE_EXTEND_TX_VSN.
 
 for_client(#oracle_extend_tx{oracle_id = OracleId,

--- a/apps/aeoracle/src/aeo_extend_tx.erl
+++ b/apps/aeoracle/src/aeo_extend_tx.erl
@@ -25,7 +25,8 @@
          serialize/1,
          serialization_template/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Additional getters
@@ -156,6 +157,10 @@ serialization_template(?ORACLE_EXTEND_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?ORACLE_EXTEND_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 for_client(#oracle_extend_tx{oracle_id = OracleId,
                              nonce     = Nonce,

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -21,7 +21,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -178,12 +178,12 @@ serialize(#oracle_query_tx{sender_id    = SenderId,
                            query_ttl    = {QueryTTLType0, QueryTTLValue},
                            response_ttl = {?ttl_delta_atom, ResponseTTLValue},
                            fee          = Fee,
-                           ttl          = TTL}) ->
+                           ttl          = TTL} = Tx) ->
     QueryTTLType = case QueryTTLType0 of
                        ?ttl_delta_atom -> ?ttl_delta_int;
                        ?ttl_block_atom -> ?ttl_block_int
                    end,
-    {version(),
+    {version(Tx),
      [ {sender_id, SenderId}
      , {nonce, Nonce}
      , {oracle_id, OracleId}
@@ -239,8 +239,8 @@ serialization_template(?ORACLE_QUERY_TX_VSN) ->
     , {ttl, int}
     ].
 
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?ORACLE_QUERY_TX_VSN.
 
 for_client(#oracle_query_tx{sender_id = SenderId,

--- a/apps/aeoracle/src/aeo_query_tx.erl
+++ b/apps/aeoracle/src/aeo_query_tx.erl
@@ -25,7 +25,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Additional getters
@@ -242,6 +243,10 @@ serialization_template(?ORACLE_QUERY_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?ORACLE_QUERY_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 for_client(#oracle_query_tx{sender_id = SenderId,
                             nonce      = Nonce,

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -27,7 +27,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Additional getters
@@ -232,6 +233,10 @@ serialization_template(?ORACLE_REGISTER_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?ORACLE_REGISTER_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 for_client(#oracle_register_tx{account_id      = AccountId,
                                nonce           = Nonce,

--- a/apps/aeoracle/src/aeo_register_tx.erl
+++ b/apps/aeoracle/src/aeo_register_tx.erl
@@ -23,7 +23,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -169,13 +169,13 @@ serialize(#oracle_register_tx{account_id      = AccountId,
                               oracle_ttl      = {TTLType0, TTLValue},
                               fee             = Fee,
                               ttl             = TTL,
-                              abi_version     = ABIVersion}) ->
+                              abi_version     = ABIVersion} = Tx) ->
     TTLType = case TTLType0 of
                   ?ttl_delta_atom -> ?ttl_delta_int;
                   ?ttl_block_atom -> ?ttl_block_int
               end,
 
-    {version(),
+    {version(Tx),
     [ {account_id, AccountId}
     , {nonce, Nonce}
     , {query_format, QueryFormat}
@@ -229,8 +229,8 @@ serialization_template(?ORACLE_REGISTER_TX_VSN) ->
     , {abi_version, int}
     ].
 
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?ORACLE_REGISTER_TX_VSN.
 
 for_client(#oracle_register_tx{account_id      = AccountId,

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -25,7 +25,8 @@
          serialization_template/1,
          serialize/1,
          deserialize/2,
-         for_client/1
+         for_client/1,
+         valid_at_protocol/2
         ]).
 
 %% Additional getters
@@ -186,6 +187,10 @@ serialization_template(?ORACLE_RESPONSE_TX_VSN) ->
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
     ?ORACLE_RESPONSE_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
 
 for_client(#oracle_response_tx{oracle_id = OracleId,
                                nonce     = Nonce,

--- a/apps/aeoracle/src/aeo_response_tx.erl
+++ b/apps/aeoracle/src/aeo_response_tx.erl
@@ -21,7 +21,7 @@
          check/3,
          process/3,
          signers/2,
-         version/0,
+         version/1,
          serialization_template/1,
          serialize/1,
          deserialize/2,
@@ -142,8 +142,8 @@ serialize(#oracle_response_tx{oracle_id    = OracleId,
                               response     = Response,
                               response_ttl = {?ttl_delta_atom, ResponseTTLValue},
                               fee          = Fee,
-                              ttl          = TTL}) ->
-    {version(),
+                              ttl          = TTL} = Tx) ->
+    {version(Tx),
     [ {oracle_id, OracleId}
     , {nonce, Nonce}
     , {query_id, QueryId}
@@ -183,8 +183,8 @@ serialization_template(?ORACLE_RESPONSE_TX_VSN) ->
     , {ttl, int}
     ].
 
--spec version() -> non_neg_integer().
-version() ->
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
     ?ORACLE_RESPONSE_TX_VSN.
 
 for_client(#oracle_response_tx{oracle_id = OracleId,

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -113,7 +113,7 @@
 
 -callback type() -> atom().
 
--callback version() -> non_neg_integer().
+-callback version(tx_instance()) -> non_neg_integer().
 
 -callback fee(Tx :: tx_instance()) ->
     Fee :: integer().
@@ -360,7 +360,8 @@ custom_apply(Fun, #aetx{ cb = CB, tx = Tx}, Trees, Env) ->
 -spec serialize_for_client(Tx :: tx()) -> map().
 serialize_for_client(#aetx{ cb = CB, type = Type, tx = Tx }) ->
     Res0 = CB:for_client(Tx),
-    Res1 = Res0#{ <<"type">> => type_to_swagger_name(Type), <<"version">> => CB:version() },
+    Res1 = Res0#{ <<"type">> => type_to_swagger_name(Type),
+                  <<"version">> => CB:version(Tx) },
     case maps:get(<<"ttl">>, Res1, 0) of
         0 -> maps:remove(<<"ttl">>, Res1);
         _ -> Res1

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -449,6 +449,7 @@ type_to_swagger_name(channel_close_mutual_tx)   -> <<"ChannelCloseMutualTx">>;
 type_to_swagger_name(channel_slash_tx)          -> <<"ChannelSlashTx">>;
 type_to_swagger_name(channel_settle_tx)         -> <<"ChannelSettleTx">>;
 type_to_swagger_name(channel_snapshot_solo_tx)  -> <<"ChannelSnapshotSoloTx">>;
+%% not exposed in HTTP API:
 type_to_swagger_name(channel_offchain_tx)       -> <<"ChannelOffchainTx">>.
 
 -spec specialize_type(Tx :: tx()) -> {tx_type(), tx_instance()}.

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2638,6 +2638,9 @@ definitions:
       state_hash:
         $ref: '#/definitions/EncodedHash'
         description: 'Channel''s next state_hash'
+      block_hash:
+        $ref: '#/definitions/EncodedHash'
+        description: 'The block hash the forced progress used as an on-chain environment'
       ttl:
         type: integer
         format: int64

--- a/rebar.config
+++ b/rebar.config
@@ -66,7 +66,7 @@
                      {ref,"3271d6f"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                     {ref,"6dce265"}}},
+                     {ref,"ecde108"}}},
 
         %% forks
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"6dce265753af4e651f77746e77ea125145c85dd3"}},
+      {ref,"ecde108939ca407d8f92e991f062e51fc13f3beb"}},
   0},
  {<<"aesophia">>,
   {git,"https://github.com/aeternity/aesophia.git",


### PR DESCRIPTION
PT [SC: new serialization required for pinning env](https://www.pivotaltracker.com/story/show/165214322)

Adds a v2 backwards compatible serialization for `channel_offchain_tx` and `channel_force_progress_tx` introducing a new field in them `block_hash` that represents the pinned block.

prerequisite for [SC calls: pin enviroment to a block hash](https://www.pivotaltracker.com/story/show/160843011)