### PR TITLE
Add Contract.creator and address checking primitives

### DIFF
--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -478,6 +478,7 @@ verify_signature_(Channel, SignerId, AuthContractId, MetaTx, Trees, Env) ->
                        , tx_env      => set_auth_tx_hash(aega_meta_tx:tx(MetaTx), Env)
                        , off_chain   => false
                        , origin      => SignerPK
+                       , creator     => aect_contracts:owner_pubkey(Contract)
                        },
             CTVersion = aect_contracts:ct_version(Contract),
             {Call1, _Trees1, _Env1} = aect_dispatch:run(CTVersion, CallDef),

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -106,6 +106,7 @@ make_call_def(OwnerPubKey, ContractPubKey, GasLimit, GasPrice, Amount,
     , off_chain       => true
     , on_chain_trees  => OnChainTrees
     , origin          => OwnerPubKey
+    , creator         => OwnerPubKey
     }.
 
 

--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -138,6 +138,7 @@ run_common(#{vm := VMVersion, abi := ABIVersion},
              , trees       := Trees
              , tx_env      := TxEnv0
              , origin      := <<OriginAddr0:?PUB_SIZE/unit:8>>
+             , creator     := <<CreatorAddr:?PUB_SIZE/unit:8>>
              } = CallDef) ->
     OldContext = aetx_env:context(TxEnv0),
     TxEnv = aetx_env:set_context(TxEnv0, aetx_contract),
@@ -164,6 +165,7 @@ run_common(#{vm := VMVersion, abi := ABIVersion},
              gas            => Gas,
              gasPrice       => GasPrice,
              origin         => OriginAddr,
+             creator        => CreatorAddr,
              value          => Value,
              call_stack     => CallStack
             },

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -17,6 +17,7 @@
         , get_contract/3
         , insert_contract/2
         , enter_contract/2
+        , is_contract/2
         , lookup_contract/2
         , lookup_contract/3
         , new_with_backend/1
@@ -160,6 +161,12 @@ add_store(Contract, CtTree) ->
     Store = aect_contracts_store:new(Subtree),
     aect_contracts:set_state(Store, Contract).
 
