### PR TITLE
Add win32 support to python release test script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ references:
         epmd -daemon
         make python-env
         mkdir ${PACKAGE_TESTS_DIR:?}
-        make python-package-win32-test python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} TARBALL=${PACKAGE_TARBALL:?}
+        make python-package-win32-test python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} PACKAGE=${PACKAGE_TARBALL:?}
 
   store_package_artifacts: &store_package_artifacts
     store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ST_CT_FLAGS = --logdir system_test/logs
 ST_CT_DIR = --dir system_test/common
 ST_CT_LOCALDIR = --dir system_test/only_local
 
-SWAGGER_CODEGEN_CLI_V = 2.3.1
+SWAGGER_CODEGEN_CLI_V = 2.4.4
 SWAGGER_CODEGEN_CLI = swagger/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
 SWAGGER_CODEGEN = java -jar $(SWAGGER_CODEGEN_CLI)
 SWAGGER_ENDPOINTS_SPEC = apps/aeutils/src/endpoints.erl
@@ -306,7 +306,7 @@ python-single-uat: swagger
 	( cd $(PYTHON_DIR) && TEST_NAME=$(TEST_NAME) $(MAKE) single-uat; )
 
 python-release-test: swagger
-	( cd $(PYTHON_DIR) && WORKDIR="$(WORKDIR)" TARBALL=$(TARBALL) VER=$(VER) $(MAKE) release-test; )
+	( cd $(PYTHON_DIR) && WORKDIR="$(WORKDIR)" PACKAGE=$(PACKAGE) VER=$(VER) $(MAKE) release-test; )
 
 python-package-win32-test:
 	( cd $(PYTHON_DIR) && WORKDIR="$(WORKDIR)" PACKAGESPECFILE=$(PACKAGE_SPEC_WIN32) $(MAKE) package-win32-test; )

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -106,7 +106,13 @@
           "200" : {
             "description" : "Successful operation",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200"
+              "type" : "object",
+              "properties" : {
+                "hash" : {
+                  "type" : "string",
+                  "description" : "Hash"
+                }
+              }
             }
           },
           "404" : {
@@ -129,7 +135,14 @@
           "200" : {
             "description" : "Successful operation",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_1"
+              "type" : "object",
+              "properties" : {
+                "height" : {
+                  "type" : "integer",
+                  "format" : "int64",
+                  "description" : "Height"
+                }
+              }
             }
           },
           "404" : {
@@ -393,7 +406,15 @@
           "200" : {
             "description" : "Successful operation",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_2"
+              "type" : "object",
+              "properties" : {
+                "count" : {
+                  "type" : "integer",
+                  "format" : "int64",
+                  "description" : "Count",
+                  "minimum" : 1
+                }
+              }
             }
           },
           "400" : {
@@ -1102,7 +1123,12 @@
           "200" : {
             "description" : "Successful operation",
             "schema" : {
-              "$ref" : "#/definitions/inline_response_200_3"
+              "type" : "object",
+              "properties" : {
+                "pubkey" : {
+                  "type" : "string"
+                }
+              }
             }
           }
         }
@@ -2212,7 +2238,9 @@
       "items" : {
         "type" : "integer",
         "format" : "int32"
-      }
+      },
+      "minItems" : 42,
+      "maxItems" : 42
     },
     "Uri" : {
       "type" : "string"
@@ -2267,15 +2295,10 @@
         }
       },
       "example" : {
-        "prev_hash" : null,
         "nonce" : 1,
         "version" : 5,
-        "miner" : null,
         "target" : 6,
-        "beneficiary" : null,
-        "state_hash" : null,
         "pow" : "",
-        "prev_key_hash" : null,
         "time" : 5,
         "hash" : { },
         "height" : 0,
@@ -2322,15 +2345,9 @@
         }
       },
       "example" : {
-        "txs_hash" : null,
-        "state_hash" : null,
-        "signature" : null,
         "pof_hash" : "pof_hash",
-        "prev_hash" : null,
-        "prev_key_hash" : null,
         "time" : 7,
         "version" : 9,
-        "hash" : null,
         "height" : 2
       }
     },
@@ -2346,27 +2363,16 @@
       },
       "example" : {
         "micro_block" : {
-          "txs_hash" : null,
-          "state_hash" : null,
-          "signature" : null,
           "pof_hash" : "pof_hash",
-          "prev_hash" : null,
-          "prev_key_hash" : null,
           "time" : 7,
           "version" : 9,
-          "hash" : null,
           "height" : 2
         },
         "key_block" : {
-          "prev_hash" : null,
           "nonce" : 1,
           "version" : 5,
-          "miner" : null,
           "target" : 6,
-          "beneficiary" : null,
-          "state_hash" : null,
           "pow" : "",
-          "prev_key_hash" : null,
           "time" : 5,
           "hash" : { },
           "height" : 0,
@@ -2393,7 +2399,6 @@
           },
           "block_hash" : { },
           "block_height" : 6,
-          "hash" : null,
           "signatures" : [ "signatures", "signatures" ]
         }, {
           "tx" : {
@@ -2402,7 +2407,6 @@
           },
           "block_hash" : { },
           "block_height" : 6,
-          "hash" : null,
           "signatures" : [ "signatures", "signatures" ]
         } ]
       }
@@ -2524,7 +2528,6 @@
         }
       },
       "example" : {
-        "oracle_id" : null,
         "response_ttl" : {
           "type" : "delta",
           "value" : 1
@@ -2534,8 +2537,7 @@
         "fee" : 5,
         "sender_nonce" : 0,
         "id" : { },
-        "ttl" : 6,
-        "sender_id" : null
+        "ttl" : 6
       }
     },
     "OracleQueries" : {
@@ -2551,7 +2553,6 @@
       },
       "example" : {
         "oracle_queries" : [ {
-          "oracle_id" : null,
           "response_ttl" : {
             "type" : "delta",
             "value" : 1
@@ -2561,10 +2562,8 @@
           "fee" : 5,
           "sender_nonce" : 0,
           "id" : { },
-          "ttl" : 6,
-          "sender_id" : null
+          "ttl" : 6
         }, {
-          "oracle_id" : null,
           "response_ttl" : {
             "type" : "delta",
             "value" : 1
@@ -2574,8 +2573,7 @@
           "fee" : 5,
           "sender_nonce" : 0,
           "id" : { },
-          "ttl" : 6,
-          "sender_id" : null
+          "ttl" : 6
         } ]
       }
     },
@@ -2616,7 +2614,6 @@
         "fee" : 6,
         "ttl" : 1,
         "nonce" : 5,
-        "sender_id" : null,
         "recipient_id" : { }
       }
     },
