### PR TITLE
Introduce pinned env in noise protocol

### DIFF
--- a/apps/aechannel/src/aesc_codec.erl
+++ b/apps/aechannel/src/aesc_codec.erl
@@ -233,43 +233,53 @@ dec_ch_reest_ack(<< ChainHash:32/binary
 
 
 -type fnd_created_msg() :: #{ temporary_channel_id := chan_id()
+                            , block_hash           := binary()
                             , data                 := binary()}.
 
 -spec enc_fnd_created(fnd_created_msg()) -> binary().
 enc_fnd_created(#{ temporary_channel_id := ChanId
+                 , block_hash           := BlockHash
                  , data                 := Data }) ->
     Length = byte_size(Data),
     << ?ID_FND_CREATED:1 /unit:8
      , ChanId         :32/binary
+     , BlockHash      :32/binary
      , Length         :2 /unit:8
      , Data           :Length/bytes >>.
 
 -spec dec_fnd_created(binary()) -> fnd_created_msg().
 dec_fnd_created(<< ChanId:32/binary
+                 , BlockHash:32/binary
                  , Length:2/unit:8
                  , Data/binary >>) ->
     Length = byte_size(Data),
     #{ temporary_channel_id => ChanId
+     , block_hash           => BlockHash
      , data                 => Data}.
 
 -type fnd_signed_msg() :: #{ temporary_channel_id := chan_id()
+                           , block_hash           := binary()
                            , data                 := binary()}.
 
 -spec enc_fnd_signed(fnd_signed_msg()) -> binary().
 enc_fnd_signed(#{temporary_channel_id := ChanId,
+                 block_hash           := BlockHash,
                  data                 := Data}) ->
     Length = byte_size(Data),
     << ?ID_FND_SIGNED:1 /unit:8
      , ChanId        :32/binary
+     , BlockHash     :32/binary
      , Length        :2 /unit:8
      , Data          :Length/bytes >>.
 
 -spec dec_fnd_signed(binary()) -> fnd_signed_msg().
 dec_fnd_signed(<< ChanId:32/binary
+                , BlockHash:32/binary
                 , Length:2/unit:8
                 , Data/binary >>) ->
     Length = byte_size(Data),
     #{ temporary_channel_id => ChanId
+     , block_hash           => BlockHash
      , data                 => Data}.
 
 -type fnd_locked_msg() :: #{ temporary_channel_id := chan_id()
@@ -289,22 +299,27 @@ dec_fnd_locked(<< ChanId:32/binary
      , channel_id           => OnChainId }.
 
 -type update_msg() :: #{ channel_id := chan_id()
+                       , block_hash := binary()
                        , data       := binary()}.
 -spec enc_update(update_msg()) -> binary().
 enc_update(#{ channel_id := ChanId
+            , block_hash := BlockHash
             , data   := Data }) ->
     Length = byte_size(Data),
     << ?ID_UPDATE:1 /unit:8
      , ChanId    :32/binary
+     , BlockHash :32/binary
      , Length    :2 /unit:8
      , Data      :Length/bytes >>.
 
 -spec dec_update(binary()) -> update_msg().
 dec_update(<< ChanId:32/binary
+            , BlockHash :32/binary
             , Length:2 /unit:8
             , Data/bytes >>) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
+     , block_hash => BlockHash
      , data   => Data }.
 
 -type update_ack_msg() :: #{ channel_id := chan_id()
@@ -348,43 +363,54 @@ dec_update_err(<< ChanId :32/binary
      , error_code => ErrCode }.
 
 -type deposit_msg() :: #{ channel_id := chan_id()
+                        , block_hash := binary()
                         , data       := binary()}.
 
 -spec enc_dep_created(deposit_msg()) -> binary().
 enc_dep_created(#{ channel_id := ChanId
+                 , block_hash := BlockHash
                  , data       := Data }) ->
     Length = byte_size(Data),
     << ?ID_DEP_CREATED:1 /unit:8
      , ChanId         :32/binary
+     , BlockHash      :32/binary
      , Length         :2 /unit:8
      , Data/bytes >>.
 
 -spec dec_dep_created(binary()) -> deposit_msg().
 dec_dep_created(<< ChanId:32/binary
+                 , BlockHash:32/binary
                  , Length:2 /unit:8
                  , Data/bytes >>) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