+-spec is_contract(aect_contracts:pubkey(), tree()) -> boolean().
+is_contract(Pubkey, #contract_tree{ contracts = CtTree }) ->
+    case aeu_mtrees:lookup(Pubkey, CtTree) of
+        {value, _} -> true;
+        none       -> false
+    end.
 
 -spec lookup_contract(aect_contracts:pubkey(), tree()) -> {value, aect_contracts:contract()} | none.
 lookup_contract(Pubkey, Tree) ->

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -4144,6 +4144,12 @@ sophia_address_checks(_Cfg) ->
     [ ?assertEqual(true, ?call(call_contract, Acc, Cx, check_oq2, bool, {C2, X}))
       || Cx <- [C1, C2], X <- [<<OQ21:256>>, <<OQ22:256>>] ],
 
+    C3 = ?call(create_contract, Acc, address_checks, {}),
+    ?call(call_contract, Acc, C3, register1, word, {}),
+    OQ31 = ?call(call_contract, Acc, C1, query1, word, {C3, <<"baz">>}),
+    ?assertEqual(false, ?call(call_contract, Acc, C1, check_oq1, bool, {C1, <<OQ31:256>>})),
+    ?assertEqual(true, ?call(call_contract, Acc, C1, check_oq1, bool, {C3, <<OQ31:256>>})),
+
     ok.
 
 

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -159,6 +159,8 @@ primop_base_gas(?PRIM_CALL_ORACLE_EXTEND             ) -> 12000;
 primop_base_gas(?PRIM_CALL_ORACLE_GET_ANSWER         ) -> 12000;
 primop_base_gas(?PRIM_CALL_ORACLE_GET_QUESTION       ) -> 12000;
 primop_base_gas(?PRIM_CALL_ORACLE_QUERY_FEE          ) -> 12000;
+primop_base_gas(?PRIM_CALL_ORACLE_CHECK              ) -> 5000;
+primop_base_gas(?PRIM_CALL_ORACLE_CHECK_QUERY        ) -> 5000;
 primop_base_gas(?PRIM_CALL_AENS_RESOLVE              ) -> 12000;
 primop_base_gas(?PRIM_CALL_AENS_PRECLAIM             ) -> 12000;
 primop_base_gas(?PRIM_CALL_AENS_CLAIM                ) -> 12000;
@@ -178,7 +180,10 @@ primop_base_gas(?PRIM_CALL_CRYPTO_SHA256             ) -> 30;
 primop_base_gas(?PRIM_CALL_CRYPTO_BLAKE2B            ) -> 30;
 primop_base_gas(?PRIM_CALL_CRYPTO_SHA256_STRING      ) -> 30;
 primop_base_gas(?PRIM_CALL_CRYPTO_BLAKE2B_STRING     ) -> 30;
-primop_base_gas(?PRIM_CALL_AUTH_TX_HASH              ) -> 0.
+primop_base_gas(?PRIM_CALL_AUTH_TX_HASH              ) -> 0;
+primop_base_gas(?PRIM_CALL_ADDR_IS_CONTRACT          ) -> 5000;
+primop_base_gas(?PRIM_CALL_ADDR_IS_ORACLE            ) -> 5000.
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Naming system variables

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -477,26 +477,12 @@ oracle_check(Oracle, QFormat, RFormat, #state{trees = ChainTrees}) ->
             {ok, bool2word(false)}
     end.
 
-oracle_check_query(Oracle, Query, QFormat, RFormat, #state{trees = ChainTrees}) ->
+oracle_check_query(Oracle, Query, QFormat, RFormat, #state{trees = ChainTrees} = State) ->
     Trees = get_on_chain_trees(ChainTrees),
     OraclesTree = aec_trees:oracles(Trees),
     case aeo_state_tree:lookup_query(Oracle, Query, OraclesTree) of
         {value, _} ->
-            {value, O} = aeo_state_tree:lookup_oracle(Oracle, OraclesTree),
-            {ok, ChainRFormat} = oracle_typerep(aeo_oracles:abi_version(O),
-                                                aeo_oracles:response_format(O)),
-            {ok, ChainQFormat} = oracle_typerep(aeo_oracles:abi_version(O),
-                                                aeo_oracles:query_format(O)),
-            ABIVersion         = aeo_oracles:abi_version(O),
-            case ABIVersion of
-                ?ABI_NO_VM -> %% Question/Response is non-sophia string
-                    Equal = string == QFormat andalso string == ChainQFormat andalso
-                            string == RFormat andalso string == ChainRFormat,
-                    {ok, bool2word(Equal)};
-                _Other ->
-                    Equal = (QFormat == ChainQFormat) andalso (RFormat == ChainRFormat),
-                    {ok, bool2word(Equal)}
-            end;
+            oracle_check(Oracle, QFormat, RFormat, State);
         none ->
             {ok, bool2word(false)}
     end.

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1020,7 +1020,10 @@ acm_dutch_auction_contract(Config) ->
                  priv_key := CPriv}} = proplists:get_value(accounts, Config),
 
     %% Compile test contract
-    Contract = compile_test_contract("acm_dutch_auction"),
+    Contract = case aect_test_utils:latest_protocol_version() of
+                   Vsn when Vsn < ?FORTUNA_PROTOCOL_VSN -> compile_test_contract("acm_dutch_auction");
+                   _                                    -> compile_test_contract("aevm_3/acm_dutch_auction")
+               end,
 
     %% Set auction start amount and decrease per mine and fee.
     StartAmt = 50000,

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -1258,6 +1258,7 @@ run_contract(CallerId, Contract, GasLimit, GasPrice, CallData, Origin, Amount,
                , tx_env      => S1#state.tx_env
                , off_chain   => false
                , origin      => Origin
+               , creator     => aect_contracts:owner_pubkey(Contract)
                },
     CTVersion = aect_contracts:ct_version(Contract),
     {Call1, Trees1, Env1} = aect_dispatch:run(CTVersion, CallDef),

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -136,15 +136,15 @@
     {ok, aeo_oracles:relative_ttl()} | {error, term()}.
 
 -callback oracle_check(Oracle :: pubkey(),
-                       RFormat :: aeb_aevm_data:type(),
                        QFormat :: aeb_aevm_data:type(),
+                       RFormat :: aeb_aevm_data:type(),
                        ChainState :: chain_state()) ->
     {ok, non_neg_integer()} | {error, term()}.
 
 -callback oracle_check_query(Oracle :: pubkey(),
                              Query :: pubkey(),
-                             RFormat :: aeb_aevm_data:type(),
                              QFormat :: aeb_aevm_data:type(),
+                             RFormat :: aeb_aevm_data:type(),
                              ChainState :: chain_state()) ->
     {ok, non_neg_integer()} | {error, term()}.
 

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -135,6 +135,26 @@
                                     ChainState :: chain_state()) ->
     {ok, aeo_oracles:relative_ttl()} | {error, term()}.
 
+-callback oracle_check(Oracle :: pubkey(),
+                       RFormat :: aeb_aevm_data:type(),
+                       QFormat :: aeb_aevm_data:type(),
+                       ChainState :: chain_state()) ->
+    {ok, non_neg_integer()} | {error, term()}.
+
+-callback oracle_check_query(Oracle :: pubkey(),
+                             Query :: pubkey(),
+                             RFormat :: aeb_aevm_data:type(),
+                             QFormat :: aeb_aevm_data:type(),
+                             ChainState :: chain_state()) ->
+    {ok, non_neg_integer()} | {error, term()}.
+
+%% -- Address --
+-callback addr_is_contract(Addr :: pubkey(), ChainState :: chain_state()) ->
+    {ok, non_neg_integer()} | {error, term()}.
+
+-callback addr_is_oracle(Addr :: pubkey(), ChainState :: chain_state()) ->
+    {ok, non_neg_integer()} | {error, term()}.
+
 %% -- Name Services --
 
 -callback aens_resolve(Name :: binary(),

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -429,7 +429,6 @@ loop(CP, StateIn) ->
                 ?CREATOR ->
                     %% 0x2f Creator δ=0 α=1
                     %% Get address of contract creator.
-                    %% µ's[0] ≡ Ia
                     Arg = aevm_eeevm_state:creator(State0),
                     State1 = push(Arg, State0),
                     next_instruction(CP, State, State1);

--- a/apps/aevm/src/aevm_eeevm.erl
+++ b/apps/aevm/src/aevm_eeevm.erl
@@ -425,6 +425,14 @@ loop(CP, StateIn) ->
                     <<Val:256/integer-unsigned>> = Hash,
                     State4 = push(Val, State3),
                     next_instruction(CP, State, State4);
+                %% 2f: Non-standard Env information
+                ?CREATOR ->
+                    %% 0x2f Creator δ=0 α=1
+                    %% Get address of contract creator.
+                    %% µ's[0] ≡ Ia
+                    Arg = aevm_eeevm_state:creator(State0),
+                    State1 = push(Arg, State0),
+                    next_instruction(CP, State, State1);
                 %% 30s: Environmental Information
                 ?ADDRESS ->
                     %% 0x30 Address δ=0 α=1
@@ -1207,7 +1215,7 @@ is_valid_instruction(16#2b          ,_VM) -> false;
 is_valid_instruction(16#2c          ,_VM) -> false;
 is_valid_instruction(16#2d          ,_VM) -> false;
 is_valid_instruction(16#2e          ,_VM) -> false;
-is_valid_instruction(16#2f          ,_VM) -> false;
+is_valid_instruction(?CREATOR       , VM) -> ?IS_AEVM_SOPHIA(VM) andalso VM >= ?VM_AEVM_SOPHIA_3;
 is_valid_instruction(?ADDRESS       ,_VM) -> true;
 is_valid_instruction(?BALANCE       ,_VM) -> true;
 is_valid_instruction(?ORIGIN        ,_VM) -> true;

--- a/apps/aevm/src/aevm_eeevm_state.erl
+++ b/apps/aevm/src/aevm_eeevm_state.erl
@@ -26,6 +26,7 @@
         , code/1
         , coinbase/1
         , cp/1
+        , creator/1
         , data/1
         , difficulty/1
         , do_return/3
@@ -122,6 +123,7 @@ init(#{ env  := Env
          , gas         => maps:get(gas, Exec)
          , gas_price   => maps:get(gasPrice, Exec)
          , origin      => maps:get(origin, Exec)
+         , creator     => maps:get(creator, Exec)
          , value       => maps:get(value, Exec)
          , call_stack  => maps:get(call_stack, Exec, [])
 
@@ -589,6 +591,7 @@ jumpdests(State)   -> maps:get(jumpdests, State).
 stack(State)       -> maps:get(stack, State).
 mem(State)         -> maps:get(memory, State).
 number(State)      -> maps:get(number, State).
+creator(State)     -> maps:get(creator, State).
 origin(State)      -> maps:get(origin, State).
 out(State)         -> maps:get(out, State).
 out_type(State)    -> maps:get(out_type, State).

--- a/apps/aevm/src/aevm_opcodes.erl
+++ b/apps/aevm/src/aevm_opcodes.erl
@@ -51,6 +51,7 @@ opcode(GasTable, ?SHL)            -> { 2,  1, maps:get('GVERYLOW', GasTable)};
 opcode(GasTable, ?SHR)            -> { 2,  1, maps:get('GVERYLOW', GasTable)};
 opcode(GasTable, ?SAR)            -> { 2,  1, maps:get('GVERYLOW', GasTable)};
 opcode(GasTable, ?SHA3)           -> { 2,  1, maps:get('GSHA3', GasTable)};
+opcode(GasTable, ?CREATOR)        -> { 0,  1, maps:get('GBASE', GasTable)};
 opcode(GasTable, ?ADDRESS)        -> { 0,  1, maps:get('GBASE', GasTable)};
 opcode(GasTable, ?BALANCE)        -> { 1,  1, maps:get('GBALANCE', GasTable)};
 opcode(GasTable, ?ORIGIN)         -> { 0,  1, maps:get('GBASE', GasTable)};

--- a/apps/aevm/test/aevm_test_utils.erl
+++ b/apps/aevm/test/aevm_test_utils.erl
@@ -214,8 +214,9 @@ get_config({DirPath, TestName,_Opts}) ->
                   , vm_version => ?VM_AEVM_SOLIDITY_1
                   , abi_version => ?ABI_SOLIDITY_1
                   },
+    maps:update_with(exec, fun(Exec) -> maps:merge(#{creator => undefined}, Exec) end,
     maps:update_with(env, fun(Env) -> maps:merge(DefaultEnv, Env) end,
-                     TestConfig).
+                     TestConfig)).
 
 get_config_file(DirPath, TestName) ->
     FileName = config_filename(DirPath, TestName),

--- a/docs/release-notes/next-fortuna/PT-165440601-165713319-sophia_addons.md
+++ b/docs/release-notes/next-fortuna/PT-165440601-165713319-sophia_addons.md
@@ -1,0 +1,2 @@
+* Added Address.is_contract, Address.is_oracle, Oracle.check and Oracle.check_query to Sophia and AEVM
+* Added Contract.creator to Sophia and AEVM

--- a/rebar.config
+++ b/rebar.config
@@ -62,7 +62,7 @@
                    {ref, "9ff46af"}}},
 
         {aebytecode, {git, "https://github.com/aeternity/aebytecode.git",
-                     {ref,"2555868"}}},
+                     {ref,"08a09b0"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                            {ref,"816bf99"}}},
@@ -183,7 +183,7 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"0aa1c89"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"f8ee8f7"}}},
                             {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {ref, "e76162c"}}}
                            ]}
                    ]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"2555868990ac2a08876e86b1b798b4750273591f"}},
