### PR TITLE
PT165141235: Fix systemd restart on failure issues with aeternity-node (in Ubuntu package)

### DIFF
--- a/debian/aeternity-node.service
+++ b/debian/aeternity-node.service
@@ -4,10 +4,10 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-Type=forking
+Type=simple
 User=aeternity
 Group=aeternity
-ExecStart=/opt/aeternity/node/bin/aeternity start
+ExecStart=/opt/aeternity/node/bin/aeternity foreground &
 ExecStop=/opt/aeternity/node/bin/aeternity stop
 Restart=on-failure
 # Systemd does not play well with user set limits with ulimit.


### PR DESCRIPTION
 Fixes issues with restart on failure for aeternity-node when ran with systemd (from Debian/Ubuntu package).

* Change aeternity-node start command in systemd service file to foreground.
* Change systemd service file type to simple.
* Remote console is loading
* (Sub)Process killing and restarting of service seems to be working
* Logs are duplicated in node log files and syslog. (Requested not to fix on devops stand-up.)

Tested on Ubuntu 18.04 from package. Tested on 16.04 with released binary from GitHub and service file.
