### PR TITLE
PT-165593894: Upload *.deb files to CircleCI storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1130,7 +1130,6 @@ workflows:
           filters:
             branches:
               only:
-                - 165593894_upload_deb_files_to_ci_storage
                 - master
             tags:
               only: *stable_tag_regex

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,10 +630,7 @@ jobs:
     steps:
       - checkout
       - *build_ubuntu_package
-      - persist_to_workspace:
-          root: *packages_workspace
-          paths:
-            - "*.deb"
+      - *store_package_artifacts
       - *fail_notification
 
   upload_build_artifacts:
@@ -1133,6 +1130,7 @@ workflows:
           filters:
             branches:
               only:
+                - 165593894_upload_deb_files_to_ci_storage
                 - master
             tags:
               only: *stable_tag_regex

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,6 +630,10 @@ jobs:
     steps:
       - checkout
       - *build_ubuntu_package
+      - persist_to_workspace:
+          root: *packages_workspace
+          paths:
+            - "*.deb"
       - *fail_notification
 
   upload_build_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1133,7 +1133,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - 165593894_upload_deb_files_to_ci_storage
             tags:
               only: *stable_tag_regex
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1133,7 +1133,7 @@ workflows:
           filters:
             branches:
               only:
-                - 165593894_upload_deb_files_to_ci_storage
+                - master
             tags:
               only: *stable_tag_regex
 


### PR DESCRIPTION
Add *.deb (ubuntu_package) files to persist_to_workspace in CircleCI as for linux_package and osx_package.

Restored as before 2cff31af21bca.  Removed by mistake before #2346 was merged. 

Tested with CirlceCI branch filter in: https://circleci.com/gh/aeternity/aeternity/27769