+      {ref,"08a09b065b9c5c4d1c499372a90914c80349dace"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",

--- a/test/aebytecode_aevm_SUITE.erl
+++ b/test/aebytecode_aevm_SUITE.erl
@@ -33,6 +33,7 @@ execute_identy_fun_from_file(_Cfg) ->
                           gas => 1000000,
                           gasPrice => 1,
                           origin => 0,
+                          creator => 0,
                           value => 0 },
                env => #{currentCoinbase => 0,
                         currentDifficulty => 0,

--- a/test/contract_solidity_bytecode_aevm_SUITE.erl
+++ b/test/contract_solidity_bytecode_aevm_SUITE.erl
@@ -230,6 +230,7 @@ do_execute_call(#{ code := Code
                     , gasPrice => GasPrice
                     , origin => Origin
                     , value => Value
+                    , creator => undefined %% Not in solidity VM
                     },
            env => #{ currentCoinbase => CoinBase
                    , currentDifficulty => Difficulty

--- a/test/contract_sophia_bytecode_aevm_SUITE.erl
+++ b/test/contract_sophia_bytecode_aevm_SUITE.erl
@@ -175,6 +175,7 @@ do_execute_call(#{ code := Code
                     , gasPrice => GasPrice
                     , origin => Origin
                     , value => Value
+                    , creator => Origin
                     },
            env => #{ currentCoinbase => CoinBase
                    , currentDifficulty => Difficulty

