### PR TITLE
Script running property based tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,16 @@ references:
       # construct and export PACKAGE_TARBALL environment variable available to all jobs
       command: .circleci/set_package_path.sh
 
+  quickcheck_cache_key: &quickcheck_cache_key quickcheck-cache-v1
+  restore_quickcheck_cache: &restore_quickcheck_cache
+    restore_cache:
+      key: *quickcheck_cache_key
+  save_quickcheck_cache: &save_quickcheck_cache
+    save_cache:
+      key: *quickcheck_cache_key
+      paths:
+        - "eqc-lib/eqc.zip"
+
   build_package: &build_package
     run:
       name: Build Package Tarball
@@ -834,6 +844,29 @@ jobs:
       - store_artifacts:
           path: *system_test_host_logs
 
+  quickcheck_tests:
+    executor: builder_container_stable
+    <<: *container_config
+    steps:
+      - checkout
+      - *restore_quickcheck_cache
+      - run:
+          name: QuickCheck Registration
+          command: |
+            make eqc-lib-registration && make eqc-lib-start
+      - run:
+          name: QuickCheck Tests
+          environment:
+            # > [Jobs have a maximum runtime of 5 hours.](https://circleci.com/docs/2.0/configuration-reference/#jobs).
+            # If max job runtime reached, reduce this testing time multiplier variable (or parallelize job).
+            EQC_EUNIT_TESTING_TIME_MULTIPLIER: 40
+          no_output_timeout: 30m
+          command: |
+            make eqc-lib-test
+      - *save_quickcheck_cache
+      - *store_rebar3_crashdump
+      - *fail_notification
+
   deploy_integration:
     executor: infrastructure_container_unstable
     <<: *infrastructure_config
@@ -1386,3 +1419,14 @@ workflows:
                 - master
     jobs:
       - docker_system_tests
+
+  property_based_tests:
+    triggers:
+      - schedule:
+          cron: "0 0,12 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - quickcheck_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,12 +851,9 @@ jobs:
       - checkout
       - *restore_quickcheck_cache
       - run:
-          command: |
-            make eqc-lib/eqc
-      - run:
           name: QuickCheck Registration
           command: |
-            echo "make eqc-lib-registration && make eqc-lib-start"
+            make eqc-lib-registration && make eqc-lib-start
       - run:
           name: QuickCheck Tests
           environment:
@@ -865,7 +862,7 @@ jobs:
             EQC_EUNIT_TESTING_TIME_MULTIPLIER: 40
           no_output_timeout: 30m
           command: |
-            echo "make eqc-lib-test"
+            make eqc-lib-test
       - *save_quickcheck_cache
       - *store_rebar3_crashdump
       - *fail_notification
@@ -966,13 +963,6 @@ jobs:
 # and all its transitively dependent jobs must also have a filters tags section.
 workflows:
   version: 2
-  tmp_eqc_run:
-    jobs:
-      - quickcheck_tests:
-          filters:
-            branches:
-              only: PT-164548714-eqc-run--ci
-
   build_test_deploy:
     jobs:
       - build:
@@ -982,7 +972,6 @@ workflows:
                 - env/dev1
                 - env/dev2
                 - system-tests
-                - PT-164548714-eqc-run--ci
             tags:
               only: *tag_regex
 
@@ -993,7 +982,6 @@ workflows:
                 - env/dev1
                 - env/dev2
                 - system-tests
-                - PT-164548714-eqc-run--ci
 
       - docker_smoke_tests:
           filters:
@@ -1003,7 +991,6 @@ workflows:
                 - env/dev2
                 - system-tests
                 - master
-                - PT-164548714-eqc-run--ci
 
       - docker_system_smoke_tests:
           requires:
@@ -1169,7 +1156,6 @@ workflows:
             branches:
               ignore:
                 - system-tests
-                - PT-164548714-eqc-run--ci
             tags:
               only: *tag_regex
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,16 +155,6 @@ references:
       # construct and export PACKAGE_TARBALL environment variable available to all jobs
       command: .circleci/set_package_path.sh
 
