### PR TITLE
Handle GAMetaTx better in mempool

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -725,6 +725,7 @@ cmd_run(Cmd, Dir, BinDir, Args, Env, FindLocalBin) ->
                              {error, Err, Res};
                          {P, {data, Msg}} ->
                              Fun(Fun, P, Res ++ Msg)
+                     after 30000 -> {error, timeout, Res}
                      end
              end,
     WaitFun(WaitFun, Port, "").


### PR DESCRIPTION
The mempool is doing a lot of special handling based on `Nonce` - this breaks down for GA MetaTxs... This makes a crude fix for this. In the long run the mempool could need a bigger overhaul.