+     , block_hash => BlockHash
      , data       => Data }.
 
 -spec enc_dep_signed(deposit_msg()) -> binary().
 enc_dep_signed(#{ channel_id := ChanId
+                , block_hash := BlockHash
                 , data       := Data }) ->
     Length = byte_size(Data),
     << ?ID_DEP_SIGNED:1 /unit:8
      , ChanId        :32/binary
+     , BlockHash     :32/binary
      , Length        :2 /unit:8
      , Data/bytes >>.
 
 -spec dec_dep_signed(binary()) -> deposit_msg().
 dec_dep_signed(<< ChanId:32/binary
+                , BlockHash:32/binary
                 , Length:2 /unit:8
                 , Data/bytes >>) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
+     , block_hash => BlockHash
      , data       => Data }.
 
--spec enc_dep_locked(deposit_msg()) -> binary().
+-type dep_locked_msg() :: #{ channel_id := chan_id()
+                           , data       := binary()}.
+-spec enc_dep_locked(dep_locked_msg()) -> binary().
 enc_dep_locked(#{ channel_id := ChanId
                 , data       := Data }) ->
     Length = byte_size(Data),
@@ -393,7 +419,7 @@ enc_dep_locked(#{ channel_id := ChanId
      , Length        :2 /unit:8
      , Data/bytes >>.
 
--spec dec_dep_locked(binary()) -> deposit_msg().
+-spec dec_dep_locked(binary()) -> dep_locked_msg().
 dec_dep_locked(<< ChanId:32/binary
                 , Length:2 /unit:8
                 , Data/bytes >>) ->
@@ -423,43 +449,54 @@ dec_dep_err(<< ChanId :32/binary
      , error_code => ErrCode }.
 
 -type withdrawal_msg() :: #{ channel_id := chan_id()
+                           , block_hash := binary()
                            , data       := binary()}.
 
 -spec enc_wdraw_created(withdrawal_msg()) -> binary().
 enc_wdraw_created(#{ channel_id := ChanId
+                   , block_hash := BlockHash
                    , data       := Data }) ->
     Length = byte_size(Data),
     << ?ID_WDRAW_CREATED:1 /unit:8
      , ChanId           :32/binary
+     , BlockHash        :32/binary
      , Length           :2 /unit:8
      , Data/bytes >>.
 
 -spec dec_wdraw_created(binary()) -> withdrawal_msg().
 dec_wdraw_created(<< ChanId:32/binary
+                   , BlockHash:32/binary
                    , Length:2 /unit:8
                    , Data/bytes >>) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
+     , block_hash => BlockHash
      , data       => Data }.
 
 -spec enc_wdraw_signed(withdrawal_msg()) -> binary().
 enc_wdraw_signed(#{ channel_id := ChanId
+                  , block_hash := BlockHash
                   , data       := Data }) ->
     Length = byte_size(Data),
     << ?ID_WDRAW_SIGNED:1 /unit:8
      , ChanId          :32/binary
+     , BlockHash       :32/binary
      , Length          :2 /unit:8
      , Data/bytes >>.
 
 -spec dec_wdraw_signed(binary()) -> withdrawal_msg().
 dec_wdraw_signed(<< ChanId:32/binary
-                   , Length:2 /unit:8
-                   , Data/bytes >>) ->
+                  , BlockHash:32/binary
+                  , Length:2 /unit:8
+                  , Data/bytes >>) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
+     , block_hash => BlockHash
      , data       => Data }.
 
--spec enc_wdraw_locked(withdrawal_msg()) -> binary().
+-type wdraw_locked_msg() :: #{ channel_id := chan_id()
+                             , data       := binary()}.
+-spec enc_wdraw_locked(wdraw_locked_msg()) -> binary().
 enc_wdraw_locked(#{ channel_id := ChanId
                   , data       := Data }) ->
     Length = byte_size(Data),