-  quickcheck_cache_key: &quickcheck_cache_key quickcheck-cache-v1
-  restore_quickcheck_cache: &restore_quickcheck_cache
-    restore_cache:
-      key: *quickcheck_cache_key
-  save_quickcheck_cache: &save_quickcheck_cache
-    save_cache:
-      key: *quickcheck_cache_key
-      paths:
-        - "eqc-lib/eqc.zip"
-
   build_package: &build_package
     run:
       name: Build Package Tarball
@@ -844,29 +834,6 @@ jobs:
       - store_artifacts:
           path: *system_test_host_logs
 
-  quickcheck_tests:
-    executor: builder_container_stable
-    <<: *container_config
-    steps:
-      - checkout
-      - *restore_quickcheck_cache
-      - run:
-          name: QuickCheck Registration
-          command: |
-            make eqc-lib-registration && make eqc-lib-start
-      - run:
-          name: QuickCheck Tests
-          environment:
-            # > [Jobs have a maximum runtime of 5 hours.](https://circleci.com/docs/2.0/configuration-reference/#jobs).
-            # If max job runtime reached, reduce this testing time multiplier variable (or parallelize job).
-            EQC_EUNIT_TESTING_TIME_MULTIPLIER: 40
-          no_output_timeout: 30m
-          command: |
-            make eqc-lib-test
-      - *save_quickcheck_cache
-      - *store_rebar3_crashdump
-      - *fail_notification
-
   deploy_integration:
     executor: infrastructure_container_unstable
     <<: *infrastructure_config
@@ -1419,14 +1386,3 @@ workflows:
                 - master
     jobs:
       - docker_system_tests
-
-  property_based_tests:
-    triggers:
-      - schedule:
-          cron: "0 0,12 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - quickcheck_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,9 +851,12 @@ jobs:
       - checkout
       - *restore_quickcheck_cache
       - run:
+          command: |
+            make eqc-lib/eqc
+      - run:
           name: QuickCheck Registration
           command: |
-            make eqc-lib-registration && make eqc-lib-start
+            echo "make eqc-lib-registration && make eqc-lib-start"
       - run:
           name: QuickCheck Tests
           environment:
@@ -862,7 +865,7 @@ jobs:
             EQC_EUNIT_TESTING_TIME_MULTIPLIER: 40
           no_output_timeout: 30m
           command: |
-            make eqc-lib-test
+            echo "make eqc-lib-test"
       - *save_quickcheck_cache
       - *store_rebar3_crashdump
       - *fail_notification
@@ -963,6 +966,13 @@ jobs:
 # and all its transitively dependent jobs must also have a filters tags section.
 workflows:
   version: 2
+  tmp_eqc_run:
+    jobs:
+      - quickcheck_tests:
+          filters:
+            branches:
+              only: PT-164548714-eqc-run--ci
+
   build_test_deploy:
     jobs:
       - build:
@@ -972,6 +982,7 @@ workflows:
                 - env/dev1
                 - env/dev2
                 - system-tests
+                - PT-164548714-eqc-run--ci
             tags:
               only: *tag_regex
 
@@ -982,6 +993,7 @@ workflows:
                 - env/dev1
                 - env/dev2
                 - system-tests
+                - PT-164548714-eqc-run--ci
 
       - docker_smoke_tests:
           filters:
@@ -991,6 +1003,7 @@ workflows:
                 - env/dev2
                 - system-tests
                 - master
+                - PT-164548714-eqc-run--ci
 
       - docker_system_smoke_tests:
           requires:
@@ -1156,6 +1169,7 @@ workflows:
             branches:
               ignore:
                 - system-tests
+                - PT-164548714-eqc-run--ci
             tags:
               only: *tag_regex
 

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ debian/.debhelper/
 debian/aeternity-node*
 debian/changelog
 debian/files
+eqc-lib

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ debian/aeternity-node*
 debian/changelog
 debian/files
 eqc-lib
+eqc

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ST_CT_DIR = --dir system_test/common
 ST_CT_LOCALDIR = --dir system_test/only_local
 
 EQC_EUNIT_TEST_FLAGS ?=
