### PR TITLE
Cover all cases when doing DER encoding/decoding

### DIFF
--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -1513,14 +1513,12 @@ basic_auth(Nonce, TxHash, Privkey) ->
 bitcoin_auth(_GA, Nonce, TxHash, S) ->
     Val = <<32:256, TxHash/binary, (list_to_integer(Nonce)):256>>,
     Sig = crypto:sign(ecdsa, sha256, {digest, aec_hash:hash(tx, Val)}, [?SECP256K1_PRIV, secp256k1]),
-    {aega_test_utils:make_calldata("bitcoin_auth", "authorize", [Nonce, der_decode(Sig)]), S}.
+    {aega_test_utils:make_calldata("bitcoin_auth", "authorize", [Nonce, der_sig_decode(Sig)]), S}.
 
-der_decode(<<16#30, _:16, 32, R:32/binary, _, 32, S:32/binary>>) ->
-    aega_test_utils:to_hex_lit(64, <<R:32/binary, S:32/binary>>);
-der_decode(<<16#30, _:16, 33, _, R:32/binary, _, 32, S:32/binary>>) ->
-    aega_test_utils:to_hex_lit(64, <<R:32/binary, S:32/binary>>);
-der_decode(<<16#30, _:16, 32, R:32/binary, _, 33, _, S:32/binary>>) ->
-    aega_test_utils:to_hex_lit(64, <<R:32/binary, S:32/binary>>);
-der_decode(<<16#30, _:16, 33, _, R:32/binary, _, 33, _, S:32/binary>>) ->
-    aega_test_utils:to_hex_lit(64, <<R:32/binary, S:32/binary>>).
+der_sig_decode(<<16#30, _Len0:8, 16#02, Len1:8, Rest/binary>>) ->
+    <<R:Len1/binary, 16#02, Len2:8, S/binary>> = Rest,
+    aega_test_utils:to_hex_lit(64, <<(der_part_trunc(Len1, R)):32/binary,
+                                     (der_part_trunc(Len2, S)):32/binary>>).
 
+der_part_trunc(33, <<0, Rest/binary>>)   -> Rest;
+der_part_trunc(Len, Part) when Len =< 32 -> <<0:((32-Len)*8), Part/binary>>.


### PR DESCRIPTION
CI found an issue where the DER encoding/encoding failed with a function clause...

https://circleci.com/gh/aeternity/aeternity/29624#tests/containers/1

This is the more general implementation of the encode/decode - QuickCheck properties in `quviq/epoch-eqc`