@@ -468,7 +505,7 @@ enc_wdraw_locked(#{ channel_id := ChanId
      , Length          :2 /unit:8
      , Data/bytes >>.
 
--spec dec_wdraw_locked(binary()) -> withdrawal_msg().
+-spec dec_wdraw_locked(binary()) -> wdraw_locked_msg().
 dec_wdraw_locked(<< ChanId:32/binary
                   , Length:2 /unit:8
                   , Data/bytes >>) ->
@@ -540,43 +577,53 @@ dec_leave_ack(<< ChanId:32/binary >>) ->
     #{ channel_id => ChanId }.
 
 -type shutdown_msg() :: #{channel_id := chan_id(),
+                          block_hash := binary(),
                           data       := binary() }.
 
 -spec enc_shutdown(shutdown_msg()) -> binary().
 enc_shutdown(#{channel_id := ChanId,
+               block_hash := BlockHash,
                data       := Data }) ->
     Length = byte_size(Data),
     << ?ID_SHUTDOWN:1 /unit:8
      , ChanId      :32/binary
+     , BlockHash   :32/binary
      , Length      :2 /unit:8
      , Data        :Length/bytes >>.
 
 -spec dec_shutdown(binary()) -> shutdown_msg().
 dec_shutdown(<< ChanId:32/binary
+              , BlockHash:32/binary
               , Length:2 /unit:8
               , Data/bytes >>) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
+     , block_hash => BlockHash
      , data       => Data }.
 
 -type shutdown_ack_msg() :: #{channel_id := chan_id(),
+                              block_hash := binary(),
                               data       := binary() }.
 
 -spec enc_shutdown_ack(shutdown_ack_msg()) -> binary().
 enc_shutdown_ack(#{channel_id := ChanId,
+                   block_hash := BlockHash,
                    data       := Data }) ->
     Length = byte_size(Data),
     << ?ID_SHUTDOWN_ACK:1 /unit:8
      , ChanId          :32/binary
+     , BlockHash       :32/binary
      , Length          :2 /unit:8
      , Data            :Length/bytes >>.
 
 -spec dec_shutdown_ack(binary()) -> shutdown_ack_msg().
 dec_shutdown_ack(<< ChanId:32/binary
+                  , BlockHash:32/binary
                   , Length:2 /unit:8
                   , Data/bytes >>) ->
     Length = byte_size(Data),
     #{ channel_id => ChanId
+     , block_hash => BlockHash
      , data       => Data }.
 
 -type inband_msg() :: #{channel_id := chan_id(),

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -83,6 +83,8 @@
 -type sign_tag() :: create_tx
                   | funding_created.
 
+-define(DUMMY_BLOCK_HASH, <<12345:32/unit:8>>).
+
 -define(MINIMUM_DEPTH, 4). % number of blocks until an opening tx
                            % should be considered final
 
@@ -2002,11 +2004,13 @@ send_funding_created_msg(SignedTx, #data{channel_id = Ch,
                                          session    = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ temporary_channel_id => Ch
-           ,  data                => TxBin},
+           , block_hash           => ?DUMMY_BLOCK_HASH
+           , data                 => TxBin},
     aesc_session_noise:funding_created(Sn, Msg),
     log(snd, ?FND_CREATED, Msg, Data).
 
 check_funding_created_msg(#{ temporary_channel_id := ChanId
+                           , block_hash           := ?DUMMY_BLOCK_HASH
                            , data                 := TxBin } = Msg,
                           #data{ state = State, opts = Opts, 
                                  channel_id = ChanId } = Data) ->