+EQC_EUNIT_TESTING_TIME_MULTIPLIER ?= 1
 
 SWAGGER_CODEGEN_CLI_V = 2.4.4
 SWAGGER_CODEGEN_CLI = swagger/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
@@ -302,7 +303,7 @@ $(AEVM_EXTERNAL_TEST_DIR)/ethereum_tests:
 
 .PHONY: eqc-test
 eqc-test: eqc
-	$(REBAR) as test,eqc eunit $(EQC_EUNIT_TEST_FLAGS)
+	env ERL_FLAGS="-eqc_testing_time_multiplier $(EQC_EUNIT_TESTING_TIME_MULTIPLIER)" $(REBAR) as test,eqc eunit $(EQC_EUNIT_TEST_FLAGS)
 
 EQC_TEST_REPO = https://github.com/Quviq/epoch-eqc.git
 EQC_TEST_VERSION = 71b0ad8e

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,21 @@ aevm-test-deps:
 $(AEVM_EXTERNAL_TEST_DIR)/ethereum_tests:
 	@git clone https://github.com/ethereum/tests.git $(AEVM_EXTERNAL_TEST_DIR)/ethereum_tests
 
+.PHONY: eqc-test
+eqc-test: eqc
+	$(REBAR) as test,eqc eunit --app eqc_test
+
+EQC_TEST_REPO = https://github.com/Quviq/epoch-eqc.git
+EQC_TEST_VERSION = 71b0ad8e
+
+.PHONY: eqc
+eqc: | eqc/.git
+	## TODO Re-fetch repo if version not found in local repo.
+	( cd $@ && git reset --quiet --soft $(EQC_TEST_VERSION) && git stash --quiet --all; )
+
+eqc/.git:
+	git clone --quiet --no-checkout $(EQC_TEST_REPO) $(@D)
+
 .PHONY: eqc-registration
 eqc-registration:
 	erl -noinput -run eqc force_registration "$${EQC_REGISTRATION_KEY:?}" -run init stop
@@ -308,8 +323,8 @@ EQC_LIB_DOWNLOAD_URL = http://quviq-licencer.com/downloads/eqcR20-$(EQC_LIB_VSN)
 EQC_LIB_DOWNLOAD_SHA256 = c02a978cb7b7665fee220dda303c86fd517b89ce7fdafc5cc7181eadab26424e
 EQC_LIB_ROOT_DIR = "Quviq QuickCheck version $(EQC_LIB_VSN)"
 
-.PHONY: eqc-lib-registration eqc-lib-start
-eqc-lib-registration eqc-lib-start: eqc-lib-%: | eqc-lib/eqc
+.PHONY: eqc-lib-test eqc-lib-registration eqc-lib-start
+eqc-lib-test eqc-lib-registration eqc-lib-start: eqc-lib-%: | eqc-lib/eqc
 	( export ERL_LIBS="$(CURDIR)"/$(word 1,$|)/$(EQC_LIB_ROOT_DIR); $(MAKE) eqc-$*; )
 
 eqc-lib/eqc: | eqc-lib/eqc.zip
@@ -392,10 +407,17 @@ clean:
 	@-rm $(SWAGGER_ENDPOINTS_SPEC)
 	( cd $(HTTP_APP) && $(MAKE) clean; )
 	@$(MAKE) multi-distclean