--- a/test/contracts/address_checks.aes
+++ b/test/contracts/address_checks.aes
@@ -1,0 +1,41 @@
+contract AddrCheck =
+  type q_type1 = string
+  type q_type2 = (int, int)
+  type r_type1 = int
+  type r_type2 = map(int, string)
+
+  type o_type1 = oracle(q_type1, r_type1)
+  type o_type2 = oracle(q_type2, r_type2)
+  type oq_type1 = oracle_query(q_type1, r_type1)
+  type oq_type2 = oracle_query(q_type2, r_type2)
+
+  function register1() : o_type1 =
+    Oracle.register(Contract.address, 12, RelativeTTL(100))
+
+  function register2() : o_type2 =
+    Oracle.register(Contract.address, 12, RelativeTTL(100))
+
+  function query1(o, q) : oq_type1 =
+    Oracle.query(o, q, 12, RelativeTTL(20), RelativeTTL(30))
+
+  function query2(o, q) : oq_type2 =
+    Oracle.query(o, q, 12, RelativeTTL(20), RelativeTTL(30))
+
+  function is_o(a : address) : bool =
+    Address.is_oracle(a)
+
+  function is_c(a : address) : bool =
+    Address.is_contract(a)
+
+  function check_o1(o : o_type1) : bool =
+    Oracle.check(o)
+
+  function check_o2(o : o_type2) : bool =
+    Oracle.check(o)
+
+  function check_oq1(o, oq : oq_type1) : bool =
+    Oracle.check_query(o, oq)
+
+  function check_oq2(o, oq : oq_type2) : bool =
+    Oracle.check_query(o, oq)
+