@@ -2023,16 +2027,17 @@ check_funding_created_msg(#{ temporary_channel_id := ChanId
             Err
     end.
 
-
 send_funding_signed_msg(SignedTx, #data{channel_id = Ch,
                                         session    = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ temporary_channel_id  => Ch
+           , block_hash            => ?DUMMY_BLOCK_HASH
            , data                  => TxBin},
     aesc_session_noise:funding_signed(Sn, Msg),
     log(snd, ?FND_CREATED, Msg, Data).
 
 check_funding_signed_msg(#{ temporary_channel_id := ChanId
+                          , block_hash           := ?DUMMY_BLOCK_HASH
                           , data                 := TxBin} = Msg,
                           #data{ channel_id = ChanId } = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
@@ -2071,11 +2076,13 @@ send_deposit_created_msg(SignedTx, #data{on_chain_id = Ch,
                                          session     = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ channel_id => Ch
+           , block_hash => ?DUMMY_BLOCK_HASH
            , data       => TxBin},
     aesc_session_noise:deposit_created(Sn, Msg),
     log(snd, ?DEP_CREATED, Msg, Data).
 
 check_deposit_created_msg(#{ channel_id := ChanId
+                           , block_hash := ?DUMMY_BLOCK_HASH
                            , data       := TxBin} = Msg,
                           #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
@@ -2092,11 +2099,13 @@ send_deposit_signed_msg(SignedTx, #data{on_chain_id = Ch,
                                         session     = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ channel_id  => Ch
+           , block_hash  => ?DUMMY_BLOCK_HASH
            , data        => TxBin},
     aesc_session_noise:deposit_signed(Sn, Msg),
     log(snd, ?DEP_SIGNED, Msg, Data).
 
 check_deposit_signed_msg(#{ channel_id := ChanId
+                          , block_hash := ?DUMMY_BLOCK_HASH
                           , data       := TxBin} = Msg,
                           #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
@@ -2164,11 +2173,13 @@ send_withdraw_created_msg(SignedTx, #data{on_chain_id = Ch,
                                           session     = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ channel_id => Ch
+           , block_hash => ?DUMMY_BLOCK_HASH
            , data       => TxBin},
     aesc_session_noise:wdraw_created(Sn, Msg),
     log(snd, ?WDRAW_CREATED, Msg, Data).
 
 check_withdraw_created_msg(#{ channel_id := ChanId
+                            , block_hash := ?DUMMY_BLOCK_HASH
                             , data       := TxBin} = Msg,
                            #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
@@ -2185,11 +2196,13 @@ send_withdraw_signed_msg(SignedTx, #data{on_chain_id = Ch,
                                          session     = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ channel_id  => Ch
+           , block_hash => ?DUMMY_BLOCK_HASH
            , data        => TxBin},
     aesc_session_noise:wdraw_signed(Sn, Msg),
     log(snd, ?WDRAW_SIGNED, Msg, Data).
 
 check_withdraw_signed_msg(#{ channel_id := ChanId
+                           , block_hash := ?DUMMY_BLOCK_HASH
                            , data       := TxBin} = Msg,
                           #data{on_chain_id = ChanId} = Data) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
@@ -2229,6 +2242,7 @@ send_update_msg(SignedTx, #data{ on_chain_id = OnChainId
                                , session     = Sn} = Data) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     Msg = #{ channel_id => OnChainId
+           , block_hash => ?DUMMY_BLOCK_HASH
            , data       => TxBin },
     aesc_session_noise:update(Sn, Msg),
     log(snd, ?UPDATE, Msg, Data).
@@ -2243,6 +2257,7 @@ check_update_msg(Type, Msg, D) ->
     end.
 
 check_update_msg_(Type, #{ channel_id := ChanId
+                         , block_hash := ?DUMMY_BLOCK_HASH
                          , data       := TxBin } = Msg,
                   #data{ on_chain_id = ChanId } = D) ->
     try aetx_sign:deserialize_from_binary(TxBin) of
