### PR TITLE
Lower the price of GAMetaTx and cripple the functionality

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -97,7 +97,7 @@ tx_base_gas(channel_settle_tx) -> ?TX_BASE_GAS;
 tx_base_gas(channel_snapshot_solo_tx) -> ?TX_BASE_GAS;
 tx_base_gas(channel_withdraw_tx) -> ?TX_BASE_GAS;
 tx_base_gas(ga_attach_tx) -> 5 * ?TX_BASE_GAS;
-tx_base_gas(ga_meta_tx) -> 30 * ?TX_BASE_GAS;
+tx_base_gas(ga_meta_tx) -> 5 * ?TX_BASE_GAS;
 tx_base_gas(name_preclaim_tx) -> ?TX_BASE_GAS;
 tx_base_gas(name_revoke_tx) -> ?TX_BASE_GAS;
 tx_base_gas(name_transfer_tx) -> ?TX_BASE_GAS;

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -55,6 +55,7 @@ call_(Gas, Value, Data, StateIn) ->
     try
         PrimOp = get_primop(Data),
         BaseGas = aec_governance:primop_base_gas(PrimOp),
+        InAuth  = undefined /= aevm_eeevm_state:auth_tx_hash(StateIn),
         case BaseGas =< Gas of
             false ->
                 {error, ?AEVM_PRIMOP_ERR_REASON_OOG({base, PrimOp}, BaseGas, StateIn)};
@@ -65,6 +66,8 @@ call_(Gas, Value, Data, StateIn) ->
                 crypto_call(Gas, PrimOp, Value, Data, StateIn);
             true when ?PRIM_CALL_IN_AUTH_RANGE(PrimOp) ->
                 auth_call(Gas, PrimOp, Value, Data, StateIn);
+            true when InAuth ->
+                {error, ?AEVM_PRIMOP_ERR_REASON_OOG({base, PrimOp}, BaseGas, StateIn)};
             true ->
                 ChainIn = #chain{api = aevm_eeevm_state:chain_api(StateIn),
                                  state = aevm_eeevm_state:chain_state(StateIn),

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -425,6 +425,7 @@ get_contract_call_input(Target, IOffset, ISize, State) ->
                             aevm_eeevm:eval_error(out_of_gas)
                     end
                 end,
+            InAuth  = undefined /= aevm_eeevm_state:auth_tx_hash(State),
             case Target == ?PRIM_CALLS_CONTRACT of
                 true ->
                     %% The first argument is the primop id, throw out_of_gas otherwise
@@ -443,6 +444,8 @@ get_contract_call_input(Target, IOffset, ISize, State) ->
                         error ->
                             aevm_eeevm:eval_error(out_of_gas)
                     end;
+                false when InAuth ->
+                    aevm_eeevm:eval_error(out_of_gas);
                 false ->
                     %% The first element in the arg tuple is the function hash,
                     %% throw out_of_gas otherwise

--- a/test/contracts/simple_auth.aes
+++ b/test/contracts/simple_auth.aes
@@ -1,7 +1,27 @@
+contract Remote =
+  function main : (int) => int
+
 contract Auth1 =
   record state = { secret : int }
+
+  datatype auth_test = Spend(address, int)
+                     | OracleReg
+                     | RemoteCall(Remote)
 
   function init(s : int) = { secret = s }
 
   function authorize(s : int, x : int) : bool =
     state.secret == s
+
+  function do_auth_test(at : auth_test) : bool =
+    switch(at)
+      Spend(to, tokens) =>
+        Chain.spend(to, tokens)
+      OracleReg         =>
+        Oracle.register(Contract.address, 12345, RelativeTTL(1000))
+        ()
+      RemoteCall(r)     =>
+        r.main(42)
+        ()
+    true
+


### PR DESCRIPTION
We want to offer not-too-pricey use cases for generalized accounts. But
unless we cripple what the authentication function can do it is in principle a
contract call and must be priced accordingly. Here we disallow remote calls,
spend, oracle primops and name primops.