+	@$(MAKE) eqc-clean
 	@rm -rf _build/system_test+test _build/system_test _build/test _build/prod _build/local
 	@rm -rf _build/default/plugins
 	@rm -rf $$(ls -d _build/default/lib/* | grep -v '[^_]rocksdb') ## Dependency `rocksdb` takes long to build.
 
+.PHONY: eqc-clean
+eqc-clean:
+	rm -rf .eqc-info current_counterexample.eqc
+	rm -rf _build/test+eqc
+
+## Do not delete `eqc`.
 distclean: clean
 	( cd otp_patches && $(MAKE) distclean; )
 	( cd $(HTTP_APP) && $(MAKE) distclean; )

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ ST_CT_FLAGS = --logdir system_test/logs
 ST_CT_DIR = --dir system_test/common
 ST_CT_LOCALDIR = --dir system_test/only_local
 
+EQC_EUNIT_TEST_FLAGS ?=
+
 SWAGGER_CODEGEN_CLI_V = 2.4.4
 SWAGGER_CODEGEN_CLI = swagger/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
 SWAGGER_CODEGEN = java -jar $(SWAGGER_CODEGEN_CLI)
@@ -64,7 +66,10 @@ endif
 ifdef TEST
 CT_TEST_FLAGS += --case=$(TEST)
 EUNIT_TEST_FLAGS += --module=$(TEST)
+EQC_EUNIT_TEST_FLAGS += --module=$(TEST)
 unexport TEST
+else
+EQC_EUNIT_TEST_FLAGS += --app eqc_test
 endif
 
 ifdef VERBOSE
@@ -297,7 +302,7 @@ $(AEVM_EXTERNAL_TEST_DIR)/ethereum_tests:
 
 .PHONY: eqc-test
 eqc-test: eqc
-	$(REBAR) as test,eqc eunit --app eqc_test
+	$(REBAR) as test,eqc eunit $(EQC_EUNIT_TEST_FLAGS)
 
 EQC_TEST_REPO = https://github.com/Quviq/epoch-eqc.git
 EQC_TEST_VERSION = 71b0ad8e

--- a/eqc_test/src/aeminer_pow_eqc_tests.erl
+++ b/eqc_test/src/aeminer_pow_eqc_tests.erl
@@ -2,4 +2,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 quickcheck_test_() ->
-    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING).
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING, fun testing_time_ms/1).
+
+testing_time_ms(PropName) when is_atom(PropName) ->
+    aeeqc_eunit:testing_time_multiplier() * 500.

--- a/eqc_test/src/aeminer_pow_eqc_tests.erl
+++ b/eqc_test/src/aeminer_pow_eqc_tests.erl
@@ -1,0 +1,5 @@
+-module(aeminer_pow_eqc_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+quickcheck_test_() ->
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING).

--- a/eqc_test/src/aeser_rlp_eqc_tests.erl
+++ b/eqc_test/src/aeser_rlp_eqc_tests.erl
@@ -1,0 +1,5 @@
+-module(aeser_rlp_eqc_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+quickcheck_test_() ->
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING).

--- a/eqc_test/src/aeser_rlp_eqc_tests.erl
+++ b/eqc_test/src/aeser_rlp_eqc_tests.erl
@@ -2,4 +2,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 quickcheck_test_() ->
-    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING).
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING, fun testing_time_ms/1).
+
+testing_time_ms(PropName) when is_atom(PropName) ->
+    aeeqc_eunit:testing_time_multiplier() * 500.

--- a/eqc_test/src/aeso_utils_eqc_tests.erl
+++ b/eqc_test/src/aeso_utils_eqc_tests.erl
@@ -1,0 +1,5 @@
+-module(aeso_utils_eqc_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+quickcheck_test_() ->
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING).

--- a/eqc_test/src/aeso_utils_eqc_tests.erl
+++ b/eqc_test/src/aeso_utils_eqc_tests.erl
@@ -2,4 +2,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 quickcheck_test_() ->
-    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING).
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING, fun testing_time_ms/1).
+
+testing_time_ms(PropName) when is_atom(PropName) ->
+    aeeqc_eunit:testing_time_multiplier() * 500.

--- a/eqc_test/src/der_enc_eqc_tests.erl
+++ b/eqc_test/src/der_enc_eqc_tests.erl
@@ -1,0 +1,8 @@
+-module(der_enc_eqc_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+quickcheck_test_() ->
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING, fun testing_time_ms/1).
+
+testing_time_ms(PropName) when is_atom(PropName) ->
+    aeeqc_eunit:testing_time_multiplier() * 500.

--- a/eqc_test/src/eqc_test.app.src
+++ b/eqc_test/src/eqc_test.app.src
@@ -1,0 +1,6 @@
+{application, eqc_test,
+ [{description, "Dummy app for enabling running only the QuickCheck tests"},
+  {vsn, ""},
+  {registered, []},
+  {applications, []}
+ ]}.

--- a/eqc_test/src/eqc_test_enabled_tests.erl
+++ b/eqc_test/src/eqc_test_enabled_tests.erl
@@ -1,0 +1,84 @@
+-module(eqc_test_enabled_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DISABLED_PROPS_MODS,
+        [ aec_sync_eqc
+        , aeso_data_eqc
+        , aeso_heap_eqc
+        , aeu_mp_trees_eqc
+        , fate_compiler_eqc
+        , txs_eqc
+        , txs_ga_eqc
+        , txs_glue_eqc
+        , txs_hardfork_eqc
+        , txs_sign_eqc
+        , txs_sign_meta_eqc
+        ]).
+
+-define(REBAR3_BUILD_DIR, "_build").
+-define(REBAR3_PROFILE_DIR, "test+eqc").
+-define(BEAM_SUFFIX, ".beam").
+
+each_eqc_mod_is_hooked_unless_whitelisted_test() ->
+    Path = [_|_] = code:get_path(),
+    PropsPath = [_|_] = props_path(Path),
+    TestsPath = [_|_] = tests_path(Path),
+    PropsMods       = [_|_] = lists:filter(fun is_props_mod/1, mods_from_beam_files([_|_] = find_beam_files_in_path(PropsPath))),
+    ActualTestsMods = [_|_] = lists:filter(fun is_tests_mod/1, mods_from_beam_files([_|_] = find_beam_files_in_path(TestsPath))),
+    ExpectedTestsMods = lists:map(fun tests_mod/1, PropsMods),
+    ExpectedMissingTestsMods = lists:map(fun tests_mod/1, ?DISABLED_PROPS_MODS),
+    ?assertEqual(ExpectedMissingTestsMods, lists:sort(ExpectedTestsMods -- ActualTestsMods)). %% This prints missing `*_tests` modules: error message would be clearer if it printed properties (`*_eqc`) modules.
+
+props_path(Path) ->
+    lists:filter(fun is_props_dir/1, Path).
+
+is_props_dir(Dir) ->
+    shallow_path_prefix(?REBAR3_BUILD_DIR, [?REBAR3_PROFILE_DIR, "extras", "eqc"], Dir).
+
+tests_path(Path) ->
+    lists:filter(fun is_tests_dir/1, Path).
+
+is_tests_dir(Dir) ->
+    shallow_path_prefix(?REBAR3_BUILD_DIR, [?REBAR3_PROFILE_DIR, "lib", "eqc_test"], Dir).
+
+shallow_path_prefix(ShallowSplittingComponent = [_|_], Prefix = [[_|_]|_], Dir) ->
+    Components = lists:map(fun filename_to_string/1, filename:split(Dir)),
+    shallow_prefix(ShallowSplittingComponent, Prefix, Components).
+
+shallow_prefix(ShallowSplittingElem, Prefix, List) ->
+    case
+        lists:splitwith(
+          fun(El) -> El =/= ShallowSplittingElem end,
+          lists:reverse(List))
+    of
+        {_, []} ->
+            false;
+        {RevT, [X|_]} when X =:= ShallowSplittingElem ->
+            lists:prefix(Prefix, lists:reverse(RevT))
+    end.
+
+find_beam_files_in_path(Path) ->
+    lists:flatmap(fun find_beam_files_in_dir/1, Path).
+
+find_beam_files_in_dir(Dir) ->
+    filelib:wildcard("**/*" ++ ?BEAM_SUFFIX, Dir).
+
+mods_from_beam_files(Fs) ->
+    lists:map(fun mod_from_beam_file/1, Fs).
+
+mod_from_beam_file(F) ->
+    ModS = filename_to_string(filename:basename(F, ?BEAM_SUFFIX)),
+    list_to_atom(ModS).
+
+is_props_mod(Mod) ->
+    aeeqc_props:is_props_mod(atom_to_list(Mod)).
+
+is_tests_mod(Mod) ->
+    aeeqc_eunit:is_tests_mod(atom_to_list(Mod)).
+
+tests_mod(Mod) ->
+    list_to_atom(aeeqc_eunit:tests_mod(atom_to_list(Mod))).
+
+-spec filename_to_string(file:filename_all() | file:name_all()) -> string().
+filename_to_string(Filename) ->
+    lists:flatten(io_lib:format("~s", [Filename])).

--- a/eqc_test/src/helpers/aeeqc_eunit.erl
+++ b/eqc_test/src/helpers/aeeqc_eunit.erl
@@ -1,6 +1,7 @@
 -module(aeeqc_eunit).
 -export([is_tests_mod/1]).
--export([props_mod_test_repr/1]).
+-export([props_mod_test_repr/2]).
+-export([testing_time_multiplier/0]).
 -export([tests_mod/1]).
 
 -define(SUFFIX, "_tests").
@@ -15,13 +16,15 @@ is_tests_mod(ModS) ->
             false
     end.
 
-props_mod_test_repr(TestsModS) ->
+props_mod_test_repr(TestsModS, TestingTimeMsFun) ->
     PropsMod = list_to_atom(props_mod(TestsModS)),
     {setup,
      fun() -> eqc:start() end,
      fun(_) -> eqc:stop() end,
      lists:map(
-       fun(PropName) -> prop_test_repr(PropsMod, PropName) end,
+       fun(PropName) ->
+               prop_test_repr(PropsMod, PropName, TestingTimeMsFun(PropName))
+       end,
        aeeqc_props:prop_names(PropsMod))
      }.
 
@@ -30,14 +33,15 @@ props_mod(TestsModS) ->
     ?REV_SUFFIX ++ RevPropsModS = lists:reverse(TestsModS),
     lists:reverse(RevPropsModS).
 
-prop_test_repr(Mod, Name) ->
-    prop_test_repr(Mod, Name, 500).
-
-prop_test_repr(Mod, Name, Ms) ->
+prop_test_repr(Mod, Name, Ms) when is_integer(Ms), Ms > 0 ->
     {atom_to_list(Mod) ++ ":" ++ atom_to_list(Name),
      {timeout, (Ms * 3) / 1000,
       fun() -> true = eqc:quickcheck(eqc:testing_time(Ms / 1000, Mod:Name())) end
      }}.
+
+testing_time_multiplier() ->
+    {ok, [[MS]]} = init:get_argument(eqc_testing_time_multiplier),
+    case list_to_integer(MS) of M when is_integer(M), M > 0 -> M end.
 
 tests_mod(ModS) ->
     ModS ++ ?SUFFIX.

--- a/eqc_test/src/helpers/aeeqc_eunit.erl
+++ b/eqc_test/src/helpers/aeeqc_eunit.erl
@@ -1,0 +1,43 @@
+-module(aeeqc_eunit).
+-export([is_tests_mod/1]).
+-export([props_mod_test_repr/1]).
+-export([tests_mod/1]).
+
+-define(SUFFIX, "_tests").
+-define(REV_SUFFIX, "stset_").
+
+is_tests_mod(ModS) ->
+    ?REV_SUFFIX = lists:reverse(?SUFFIX),
+    case lists:reverse(ModS) of
+        ?REV_SUFFIX ++ _ ->
+            true;
+        _ ->
+            false
+    end.
+
+props_mod_test_repr(TestsModS) ->
+    PropsMod = list_to_atom(props_mod(TestsModS)),
+    {setup,
+     fun() -> eqc:start() end,
+     fun(_) -> eqc:stop() end,
+     lists:map(
+       fun(PropName) -> prop_test_repr(PropsMod, PropName) end,
+       aeeqc_props:prop_names(PropsMod))
+     }.
+
+props_mod(TestsModS) ->
+    ?REV_SUFFIX = lists:reverse(?SUFFIX),
+    ?REV_SUFFIX ++ RevPropsModS = lists:reverse(TestsModS),
+    lists:reverse(RevPropsModS).
+
+prop_test_repr(Mod, Name) ->
+    prop_test_repr(Mod, Name, 500).
+
+prop_test_repr(Mod, Name, Ms) ->
+    {atom_to_list(Mod) ++ ":" ++ atom_to_list(Name),
+     {timeout, (Ms * 3) / 1000,
+      fun() -> true = eqc:quickcheck(eqc:testing_time(Ms / 1000, Mod:Name())) end
+     }}.
+
+tests_mod(ModS) ->
+    ModS ++ ?SUFFIX.

--- a/eqc_test/src/helpers/aeeqc_props.erl
+++ b/eqc_test/src/helpers/aeeqc_props.erl
@@ -1,0 +1,33 @@
+-module(aeeqc_props).
+-export([is_props_mod/1]).
+-export([prop_names/1]).
+
+-define(MOD_SUFFIX, "_eqc").
+-define(REV_MOD_SUFFIX, "cqe_").
+
+is_props_mod(ModS) ->
+    ?REV_MOD_SUFFIX = lists:reverse(?MOD_SUFFIX),
+    case lists:reverse(ModS) of
+        ?REV_MOD_SUFFIX ++ _ ->
+            true;
+        _ ->
+            false
+    end.
+
+prop_names(Mod) ->
+    lists:map(
+      fun({Name, 0}) when is_atom(Name) -> Name end,
+      lists:filter(
+        fun is_property/1,
+        Mod:module_info(exports))).
+
+is_property({Name, Arity}) when is_integer(Arity), Arity > 0,
+                                is_atom(Name) ->
+    false;
+is_property({Name, 0}) ->
+    case atom_to_list(Name) of
+        "prop_" ++ _ ->
+            true;
+        _ ->
+            false
+    end.

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
 %% `otp_patches/`.
 {minimum_otp_vsn, "20.1"}.
 
-{project_app_dirs, ["apps/*", "lib/*", "."]}.
+{project_app_dirs, ["apps/*"]}.
 
 {erl_opts, [debug_info, {parse_transform, lager_transform},
             {lager_extra_sinks, [epoch_mining,

--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,8 @@
 %% `otp_patches/`.
 {minimum_otp_vsn, "20.1"}.
 
+{project_app_dirs, ["apps/*", "lib/*", "."]}.
+
 {erl_opts, [debug_info, {parse_transform, lager_transform},
             {lager_extra_sinks, [epoch_mining,
                                  epoch_metrics, epoch_sync]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -209,7 +209,14 @@
                     {websocket_client, ".*", {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}}
                 ]},
                 {ct_opts, [{create_priv_dir, auto_per_tc}]}
-            ]}
+            ]},
+            {eqc, [{project_app_dirs, ["eqc_test"]},
+                   {extra_src_dirs, [ "eqc/aecore_eqc"
+                                    , "eqc/aega_eqc"
+                                    , "eqc/aeminer_eqc"
+                                    , "eqc/aesophia_eqc"
+                                    , "eqc/aeutils_eqc"
+                                    ]}]}
            ]
 }.
 


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/n/projects/2124891/stories/164548714

Delivers https://www.pivotaltracker.com/story/show/162781914

TODO:
* [x] Ease running only one property module
* [ ] ~Hook `txs_glue_eqc` test - it requires more than 0.5s for exercising all features~
  * It is now failing with current master so I am keeping this out.
* [x] Hook to CI (with caching of test archive)
  * Partially done in [this temporary commit](https://github.com/aeternity/aeternity/commit/74fd1f63efc4fae0402b6a3791c826508eca3b5d#diff-1d37e48f9ceff6d8030570cd36286a61) - needs refreshing.
  * Done. Notice the `curl ... http://quviq-licencer.com/downloads/eqcR20-1.44.1.zip` invocation in [the first CI workflow](https://circleci.com/gh/aeternity/aeternity/30416) while none in [the second one](https://circleci.com/gh/aeternity/aeternity/30417).
* [x] Make test time configurable (not always 0.5s per property) so to enable CI to configure at least 20s per property

Sample usage (not needed once CI hooked):
```
env EQC_REGISTRATION_KEY='YourLicenceHere' make eqc-lib-registration && make eqc-lib-start && { make eqc-clean; make eqc-lib-test; }
```