@@ -2393,10 +2408,13 @@ send_shutdown_ack_msg(SignedTx, #data{session = Session} = Data) ->
 shutdown_msg(SignedTx, #data{ on_chain_id = OnChainId }) ->
     TxBin = aetx_sign:serialize_to_binary(SignedTx),
     #{ channel_id => OnChainId
+     , block_hash => ?DUMMY_BLOCK_HASH
      , data       => TxBin }.
 
 
-check_shutdown_msg(#{channel_id := ChanId, data := TxBin} = Msg,
+check_shutdown_msg(#{channel_id := ChanId,
+                     block_hash := ?DUMMY_BLOCK_HASH,
+                     data := TxBin} = Msg,
                    #data{on_chain_id = ChanId} = D) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
     case check_tx_and_verify_signatures(SignedTx, channel_close_mutual_tx,
@@ -2423,7 +2441,8 @@ serialize_close_mutual_tx(Tx) ->
     {_, Elems} = aesc_close_mutual_tx:serialize(Tx),
     lists:keydelete(nonce, 1, Elems).
 
-check_shutdown_ack_msg(#{data := TxBin} = Msg,
+check_shutdown_ack_msg(#{data       := TxBin,
+                         block_hash := ?DUMMY_BLOCK_HASH} = Msg,
                        #data{latest = {shutdown, MySignedTx}} = D) ->
     SignedTx = aetx_sign:deserialize_from_binary(TxBin),
     case check_tx_and_verify_signatures(SignedTx, channel_close_mutual_tx,

--- a/docs/release-notes/next-fortuna/PT-165593709_pinned_env_in_noise
+++ b/docs/release-notes/next-fortuna/PT-165593709_pinned_env_in_noise
@@ -1,2 +1,2 @@
-* Introduces a pinned environment in State Channels noise protocol. This is
+* Introduces a pinned environment in State Channels noise protocol (off-chain), by introducing a `block_hash` field in some of the messages. This is
   not backwards compatible

--- a/docs/release-notes/next-fortuna/PT-165593709_pinned_env_in_noise
+++ b/docs/release-notes/next-fortuna/PT-165593709_pinned_env_in_noise
@@ -1,0 +1,2 @@
+* Introduces a pinned environment in State Channels noise protocol. This is
+  not backwards compatible

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -13,10 +13,6 @@
 -export([
     test_simple_same_node_channel/1,
     test_simple_different_nodes_channel/1,
-    test_compat_with_initiator_node_using_minerva_initial_channel_version/1,
-    test_compat_with_responder_node_using_minerva_initial_channel_version/1,
-    test_compat_with_initiator_node_using_latest_stable_version/1,
-    test_compat_with_responder_node_using_latest_stable_version/1,
     on_chain_channel/1
 ]).
 
@@ -92,10 +88,6 @@
 all() -> [
     test_simple_same_node_channel,
     test_simple_different_nodes_channel,
-    test_compat_with_initiator_node_using_minerva_initial_channel_version,
-    test_compat_with_responder_node_using_minerva_initial_channel_version,
-    test_compat_with_initiator_node_using_latest_stable_version,
-    test_compat_with_responder_node_using_latest_stable_version,
     on_chain_channel
 ].
 
@@ -132,22 +124,6 @@ test_simple_same_node_channel(Cfg) ->
 
 test_simple_different_nodes_channel(Cfg) ->
     test_different_nodes_channel_(#{}, #{}, Cfg).
-
-test_compat_with_initiator_node_using_minerva_initial_channel_version(Cfg) ->
-    test_different_nodes_channel_(set_genesis_accounts(node_base_spec_with_minerva_initial_channel_version()),
-                                  set_genesis_accounts(#{}), Cfg).
-
-test_compat_with_responder_node_using_minerva_initial_channel_version(Cfg) ->
-    test_different_nodes_channel_(set_genesis_accounts(#{}),
-                                  set_genesis_accounts(node_base_spec_with_minerva_initial_channel_version()), Cfg).
-
-test_compat_with_initiator_node_using_latest_stable_version(Cfg) ->
-    test_different_nodes_channel_(set_genesis_accounts(node_base_spec_with_latest_stable_version()),
-                                  set_genesis_accounts(#{}), Cfg).
-
-test_compat_with_responder_node_using_latest_stable_version(Cfg) ->
-    test_different_nodes_channel_(set_genesis_accounts(#{}),
-                                  set_genesis_accounts(node_base_spec_with_latest_stable_version()), Cfg).
 
 test_different_nodes_channel_(InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg) ->
     ChannelOpts = #{
@@ -253,9 +229,6 @@ on_chain_channel(Cfg) ->
 
     wait_for_value({balance, maps:get(pubkey, ?BOB), 100}, NodeNames, 5000, []),
     wait_for_value({balance, maps:get(pubkey, ?ALICE), 100}, NodeNames, 5000, []).
-
-node_base_spec_with_minerva_initial_channel_version() ->
-    #{source => {pull, "aeternity/aeternity:v2.0.0"}}.
 
 node_base_spec_with_latest_stable_version() ->
     #{source => {pull, "aeternity/aeternity:latest"}}.


### PR DESCRIPTION
PT [SC noise: add pinned env hash](https://www.pivotaltracker.com/story/show/165593709)

This PR enriches off-chain communication with pinned env for:
* new off-chain updates so the `state_hash` can be computed based on a certain pinned environment as well as checking the initial upater's signatures
* new off-chain change confirmation ( `_ACK`) for second participant's signatures checks

Signatures checks shall be checked according to the pinned environment esp with regard of GAs

This PR replaces #2368 