@@ -2764,8 +2761,7 @@
         "fee" : 6,
         "query_fee" : 0,
         "ttl" : 1,
-        "nonce" : 5,
-        "sender_id" : null
+        "nonce" : 5
       }
     },
     "OracleRespondTx" : {
@@ -2803,7 +2799,6 @@
           "type" : "delta",
           "value" : 1
         },
-        "oracle_id" : null,
         "query_id" : { },
         "response" : "response",
         "fee" : 0,
@@ -2871,10 +2866,8 @@
         "id" : { },
         "ttl" : 0,
         "pointers" : [ {
-          "id" : null,
           "key" : "key"
         }, {
-          "id" : null,
           "key" : "key"
         } ]
       }
@@ -2901,13 +2894,6 @@
           "type" : "integer",
           "format" : "int64"
         }
-      },
-      "example" : {
-        "commitment_id" : { },
-        "account_id" : null,
-        "fee" : 0,
-        "ttl" : 6,
-        "nonce" : 1
       }
     },
     "NameClaimTx" : {
@@ -2936,14 +2922,6 @@
           "type" : "integer",
           "format" : "int64"
         }
-      },
-      "example" : {
-        "name_salt" : 0,
-        "account_id" : { },
-        "fee" : 6,
-        "name" : "name",
-        "ttl" : 1,
-        "nonce" : 5
       }
     },
     "NameUpdateTx" : {
@@ -2982,22 +2960,6 @@
           "type" : "integer",
           "format" : "int64"
         }
-      },
-      "example" : {
-        "name_ttl" : 0,
-        "client_ttl" : 6,
-        "account_id" : null,
-        "fee" : 1,
-        "name_id" : { },
-        "ttl" : 5,
-        "nonce" : 5,
-        "pointers" : [ {
-          "id" : null,
-          "key" : "key"
-        }, {
-          "id" : null,
-          "key" : "key"
-        } ]
       }
     },
     "NameTransferTx" : {
@@ -3025,14 +2987,6 @@
           "type" : "integer",
           "format" : "int64"
         }
-      },
-      "example" : {
-        "account_id" : null,
-        "fee" : 0,
-        "name_id" : { },
-        "ttl" : 6,
-        "nonce" : 1,
-        "recipient_id" : null
       }
     },
     "NameRevokeTx" : {
@@ -3057,13 +3011,6 @@
           "type" : "integer",
           "format" : "int64"
         }
-      },
-      "example" : {
-        "account_id" : null,
-        "fee" : 0,
-        "name_id" : { },
-        "ttl" : 6,
-        "nonce" : 1
       }
     },
     "CommitmentId" : {
@@ -3099,7 +3046,6 @@
         }
       },
       "example" : {
-        "id" : null,
         "key" : "key"
       }
     },
@@ -3167,14 +3113,11 @@
       },
       "example" : {
         "delegate_ids" : [ null, null ],
-        "responder_id" : null,
         "locked_until" : 9,
         "lock_period" : 0,
         "responder_amount" : 0,
         "initiator_amount" : 0,
         "round" : 0,
-        "initiator_id" : null,
-        "state_hash" : null,
         "id" : { },
         "solo_round" : 0,
         "channel_amount" : 0,
@@ -3235,19 +3178,6 @@
           "description" : "Root hash of the channel's internal state tree",
           "$ref" : "#/definitions/EncodedHash"
         }
-      },
-      "example" : {
-        "responder_amount" : 0,
-        "initiator_amount" : 0,
-        "initiator_id" : { },
-        "responder_id" : null,
-        "state_hash" : null,
-        "fee" : 0,
-        "push_amount" : 0,
-        "ttl" : 0,
-        "nonce" : 0,
-        "lock_period" : 0,
-        "channel_reserve" : 0
       }
     },
     "ChannelDepositTx" : {
@@ -3290,16 +3220,6 @@
           "description" : "Channel's next round",
           "minimum" : 0
         }
-      },
-      "example" : {
-        "amount" : 0,
-        "from_id" : null,
-        "round" : 0,
-        "state_hash" : null,
-        "fee" : 0,
-        "channel_id" : { },
-        "ttl" : 0,
-        "nonce" : 0
       }
     },
     "ChannelWithdrawTx" : {
@@ -3342,16 +3262,6 @@
           "description" : "Channel's next round",
           "minimum" : 0
         }
-      },
-      "example" : {
-        "amount" : 0,
-        "round" : 0,
-        "state_hash" : null,
-        "fee" : 0,
-        "to_id" : null,
-        "channel_id" : { },
-        "ttl" : 0,
-        "nonce" : 0
       }
     },
     "ChannelForceProgressTx" : {
@@ -3437,15 +3347,6 @@
           "format" : "int64",
           "minimum" : 0
         }
-      },
-      "example" : {
-        "from_id" : null,
-        "responder_amount_final" : 0,
-        "fee" : 0,
-        "initiator_amount_final" : 0,
-        "channel_id" : { },
-        "ttl" : 0,
-        "nonce" : 0
       }
     },
     "ChannelCloseSoloTx" : {
@@ -3480,15 +3381,6 @@
           "type" : "string",
           "description" : "Proof of inclusion containing information for closing the channel"
         }
-      },
-      "example" : {
-        "from_id" : null,
-        "payload" : "payload",
-        "fee" : 0,
-        "poi" : "poi",
-        "channel_id" : { },
-        "ttl" : 0,
-        "nonce" : 0
       }
     },
     "ChannelSlashTx" : {
@@ -3523,15 +3415,6 @@
           "type" : "string",
           "description" : "Proof of inclusion containing information for closing the channel"
         }
-      },
-      "example" : {
-        "from_id" : null,
-        "payload" : "payload",
-        "fee" : 0,
-        "poi" : "poi",
-        "channel_id" : { },
-        "ttl" : 0,
-        "nonce" : 0
       }
     },
     "ChannelSettleTx" : {
@@ -3569,15 +3452,6 @@
           "format" : "int64",
           "minimum" : 0
         }
-      },
-      "example" : {
-        "from_id" : null,
-        "responder_amount_final" : 0,
-        "fee" : 0,
-        "initiator_amount_final" : 0,
-        "channel_id" : { },
-        "ttl" : 0,
-        "nonce" : 0
       }
     },
     "ChannelSnapshotSoloTx" : {
@@ -3608,14 +3482,6 @@
           "format" : "int64",
           "minimum" : 0
         }