--- a/test/contracts/aevm_3/acm_dutch_auction.aes
+++ b/test/contracts/aevm_3/acm_dutch_auction.aes
@@ -1,0 +1,25 @@
+contract DutchAuction =
+
+  record state = { amount : int,
+                   height : int,
+                   dec    : int,
+                   sold   : bool }
+
+  private function require(b : bool, err : string) =
+    if(!b) abort(err)
+
+  public function init(price, decrease) : state =
+    require(price > 0 && decrease > 0, "bad args")
+    { amount = price,
+      height = Chain.block_height,
+      dec    = decrease,
+      sold   = false }
+
+  public stateful function bid() =
+    require( !(state.sold), "sold")
+    let price =
+      state.amount - (Chain.block_height - state.height) * state.dec
+    require( Contract.balance >= price, "no money")
+    Chain.spend(Contract.creator, price)
+    Chain.spend(Call.origin, Contract.balance)
+    put(state{sold = true})

--- a/test/sophia_bytecode_aevm_SUITE.erl
+++ b/test/sophia_bytecode_aevm_SUITE.erl
@@ -52,6 +52,7 @@ execute_identity_fun_from_sophia_file(_Cfg) ->
                           gas => 1000000,
                           gasPrice => 1,
                           origin => 0,
+                          creator => 0,
                           value => 0 },
                env => #{currentCoinbase => 0,
                         currentDifficulty => 0,


### PR DESCRIPTION
Added Address.is_contract, Address.is_oracle, Oracle.check, Oracle.check_query
and Contract.creator to Sophia and AEVM

https://www.pivotaltracker.com/story/show/165440601
and https://www.pivotaltracker.com/story/show/165713319 

Doc: https://github.com/aeternity/protocol/pull/347