### PR TITLE
PT-162439780: Automatic CI build of Debian/Ubuntu packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ executors:
     docker:
       - image: aeternity/builder
         user: builder
+  builder_container_1804:
+    docker:
+      - image: aeternity/builder:1804
+        user: builder
 
 references:
   container_config: &container_config
@@ -160,6 +164,16 @@ references:
         make prod-package
         mkdir ${PACKAGES_DIR:?}
         mv _build/prod/rel/aeternity/aeternity-$(cat VERSION).tar.gz ${PACKAGE_TARBALL:?}
+
+  build_ubuntu_package: &build_ubuntu_package
+    run:
+      name: Build Ubuntu package (*.deb)
+      environment:
+        PACKAGES_DIR: *packages_workspace
+      command: |
+        make prod-deb-package
+        mkdir ${PACKAGES_DIR:?}
+        mv _build/../../*aeternity-node_$(cat VERSION).*.deb ${PACKAGES_DIR:?}
 
   package_tests_workspace: &package_tests_workspace /tmp/package_tests
   test_package: &test_package
@@ -588,6 +602,29 @@ jobs:
           root: *packages_workspace
           paths:
             - "*.tar.gz"
+      - *fail_notification
+
+  ubuntu_package:
+    executor: builder_container_1804
+    <<: *container_config
+    steps:
+      - run:
+          name: Checkout Ubuntu packaging branch
+          command: git clone https://github.com/aeternity/aeternity.git -b ubuntu_pacakging_162439771 --single-branch
+      - *set_package_path
+      - *build_ubuntu_package
+      - *test_package
+      - store_artifacts:
+          path: /tmp/package_tests/node1/log
+      - store_artifacts:
+          path: /tmp/package_tests/node2/log
+      - store_artifacts:
+          path: /tmp/package_tests/node3/log
+      - *store_package_artifacts
+      - persist_to_workspace:
+          root: *packages_workspace
+          paths:
+            - "*.deb"
       - *fail_notification
 
   upload_build_artifacts:
@@ -1084,6 +1121,11 @@ workflows:
                 - system-tests
             tags:
               only: *tag_regex
+
+      - ubuntu_package:
+          filters:
+            branches:
+              only: ci_deb_package_build_162439780
 
       - upload_build_artifacts:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -610,7 +610,7 @@ jobs:
     steps:
       - run:
           name: Checkout Ubuntu packaging branch
-          command: git clone https://github.com/aeternity/aeternity.git -b ubuntu_pacakging_162439771 --single-branch
+          command: git clone https://github.com/aeternity/aeternity.git -b ubuntu_pacakging_162439771 --single-branch .
       - *build_ubuntu_package
       - *test_package
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ references:
       command: |
         make prod-deb-package
         mkdir ${PACKAGES_DIR:?}
-        mv _build/../../*aeternity-node_$(cat VERSION).*.deb ${PACKAGES_DIR:?}
+        mv _build/../../*aeternity-node_$(cat VERSION)*.deb ${PACKAGES_DIR:?}
 
   package_tests_workspace: &package_tests_workspace /tmp/package_tests
   test_package: &test_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,7 +612,6 @@ jobs:
           name: Checkout Ubuntu packaging branch
           command: git clone https://github.com/aeternity/aeternity.git -b ubuntu_pacakging_162439771 --single-branch .
       - *build_ubuntu_package
-      - *test_package
       - store_artifacts:
           path: /tmp/package_tests/node1/log
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ references:
           make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true ;
         else
           AE_DEB_PKG_VERSION=$(cat VERSION)-1-git-${CIRCLE_BRANCH}~$(date +%Y%m%d%H%M%S)
-          make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true;
+          make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true AE_DEB_PKG_VERSION=$AE_DEB_PKG_VERSION;
         fi
         mkdir ${PACKAGES_DIR:?}
         mv _build/../../*aeternity-node_$(cat VERSION)*.deb ${PACKAGES_DIR:?}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1119,6 +1119,8 @@ workflows:
               only: *tag_regex
 
       - ubuntu_package:
+          requires:
+            - linux_package
           filters:
             branches:
               only: ci_deb_package_build_162439780

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,9 +608,7 @@ jobs:
     executor: builder_container_1804
     <<: *container_config
     steps:
-      - run:
-          name: Checkout Ubuntu packaging branch
-          command: git clone https://github.com/aeternity/aeternity.git -b ubuntu_pacakging_162439771 --single-branch .
+      - checkout
       - *build_ubuntu_package
       - store_artifacts:
           path: /tmp/package_tests/node1/log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,6 @@ jobs:
       - run:
           name: Checkout Ubuntu packaging branch
           command: git clone https://github.com/aeternity/aeternity.git -b ubuntu_pacakging_162439771 --single-branch
-      - *set_package_path
       - *build_ubuntu_package
       - *test_package
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,17 +630,6 @@ jobs:
     steps:
       - checkout
       - *build_ubuntu_package
-      - store_artifacts:
-          path: /tmp/package_tests/node1/log
-      - store_artifacts:
-          path: /tmp/package_tests/node2/log
-      - store_artifacts:
-          path: /tmp/package_tests/node3/log
-      - *store_package_artifacts
-      - persist_to_workspace:
-          root: *packages_workspace
-          paths:
-            - "*.deb"
       - *fail_notification
 
   upload_build_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,8 +170,21 @@ references:
       name: Build Ubuntu package (*.deb)
       environment:
         PACKAGES_DIR: *packages_workspace
+        # The *clean commands are for work-around in CircleCI
+        # Debian/Ubuntu package building (clean issues; fakeroot and
+        # rebar3).
+        #
+        # The debian/rules file has conditional *clean targets based on
+        # DEB_SKIP_DH_AUTO_CLEAN.
+        #
+        # This prevents the presence of broken/dummy debian/rules file without
+        # clean targets. For example when running debuild directly without
+        # `make prod-deb-package`.
       command: |
-        make prod-deb-package
+        make prod-clean
+        make clean
+        make distclean
+        make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true
         mkdir ${PACKAGES_DIR:?}
         mv _build/../../*aeternity-node_$(cat VERSION)*.deb ${PACKAGES_DIR:?}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,6 +607,7 @@ jobs:
   ubuntu_package:
     executor: builder_container_1804
     <<: *container_config
+    working_directory: ~/aeternity_deb
     steps:
       - checkout
       - *build_ubuntu_package
@@ -1119,8 +1120,6 @@ workflows:
               only: *tag_regex
 
       - ubuntu_package:
-          requires:
-            - linux_package
           filters:
             branches:
               only: ci_deb_package_build_162439780

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1141,9 +1141,10 @@ workflows:
       - ubuntu_package:
           filters:
             branches:
-              only: ci_deb_package_build_162439780
+              only:
+                - master
             tags:
-              only: /^iv-dbg-v2\..*$/
+              only: *stable_tag_regex
 
       - upload_build_artifacts:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1142,6 +1142,8 @@ workflows:
           filters:
             branches:
               only: ci_deb_package_build_162439780
+            tags:
+              only: /^iv-dbg-v2\..*$/
 
       - upload_build_artifacts:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,13 @@ references:
         make prod-clean
         make clean
         make distclean
-        make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true
+        if [ "$CIRCLE_TAG" ];
+        then
+          make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true ;
+        else
+          AE_DEB_PKG_VERSION=$(cat VERSION)-1-git-${CIRCLE_BRANCH}~$(date +%Y%m%d%H%M%S)
+          make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true;
+        fi
         mkdir ${PACKAGES_DIR:?}
         mv _build/../../*aeternity-node_$(cat VERSION)*.deb ${PACKAGES_DIR:?}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ references:
         then
           make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true ;
         else
-          AE_DEB_PKG_VERSION=$(cat VERSION)-1-git-${CIRCLE_BRANCH}~$(date +%Y%m%d%H%M%S)
+          AE_DEB_PKG_VERSION=$(cat VERSION)~git$(date +%Y%m%d%H%M%S).${CIRCLE_SHA1:0:8}-1
           make prod-deb-package DEB_SKIP_DH_AUTO_CLEAN=true AE_DEB_PKG_VERSION=$AE_DEB_PKG_VERSION;
         fi
         mkdir ${PACKAGES_DIR:?}

--- a/Makefile
+++ b/Makefile
@@ -40,20 +40,6 @@ AE_DEB_MAINT_EMAIL="info@aeternity.com"
 AE_DEB_MAINT_NAME="Aeternity Team"
 DEB_PKG_CHANGELOG_FILE=debian/changelog
 
-# Work-around CircleCI Debian/Ubuntu package building (clean issues;
-# fakeroot and rebar3).  Define *clean prerequisites for
-# prod-deb-package only when running in CircleCI.
-#
-# The debian/rules file has conditional *clean targets based on
-# CIRCLECI variable as well.
-#
-# This prevents the presence of broken/dummy debian/rules file without
-# clean targets. For example when running debuild directly without
-# `make prod-deb-package`.
-ifdef CIRCLECI
- AE_DEB_PKG_CI_PREREQUISITE = prod-clean clean distclean
-endif
-
 all:	local-build
 
 $(SWAGGER_ENDPOINTS_SPEC):
@@ -438,8 +424,8 @@ $(DEB_PKG_CHANGELOG_FILE):
 	dch --create --package=$(AE_DEB_PKG_NAME) -v $(AE_DEB_PKG_VERSION) $(AE_DEB_DCH_REL_NOTE); \
 	dch -r $(AE_DEB_DCH_REL_NOTE)
 
-prod-deb-package: $(DEB_PKG_CHANGELOG_FILE) $(AE_DEB_PKG_CI_PREREQUISITE)
-	debuild --preserve-envvar CIRCLECI -b -uc -us
+prod-deb-package: $(DEB_PKG_CHANGELOG_FILE)
+	debuild --preserve-envvar DEB_SKIP_DH_AUTO_CLEAN -b -uc -us
 
 .PHONY: \
 	all console \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,19 @@ AE_DEB_MAINT_EMAIL="info@aeternity.com"
 AE_DEB_MAINT_NAME="Aeternity Team"
 DEB_PKG_CHANGELOG_FILE=debian/changelog
 
-
+# Work-around CircleCI Debian/Ubuntu package building (clean issues;
+# fakeroot and rebar3).  Define *clean prerequisites for
+# prod-deb-package only when running in CircleCI.
+#
+# The debian/rules file has conditional *clean targets based on
+# CIRCLECI variable as well.
+#
+# This prevents the presence of broken/dummy debian/rules file without
+# clean targets. For example when running debuild directly without
+# `make prod-deb-package`.
+ifdef CIRCLECI
+ AE_DEB_PKG_CI_PREREQUISITE = prod-clean clean distclean
+endif
 
 all:	local-build
 
@@ -426,8 +438,8 @@ $(DEB_PKG_CHANGELOG_FILE):
 	dch --create --package=$(AE_DEB_PKG_NAME) -v $(AE_DEB_PKG_VERSION) $(AE_DEB_DCH_REL_NOTE); \
 	dch -r $(AE_DEB_DCH_REL_NOTE)
 
-prod-deb-package: $(DEB_PKG_CHANGELOG_FILE) prod-clean clean distclean
-	debuild -b -uc -us
+prod-deb-package: $(DEB_PKG_CHANGELOG_FILE) $(AE_DEB_PKG_CI_PREREQUISITE)
+	debuild --preserve-envvar CIRCLECI -b -uc -us
 
 .PHONY: \
 	all console \

--- a/Makefile
+++ b/Makefile
@@ -426,7 +426,7 @@ $(DEB_PKG_CHANGELOG_FILE):
 	dch --create --package=$(AE_DEB_PKG_NAME) -v $(AE_DEB_PKG_VERSION) $(AE_DEB_DCH_REL_NOTE); \
 	dch -r $(AE_DEB_DCH_REL_NOTE)
 
-prod-deb-package: $(DEB_PKG_CHANGELOG_FILE)
+prod-deb-package: $(DEB_PKG_CHANGELOG_FILE) prod-clean clean distclean
 	debuild -b -uc -us
 
 .PHONY: \

--- a/debian/rules
+++ b/debian/rules
@@ -11,9 +11,9 @@ override_dh_auto_build:
 	$(MAKE) prod-build
 
 override_dh_auto_clean:
-	$(MAKE) prod-clean
-	$(MAKE) clean
-	$(MAKE) distclean
+#	$(MAKE) prod-clean
+#	$(MAKE) clean
+#	$(MAKE) distclean
 
 override_dh_strip:
 	dh_strip --no-automatic-dbgsym

--- a/debian/rules
+++ b/debian/rules
@@ -10,10 +10,19 @@
 override_dh_auto_build:
 	$(MAKE) prod-build
 
+# Work-around CircleCI Debian/Ubuntu package building (clean issues;
+# fakeroot and rebar3).
+#
+# Run *clean targets only when not running in CircleCI.  Main Makefile
+# (prod-deb-package target) runs the clean targets before building (debuild)
+# when run in CircleCI. Prevents the presence of broken/dummy
+# debian/rules.
 override_dh_auto_clean:
-#	$(MAKE) prod-clean
-#	$(MAKE) clean
-#	$(MAKE) distclean
+	if [ -z "$CIRCLECI" ]; then \
+		$(MAKE) prod-clean; \
+		$(MAKE) clean; \
+		$(MAKE) distclean; \
+	fi
 
 override_dh_strip:
 	dh_strip --no-automatic-dbgsym

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ override_dh_auto_build:
 # when run in CircleCI. Prevents the presence of broken/dummy
 # debian/rules.
 override_dh_auto_clean:
-	if [ -z "$CIRCLECI" ]; then \
+	if [ -z "$$CIRCLECI" ]; then \
 		$(MAKE) prod-clean; \
 		$(MAKE) clean; \
 		$(MAKE) distclean; \

--- a/debian/rules
+++ b/debian/rules
@@ -13,12 +13,11 @@ override_dh_auto_build:
 # Work-around CircleCI Debian/Ubuntu package building (clean issues;
 # fakeroot and rebar3).
 #
-# Run *clean targets only when not running in CircleCI.  Main Makefile
-# (prod-deb-package target) runs the clean targets before building (debuild)
-# when run in CircleCI. Prevents the presence of broken/dummy
-# debian/rules.
+# Run *clean targets only when not running in CircleCI.  CircleCI
+# config runs the clean targets before building (debuild). Prevents
+# the presence of broken/dummy debian/rules.
 override_dh_auto_clean:
-	if [ -z "$$CIRCLECI" ]; then \
+	if [ -z "$$DEB_SKIP_DH_AUTO_CLEAN" ]; then \
 		$(MAKE) prod-clean; \
 		$(MAKE) clean; \
 		$(MAKE) distclean; \


### PR DESCRIPTION
Adds CircleCI configuration for building Ubuntu/Debian packages on tag/release and master.
Ubuntu/Debian (*.deb) package build passes (https://circleci.com/gh/aeternity/aeternity/24377).
Package is not uploaded anywhere yet - it will be part of separate ticket.