-      },
-      "example" : {
-        "from_id" : null,
-        "payload" : "payload",
-        "fee" : 0,
-        "channel_id" : { },
-        "ttl" : 0,
-        "nonce" : 0
       }
     },
     "PubKey" : {
@@ -3757,7 +3623,6 @@
         },
         "block_hash" : { },
         "block_height" : 6,
-        "hash" : null,
         "signatures" : [ "signatures", "signatures" ]
       }
     },
@@ -3965,18 +3830,14 @@
       "example" : {
         "gas_price" : 1,
         "return_type" : "return_type",
-        "return_value" : null,
         "log" : [ {
-          "address" : null,
           "data" : { },
           "topics" : [ 5, 5 ]
         }, {
-          "address" : null,
           "data" : { },
           "topics" : [ 5, 5 ]
         } ],
         "caller_id" : { },
-        "contract_id" : null,
         "gas_used" : 5,
         "caller_nonce" : 0,
         "height" : 6
@@ -4003,7 +3864,6 @@
         }
       },
       "example" : {
-        "address" : null,
         "data" : { },
         "topics" : [ 5, 5 ]
       }
@@ -4057,7 +3917,6 @@
       "example" : {
         "vm_version" : 5248,
         "log" : "log",
-        "owner_id" : null,
         "active" : true,
         "deposit" : 1,
         "abi_version" : 39500,
@@ -4225,18 +4084,14 @@
           "call_obj" : {
             "gas_price" : 1,
             "return_type" : "return_type",
-            "return_value" : null,
             "log" : [ {
-              "address" : null,
               "data" : { },
               "topics" : [ 5, 5 ]
             }, {
-              "address" : null,
               "data" : { },
               "topics" : [ 5, 5 ]
             } ],
             "caller_id" : { },
-            "contract_id" : null,
             "gas_used" : 5,
             "caller_nonce" : 0,
             "height" : 6
@@ -4248,18 +4103,14 @@
           "call_obj" : {
             "gas_price" : 1,
             "return_type" : "return_type",
-            "return_value" : null,
             "log" : [ {
-              "address" : null,
               "data" : { },
               "topics" : [ 5, 5 ]
             }, {
-              "address" : null,
               "data" : { },
               "topics" : [ 5, 5 ]
             } ],
             "caller_id" : { },
-            "contract_id" : null,
             "gas_used" : 5,
             "caller_nonce" : 0,
             "height" : 6
@@ -4291,18 +4142,14 @@
         "call_obj" : {
           "gas_price" : 1,
           "return_type" : "return_type",
-          "return_value" : null,
           "log" : [ {
-            "address" : null,
             "data" : { },
             "topics" : [ 5, 5 ]
           }, {
-            "address" : null,
             "data" : { },
             "topics" : [ 5, 5 ]
           } ],
           "caller_id" : { },
-          "contract_id" : null,
           "gas_used" : 5,
           "caller_nonce" : 0,
           "height" : 6
@@ -4606,7 +4453,6 @@
         "amount" : 0,
         "call_data" : { },
         "caller_id" : { },
-        "contract_id" : null,
         "fee" : 0,
         "gas" : 0,
         "abi_version" : 9606,
@@ -4683,7 +4529,6 @@
       "example" : {
         "gas_price" : 0,
         "amount" : 0,
-        "contract_id" : null,
         "fee" : 0,
         "nonce" : 0,
         "ttl" : 0,
@@ -4766,15 +4611,10 @@
       "example" : {
         "micro_blocks" : [ { }, { } ],
         "key_block" : {
-          "prev_hash" : null,
           "nonce" : 1,
           "version" : 5,
-          "miner" : null,
           "target" : 6,
-          "beneficiary" : null,
-          "state_hash" : null,
           "pow" : "",
-          "prev_key_hash" : null,
           "time" : 5,
           "hash" : { },
           "height" : 0,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,12 @@ environment:
       OTP_VERSION: 20.1
       ERTS_VERSION: 9.1
       BUILD_STEP: build
-      TEST_STEP: ct
+      TEST_STEPS: ct,release
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       OTP_VERSION: 20.3
       ERTS_VERSION: 9.3
       BUILD_STEP: build
-      TEST_STEP: ct
+      TEST_STEPS: ct,release
       #
       #    NOTE: This job can be used as a backup to CircleCI. Only enable it temporarily when needed.
       #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,7 +90,7 @@ after_build:
   - cmd: '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\package.bat'
 
 test_script:
-#  - cmd: '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\test.bat'
+  - cmd: '%APPVEYOR_BUILD_FOLDER%\ci\appveyor\test.bat'
   - sh: epmd -daemon
   - sh: make ct
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,12 @@ environment:
       OTP_VERSION: 20.1
       ERTS_VERSION: 9.1
       BUILD_STEP: build
-      TEST_STEPS: ct,release
+      TEST_STEPS: release
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       OTP_VERSION: 20.3
       ERTS_VERSION: 9.3
       BUILD_STEP: build
-      TEST_STEPS: ct,release
+      TEST_STEPS: release
       #
       #    NOTE: This job can be used as a backup to CircleCI. Only enable it temporarily when needed.
       #

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -11,16 +11,18 @@
 @rem    WIN_MSYS2_ROOT
 
 SETLOCAL ENABLEEXTENSIONS
-cd %APPVEYOR_BUILD_FOLDER%
+IF "%APPVEYOR_BUILD_FOLDER%"=="" (
+	cd %~dp0\..\..\
+) ELSE (
+	cd %APPVEYOR_BUILD_FOLDER%
+)
+SET /p PACKAGE_VERSION=<%~dp0%\..\..\REVISION
 
 rem Set required vars defaults
 
 IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
 IF "%PACKAGE_TESTS_DIR%"=="" SET "PACKAGE_TESTS_DIR=/tmp/package_tests"
-IF "%PACKAGE_ZIPARCHIVE%"=="" (
-	SET /p PACKAGE_VERSION=<%~dp0%\..\..\REVISION
-	SET "PACKAGE_ZIPARCHIVE=aeternity-%PACKAGE_VERSION%"
-)
+IF "%PACKAGE_ZIPARCHIVE%"=="" SET "PACKAGE_ZIPARCHIVE=aeternity-%PACKAGE_VERSION%-windows-x86_64.zip"
 IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 IF "%TEST_STEPS%"=="" SET "TEST_STEPS=ct"
@@ -61,11 +63,11 @@ GOTO FIND_NEXT_STEP
 :TEST_release
 @echo Current time: %time%
 rem Run test: release
-bash -lc "cd %BUILD_PATH% && ^
-	  epmd -daemon && ^
-	  make python-env PIP=/mingw64/bin/pip3 && ^
-	  mkdir %PACKAGE_TESTS_DIR% && ^
-	  make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE% PYTHON=/mingw64/bin/python3"
+bash -lc ^"cd %BUILD_PATH% ^&^& ^
+           epmd -daemon ^&^& ^
+           make python-env PIP=/mingw64/bin/pip3 ^&^& ^
+           mkdir %PACKAGE_TESTS_DIR% ^&^& ^
+           make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE% PYTHON=/mingw64/bin/python3^"
 
 :FINISHED_TESTING
 

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -63,9 +63,9 @@ GOTO FIND_NEXT_STEP
 rem Run test: eunit
 bash -lc "cd %BUILD_PATH% && \
 	  epmd -daemon && \
-	  make python-env && \
+	  make python-env PIP=/mingw64/bin/pip3 && \
 	  mkdir %PACKAGE_TESTS_DIR% && \
-	  make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE%"
+	  make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE% PYTHON=/mingw64/bin/python3"
 
 :FINISHED_TESTING
 

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -68,7 +68,6 @@ bash -lc ^"cd %BUILD_PATH% ^&^& ^
            make python-env PIP=/mingw64/bin/pip3 ^&^& ^
            mkdir %PACKAGE_TESTS_DIR% ^&^& ^
            curl --version ^&^& ^
-           curl --help ^&^& ^
            make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE% PYTHON=/mingw64/bin/python3^"
 
 :FINISHED_TESTING

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -60,11 +60,11 @@ GOTO FIND_NEXT_STEP
 
 :TEST_release
 @echo Current time: %time%
-rem Run test: eunit
-bash -lc "cd %BUILD_PATH% && \
-	  epmd -daemon && \
-	  make python-env PIP=/mingw64/bin/pip3 && \
-	  mkdir %PACKAGE_TESTS_DIR% && \
+rem Run test: release
+bash -lc "cd %BUILD_PATH% && ^
+	  epmd -daemon && ^
+	  make python-env PIP=/mingw64/bin/pip3 && ^
+	  mkdir %PACKAGE_TESTS_DIR% && ^
 	  make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE% PYTHON=/mingw64/bin/python3"
 
 :FINISHED_TESTING

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -67,6 +67,8 @@ bash -lc ^"cd %BUILD_PATH% ^&^& ^
            epmd -daemon ^&^& ^
            make python-env PIP=/mingw64/bin/pip3 ^&^& ^
            mkdir %PACKAGE_TESTS_DIR% ^&^& ^
+           curl --version ^&^& ^
+           curl --help ^&^& ^
            make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE% PYTHON=/mingw64/bin/python3^"
 
 :FINISHED_TESTING

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -67,7 +67,6 @@ bash -lc ^"cd %BUILD_PATH% ^&^& ^
            epmd -daemon ^&^& ^
            make python-env PIP=/mingw64/bin/pip3 ^&^& ^
            mkdir %PACKAGE_TESTS_DIR% ^&^& ^
-           curl --version ^&^& ^
            make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE% PYTHON=/mingw64/bin/python3^"
 
 :FINISHED_TESTING

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -3,18 +3,28 @@
 @rem Currently only supports MSYS2 builds.
 @rem See https://www.appveyor.com/docs/installed-software#mingw-msys-cygwin
 @rem Required vars:
-@rem    TEST_STEP
-@rem    WIN_MSYS2_ROOT
+@rem    ERTS_VERSION
+@rem    PACKAGE_TESTS_DIR
+@rem    PACKAGE_ZIPARCHIVE
 @rem    PLATFORM
+@rem    TEST_STEPS
+@rem    WIN_MSYS2_ROOT
 
 SETLOCAL ENABLEEXTENSIONS
 cd %APPVEYOR_BUILD_FOLDER%
 
 rem Set required vars defaults
+
 IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
+IF "%PACKAGE_TESTS_DIR%"=="" SET "PACKAGE_TESTS_DIR=/tmp/package_tests"
+IF "%PACKAGE_ZIPARCHIVE%"=="" (
+	SET /p PACKAGE_VERSION=<%~dp0%\..\..\REVISION
+	SET "PACKAGE_ZIPARCHIVE=aeternity-%PACKAGE_VERSION%"
+)
 IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
-IF "%TEST_STEP%"=="" SET "TEST_STEP=ct"
+IF "%TEST_STEPS%"=="" SET "TEST_STEPS=ct"
+
 SET BASH_BIN="%WIN_MSYS2_ROOT%\usr\bin\bash"
 
 @echo Current time: %time%
@@ -24,25 +34,40 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary
 @echo on
 SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
-:TESTSTART
-GOTO TEST_%TEST_STEP%
+:FIND_NEXT_STEP
+set NEXT_STEP=
+@for /f "tokens=1* delims=, " %%i in ("%TEST_STEPS%") do @(
+	set "NEXT_STEP=%%i"
+	set "TEST_STEPS=%%j"
+)
+
+IF "%NEXT_STEP%"=="" GOTO FINISHED_TESTING
+GOTO TEST_%NEXT_STEP%
 
 :TEST_ct
 @echo Current time: %time%
 rem Run test: ct
 bash -lc "cd %BUILD_PATH% && epmd -daemon && make ct"
 
-GOTO TEST_DONE
+GOTO FIND_NEXT_STEP
 
 :TEST_eunit
 @echo Current time: %time%
 rem Run test: eunit
 bash -lc "cd %BUILD_PATH% && epmd -daemon && make eunit"
 
-GOTO TEST_DONE
+GOTO FIND_NEXT_STEP
 
-:TEST_
-:TEST_DONE
+:TEST_release
+@echo Current time: %time%
+rem Run test: eunit
+bash -lc "cd %BUILD_PATH% && \
+	  epmd -daemon && \
+	  make python-env && \
+	  mkdir %PACKAGE_TESTS_DIR% && \
+	  make python-release-test WORKDIR=%PACKAGE_TESTS_DIR% PACKAGE=`pwd`/%PACKAGE_ZIPARCHIVE%"
+
+:FINISHED_TESTING
 
 @echo Current time: %time%
 rem Finished test phase

--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -39,10 +39,15 @@ local setup differs, you need to set these variables yourself.
 
 ```
 ERTS_VERSION=9.3
+FORCE_STYRENE_REINSTALL=false
+JDK_URL=https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip
 OTP_VERSION=20.3
-WIN_OTP_PATH=C:\Program Files\erl
-WIN_MSYS2_ROOT=C:\msys64
 PLATFORM=x64
+WIN_JDK_BASEPATH=C:\Program Files\Java
+WIN_JDK_PATH=C:\Program Files\Java\jdk11
+WIN_MSYS2_ROOT=C:\msys64
+WIN_OTP_PATH=C:\Program Files\erl
+
 ```
 
 You can execute the script directly in a `cmd` window.
@@ -55,8 +60,8 @@ script `scripts/windows/msys2_shell.bat` to do so.
 That script uses the following environment variables:
 
 ```
-WIN_MSYS2_ROOT=C:\msys64
 PLATFORM=x64
+WIN_MSYS2_ROOT=C:\msys64
 ```
 
 In the opened shell go into your build directory and build the system like on

--- a/py/Makefile
+++ b/py/Makefile
@@ -6,6 +6,7 @@ PIP ?= $(BIN)/pip
 VIRTUALENV ?= virtualenv
 VIRTUALENV_PYTHON ?= python2.7
 UNAME_S = $(shell uname -s)
+BLOCKS ?= 25
 
 .PHONY: venv-present
 venv-present:
@@ -33,7 +34,7 @@ single-uat:
 
 .PHONY: release-test
 release-test:
-	@$(PYTHON) $(PYTHON_TESTS)/release.py --workdir="$(WORKDIR)" --package=$(PACKAGE) --blocks=100 --version=$(VER)
+	@$(PYTHON) $(PYTHON_TESTS)/release.py --workdir="$(WORKDIR)" --package=$(PACKAGE) --blocks=$(BLOCKS) --version=$(VER)
 
 .PHONY: package-win32-test
 package-win32-test:

--- a/py/Makefile
+++ b/py/Makefile
@@ -1,13 +1,15 @@
 BIN = $(abspath bin)
 NOSE = $(BIN)/nosetests
-PYTHON = $(BIN)/python
+PYTHON ?= $(BIN)/python
 PYTHON_TESTS = $(abspath tests)
 PIP = $(BIN)/pip
+VIRTUALENV ?= virtualenv
+VIRTUALENV_PYTHON ?= python2.7
 
 
 .PHONY: venv-present
 venv-present:
-	@virtualenv --python=python2.7 -q .
+	@$(VIRTUALENV) --python=$(VIRTUALENV_PYTHON) -q .
 
 .PHONY: env
 env: venv-present
@@ -23,7 +25,7 @@ single-uat:
 
 .PHONY: release-test
 release-test:
-	@$(PYTHON) $(PYTHON_TESTS)/release.py --workdir="$(WORKDIR)" --tarball=$(TARBALL) --blocks=100 --version=$(VER)
+	@$(PYTHON) $(PYTHON_TESTS)/release.py --workdir="$(WORKDIR)" --package=$(PACKAGE) --blocks=100 --version=$(VER)
 
 .PHONY: package-win32-test
 package-win32-test:

--- a/py/Makefile
+++ b/py/Makefile
@@ -2,18 +2,26 @@ BIN = $(abspath bin)
 NOSE = $(BIN)/nosetests
 PYTHON ?= $(BIN)/python
 PYTHON_TESTS = $(abspath tests)
-PIP = $(BIN)/pip
+PIP ?= $(BIN)/pip
 VIRTUALENV ?= virtualenv
 VIRTUALENV_PYTHON ?= python2.7
-
+UNAME_S = $(shell uname -s)
 
 .PHONY: venv-present
 venv-present:
+ifeq ($(filter MINGW%,$(UNAME_S)),)
 	@$(VIRTUALENV) --python=$(VIRTUALENV_PYTHON) -q .
+else
+	@echo "No virtualenv will be set up because it is not used on win32/msys2."
+endif
 
 .PHONY: env
 env: venv-present
+ifeq ($(filter MINGW%,$(UNAME_S)),)
 	@. bin/activate && $(PIP) -q install -r requirements.txt
+else
+	@$(PIP) -q install -r requirements-win32.txt
+endif
 
 .PHONY: uats
 uats:

--- a/py/requirements-win32.txt
+++ b/py/requirements-win32.txt
@@ -1,0 +1,8 @@
+##
+## This is a subset of the dependencies defined in py/requirements.txt. These dependencies can't be installed via the OS
+## package manager.
+##
+msgpack==0.6.1
+pystache==0.5.4
+urllib3==1.24.1
+waiting==1.4.1

--- a/py/requirements-win32.txt
+++ b/py/requirements-win32.txt
@@ -2,7 +2,5 @@
 ## This is a subset of the dependencies defined in py/requirements.txt. These dependencies can't be installed via the OS
 ## package manager.
 ##
-msgpack==0.6.1
 pystache==0.5.4
-urllib3==1.24.1
 waiting==1.4.1

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,3 +1,10 @@
+##
+## When updating these dependencies you must ensure that the relevant entries in the following files are kept up-to-date.
+## as well. This is required due to the more complicated python setup on Windows/msys2. Look for the tag WINDOWS_PYTHON.
+##
+## - scripts/windows/msys2_prepare.py
+## - py/requirements-win32.txt
+##
 base58==0.2.5
 certifi==2017.7.27.1
 cffi==1.11.5

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -1,11 +1,14 @@
+import argparse
+import functools
+import logging
 import os
+import pystache
+import shutil
+import signal
+import subprocess
 import sys
 import time
-import argparse
 import urllib3
-import shutil
-import pystache
-import logging
 from waiting import wait
 
 from swagger_client.rest import ApiException
@@ -15,13 +18,14 @@ from swagger_client.configuration import Configuration
 
 # these are executed for every node
 NODE_SETUP_COMMANDS = [
-        "sed -ibkp 's/-sname aeternity/-sname {{ name }}/g' ./releases/{{ version }}/vm.args"
+        "sed -ibkp 's/-sname aeternity/-sname {{ name }}/g' {{ package_basepath }}/releases/{{ version }}/vm.args"
         ]
 # node's setup
 SETUP = {
         "node1": {
             "host": "localhost:9813/v2",
-            "name": "epoch1",
+            "listen_address": "0.0.0.0:9813",
+            "name": "aeternity1",
             "user_config": '''
 ---
 keys:
@@ -62,17 +66,14 @@ chain:
 fork_management:
     network_id: ae_smoke_test
 ''',
-            "config": '''[
-{aecore,
- [
-  {expected_mine_rate, 100}
- ]}
-].
-'''
+            "config": [
+                "-aecore expected_mine_rate 100"
+                ]
                 },
         "node2": {
             "host": "localhost:9823/v2",
-            "name": "epoch2",
+            "listen_address": "0.0.0.0:9823",
+            "name": "aeternity2",
             "user_config": '''
 ---
 keys:
@@ -111,17 +112,14 @@ chain:
 fork_management:
     network_id: ae_smoke_test
 ''',
-            "config": '''[
-{aecore,
- [
-  {expected_mine_rate, 100}
- ]}
-].
-'''
+            "config": [
+                "-aecore expected_mine_rate 100"
+                ]
                 },
         "node3": {
             "host": "localhost:9833/v2",
-            "name": "epoch3",
+            "listen_address": "0.0.0.0:9833",
+            "name": "aeternity3",
             "user_config": '''
 ---
 keys:
@@ -160,13 +158,9 @@ chain:
 fork_management:
     network_id: ae_smoke_test
 ''',
-            "config": '''[
-{aecore,
- [
-  {expected_mine_rate, 100}
- ]}
-].
-'''
+            "config": [
+                "-aecore expected_mine_rate 100"
+                ]
                 }
         }
 
@@ -180,33 +174,77 @@ def node_is_online(api):
 def wait_all_nodes_are_online(apis, timeout_seconds):
     wait(lambda: all([node_is_online(api) for api in apis]), timeout_seconds, sleep_seconds=1)
 
+def wait_all_nodes_are_offline(apis, timeout_seconds):
+    wait(lambda: not any([node_is_online(api) for api in apis]), timeout_seconds, sleep_seconds=1)
+
 def executable(temp_dir):
-    return os.path.join(temp_dir, "bin", "epoch")
+    filename = os.path.join(temp_dir, package_basepath(), "bin", "aeternity")
+    if sys.platform == "win32":
+        return filename + ".cmd"
+    return filename
+
+def extract_package(package_name, temp_dir):
+    ext = os.path.splitext(package_name)[1]
+    if ext == ".zip":
+        extract_ziparchive(package_name, temp_dir)
+    elif ext == ".gz":
+        extract_tarball(package_name, temp_dir)
+    else:
+        sys.exit("ERROR: Unsupported package file format " + ext)
 
 def extract_tarball(tarball_name, temp_dir):
     print("Extracting tar to " + temp_dir)
-    os.system("tar xC " + temp_dir + " -f " + tarball_name)
+    subprocess.call("tar -xC " + temp_dir + " -f " + tarball_name, shell=True)
 
-def stop_node(temp_dir):
-    print("Stopping " + temp_dir)
-    os.system(executable(temp_dir) + " stop")
+def extract_ziparchive(zip_name, temp_dir):
+    print("Extracting zip to " + temp_dir)
+    subprocess.call("unzip -q " + zip_name + " -d " + temp_dir, shell=True)
 
-def start_node(temp_dir):
+def find_pid(line, listen_address, acc):
+    parts = [p for p in line.split(' ') if not p == '']
+    if not len(parts) == 5:
+        return acc
+    if not parts[1] == listen_address:
+        return acc
+    return parts[4]
+
+def stop_node(node, temp_dir):
     binary = executable(temp_dir)
-    assert os.path.isfile(binary)
-    assert os.access(binary, os.X_OK)
+    assert os.path.isfile(binary), "Not a file: " + binary
+    assert os.access(binary, os.X_OK), "Can't access file: " + binary
+    print("Stopping " + binary)
+    os.chdir(temp_dir)
+    if sys.platform == "win32":
+        # We need to find the PID listening on the right port
+        listen_address = SETUP[node]["listen_address"]
+        result_lines = subprocess.check_output("netstat -ano -p TCP").decode("utf-8").split("\r\n")
+        pid = functools.reduce(lambda acc, r: find_pid(r, listen_address, acc), result_lines, "")
+        os.kill(int(pid), signal.SIGTERM)
+    else:
+        return subprocess.call(binary + " stop", shell=True)
+
+def start_node(node, temp_dir):
+    binary = executable(temp_dir)
+    assert os.path.isfile(binary), "Not a file: " + binary
+    assert os.access(binary, os.X_OK), "Can't access file: " + binary
     print("Starting " + binary)
     os.chdir(temp_dir)
-    os.system('ERL_FLAGS="-config `pwd`/p.config" bin/aeternity start')
+    erl_flags = " ".join(SETUP[node]["config"])
+    if sys.platform == "win32":
+        sub_env = os.environ
+        sub_env["ERL_FLAGS"] = erl_flags
+        subprocess.Popen([binary, "console"], env=sub_env)
+    else:
+        subprocess.call('ERL_FLAGS="' + erl_flags + '" ' + binary + ' start', shell=True)
 
 def eval_on_node(temp_dir, quoted_code):
     binary = executable(temp_dir)
-    assert os.path.isfile(binary)
-    assert os.access(binary, os.X_OK)
+    assert os.path.isfile(binary), "Not a file: " + binary
+    assert os.access(binary, os.X_OK), "Can't access file: " + binary
     cmd = binary + " eval " + quoted_code
     print("Evaluating " + cmd)
     os.chdir(temp_dir)
-    return os.system(cmd)
+    return subprocess.call(cmd, shell=True)
 
 def existing_empty_dir(s):
     if s == "":
@@ -231,16 +269,16 @@ def read_argv(argv):
                         help='Working directory for testing. It must exist and be empty.')
     parser.add_argument('--blocks', type=int, default=10,
                         help='Number of blocks to mine')
-    parser.add_argument('--tarball', required=True,
-                        help='Release package tarball')
+    parser.add_argument('--package', required=True,
+                        help='Release package archive (.tar.gz for linux and macos, .zip for win32)')
 
     parser.add_argument('--version', required=True,
                         help='Release package version')
 
     args = parser.parse_args()
-    tar_file_name = args.tarball
+    package_file_name = args.package
     blocks = args.blocks
-    return (args.workdir, tar_file_name, blocks, args.version)
+    return (args.workdir, package_file_name, blocks, args.version)
 
 def tail_logs(temp_dir, log_name):
     n = 200 # last 200 lines
@@ -259,18 +297,21 @@ def setup_node(node, path, test_dir, version):
     shutil.copy(os.path.join(test_dir, "tests", "peer_keys", node, "peer_key.pub"), "keys")
 
     for command in NODE_SETUP_COMMANDS:
-        os.system(pystache.render(command, {"version": version, \
-                                            "name": SETUP[node]["name"]}))
+        subprocess.call(pystache.render(command, {"version": version, \
+                                                  "package_basepath": package_basepath(), \
+                                                  "name": SETUP[node]["name"]}), shell=True)
     ucfg = open(os.path.join(path, "aeternity.yaml"), "w")
     ucfg.write(SETUP[node]["user_config"])
     ucfg.close()
-    cfg = open(os.path.join(path, "p.config"), "w")
-    cfg.write(SETUP[node]["config"])
-    cfg.close()
+
+def package_basepath():
+    if sys.platform == "win32":
+        return os.path.join("usr", "lib", "aeternity")
+    return "."
 
 def main(argv):
     logging.getLogger("urllib3").setLevel(logging.ERROR)
-    root_dir, tar_file_name, blocks_to_mine, version = read_argv(argv)
+    root_dir, package_file_name, blocks_to_mine, version = read_argv(argv)
     curr_dir = os.getcwd()
     temp_dir_dev1 = os.path.join(root_dir, "node1")
     os.makedirs(temp_dir_dev1)
@@ -279,16 +320,15 @@ def main(argv):
     temp_dir_dev3 = os.path.join(root_dir, "node3")
 
 
-    print("Tar name: " + tar_file_name)
-    extract_tarball(tar_file_name, temp_dir_dev1)
+    print("Package name: " + package_file_name)
+    extract_package(package_file_name, temp_dir_dev1)
     shutil.copytree(temp_dir_dev1, temp_dir_dev2)
     shutil.copytree(temp_dir_dev1, temp_dir_dev3)
 
     node_names = ["node1", "node2", "node3"]
     node_dirs = [temp_dir_dev1, temp_dir_dev2, temp_dir_dev3]
     [setup_node(n, d, curr_dir, version) for n, d in zip(node_names, node_dirs)]
-    [start_node(d) for d in node_dirs]
-
+    [start_node(n, d) for n, d in zip(node_names, node_dirs)]
 
     empty_config = Configuration()
     node_objs = []
@@ -317,13 +357,15 @@ def main(argv):
     except urllib3.exceptions.MaxRetryError as e:
         test_failed = True
         print("node died")
-    [stop_node(d) for d in node_dirs]
+    [stop_node(n, d) for n, d in zip(node_names, node_dirs)]
+    wait_all_nodes_are_offline(node_objs, 10)
 
     if not test_failed:
         print("Checking that nodes are able to start with persisted non-empty DB")
-        [start_node(d) for d in node_dirs]
+        [start_node(n, d) for n, d in zip(node_names, node_dirs)]
         wait_all_nodes_are_online(node_objs, 60)
-        [stop_node(d) for d in node_dirs]
+        [stop_node(n, d) for n, d in zip(node_names, node_dirs)]
+        wait_all_nodes_are_offline(node_objs, 10)
 
     if test_failed:
         for name, node_dir in zip(node_names, node_dirs):

--- a/scripts/windows/msys2_env_build.sh
+++ b/scripts/windows/msys2_env_build.sh
@@ -48,6 +48,7 @@ WIN_PRG_FLS64="${WIN_C_DRV}\\Program Files"
 WIN_PRG_FLS32="${WIN_C_DRV}\\Program Files (x86)"
 ERL_TOP="${PRG_FLS64}/erl${ERTS_VERSION}"
 WIN_ERL_TOP="${WIN_PRG_FLS64}\\erl${ERTS_VERSION}"
+JAVA_TOP="${JAVA_TOP:-${PRG_FLS64}/Java/jdk${JAVA_VERSION}}"
 
 VISUAL_STUDIO_ROOT=${PRG_FLS32}/Microsoft\ Visual\ Studio/2017/Community
 WIN_VISUAL_STUDIO_ROOT="${WIN_PRG_FLS32}\\Microsoft Visual Studio\\2017\\Community"
@@ -58,7 +59,8 @@ WIN_MSVC_ROOT=${WIN_VISUAL_STUDIO_ROOT}\\VC\\Tools\\MSVC\\${MSVC_VERSION}
 WIN_MSVC=${WIN_MSVC_ROOT}/bin\\Hostx64\\x64
 
 PATH="/usr/local/bin:/usr/bin:/bin:/c/Windows/system32:/c/Windows:/c/Windows/System32/Wbem:${PATH}"
-PATH="${MSVC}:${ERL_TOP}/bin:${PATH}:${ERL_TOP}/erts-${ERTS_VERSION}/bin:${MSYS2_ROOT}/mingw64/bin"
+PATH="${HOME}/.local/bin:${MSVC}:${ERL_TOP}/bin:${PATH}:${ERL_TOP}/erts-${ERTS_VERSION}/bin:${MSYS2_ROOT}/mingw64/bin"
+PATH="${JAVA_TOP}/bin:${PATH}"
 
 INCLUDE="${INCLUDE};${WIN_MSYS2_ROOT}\\mingw64\\include;${WIN_MSYS2_ROOT}\\usr\\include"
 LIB="${LIB};${WIN_MSYS2_ROOT}\\mingw64\\lib;${WIN_MSYS2_ROOT}\\mingw64\\bin;${WIN_ERL_TOP}\\usr\\lib;"

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -36,6 +36,7 @@ cmake ^
 curl ^
 gcc ^
 git ^
+libcurl ^
 libopenssl ^
 make ^
 mingw-w64-x86_64-SDL ^

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -36,6 +36,7 @@ cmake ^
 curl ^
 gcc ^
 git ^
+libopenssl ^
 make ^
 mingw-w64-i686-binutils ^
 mingw-w64-i686-gcc ^

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -93,6 +93,10 @@ rem Remove breaking tools
 %BASH_BIN% -lc "%PACMAN_RM% %PACMAN_PACKAGES_REMOVE% || true"
 
 @echo Current time: %time%
+rem Install required tools
+%BASH_BIN% -lc "%PACMAN% %PACMAN_PACKAGES% %PACMAN_PYTHON_PACKAGES%"
+
+@echo Current time: %time%
 rem Ensure Erlang/OTP %OTP_VERSION% is installed
 
 IF EXIST "%WIN_OTP_PATH%%ERTS_VERSION%\bin\" GOTO OTPINSTALLED

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -28,7 +28,6 @@ IF "%WIN_OTP_PATH%"=="" SET "WIN_OTP_PATH=C:\Program Files\erl"
 SET "BASH_BIN=%WIN_MSYS2_ROOT%\usr\bin\bash"
 SET "PACMAN=pacman --noconfirm --needed -S"
 SET "PACMAN_RM=pacman --noconfirm -Rsc"
-SET "PIP=/mingw64/bin/pip3 install"
 SET "WIN_STYRENE_PATH=%TMP%\styrene"
 
 SET PACMAN_PACKAGES=base-devel ^
@@ -92,11 +91,6 @@ rem Upgrade the MSYS2 platform
 rem Remove breaking tools
 
 %BASH_BIN% -lc "%PACMAN_RM% %PACMAN_PACKAGES_REMOVE% || true"
-
-@echo Current time: %time%
-rem Install additional python packages
-
-%BASH_BIN% -lc "%PIP% -r py/requirements-win32.txt"
 
 @echo Current time: %time%
 rem Ensure Erlang/OTP %OTP_VERSION% is installed

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -98,7 +98,7 @@ rem Ensure Erlang/OTP %OTP_VERSION% is installed
 IF EXIST "%WIN_OTP_PATH%%ERTS_VERSION%\bin\" GOTO OTPINSTALLED
 SET "OTP_PACKAGE=otp_win64_%OTP_VERSION%.exe"
 SET "OTP_URL=http://erlang.org/download/%OTP_PACKAGE%"
-PowerShell -Command "(New-Object System.Net.WebClient).DownloadFile(\"%OTP_URL%\", \"%TMP\%OTP_PACKAGE%\")"
+PowerShell -Command "(New-Object System.Net.WebClient).DownloadFile(\"%OTP_URL%\", \"%TMP%\%OTP_PACKAGE%\")"
 START "" /WAIT "%TMP%\%OTP_PACKAGE%" /S
 :OTPINSTALLED
 

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -76,13 +76,6 @@ rem Set up msys2 env variables
 COPY %~dp0\msys2_env_build.sh %WIN_MSYS2_ROOT%\etc\profile.d\env_build.sh
 
 @echo Current time: %time%
-rem Upgrade the MSYS2 platform
-
-%BASH_BIN% -lc "%PACMAN% -y pacman"
-@echo Current time: %time%
-%BASH_BIN% -lc "%PACMAN% -u"
-
-@echo Current time: %time%
 rem Remove 32-bit tools
 
 %BASH_BIN% -lc "pacman -Qet | grep i686 | awk '{ print $1; }' | xargs %PACMAN_RM% || true"
@@ -92,6 +85,13 @@ rem Remove 32-bit tools
 rem Remove breaking tools
 
 %BASH_BIN% -lc "%PACMAN_RM% %PACMAN_PACKAGES_REMOVE% || true"
+
+@echo Current time: %time%
+rem Upgrade the MSYS2 platform
+
+%BASH_BIN% -lc "%PACMAN% -y pacman"
+@echo Current time: %time%
+%BASH_BIN% -lc "%PACMAN% -u"
 
 @echo Current time: %time%
 rem Install required tools

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -38,9 +38,6 @@ gcc ^
 git ^
 libopenssl ^
 make ^
-mingw-w64-i686-binutils ^
-mingw-w64-i686-gcc ^
-mingw-w64-i686-nsis ^
 mingw-w64-x86_64-SDL ^
 mingw-w64-x86_64-binutils ^
 mingw-w64-x86_64-gcc ^
@@ -53,10 +50,6 @@ unzip ^
 zip
 
 SET PACMAN_PACKAGES_REMOVE=gcc-fortran ^
-mingw-w64-i686-gcc-ada ^
-mingw-w64-i686-gcc-fortran ^
-mingw-w64-i686-gcc-libgfortran ^
-mingw-w64-i686-gcc-objc ^
 mingw-w64-x86_64-gcc-ada ^
 mingw-w64-x86_64-gcc-fortran ^
 mingw-w64-x86_64-gcc-libgfortran ^
@@ -88,6 +81,12 @@ rem Upgrade the MSYS2 platform
 %BASH_BIN% -lc "%PACMAN% -y pacman"
 @echo Current time: %time%
 %BASH_BIN% -lc "%PACMAN% -u"
+
+@echo Current time: %time%
+rem Remove 32-bit tools
+
+%BASH_BIN% -lc "pacman -Qet | grep i686 | awk '{ print $1; }' | xargs %PACMAN_RM% || true"
+%BASH_BIN% -lc "pacman -Qdt | grep i686 | awk '{ print $1; }' | xargs %PACMAN_RM% || true"
 
 @echo Current time: %time%
 rem Remove breaking tools

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -28,6 +28,7 @@ IF "%WIN_OTP_PATH%"=="" SET "WIN_OTP_PATH=C:\Program Files\erl"
 SET "BASH_BIN=%WIN_MSYS2_ROOT%\usr\bin\bash"
 SET "PACMAN=pacman --noconfirm --needed -S"
 SET "PACMAN_RM=pacman --noconfirm -Rsc"
+SET "PIP=/mingw64/bin/pip3"
 SET "WIN_STYRENE_PATH=%TMP%\styrene"
 
 SET PACMAN_PACKAGES=base-devel ^

--- a/scripts/windows/msys2_shell.bat
+++ b/scripts/windows/msys2_shell.bat
@@ -1,14 +1,14 @@
 @echo on
 @rem Script to open a msys2 shell ready for building.
 @rem Required vars:
-@rem    WIN_MSYS2_ROOT
 @rem    PLATFORM
+@rem    WIN_MSYS2_ROOT
 
 SETLOCAL ENABLEEXTENSIONS
 
 rem Set required vars defaults
-IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
+IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
 
 @echo Current time: %time%
 rem Set the paths appropriately


### PR DESCRIPTION
This PR add support for running the python release tests on Windows. Differences to running on Linux/macOS are:

- Use of `.zip` file instead of `.tar.gz`
- Use of Python3 instead of Python2, because a Python2 setup wasn't possible
- Use of OS package manager for some Python dependencies, while the rest is installed via pip outside of any virtualenv.
- Simulating user behaviour on Windows by using node `console` instead of `start`