### PR TITLE
Pt 159406473 sc continuous chain monitoring 3

### DIFF
--- a/apps/aechannel/src/aesc_channels.erl
+++ b/apps/aechannel/src/aesc_channels.erl
@@ -57,6 +57,21 @@
 %%% Types
 %%%===================================================================
 
+-export_type([ channel/0
+             , id/0
+             , amount/0
+             , pubkey/0
+             , round/0
+             , solo_round/0
+             , is_active/0
+             , lock_period/0
+             , locked_until/0
+             , state_hash/0
+             , serialized/0
+             , seq_number/0
+             , payload/0
+             ]).
+
 -type id() :: aeser_id:id().
 -type pubkey() :: aec_keys:pubkey().
 -type amount() :: non_neg_integer().
@@ -66,11 +81,17 @@
 -type auth() :: basic | {hash32(), aeser_id:id()}.
 -type serialized() :: binary().
 -type sc_nonce() :: non_neg_integer() | hash32().
+-type round()        :: seq_number().
+-type solo_round()   :: round().
+-type is_active()    :: boolean().
+-type lock_period()  :: non_neg_integer().
+-type locked_until() :: undefined | aec_blocks:height().
+-type state_hash()   :: binary().
 
--record(channel, {id                     :: aeser_id:id(),
-                  initiator_id           :: aeser_id:id(),
-                  responder_id           :: aeser_id:id(),
-                  delegate_ids           :: [aeser_id:id()],
+-record(channel, {id                     :: id(),
+                  initiator_id           :: id(),
+                  responder_id           :: id(),
+                  delegate_ids           :: [id()],
                   channel_amount         :: amount(),
                   initiator_amount       :: amount(),
                   responder_amount       :: amount(),
@@ -86,13 +107,6 @@
 
 -opaque channel() :: #channel{}.
 
--export_type([id/0,
-              pubkey/0,
-              amount/0,
-              seq_number/0,
-              channel/0,
-              serialized/0,
-              payload/0]).
 
 -define(CHANNEL_TYPE, channel).
 -define(CHANNEL_VSN_1, 1).
@@ -113,7 +127,7 @@ close_solo(Ch, PoI, Height) ->
                                     state_hash(Ch)).  % keep the state hash
 
 %% close solo with a payload
--spec close_solo(channel(), aesc_offchain_tx:tx(), aec_trees:poi(), aec_blocks:height()) -> channel().
+-spec close_solo(channel(), payload(), aec_trees:poi(), aec_blocks:height()) -> channel().
 close_solo(Ch, PayloadTx, PoI, Height) ->
     close_solo_int(Ch, PoI, Height, aesc_offchain_tx:round(PayloadTx),
                                     aesc_offchain_tx:state_hash(PayloadTx)).
@@ -138,7 +152,7 @@ deposit(#channel{channel_amount = ChannelAmount} = Ch, Amount, Round, StateHash)
                solo_round         = 0,
                round              = Round}.
 
--spec deserialize(pubkey(), binary()) -> channel().
+-spec deserialize(pubkey(), serialized()) -> channel().
 deserialize(IdBin, Bin) ->
     case aeser_chain_objects:deserialize_type_and_vsn(Bin) of
         {?CHANNEL_TYPE = Type, ?CHANNEL_VSN_1 = Vsn, _Rest} ->
@@ -202,7 +216,7 @@ deserialize_auth(<<AuthFun:?HASH_SIZE/binary, AuthContract:?PUB_SIZE/binary>>) -
     {AuthFun, aeser_id:create(contract, AuthContract)}.
 
 %% set a new state
--spec snapshot_solo(channel(), aesc_offchain_tx:tx()) -> channel().
+-spec snapshot_solo(channel(), payload()) -> channel().
 snapshot_solo(Ch, PayloadTx) ->
     Round = aesc_offchain_tx:round(PayloadTx),
     StateHash = aesc_offchain_tx:state_hash(PayloadTx),
@@ -234,7 +248,7 @@ force_progress(Ch0, StateHash, Round, IAmt, RAmt, Height) ->
         false -> Ch1#channel{locked_until = Height + lock_period(Ch0)}
     end.
 
--spec is_active(channel()) -> boolean().
+-spec is_active(channel()) -> is_active().
 is_active(#channel{locked_until = LockedUntil}) ->
     %% since we can not close a channel on a block height 0,
     %% we use this value to denote active
@@ -305,7 +319,7 @@ parse_auth(Account) ->
 peers(#channel{} = Ch) ->
     [initiator_pubkey(Ch), responder_pubkey(Ch)].
 
--spec serialize(channel()) -> binary().
+-spec serialize(channel()) -> serialized().
 serialize(#channel{initiator_id = InitiatorId,
                    responder_id = ResponderId,
                    delegate_ids = DelegateIds,
@@ -411,7 +425,7 @@ withdraw(#channel{channel_amount = ChannelAmount} = Ch, Amount, Round, StateHash
 %%% Getters
 %%%===================================================================
 
--spec locked_until(channel()) -> undefined | aec_blocks:height().
+-spec locked_until(channel()) -> locked_until().
 locked_until(#channel{locked_until = FBU}) ->
     FBU.
 
@@ -455,7 +469,7 @@ responder_amount(#channel{responder_amount = ResponderAmount}) ->
 channel_reserve(#channel{channel_reserve = ChannelReserve}) ->
     ChannelReserve.
 
--spec lock_period(channel()) -> non_neg_integer().
+-spec lock_period(channel()) -> lock_period().
 lock_period(#channel{lock_period = LockPeriod}) ->
     LockPeriod.
 
@@ -467,19 +481,19 @@ delegate_ids(#channel{delegate_ids = Ids}) ->
 delegate_pubkeys(#channel{delegate_ids = Ids}) ->
     [aeser_id:specialize(Id, account) || Id <- Ids].
 
--spec state_hash(channel()) -> binary().
+-spec state_hash(channel()) -> state_hash().
 state_hash(#channel{state_hash = StateHash}) ->
     StateHash.
 
--spec round(channel()) -> non_neg_integer().
+-spec round(channel()) -> round().
 round(#channel{round = Round}) ->
     Round.
 
--spec solo_round(channel()) -> non_neg_integer().
+-spec solo_round(channel()) -> solo_round().
 solo_round(#channel{solo_round = SoloRound}) ->
     SoloRound.
 
--spec fetch_amount_from_poi(aec_trees:poi(), aec_keys:pubkey()) -> non_neg_integer().
+-spec fetch_amount_from_poi(aec_trees:poi(), aec_keys:pubkey()) -> amount().
 fetch_amount_from_poi(PoI, Pubkey) ->
     {ok, Account} = aec_trees:lookup_poi(accounts, Pubkey, PoI),
     aec_accounts:balance(Account).

--- a/apps/aechannel/src/aesc_close_mutual_tx.erl
+++ b/apps/aechannel/src/aesc_close_mutual_tx.erl
@@ -33,7 +33,9 @@
 -export([set_channel_id/2]).
 -endif.
 
--export([channel_pubkey/1]).
+% aesc_signable_transaction callbacks
+-export([channel_id/1,
+         channel_pubkey/1]).
 
 %%%===================================================================
 %%% Types
@@ -106,6 +108,9 @@ origin(#channel_close_mutual_tx{from_id = FromId}) ->
 
 channel_pubkey(#channel_close_mutual_tx{channel_id = ChannelId}) ->
     aeser_id:specialize(ChannelId, channel).
+
+channel_id(#channel_close_mutual_tx{channel_id = ChannelId}) ->
+    ChannelId.
 
 -spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_close_mutual_tx{}, Trees,_Env) ->

--- a/apps/aechannel/src/aesc_close_solo_tx.erl
+++ b/apps/aechannel/src/aesc_close_solo_tx.erl
@@ -27,6 +27,10 @@
          valid_at_protocol/2
         ]).
 
+% aesc_signable_transaction callbacks
+-export([channel_id/1,
+         channel_pubkey/1]).
+
 %%%===================================================================
 %%% Types
 %%%===================================================================
@@ -98,6 +102,9 @@ origin(#channel_close_solo_tx{} = Tx) ->
 
 channel_pubkey(#channel_close_solo_tx{channel_id = ChannelId}) ->
     aeser_id:specialize(ChannelId, channel).
+
+channel_id(#channel_close_solo_tx{channel_id = ChannelId}) ->
+    ChannelId.
 
 from_pubkey(#channel_close_solo_tx{from_id = FromPubKey}) ->
     aeser_id:specialize(FromPubKey, account).

--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -53,8 +53,11 @@
 %% Non-encoded cast types
 -define(DISCONNECT, disconnect).
 -define(SIGNED, signed).
+-define(SETTLE, settle).
 -define(MIN_DEPTH_ACHIEVED, minimum_depth_achieved).
+-define(CHANNEL_CHANGED, channel_changed).
 -define(CHANNEL_CLOSING, channel_closing).
+-define(CHANNEL_UNLOCKED, channel_unlocked).
 
 %% Error codes
 -define(ERR_VALIDATION, 1).

--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -58,6 +58,7 @@
 -define(CHANNEL_CHANGED, channel_changed).
 -define(CHANNEL_CLOSING, channel_closing).
 -define(CHANNEL_UNLOCKED, channel_unlocked).
+-define(CHANNEL_CLOSED, channel_closed).
 
 %% Error codes
 -define(ERR_VALIDATION, 1).

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -56,7 +56,7 @@
           payload       :: binary(),
           update        :: aesc_offchain_update:update(),
           state_hash    :: binary(),
-          round         :: aesc_channels:seq_number(),
+          round         :: aesc_channels:round(),
           offchain_trees:: aec_trees:trees(),
           ttl           :: aetx:tx_ttl(),
           fee           :: non_neg_integer(),
@@ -319,7 +319,7 @@ channel_id(#channel_force_progress_tx{channel_id = ChannelId}) ->
 updates(#channel_force_progress_tx{update = Update}) ->
     [Update].
 
--spec round(tx()) -> aesc_channels:seq_number().
+-spec round(tx()) -> aesc_channels:round().
 round(#channel_force_progress_tx{round = Round}) ->
     Round.
 

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -874,12 +874,12 @@ awaiting_signature(cast, {?SIGNED, ?SHUTDOWN_ACK, SignedTx} = Msg,
             close(close_mutual, D2)
         end, D);
 awaiting_signature(cast, {?SIGNED, settle_tx, SignedTx} = Msg,
-                   #data{latest = {sign, settle_tx, _STx, _Updates}} = D) ->
-    maybe_check_sigs(SignedTx, channel_settle_tx, not_settle_tx, me,
+                   #data{latest = {sign, settle_tx, _STx, Updates}} = D) ->
+    maybe_check_sigs(SignedTx, Updates, channel_settle_tx, not_settle_tx, me,
         fun() ->
                 D1 = D#data{log = log_msg(rcv, ?SIGNED, Msg, D#data.log),
                             latest = undefined},
-                settle_signed(SignedTx, D1)
+                settle_signed(SignedTx, Updates, D1)
         end, D);
                                                         
 %% Other
@@ -1044,7 +1044,7 @@ withdraw_locked_complete(SignedTx, Updates, #data{state = State, opts = Opts} = 
                                                             OnChainEnv, Opts)},
     next_state(open, D1).
 
-settle_signed(SignedTx, #data{ on_chain_id = ChId} = D) ->
+settle_signed(SignedTx, Updates, #data{ on_chain_id = ChId} = D) ->
     lager:debug("SignedTx = ~p", [SignedTx]),
     case aec_chain:get_channel(ChId) of
         {ok, Ch} ->
@@ -1053,11 +1053,11 @@ settle_signed(SignedTx, #data{ on_chain_id = ChId} = D) ->
                 case is_channel_locked(LockedUntil) of
                     true ->
                         lager:debug("channel is locked", []),
-                        start_min_depth_watcher(unlock, SignedTx, D);
+                        start_min_depth_watcher(unlock, SignedTx, Updates, D);
                     false ->
                         lager:debug("channel not locked, pushing settle", []),
                         ok = aec_tx_pool:push(SignedTx),
-                        start_min_depth_watcher(close, SignedTx, D)
+                        start_min_depth_watcher(close, SignedTx, Updates, D)
                 end,
             next_state(channel_closing, D1);
         {error,_} = Error ->
@@ -1619,14 +1619,15 @@ handle_call_(St, close_solo, From, D) ->
             keep_state(D, [{reply, From, {error, channel_closing}}]);
         _ ->
             {ok, CloseSoloTx, Updates} = close_solo_tx_for_signing(D),
-            D1 = set_ongoing(request_signing(close_solo_tx, CloseSoloTx, D)),
+            D1 = set_ongoing(request_signing(
+                               close_solo_tx, CloseSoloTx, Updates, D)),
             next_state(awaiting_signature, D1, [{reply, From, ok}])
     end;
 handle_call_(St, slash, From, D) ->
     case St of
         channel_closing ->
-            {ok, SlashTx} = slash_tx_for_signing(D),
-            D1 = set_ongoing(request_signing(slash_tx, SlashTx, D)),
+            {ok, SlashTx, Updates} = slash_tx_for_signing(D),
+            D1 = set_ongoing(request_signing(slash_tx, SlashTx, Updates, D)),
             next_state(awaiting_signature, D1, [{reply, From, ok}]);
         _ ->
             keep_state(D, [{reply, From, {error, channel_not_closing}}])
@@ -1634,8 +1635,8 @@ handle_call_(St, slash, From, D) ->
 handle_call_(St, settle, From, D) ->
     case St of
         channel_closing ->
-            {ok, SettleTx} = settle_tx_for_signing(D),
-            D1 = set_ongoing(request_signing(settle_tx, SettleTx, D)),
+            {ok, SettleTx, Updates} = settle_tx_for_signing(D),
+            D1 = set_ongoing(request_signing(settle_tx, SettleTx, Updates, D)),
             next_state(awaiting_signature, D1, [{reply, From, ok}]);
         _ ->
             keep_state(D, [{reply, From, {error, channel_not_closed}}])
@@ -1682,7 +1683,7 @@ handle_common_event_(cast, {?CHANNEL_CLOSING, Info} = Msg, _St, _, D) ->
         {can_slash, Round, SignedTx} ->
             {ok, SlashTx, Updates} = slash_tx_for_signing(Round, SignedTx, D1),
             report_on_chain_tx(can_slash, SignedTx, D1),
-            D2 = set_ongoing(request_signing(slash_tx, SlashTx, D1)),
+            D2 = set_ongoing(request_signing(slash_tx, SlashTx, Updates, D1)),
             next_state(awaiting_signature, D2);
         {ok, proper_solo_closing, SignedTx} ->
             lager:debug("Channel solo-closing", []),
@@ -1716,7 +1717,7 @@ handle_common_event_(cast, {?CHANNEL_CHANGED, #{tx_hash := TxHash} = Info} = Msg
 handle_common_event_(cast, {?CHANNEL_CLOSED, #{tx := SignedTx} = _Info} = Msg, _St, _, D) ->
     %% Start a minimum-depth watch, then (if confirmed) terminate
     report_on_chain_tx(channel_closed, SignedTx, D),
-    {ok, D1} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_CLOSED}, SignedTx, D),
+    {ok, D1} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_CLOSED}, SignedTx, [], D),
     next_state(channel_closed, log(rcv, msg_type(Msg), Msg, D1));
 handle_common_event_({call, From}, Req, St, Mode, D) ->
     case Mode of
@@ -2166,14 +2167,14 @@ settle_tx(Account, Nonce, #data{ opts  = #{initiator := I,
     {ok, RAmt} = aesc_offchain_state:balance(R, State),
     Fee = maps:get(fee, Opts1),
     TTL = adjust_ttl(maps:get(ttl, Opts1, 0)),
-    {ok, _} = Ok = aesc_settle_tx:new(#{ channel_id => aeser_id:create(channel, ChanId)
-                                       , from_id    => aeser_id:create(account, Account)
-                                       , initiator_amount_final => IAmt
-                                       , responder_amount_final => RAmt
-                                       , ttl        => TTL
-                                       , fee        => Fee
-                                       , nonce      => Nonce }),
-    Ok.
+    {ok, Tx} = aesc_settle_tx:new(#{ channel_id => aeser_id:create(channel, ChanId)
+                                   , from_id    => aeser_id:create(account, Account)
+                                   , initiator_amount_final => IAmt
+                                   , responder_amount_final => RAmt
+                                   , ttl        => TTL
+                                   , fee        => Fee
+                                   , nonce      => Nonce }),
+    {ok, Tx, []}.
 
 close_solo_tx_for_signing(D) ->
     Account = my_account(D),
@@ -2923,7 +2924,7 @@ start_min_depth_watcher(Type, SignedTx, Updates,
                                Sub, TxHash, OnChainId, MinDepth, ?MODULE, WOpts),
             evt({watcher, Watcher1}),
             {ok, D1#data{watcher = Watcher1,
-                         latest = {min_depth, Type, TxHash, SignedTx, Updates}}};
+                         latest = {min_depth, Sub, TxHash, SignedTx, Updates}}};
         {{?MIN_DEPTH, Sub}, Pid} when is_pid(Pid) ->
             ok = aesc_fsm_min_depth_watcher:watch_for_min_depth(
                    Pid, TxHash, MinDepth, ?MODULE, Sub),

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1108,12 +1108,8 @@ awaiting_locked(cast, {?DEP_ERR, _Msg}, D) ->
 awaiting_locked(cast, {?WDRAW_ERR, _Msg}, D) ->
     %% TODO: Stop min depth watcher!
     handle_update_conflict(?WDRAW_SIGNED, D);
-awaiting_locked(cast, {?CHANNEL_CHANGED, #{tx_hash := TxHash}} = Msg,
-                #data{ latest = {?MIN_DEPTH, ?WATCH_DEP, TxHash, _, _}} = D) ->
-    %% Expected
-    keep_state(log(rcv, ?CHANNEL_CHANGED, Msg, D));
 awaiting_locked(Type, Msg, D) ->
-    lager:debug("Unexpected. Msg = ~p, Latest = ~p", [Msg, D#data.latest]),
+    lager:debug("Unexpected ~p: Msg = ~p, Latest = ~p", [Type, Msg, D#data.latest]),
     handle_common_event(Type, Msg, error, D).
 
 awaiting_initial_state(enter, _OldSt, _D) -> keep_state_and_data;

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -96,6 +96,7 @@
                   | deposit_tx
                   | withdraw_tx
                   | close_solo_tx
+                  | settle_tx
                   | ?FND_CREATED
                   | ?DEP_CREATED
                   | ?WDRAW_CREATED
@@ -162,11 +163,14 @@
                    | {sign | ack, sign_tag(), aetx_sign:signed_tx(), [aesc_offchain_update:update()]}
                    | {create | shutdown | deposit | withdraw, aetx_sign:signed_tx(),
                       [aesc_offchain_update:update()]}
-                   | {watch, ?WATCH_FND
-                           | ?WATCH_DEP
-                           | ?WATCH_WDRAW
-                           | deposit
-                           | withdraw,
+                   | {?MIN_DEPTH, ?WATCH_FND
+                                | ?WATCH_DEP
+                                | ?WATCH_WDRAW
+                                | ?WATCH_CLOSED,
+                      TxHash :: binary(), aetx_sign:signed_tx(),
+                      [aesc_offchain_update:update()]}
+                   | {watch, unlock
+                           | close,
                       TxHash :: binary(), aetx_sign:signed_tx(),
                       [aesc_offchain_update:update()]}
                    | {reestablish, OffChainTx :: aetx_sign:signed_tx()}.
@@ -1070,7 +1074,7 @@ is_channel_locked(LockedUntil) ->
 
 awaiting_locked(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_FND, TxHash},
-                #data{latest = {min_depth, ?WATCH_FND, TxHash, CTx, Updates}} = D) ->
+                #data{latest = {?MIN_DEPTH, ?WATCH_FND, TxHash, CTx, Updates}} = D) ->
     report(info, own_funding_locked, D),
     next_state(
       signed, send_funding_locked_msg(D#data{on_chain_id = ChainId,
@@ -1078,7 +1082,7 @@ awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_FND, TxHash},
                                                        Updates}}));
 awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_DEP, TxHash},
                 #data{on_chain_id = ChainId,
-                      latest = {min_depth, ?WATCH_DEP, TxHash, SignedTx, Updates}} = D) ->
+                      latest = {?MIN_DEPTH, ?WATCH_DEP, TxHash, SignedTx, Updates}} = D) ->
     report(info, own_deposit_locked, D),
     next_state(
       dep_signed, send_deposit_locked_msg(
@@ -1086,7 +1090,7 @@ awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_DEP, TxHash},
                     D#data{latest = {deposit, SignedTx, Updates}}));
 awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_WDRAW, TxHash},
                 #data{on_chain_id = ChainId,
-                      latest = {min_depth, ?WATCH_WDRAW, TxHash, SignedTx, Updates}} = D) ->
+                      latest = {?MIN_DEPTH, ?WATCH_WDRAW, TxHash, SignedTx, Updates}} = D) ->
     report(info, own_withdraw_locked, D),
     next_state(
       wdraw_signed, send_withdraw_locked_msg(
@@ -1105,7 +1109,7 @@ awaiting_locked(cast, {?WDRAW_ERR, _Msg}, D) ->
     %% TODO: Stop min depth watcher!
     handle_update_conflict(?WDRAW_SIGNED, D);
 awaiting_locked(cast, {?CHANNEL_CHANGED, #{tx_hash := TxHash}} = Msg,
-                #data{ latest = {min_depth, ?WATCH_DEP, TxHash, _}} = D) ->
+                #data{ latest = {?MIN_DEPTH, ?WATCH_DEP, TxHash, _, _}} = D) ->
     %% Expected
     keep_state(log(rcv, ?CHANNEL_CHANGED, Msg, D));
 awaiting_locked(Type, Msg, D) ->
@@ -1354,7 +1358,7 @@ channel_closing(Type, Msg, D) ->
 channel_closed(enter, _OldSt, D) ->
     keep_state(D#data{ongoing_update = false});
 channel_closed(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_CLOSED, TxHash},
-               #data{ latest = {min_depth, ?WATCH_CLOSED, TxHash, _}
+               #data{ latest = {?MIN_DEPTH, ?WATCH_CLOSED, TxHash, _, _}
                     , on_chain_id = ChainId } = D) ->
     close(closed_confirmed, D);
 channel_closed(cast, {?CHANNEL_CHANGED, _Info} = Msg, D) ->
@@ -1705,7 +1709,7 @@ handle_common_event_(cast, {?CHANNEL_CHANGED, #{tx_hash := TxHash} = Info} = Msg
                      _St, _, D) ->
     D1 = log(rcv, msg_type(Msg), Msg, D),
     case D1#data.latest of
-        {min_depth, _, LatestTxHash, _} when TxHash =/= LatestTxHash ->
+        {?MIN_DEPTH, _, LatestTxHash, _, _} when TxHash =/= LatestTxHash ->
             %% This is a problem: channel changed while waiting to confirm
             %% other tx hash
             close({error, unexpected_tx_on_chain}, D);
@@ -2924,11 +2928,11 @@ start_min_depth_watcher(Type, SignedTx, Updates,
                                Sub, TxHash, OnChainId, MinDepth, ?MODULE, WOpts),
             evt({watcher, Watcher1}),
             {ok, D1#data{watcher = Watcher1,
-                         latest = {min_depth, Sub, TxHash, SignedTx, Updates}}};
+                         latest = {?MIN_DEPTH, Sub, TxHash, SignedTx, Updates}}};
         {{?MIN_DEPTH, Sub}, Pid} when is_pid(Pid) ->
             ok = aesc_fsm_min_depth_watcher:watch_for_min_depth(
                    Pid, TxHash, MinDepth, ?MODULE, Sub),
-            {ok, D1#data{latest = {min_depth, Sub, TxHash, SignedTx, Updates}}};
+            {ok, D1#data{latest = {?MIN_DEPTH, Sub, TxHash, SignedTx, Updates}}};
         {unlock, Pid} when Pid =/= undefined ->
             ok = aesc_fsm_min_depth_watcher:watch_for_unlock(Pid, ?MODULE),
             {ok, D1#data{latest = {watch, unlock, TxHash, SignedTx, Updates}}};

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -47,6 +47,7 @@
 -export([minimum_depth_achieved/4,     %% (Fsm, OnChainId, Type, TxHash)
          channel_changed_on_chain/2,   %% (Fsm, Info)
          channel_closing_on_chain/2,
+         channel_closed_on_chain/2,    %% (Fsm, Info)
          channel_unlocked/2]). %% (Fsm, Info)
 
 -export([init/1,
@@ -76,6 +77,7 @@
          open/3,
          channel_closing/3,   % on-chain closing has been detected
          mutual_closing/3,
+         channel_closed/3,
          disconnected/3]).
 
 -export([timeouts/0,
@@ -108,6 +110,8 @@
 -define(WATCH_FND, funding).
 -define(WATCH_DEP, deposit).
 -define(WATCH_WDRAW, withdraw).
+-define(WATCH_CLOSED, closed).
+-define(MIN_DEPTH, min_depth).
 
 -define(UPDATE_CAST(R), R==?UPDATE; R==?DEP_CREATED; R==?WDRAW_CREATED).
 -define(UPDATE_REQ(R),
@@ -141,6 +145,12 @@
                          ; T =:= ?SHUTDOWN_ACK
                          ; T =:= ?CH_REESTABL
                          ; T =:= ?CH_REEST_ACK).
+
+-define(WATCHER_EVENT(T), T =:= ?CHANNEL_CHANGED
+                        ; T =:= ?CHANNEL_UNLOCKED
+                        ; T =:= ?MIN_DEPTH_ACHIEVED
+                        ; T =:= ?CHANNEL_CLOSING
+                        ; T =:= ?CHANNEL_CLOSED).
 
 -define(KEEP, 10).
 
@@ -262,6 +272,9 @@ channel_changed_on_chain(Fsm, Info) ->
 channel_closing_on_chain(Fsm, Info) ->
     gen_statem:cast(Fsm, {?CHANNEL_CLOSING, Info}).
 
+channel_closed_on_chain(Fsm, Info) ->
+    gen_statem:cast(Fsm, {?CHANNEL_CLOSED, Info}).
+
 channel_unlocked(Fsm, Info) ->
     lager:debug("sending unlocked", []),
     gen_statem:cast(Fsm, {?CHANNEL_UNLOCKED, Info}).
@@ -310,6 +323,7 @@ timer_subst(wdraw_signed            ) -> funding_lock;
 timer_subst(initialized             ) -> accept;
 timer_subst(mutual_closing          ) -> accept;
 timer_subst(channel_closing         ) -> idle;
+timer_subst(channel_closed          ) -> idle;
 timer_subst(channel_changed         ) -> idle.
 
 default_timeouts() ->
@@ -466,6 +480,8 @@ connection_died(Fsm) ->
     stop_ok(catch gen_statem:stop(Fsm)).
 
 stop_ok(ok) ->
+    ok;
+stop_ok({'EXIT', noproc}) ->
     ok;
 stop_ok({'EXIT', {normal,{sys,terminate,_}}}) ->
     ok.
@@ -756,7 +772,7 @@ awaiting_signature(cast, {?SIGNED, ?FND_CREATED, SignedTx} = Msg,
                                                 latest = {ack, ?FND_CREATED,
                                                           HSCTx, Updates}})),
             report_on_chain_tx(?FND_CREATED, NewSignedTx, D1),
-            {ok, D2} = start_min_depth_watcher(?WATCH_FND, NewSignedTx,
+            {ok, D2} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_FND}, NewSignedTx,
                                                Updates, D1),
             gproc_register_on_chain_id(D2),
             next_state(awaiting_locked, D2)
@@ -772,7 +788,7 @@ awaiting_signature(cast, {?SIGNED, ?DEP_CREATED, SignedTx} = Msg,
                                                            ?DEP_CREATED,
                                                            HSCTx, Updates}}),
             report_on_chain_tx(?DEP_CREATED, NewSignedTx, D1),
-            {ok, D2} = start_min_depth_watcher(?WATCH_DEP, NewSignedTx,
+            {ok, D2} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_DEP}, NewSignedTx,
                                                Updates, D1),
             next_state(awaiting_locked,
                       log(rcv, ?SIGNED, Msg, D2))
@@ -788,7 +804,7 @@ awaiting_signature(cast, {?SIGNED, ?WDRAW_CREATED, SignedTx} = Msg,
                                                            ?WDRAW_CREATED,
                                                            HSCTx, Updates}}),
             report_on_chain_tx(?WDRAW_CREATED, NewSignedTx, D1),
-            {ok, D2} = start_min_depth_watcher(?WATCH_WDRAW, NewSignedTx,
+            {ok, D2} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_WDRAW}, NewSignedTx,
                                                Updates, D1),
             next_state(awaiting_locked, log(rcv, ?SIGNED, Msg, D2))
         end, D);
@@ -881,7 +897,7 @@ half_signed(cast, {?FND_SIGNED, Msg}, #data{role = initiator,
             ok = aec_tx_pool:push(SignedTx),
             D2 = D1#data{create_tx = SignedTx},
             {ack, create_tx, _, Updates} = Latest,
-            {ok, D3} = start_min_depth_watcher(?WATCH_FND, SignedTx, Updates, D2),
+            {ok, D3} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_FND}, SignedTx, Updates, D2),
             next_state(awaiting_locked, D3);
         {error, Error} ->
             close(Error, D)
@@ -901,7 +917,7 @@ dep_half_signed(cast, {?DEP_SIGNED, Msg}, #data{latest = Latest} = D) ->
             report_on_chain_tx(?DEP_SIGNED, SignedTx, D1),
             ok = aec_tx_pool:push(SignedTx),
             {ack, deposit_tx, _, Updates} = Latest,
-            {ok, D2} = start_min_depth_watcher(deposit, SignedTx, Updates, D1),
+            {ok, D2} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_DEP}, SignedTx, Updates, D1),
             next_state(awaiting_locked, D2);
         {error, _Error} ->
             handle_update_conflict(?DEP_SIGNED, D)
@@ -963,7 +979,8 @@ wdraw_half_signed(cast, {?WDRAW_SIGNED, Msg}, #data{latest = Latest} = D) ->
             report_on_chain_tx(?WDRAW_SIGNED, SignedTx, D1),
             ok = aec_tx_pool:push(SignedTx),
             {ack, withdraw_tx, _, Updates} = Latest,
-            {ok, D2} = start_min_depth_watcher(withdraw, SignedTx, Updates, D1),
+            {ok, D2} = start_min_depth_watcher(
+                         {?MIN_DEPTH, ?WATCH_WDRAW}, SignedTx, Updates, D1),
             next_state(awaiting_locked, D2);
         {error, _Error} ->
             handle_update_conflict(?WDRAW_SIGNED, D)
@@ -1037,7 +1054,7 @@ is_channel_locked(LockedUntil) ->
 
 awaiting_locked(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_FND, TxHash},
-                #data{latest = {watch, ?WATCH_FND, TxHash, CTx, Updates}} = D) ->
+                #data{latest = {min_depth, ?WATCH_FND, TxHash, CTx, Updates}} = D) ->
     report(info, own_funding_locked, D),
     next_state(
       signed, send_funding_locked_msg(D#data{on_chain_id = ChainId,
@@ -1045,7 +1062,7 @@ awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_FND, TxHash},
                                                        Updates}}));
 awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_DEP, TxHash},
                 #data{on_chain_id = ChainId,
-                      latest = {watch, ?WATCH_DEP, TxHash, SignedTx, Updates}} = D) ->
+                      latest = {min_depth, ?WATCH_DEP, TxHash, SignedTx, Updates}} = D) ->
     report(info, own_deposit_locked, D),
     next_state(
       dep_signed, send_deposit_locked_msg(
@@ -1053,7 +1070,7 @@ awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_DEP, TxHash},
                     D#data{latest = {deposit, SignedTx, Updates}}));
 awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_WDRAW, TxHash},
                 #data{on_chain_id = ChainId,
-                      latest = {watch, ?WATCH_WDRAW, TxHash, SignedTx, Updates}} = D) ->
+                      latest = {min_depth, ?WATCH_WDRAW, TxHash, SignedTx, Updates}} = D) ->
     report(info, own_withdraw_locked, D),
     next_state(
       wdraw_signed, send_withdraw_locked_msg(
@@ -1071,7 +1088,12 @@ awaiting_locked(cast, {?DEP_ERR, _Msg}, D) ->
 awaiting_locked(cast, {?WDRAW_ERR, _Msg}, D) ->
     %% TODO: Stop min depth watcher!
     handle_update_conflict(?WDRAW_SIGNED, D);
+awaiting_locked(cast, {?CHANNEL_CHANGED, #{tx_hash := TxHash}} = Msg,
+                #data{ latest = {min_depth, ?WATCH_DEP, TxHash, _}} = D) ->
+    %% Expected
+    keep_state(log(rcv, ?CHANNEL_CHANGED, Msg, D));
 awaiting_locked(Type, Msg, D) ->
+    lager:debug("Unexpected. Msg = ~p, Latest = ~p", [Msg, D#data.latest]),
     handle_common_event(Type, Msg, error, D).
 
 awaiting_initial_state(enter, _OldSt, _D) -> keep_state_and_data;
@@ -1308,11 +1330,26 @@ channel_closing(cast, {?CHANNEL_UNLOCKED, #{chan_id := ChId}} = Msg,
             ok
     end,
     keep_state(D1);
-channel_closing(cast, {?MIN_DEPTH_ACHIEVED, _ChanId, close, undefined},
-                #data{latest = {watch, close, undefined, _}} = D) ->
-    report(info, closed, D),
-    close(closed, D);
+%% channel_closing(cast, {?MIN_DEPTH_ACHIEVED, _ChanId, close, undefined},
+%%                 #data{latest = {min_depth, close, undefined, _}} = D) ->
+%%     report(info, closed, D),
+%%     close(closed, D);
 channel_closing(Type, Msg, D) ->
+    handle_common_event(Type, Msg, discard, D).
+
+channel_closed(enter, _OldSt, D) ->
+    keep_state(D#data{ongoing_update = false});
+channel_closed(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_CLOSED, TxHash},
+               #data{ latest = {min_depth, ?WATCH_CLOSED, TxHash, _}
+                    , on_chain_id = ChainId } = D) ->
+    close(closed_confirmed, D);
+channel_closed(cast, {?CHANNEL_CHANGED, _Info} = Msg, D) ->
+    %% This is a weird case. The channel was closed, but now isn't.
+    %% This would indicate a fork switch. TODO: detect channel status
+    %% and respond accordingly. For now. Panic and terminate
+    report(info, zombie_channel, D),
+    close(zombie_channel, log(rcv, msg_type(Msg), Msg, D));
+channel_closed(Type, Msg, D) ->
     handle_common_event(Type, Msg, discard, D).
 
 disconnected(cast, {?CH_REESTABL, _Msg}, D) ->
@@ -1324,6 +1361,9 @@ close(Reason, D) ->
 
 close_(close_mutual, D) ->
     report(info, close_mutual, D),
+    {stop, normal, D};
+close_(closed_confirmed, D) ->
+    report(info, closed_confirmed, D),
     {stop, normal, D};
 close_(leave, D) ->
     {stop, normal, D};
@@ -1640,10 +1680,24 @@ handle_common_event_(cast, {?CHANNEL_CLOSING, Info} = Msg, _St, _, D) ->
             lager:debug("Channel not found, or other: ~p", [Error]),
             close(channel_no_longer_active, D)
     end;
-handle_common_event_(cast, {?CHANNEL_CHANGED, Info} = Msg, _St, _, D) ->
-    lager:debug("Fsm notes channel change ~p", [Info]),
-    report_on_chain_tx(channel_changed, maps:get(tx, Info), D),
-    keep_state(log(rcv, msg_type(Msg), Msg, D));
+handle_common_event_(cast, {?CHANNEL_CHANGED, #{tx_hash := TxHash} = Info} = Msg,
+                     _St, _, D) ->
+    D1 = log(rcv, msg_type(Msg), Msg, D),
+    case D1#data.latest of
+        {min_depth, _, LatestTxHash, _} when TxHash =/= LatestTxHash ->
+            %% This is a problem: channel changed while waiting to confirm
+            %% other tx hash
+            close({error, unexpected_tx_on_chain}, D);
+        _ ->
+            lager:debug("Fsm notes channel change ~p", [Info]),
+            report_on_chain_tx(channel_changed, maps:get(tx, Info), D1),
+            keep_state(D1)
+    end;
+handle_common_event_(cast, {?CHANNEL_CLOSED, #{tx := SignedTx} = _Info} = Msg, _St, _, D) ->
+    %% Start a minimum-depth watch, then (if confirmed) terminate
+    report_on_chain_tx(channel_closed, SignedTx, D),
+    {ok, D1} = start_min_depth_watcher({?MIN_DEPTH, ?WATCH_CLOSED}, SignedTx, D),
+    next_state(channel_closed, log(rcv, msg_type(Msg), Msg, D1));
 handle_common_event_({call, From}, Req, St, Mode, D) ->
     case Mode of
         error_all ->
@@ -1667,6 +1721,7 @@ handle_common_event_(Type, Msg, St, Err, D) when Err==error;
 msg_type(Msg) when is_tuple(Msg) ->
     T = element(1, Msg),
     if ?KNOWN_MSG_TYPE(T) -> T;
+       ?WATCHER_EVENT(T) -> T;
        true -> unknown
     end;
 msg_type(T) -> T.
@@ -1683,10 +1738,11 @@ error_binary(E) when is_atom(E) ->
     atom_to_binary(E, latin1).
 
 
-terminate(Reason, _State, Data) ->
+terminate(Reason, _State, #data{session = Sn} = Data) ->
     lager:debug("terminate(~p, ~p, _)", [Reason, _State]),
     report(info, {died, Reason}, Data),
     report(debug, {log, win_to_list(Data#data.log)}, Data),
+    try aesc_session_noise:close(Sn) catch error:_ -> ok end,
     ok.
 
 code_change(_OldVsn, OldState, OldData, _Extra) ->
@@ -2090,8 +2146,8 @@ settle_tx(Account, Nonce, #data{ opts  = #{initiator := I,
     {ok, RAmt} = aesc_offchain_state:balance(R, State),
     Fee = maps:get(fee, Opts1),
     TTL = adjust_ttl(maps:get(ttl, Opts1, 0)),
-    {ok, _} = Ok = aesc_settle_tx:new(#{ channel_id => aec_id:create(channel, ChanId)
-                                       , from_id    => aec_id:create(account, Account)
+    {ok, _} = Ok = aesc_settle_tx:new(#{ channel_id => aeser_id:create(channel, ChanId)
+                                       , from_id    => aeser_id:create(account, Account)
                                        , initiator_amount_final => IAmt
                                        , responder_amount_final => RAmt
                                        , ttl        => TTL
@@ -2841,13 +2897,17 @@ start_min_depth_watcher(Type, SignedTx, Updates,
     evt({nonce, Nonce}),
     {OnChainId, D1} = on_chain_id(D, Tx),
     case {Type, Watcher0} of
-        {funding, undefined} ->
+        {{?MIN_DEPTH, ?WATCH_FND = Sub}, undefined} ->
             WOpts = maps:get(watcher, Opts, #{}),
             {ok, Watcher1} = aesc_fsm_min_depth_watcher:start_link(
-                               Type, TxHash, OnChainId, MinDepth, ?MODULE, WOpts),
+                               Sub, TxHash, OnChainId, MinDepth, ?MODULE, WOpts),
             evt({watcher, Watcher1}),
             {ok, D1#data{watcher = Watcher1,
-                         latest = {watch, Type, TxHash, SignedTx, Updates}}};
+                         latest = {min_depth, Type, TxHash, SignedTx, Updates}}};
+        {{?MIN_DEPTH, Sub}, Pid} when is_pid(Pid) ->
+            ok = aesc_fsm_min_depth_watcher:watch_for_min_depth(
+                   Pid, TxHash, MinDepth, ?MODULE, Sub),
+            {ok, D1#data{latest = {min_depth, Sub, TxHash, SignedTx, Updates}}};
         {unlock, Pid} when Pid =/= undefined ->
             ok = aesc_fsm_min_depth_watcher:watch_for_unlock(Pid, ?MODULE),
             {ok, D1#data{latest = {watch, unlock, TxHash, SignedTx, Updates}}};
@@ -2855,6 +2915,7 @@ start_min_depth_watcher(Type, SignedTx, Updates,
             ok = aesc_fsm_min_depth_watcher:watch_for_channel_close(Pid, MinDepth, ?MODULE),
             {ok, D1#data{latest = {watch, close, TxHash, SignedTx, Updates}}};
         {_, Pid} when Pid =/= undefined ->  % assertion
+            lager:debug("Unknown Type = ~p, Pid = ~p", [Type, Pid]),
             ok = aesc_fsm_min_depth_watcher:watch(
                    Pid, Type, TxHash, MinDepth, ?MODULE),
             {ok, D1#data{latest = {watch, Type, TxHash, SignedTx, Updates}}}
@@ -3093,6 +3154,9 @@ check_tx_and_verify_signatures(SignedTx, Updates, Type, Data, Pubkeys, ErrTypeMs
     #data{state = State, opts = Opts} = Data,
     Aetx = aetx_sign:tx(SignedTx),
     case aetx:specialize_type(Aetx) of
+        {channel_settle_tx, _Tx} ->
+            %% TODO: conduct more relevant checks
+            verify_signatures(Pubkeys, SignedTx);
         {Type, _Tx} -> % check type
             case call_cb(Aetx, channel_pubkey, []) of
                 ChannelPubkey -> % expected pubkey
@@ -3116,7 +3180,7 @@ check_tx_and_verify_signatures(SignedTx, Updates, Type, Data, Pubkeys, ErrTypeMs
             end;
         _E ->
             {error, ErrTypeMsg}
-    end.
+    end.    
 
 maybe_check_sigs_create(Tx, Updates, Who, NextState,
                        #data{state = State, opts = Opts} = D) ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -15,6 +15,8 @@
          get_contract_call/4,     %% (fsm(), contract_id(), caller(), round())
          leave/1,
          close_solo/1,
+         slash/1,
+         settle/1,
          shutdown/1,              %% (fsm())
          client_died/1,           %% (fsm())
          connection_died/1,       %% (fsm())
@@ -43,7 +45,9 @@
 
 %% Used by min-depth watcher
 -export([minimum_depth_achieved/4,     %% (Fsm, OnChainId, Type, TxHash)
-         channel_closing_on_chain/2]). %% (Fsm, OnChainId)
+         channel_changed_on_chain/2,   %% (Fsm, Info)
+         channel_closing_on_chain/2,
+         channel_unlocked/2]). %% (Fsm, Info)
 
 -export([init/1,
          callback_mode/0,
@@ -139,11 +143,6 @@
                          ; T =:= ?CH_REEST_ACK).
 
 -define(KEEP, 10).
--record(w, { n = 0         :: non_neg_integer()
-           , keep = ?KEEP  :: non_neg_integer()
-           , a = []        :: list()
-           , b = []        :: list()
-           }).
 
 -type latest_op() :: undefined % no pending op
                    | {sign | ack, sign_tag(), aetx_sign:signed_tx(), [aesc_offchain_update:update()]}
@@ -159,7 +158,7 @@
                    | {reestablish, OffChainTx :: aetx_sign:signed_tx()}.
 
 -record(data, { role                   :: role()
-              , channel_status         :: undefined | open
+              , channel_status         :: undefined | open | closing
               , cur_statem_state       :: undefined | atom()
               , state                  :: aesc_offchain_state:state()
               , session                :: pid()
@@ -172,7 +171,7 @@
               , latest = undefined     :: latest_op()
               , ongoing_update = false :: boolean()
               , last_reported_update   :: undefined | non_neg_integer()
-              , log = #w{}             :: #w{}
+              , log = aesc_window:new(#{}) :: aesc_window:window()
               , strict_checks = true   :: boolean()
               }).
 
@@ -257,8 +256,15 @@ signing_response(Fsm, Tag, Obj) ->
 minimum_depth_achieved(Fsm, ChanId, Type, TxHash) ->
     gen_statem:cast(Fsm, {?MIN_DEPTH_ACHIEVED, ChanId, Type, TxHash}).
 
-channel_closing_on_chain(Fsm, ChanId) ->
-    gen_statem:cast(Fsm, {?CHANNEL_CLOSING, ChanId}).
+channel_changed_on_chain(Fsm, Info) ->
+    gen_statem:cast(Fsm, {?CHANNEL_CHANGED, Info}).
+
+channel_closing_on_chain(Fsm, Info) ->
+    gen_statem:cast(Fsm, {?CHANNEL_CLOSING, Info}).
+
+channel_unlocked(Fsm, Info) ->
+    lager:debug("sending unlocked", []),
+    gen_statem:cast(Fsm, {?CHANNEL_UNLOCKED, Info}).
 
 where(ChanId, Role) when Role == initiator; Role == responder ->
     gproc:where(gproc_name_by_role(ChanId, Role));
@@ -303,7 +309,8 @@ timer_subst(dep_signed              ) -> funding_lock;
 timer_subst(wdraw_signed            ) -> funding_lock;
 timer_subst(initialized             ) -> accept;
 timer_subst(mutual_closing          ) -> accept;
-timer_subst(channel_closing         ) -> idle.
+timer_subst(channel_closing         ) -> idle;
+timer_subst(channel_changed         ) -> idle.
 
 default_timeouts() ->
     #{ accept         => 120000
@@ -436,6 +443,14 @@ close_solo(Fsm) ->
     lager:debug("close_solo(~p)", [Fsm]),
     gen_statem:call(Fsm, close_solo).
 
+settle(Fsm) ->
+    lager:debug("settle(~p)", [Fsm]),
+    gen_statem:call(Fsm, settle).
+
+slash(Fsm) ->
+    lager:debug("slash(~p)", [Fsm]),
+    gen_statem:call(Fsm, slash).
+
 shutdown(Fsm) ->
     lager:debug("shutdown(~p)", [Fsm]),
     gen_statem:call(Fsm, shutdown).
@@ -443,12 +458,17 @@ shutdown(Fsm) ->
 client_died(Fsm) ->
     %TODO: possibility for reconnect
     lager:debug("client died(~p)", [Fsm]),
-    ok = gen_statem:stop(Fsm).
+    stop_ok(catch gen_statem:stop(Fsm)).
 
 connection_died(Fsm) ->
     %TODO: possibility for reconnect
     lager:debug("connection to participant died(~p)", [Fsm]),
-    ok = gen_statem:stop(Fsm).
+    stop_ok(catch gen_statem:stop(Fsm)).
+
+stop_ok(ok) ->
+    ok;
+stop_ok({'EXIT', {normal,{sys,terminate,_}}}) ->
+    ok.
 
 start_link(#{} = Arg) ->
     gen_statem:start_link(?MODULE, Arg, ?GEN_STATEM_OPTS).
@@ -513,7 +533,7 @@ init(#{opts := Opts0} = Arg) ->
                 session = Session,
                 opts    = Opts,
                 state   = State,
-                log     = #w{keep = maps:get(log_keep, Opts)}},
+                log     = aesc_window:new(maps:get(log_keep, Opts))},
     lager:debug("Session started, Data = ~p", [Data]),
     %% TODO: Amend the fsm above to include this step. We have transport-level
     %% connectivity, but not yet agreement on the channel parameters. We will next send
@@ -735,7 +755,7 @@ awaiting_signature(cast, {?SIGNED, ?FND_CREATED, SignedTx} = Msg,
                   log(rcv, ?SIGNED, Msg, D#data{create_tx = NewSignedTx,
                                                 latest = {ack, ?FND_CREATED,
                                                           HSCTx, Updates}})),
-            report(on_chain_tx, NewSignedTx, D1),
+            report_on_chain_tx(?FND_CREATED, NewSignedTx, D1),
             {ok, D2} = start_min_depth_watcher(?WATCH_FND, NewSignedTx,
                                                Updates, D1),
             gproc_register_on_chain_id(D2),
@@ -751,7 +771,7 @@ awaiting_signature(cast, {?SIGNED, ?DEP_CREATED, SignedTx} = Msg,
                                           D#data{latest = {ack,
                                                            ?DEP_CREATED,
                                                            HSCTx, Updates}}),
-            report(on_chain_tx, NewSignedTx, D1),
+            report_on_chain_tx(?DEP_CREATED, NewSignedTx, D1),
             {ok, D2} = start_min_depth_watcher(?WATCH_DEP, NewSignedTx,
                                                Updates, D1),
             next_state(awaiting_locked,
@@ -767,7 +787,7 @@ awaiting_signature(cast, {?SIGNED, ?WDRAW_CREATED, SignedTx} = Msg,
                                           D#data{latest = {ack,
                                                            ?WDRAW_CREATED,
                                                            HSCTx, Updates}}),
-            report(on_chain_tx, NewSignedTx, D1),
+            report_on_chain_tx(?WDRAW_CREATED, NewSignedTx, D1),
             {ok, D2} = start_min_depth_watcher(?WATCH_WDRAW, NewSignedTx,
                                                Updates, D1),
             next_state(awaiting_locked, log(rcv, ?SIGNED, Msg, D2))
@@ -818,9 +838,18 @@ awaiting_signature(cast, {?SIGNED, ?SHUTDOWN_ACK, SignedTx} = Msg,
             D1 = send_shutdown_ack_msg(NewSignedTx, D),
             D2 = D1#data{latest = undefined,
                         log    = log_msg(rcv, ?SIGNED, Msg, D1#data.log)},
-            report(on_chain_tx, NewSignedTx, D1),
+            report_on_chain_tx(close_mutual, NewSignedTx, D1),
             close(close_mutual, D2)
         end, D);
+awaiting_signature(cast, {?SIGNED, settle_tx, SignedTx} = Msg,
+                   #data{latest = {sign, settle_tx, _STx, _Updates}} = D) ->
+    maybe_check_sigs(SignedTx, channel_settle_tx, not_settle_tx, me,
+        fun() ->
+                D1 = D#data{log = log_msg(rcv, ?SIGNED, Msg, D#data.log),
+                            latest = undefined},
+                settle_signed(SignedTx, D1)
+        end, D);
+                                                        
 %% Other
 awaiting_signature(Type, Msg, D) ->
     handle_common_event(Type, Msg, postpone, D).
@@ -848,7 +877,7 @@ half_signed(cast, {?FND_SIGNED, Msg}, #data{role = initiator,
         {ok, SignedTx, D1} ->
             lager:debug("funding_signed ok", []),
             report(info, funding_signed, D1),
-            report(on_chain_tx, SignedTx, D1),
+            report_on_chain_tx(?FND_SIGNED, SignedTx, D1),
             ok = aec_tx_pool:push(SignedTx),
             D2 = D1#data{create_tx = SignedTx},
             {ack, create_tx, _, Updates} = Latest,
@@ -869,7 +898,7 @@ dep_half_signed(cast, {Req, _} = Msg, D) when ?UPDATE_CAST(Req) ->
 dep_half_signed(cast, {?DEP_SIGNED, Msg}, #data{latest = Latest} = D) ->
     case check_deposit_signed_msg(Msg, D) of
         {ok, SignedTx, D1} ->
-            report(on_chain_tx, SignedTx, D1),
+            report_on_chain_tx(?DEP_SIGNED, SignedTx, D1),
             ok = aec_tx_pool:push(SignedTx),
             {ack, deposit_tx, _, Updates} = Latest,
             {ok, D2} = start_min_depth_watcher(deposit, SignedTx, Updates, D1),
@@ -931,7 +960,7 @@ wdraw_half_signed(cast, {Req,_} = Msg, D) when ?UPDATE_CAST(Req) ->
 wdraw_half_signed(cast, {?WDRAW_SIGNED, Msg}, #data{latest = Latest} = D) ->
     case check_withdraw_signed_msg(Msg, D) of
         {ok, SignedTx, D1} ->
-            report(on_chain_tx, SignedTx, D1),
+            report_on_chain_tx(?WDRAW_SIGNED, SignedTx, D1),
             ok = aec_tx_pool:push(SignedTx),
             {ack, withdraw_tx, _, Updates} = Latest,
             {ok, D2} = start_min_depth_watcher(withdraw, SignedTx, Updates, D1),
@@ -982,6 +1011,29 @@ withdraw_locked_complete(SignedTx, Updates, #data{state = State, opts = Opts} = 
                                                             OnChainEnv, Opts)},
     next_state(open, D1).
 
+settle_signed(SignedTx, #data{ on_chain_id = ChId} = D) ->
+    lager:debug("SignedTx = ~p", [SignedTx]),
+    case aec_chain:get_channel(ChId) of
+        {ok, Ch} ->
+            LockedUntil = aesc_channels:locked_until(Ch),
+            {ok, D1} =
+                case is_channel_locked(LockedUntil) of
+                    true ->
+                        lager:debug("channel is locked", []),
+                        start_min_depth_watcher(unlock, SignedTx, D);
+                    false ->
+                        lager:debug("channel not locked, pushing settle", []),
+                        ok = aec_tx_pool:push(SignedTx),
+                        start_min_depth_watcher(close, SignedTx, D)
+                end,
+            next_state(channel_closing, D1);
+        {error,_} = Error ->
+            close(Error, D)
+    end.
+
+is_channel_locked(0) -> false;
+is_channel_locked(LockedUntil) -> 
+    LockedUntil >= cur_height().
 
 awaiting_locked(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_locked(cast, {?MIN_DEPTH_ACHIEVED, ChainId, ?WATCH_FND, TxHash},
@@ -1224,7 +1276,7 @@ mutual_closing(cast, {?SHUTDOWN_ACK, Msg}, D) ->
         {ok, SignedTx, D1} ->
             lager:debug("shutdown_ack ok", []),
             ok = aec_tx_pool:push(SignedTx),
-            report(on_chain_tx, SignedTx, D1),
+            report_on_chain_tx(close_mutual, SignedTx, D1),
             close(close_mutual, D1);
         {error, _} = Error ->
             close(Error, D)
@@ -1234,7 +1286,32 @@ mutual_closing(cast, {closing_signed, _Msg}, D) ->  %% TODO: not using this, rig
 mutual_closing(Type, Msg, D) ->
     handle_common_event(Type, Msg, error, D).
 
-channel_closing(enter, _OldSt, _D) -> keep_state_and_data;
+channel_closing(enter, _OldSt, D) ->
+    D1 = if D#data.channel_status =/= closing ->
+                 report(info, closing, D),
+                 report_update(D#data{channel_status = closing});
+            true ->
+                 report_update(D)
+         end,
+    keep_state(D1#data{ongoing_update = false});
+channel_closing(cast, {?CHANNEL_UNLOCKED, #{chan_id := ChId}} = Msg,
+                #data{on_chain_id = ChId, latest = {watch, unlock, _TxHash, SignedTx, _}} = D) ->
+    lager:debug("channel unlocked", []),
+    D1 = log(rcv, ?CHANNEL_UNLOCKED, Msg, D),
+    {Type, _Tx} = aetx:specialize_type(aetx_sign:tx(SignedTx)),
+    case Type of
+        channel_settle_tx ->
+            lager:debug("pushing settle tx", []),
+            ok = aec_tx_pool:push(SignedTx);
+        _ ->
+            lager:debug("SignedTx of Type ~p - ignoring", [Type]),
+            ok
+    end,
+    keep_state(D1);
+channel_closing(cast, {?MIN_DEPTH_ACHIEVED, _ChanId, close, undefined},
+                #data{latest = {watch, close, undefined, _}} = D) ->
+    report(info, closed, D),
+    close(closed, D);
 channel_closing(Type, Msg, D) ->
     handle_common_event(Type, Msg, discard, D).
 
@@ -1488,8 +1565,26 @@ handle_call_(St, close_solo, From, D) ->
             keep_state(D, [{reply, From, {error, channel_closing}}]);
         _ ->
             {ok, CloseSoloTx, Updates} = close_solo_tx_for_signing(D),
-            D1 = request_signing(close_solo_tx, CloseSoloTx, Updates, D),
+            D1 = set_ongoing(request_signing(close_solo_tx, CloseSoloTx, D)),
             next_state(awaiting_signature, D1, [{reply, From, ok}])
+    end;
+handle_call_(St, slash, From, D) ->
+    case St of
+        channel_closing ->
+            {ok, SlashTx} = slash_tx_for_signing(D),
+            D1 = set_ongoing(request_signing(slash_tx, SlashTx, D)),
+            next_state(awaiting_signature, D1, [{reply, From, ok}]);
+        _ ->
+            keep_state(D, [{reply, From, {error, channel_not_closing}}])
+    end;
+handle_call_(St, settle, From, D) ->
+    case St of
+        channel_closing ->
+            {ok, SettleTx} = settle_tx_for_signing(D),
+            D1 = set_ongoing(request_signing(settle_tx, SettleTx, D)),
+            next_state(awaiting_signature, D1, [{reply, From, ok}]);
+        _ ->
+            keep_state(D, [{reply, From, {error, channel_not_closed}}])
     end;
 handle_call_(_, {strict_checks, Strict}, From, #data{} = D) when
         is_boolean(Strict) ->
@@ -1520,22 +1615,35 @@ handle_common_event_(timeout, St = T, St, _, D) ->
     close({timeout, T}, D);
 handle_common_event_(cast, {?DISCONNECT, _}, _St, _, D) ->
     close(disconnect, D);
-handle_common_event_(cast, {?CHANNEL_CLOSING, ChanId} = Msg, _St, _,
-                     #data{on_chain_id = ChanId} = D) ->
+handle_common_event_(cast, {?CHANNEL_CLOSING, Info} = Msg, _St, _, D) ->
     lager:debug("got ~p", [Msg]),
     D1 = log(rcv, ?CHANNEL_CLOSING, Msg, D),
-    case check_closing_event(D1) of
+    case check_closing_event(Info, D1) of
         {can_slash, Round, SignedTx} ->
             {ok, SlashTx, Updates} = slash_tx_for_signing(Round, SignedTx, D1),
-            D2 = request_signing(slash_tx, SlashTx, Updates, D1),
+            report_on_chain_tx(can_slash, SignedTx, D1),
+            D2 = set_ongoing(request_signing(slash_tx, SlashTx, D1)),
             next_state(awaiting_signature, D2);
-        {ok, Other} ->
-            lager:debug("Channel not solo-closing: ~p", [Other]),
+        {ok, proper_solo_closing, SignedTx} ->
+            lager:debug("Channel solo-closing", []),
+            report_on_chain_tx(solo_closing, SignedTx, D1),
             next_state(channel_closing, D1);
+        {ok, solo_closed, SignedTx} ->
+            lager:debug("Channel solo-closed", []),
+            report_on_chain_tx(solo_closed, SignedTx, D1),
+            close(channel_no_longer_active, D1);
+        {error, channel_active} ->
+            %% Weird, but possible e.g. due to forking (TODO: what might happen next?)
+            keep_state(log(drop, msg_type(Msg), Msg, D));
         {error, _} = Error ->
-            lager:debug("Channel no longer active: ~p", [Error]),
+            %% Couldn't find the channel object on-chain, or something weird happened
+            lager:debug("Channel not found, or other: ~p", [Error]),
             close(channel_no_longer_active, D)
     end;
+handle_common_event_(cast, {?CHANNEL_CHANGED, Info} = Msg, _St, _, D) ->
+    lager:debug("Fsm notes channel change ~p", [Info]),
+    report_on_chain_tx(channel_changed, maps:get(tx, Info), D),
+    keep_state(log(rcv, msg_type(Msg), Msg, D));
 handle_common_event_({call, From}, Req, St, Mode, D) ->
     case Mode of
         error_all ->
@@ -1937,6 +2045,11 @@ fake_close_mutual_tx(RealCloseTx, D) ->
 new_close_mutual_tx(Opts, D) ->
     new_onchain_tx_for_signing(channel_close_mutual_tx, Opts, D).
 
+
+slash_tx_for_signing(#data{ state = St } = D) ->
+    {Round, SignedTx} = aesc_offchain_state:get_latest_signed_tx(St),
+    slash_tx_for_signing(Round, SignedTx, D).
+
 slash_tx_for_signing(Round, SignedTx, D) ->
     Account = my_account(D),
     {ok, Nonce} = aec_next_nonce:pick_for_account(Account),
@@ -1962,6 +2075,30 @@ slash_tx(Account, Nonce, _Round, SignedTx, #data{ on_chain_id = ChanId
                                   , nonce      => Nonce }),
     {ok, Tx, []}.
 
+settle_tx_for_signing(#data{} = D) ->
+    Account = my_account(D),
+    {ok, Nonce} = aec_next_nonce:pick_for_account(Account),
+    settle_tx(Account, Nonce, D).
+
+settle_tx(Account, Nonce, #data{ opts  = #{initiator := I,
+                                           responder := R} = Opts
+                               , state = State } = D) ->
+    Def = tx_defaults(channel_settle_tx, #{acct => Account}, D),
+    Opts1 = maps:merge(Def, Opts),
+    ChanId = maps:get(channel_id, Opts1),
+    {ok, IAmt} = aesc_offchain_state:balance(I, State),
+    {ok, RAmt} = aesc_offchain_state:balance(R, State),
+    Fee = maps:get(fee, Opts1),
+    TTL = adjust_ttl(maps:get(ttl, Opts1, 0)),
+    {ok, _} = Ok = aesc_settle_tx:new(#{ channel_id => aec_id:create(channel, ChanId)
+                                       , from_id    => aec_id:create(account, Account)
+                                       , initiator_amount_final => IAmt
+                                       , responder_amount_final => RAmt
+                                       , ttl        => TTL
+                                       , fee        => Fee
+                                       , nonce      => Nonce }),
+    Ok.
+
 close_solo_tx_for_signing(D) ->
     Account = my_account(D),
     {ok, Nonce} = aec_next_nonce:pick_for_account(Account),
@@ -1979,13 +2116,14 @@ close_solo_tx(Account, Nonce, #data{ on_chain_id = ChanId
     {_Round, SignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
     {ok, Poi} = aesc_offchain_state:poi([{account, Initiator},
                                          {account, Responder}], State),
-    {ok, Tx} = aesc_slash_tx:new(#{ channel_id => aeser_id:create(channel, ChanId)
-                                  , from_id    => aeser_id:create(account, Account)
-                                  , payload    => aetx_sign:serialize_to_binary(SignedTx)
-                                  , poi        => Poi
-                                  , ttl        => TTL
-                                  , fee        => Fee
-                                  , nonce      => Nonce }),
+    {ok, Tx} = aesc_close_solo_tx:new(
+                 #{ channel_id => aeser_id:create(channel, ChanId)
+                  , from_id    => aeser_id:create(account, Account)
+                  , payload    => aetx_sign:serialize_to_binary(SignedTx)
+                  , poi        => Poi
+                  , ttl        => TTL
+                  , fee        => Fee
+                  , nonce      => Nonce }),
     {ok, Tx, []}.
 
 tx_defaults(Type, Opts, #data{ on_chain_id = ChanId } = D) ->
@@ -2004,6 +2142,8 @@ tx_defaults_(channel_withdraw_tx, Opts, D) ->
 tx_defaults_(channel_slash_tx = Tx, Opts, D) ->
     default_ttl(Tx, Opts, D);
 tx_defaults_(channel_close_solo_tx = Tx, Opts, D) ->
+    default_ttl(Tx, Opts, D);
+tx_defaults_(channel_settle_tx = Tx, Opts, D) ->
     default_ttl(Tx, Opts, D);
 tx_defaults_(channel_close_mutual_tx, _Opts, _D) ->
     #{}.
@@ -2693,7 +2833,7 @@ default_minimum_depth(responder) -> ?MINIMUM_DEPTH.
 
 start_min_depth_watcher(Type, SignedTx, Updates,
                         #data{watcher = Watcher0,
-                              opts = #{minimum_depth := MinDepth}} = D) ->
+                              opts = #{minimum_depth := MinDepth} = Opts} = D) ->
     Tx = aetx_sign:tx(SignedTx),
     TxHash = aetx_sign:hash(SignedTx),
     evt({tx_hash, TxHash}),
@@ -2702,16 +2842,24 @@ start_min_depth_watcher(Type, SignedTx, Updates,
     {OnChainId, D1} = on_chain_id(D, Tx),
     case {Type, Watcher0} of
         {funding, undefined} ->
+            WOpts = maps:get(watcher, Opts, #{}),
             {ok, Watcher1} = aesc_fsm_min_depth_watcher:start_link(
-                               Type, TxHash, OnChainId, MinDepth, ?MODULE),
+                               Type, TxHash, OnChainId, MinDepth, ?MODULE, WOpts),
             evt({watcher, Watcher1}),
             {ok, D1#data{watcher = Watcher1,
                          latest = {watch, Type, TxHash, SignedTx, Updates}}};
+        {unlock, Pid} when Pid =/= undefined ->
+            ok = aesc_fsm_min_depth_watcher:watch_for_unlock(Pid, ?MODULE),
+            {ok, D1#data{latest = {watch, unlock, TxHash, SignedTx, Updates}}};
+        {close, Pid} when Pid =/= undefined ->
+            ok = aesc_fsm_min_depth_watcher:watch_for_channel_close(Pid, MinDepth, ?MODULE),
+            {ok, D1#data{latest = {watch, close, TxHash, SignedTx, Updates}}};
         {_, Pid} when Pid =/= undefined ->  % assertion
             ok = aesc_fsm_min_depth_watcher:watch(
                    Pid, Type, TxHash, MinDepth, ?MODULE),
             {ok, D1#data{latest = {watch, Type, TxHash, SignedTx, Updates}}}
     end.
+
 
 
 on_chain_id(#data{on_chain_id = ID} = D, _) when ID =/= undefined ->
@@ -2750,8 +2898,6 @@ try_gproc_reg(Key, Value) ->
             error(badarg)
     end.
 
-
-
 gproc_name_by_role(Id, Role) ->
     {n, l, {aesc_channel, {Id, role, Role}}}.
 
@@ -2775,7 +2921,7 @@ cache_state(#data{ on_chain_id = ChId
 
 handle_change_config(log_keep, Keep, #data{log = L} = D)
   when is_integer(Keep), Keep >= 0 ->
-    {ok, ok, D#data{log = L#w{keep = Keep}}};
+    {ok, ok, D#data{log = aesc_window:change_keep(Keep, L)}};
 handle_change_config(_, _, _) ->
     {error, invalid_config}.
 
@@ -2808,6 +2954,10 @@ default_report_flags() ->
      , error        => true
      , debug        => false
      , on_chain_tx  => true}.
+
+
+report_on_chain_tx(Info, SignedTx, D) ->
+    report(on_chain_tx, #{tx => SignedTx, info => Info}, D).
 
 report(Tag, St, D) -> report_info(do_rpt(Tag, D), Tag, St, D).
 
@@ -2842,13 +2992,11 @@ do_rpt(Tag, #data{opts = #{report := Rpt}}) ->
 log(Op, Type, M, #data{log = Log0} = D) ->
     D#data{log = log_msg(Op, Type, M, Log0)}.
 
-log_msg(Op, Type, M, #w{n = N, a = A, keep = Keep} = W) when N < Keep ->
-    W#w{n = N+1, a = [{Op, Type, os:timestamp(), M}|A]};
-log_msg(Op, Type, M, #w{a = A} = W) ->
-    W#w{n = 1, a = [{Op, Type, os:timestamp(), M}], b = A}.
+log_msg(Op, Type, M, Log) ->
+    aesc_window:add({Op, Type, os:timestamp(), M}, Log).
 
-win_to_list(#w{a = A, b = B}) ->
-    A ++ B.
+win_to_list(Log) ->
+    aesc_window:to_list(Log).
 
 check_amounts(#{ initiator_amount   := InitiatorAmount0
                , responder_amount   := ResponderAmount0
@@ -2871,42 +3019,43 @@ process_update_error(Reason, From, D) ->
     ?LOG_CAUGHT(Reason),
     keep_state(D, [{reply, From, {error, Reason}}]).
 
-check_closing_event(#data{on_chain_id = ChanId} = D) ->
-    case aec_chain:get_channel(ChanId) of
-        {ok, Channel} ->
-            case aesc_channels:is_active(Channel) of
-                true ->
-                    check_closing_event_(Channel, D);
-                false ->
-                    {error, not_active}
-            end;
-        {error, _} = Error ->
-            Error
-    end.
+check_closing_event(Info, D) ->
+    aec_db:dirty(fun() ->
+                         try check_closing_event_(Info, D)
+                         catch
+                             error:E ->
+                                 ?LOG_CAUGHT(E),
+                                 error(E)
+                         end
+                 end).
 
-check_closing_event_(Ch, #data{state = St}) ->
-    Height = cur_height(),
+check_closing_event_(#{ tx := SignedTx
+                      , channel := Ch
+                      , block_hash := BlockHash}, #data{state = St}) ->
+    %% Get the latest channel object from the chain
     case aesc_channels:is_solo_closing(Ch) of
         true ->
-            {MyLastRound, SignedTx} =
+            {MyLastRound, LastSignedTx} =
                 aesc_offchain_state:get_latest_signed_tx(St),
             case aesc_utils:check_round_greater_than_last(
                    Ch, MyLastRound, slash) of
                 ok ->
                     %% We have a later valid channel state
-                    {can_slash, MyLastRound, SignedTx};
+                    {can_slash, MyLastRound, LastSignedTx};
                 {error, same_round} ->
-                    {ok, proper_solo_closing};
+                    {ok, proper_solo_closing, SignedTx};
                 {error, old_round} ->
                     %% This is weird: presumably, our state is out-of-date
-                    {ok, proper_solo_closing}
+                    {ok, proper_solo_closing, SignedTx}
             end;
         false ->
+            {ok, Hdr} = aec_chain:get_header(BlockHash),
+            Height = aec_headers:height(Hdr),
             case aesc_channels:is_solo_closed(Ch, Height) of
                 true ->
-                    {ok, solo_closed};
+                    {ok, solo_closed, SignedTx};
                 false ->
-                    {ok, not_solo_closing}
+                    {error, not_solo_closing}
             end
     end.
 

--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -2,9 +2,10 @@
 -module(aesc_fsm_min_depth_watcher).
 -behaviour(gen_server).
 
--export([start_link/5,   %% (TxHash, ChanId, MinimumDepth, Mod)   -> {ok, Pid}
-         watch/5,        %% (WatcherPid, Type, TxHash, MinimumDepth, Mod) -> ok
-         watch_for_channel_close/3]).
+-export([start_link/6,       %% (TxHash, ChanId, MinimumDepth, Mod, Opts) -> {ok, Pid}
+         watch/5,            %% (WatcherPid, Type, TxHash, MinimumDepth, Mod) -> ok
+         watch_for_channel_close/3,
+         watch_for_unlock/2]).
 
 -export([init/1,
          handle_call/3,
@@ -13,70 +14,193 @@
          terminate/2,
          code_change/3]).
 
+%% Fetching tx history
+-export([get_txs_since/2]).
+
 -define(GEN_SERVER_OPTS, []).
 
 -record(st, { parent
             , chan_id
+            , chan_vsn
+            , last_block                  %% last time we update channel vsn
+            , last_top                    %% the block hash of the last check
+            , tx_log = aesc_window:new()
+            , rpt_log = aesc_window:new()
             , closing = false
-            , requests = [] }).
+            , requests = []
+            , opts = #{} }).
 
+-type mode()       :: close
+                    | unlock
+                    | tx_hash
+                    | watch.
+
+-type req_info() :: #{ type         := any()
+                     , parent       := pid()
+                     , callback_mod := module() }.
+
+-type close_req() :: #{ mode      := close
+                      , min_depth := aec_blocks:height()
+                      , info      := req_info() }.
+-type unlock_req() :: #{ mode := unlock
+                       , info := req_info() }.
+-type watch_req() :: #{ mode := watch
+                      , info := req_info() }.
+-type tx_req() :: #{ mode      := tx_hash
+                   , tx_hash   := tx_hash()
+                   , min_depth := aec_blocks:height()
+                   , info      := req_info() }.
+
+-type req() :: close_req() | unlock_req() | watch_req() | tx_req().
+%% -type req() :: map().
+
+-type block_hash() :: binary().
+-type tx_hash()    :: binary().
+-type scenario()   :: top | next_block | fork_switch | {has_tx, tx_hash()}.
+-type chan_vsn()   :: undefined | { aesc_channels:round()
+                                  , aesc_channels:solo_round()
+                                  , aesc_channels:is_active()
+                                  , aesc_channels:locked_until()
+                                  , aesc_channels:state_hash() }.
+-type ch_status() :: undefined | #{ is_active    := aesc_channels:is_active()
+                                  , vsn          := chan_vsn()
+                                  , changed      := boolean()
+                                  , channel      := aesc_channels:channel()
+                                  , lock_period  := aesc_channels:lock_period()
+                                  , locked_until := aesc_channels:locked_until() }.
+
+%% -type cache() :: #{ mode := mode()
+%%                   , tx_log := aesc_window:window()
+%%                   , rpt_log := aesc_window:window()
+%%                   , last_block := block_hash()
+%%                   , chan_vsn   := chan_vsn()
+%%                   , block_hash => block_hash()
+%%                   , scenario   => scenario()
+%%                   , ch_status  => ch_status()
+%%                   , channel    => aesc_channels:channel()
+%%                   , tx_hashes  => [tx_hash()] }.
+-type cache() :: map().
+
+watch_for_channel_close(Pid, MinDepth, Mod) when is_pid(Pid) ->
+    gen_server:call(Pid, close_req(MinDepth, Mod));
 watch_for_channel_close(ChanId, MinDepth, Mod) ->
     gen_server:start_link(?MODULE, #{parent  => self(),
                                      chan_id => ChanId,
-                                     requests =>
-                                         [#{mode         => close,
-                                            min_depth    => MinDepth,
-                                            type         => close,
-                                            parent       => self(),
-                                            callback_mod => Mod}]},
+                                     requests => [close_req(MinDepth, Mod)]},
                           ?GEN_SERVER_OPTS).
 
-start_link(Type, TxHash, ChanId, MinDepth, Mod) ->
+watch_for_unlock(Pid, Mod) when is_pid(Pid) ->
+    gen_server:call(Pid, unlock_req(Mod));
+watch_for_unlock(ChanId, Mod) ->
+    gen_server:start_link(?MODULE, #{parent => self(),
+                                     chan_id => ChanId,
+                                     requests => [unlock_req(Mod)]},
+                          ?GEN_SERVER_OPTS).
+
+close_req(MinDepth, Mod) ->
+    #{mode         => close,
+      min_depth    => MinDepth,
+      info         => #{ type  => close
+                       , parent => self()
+                       , callback_mod => Mod } }.
+
+unlock_req(Mod) ->
+    #{mode => unlock,
+      info => #{ parent       => self()
+               , type         => closing
+               , callback_mod => Mod }}.
+
+get_txs_since({all_after_tx, _Hash} = StopCond, ChId) ->
+    get_txs_since_(StopCond, ChId);
+get_txs_since({any_after_block, _Hash} = StopCond, ChId) ->
+    get_txs_since_(StopCond, ChId).
+
+get_txs_since_(StopCond, ChId) ->
+    get_txs_since(StopCond, aec_chain:top_block_hash(), ChId, #{}).
+
+
+start_link(Type, TxHash, ChanId, MinDepth, Mod, Opts) ->
+    I = #{ parent       => self()
+         , type         => Type
+         , callback_mod => Mod },
+    DefReqs = [#{ mode      => tx_hash
+                , tx_hash   => TxHash
+                , min_depth => MinDepth
+                , info      => I},
+               #{ mode  => watch
+                , info  => I }],
     gen_server:start_link(?MODULE, #{parent   => self(),
                                      chan_id  => ChanId,
-                                     requests =>
-                                         [#{mode         => tx_hash,
-                                            tx_hash      => TxHash,
-                                            type         => Type,
-                                            parent       => self(),
-                                            callback_mod => Mod,
-                                            min_depth    => MinDepth},
-                                          #{mode         => watch,
-                                            parent       => self(),
-                                            callback_mod => Mod}]},
+                                     opts     => Opts,
+                                     requests => maps:get(
+                                                   requests, Opts, DefReqs)},
                           ?GEN_SERVER_OPTS).
 
 watch(Watcher, Type, TxHash, MinDepth, Mod) ->
+    I = #{ callback_mod => Mod
+         , type         => Type
+         , parent       => self()},
     gen_server:call(Watcher, #{mode         => tx_hash,
-                               type         => Type,
                                tx_hash      => TxHash,
                                min_depth    => MinDepth,
-                               callback_mod => Mod,
-                               parent       => self()}).
+                               info         => I }).
 
-init(#{parent := Parent, chan_id := ChanId, requests := Reqs}) ->
+init(#{parent := Parent, chan_id := ChanId, requests := Reqs} = I) ->
+    Opts = maps:get(opts, I, #{}),
     lager:debug("started min_depth watcher for ~p", [Parent]),
     erlang:monitor(process, Parent),
     true = aec_events:subscribe(top_changed),
     true = aec_events:subscribe({tx_event, {channel, ChanId}}),
     lager:debug("subscribed to top_changed", []),
     self() ! check_status,
-    {ok, #st{parent = Parent, chan_id = ChanId, requests = Reqs}}.
+    {ok, #st{parent = Parent, chan_id = ChanId, requests = Reqs, opts = Opts}}.
 
-handle_info({gproc_ps_event, top_changed, _}, #st{} = St) ->
-    {noreply, check_status(St)};
-handle_info({gproc_ps_event, {tx_event, E}, I}, St) ->
-    lager:debug("tx_event (ignored): ~p, I = ~p", [E, I]),
-    {noreply, St};
+
+%% Strategy for monitoring the chain.
+%%
+%% Challenges:
+%% 1. There is currently no revenue model for the SC FSM, i.e. the node
+%%    running the FSM has no way of getting reimbursed for the cost.
+%%    This means the FSM *and* the watcher must be as lightweight as possible.
+%% 2. The watcher must keep up with fork switches.
+%%
+%% To allow for lightweight monitoring, we use custom tx events keyed on the
+%% channel id. These are generated at block insertion, and are published
+%% *before* any corresponding `top_changed' event.
+%%
+%% We keep the tx events in a sliding window LIFO buffer. For each `top_changed'
+%% event, we need to consider the following scenarios:
+%% 1. The new block contains a tx for our channel: Read the channel object
+%%    and report accordingly
+%% 2. We are waiting for a minimum-depth condition: Verify that it's still
+%%    relevant, and check the depth.
+%% 3. A fork switch may have happened, changing the channel object even if
+%%    no channel tx is present in the top block: Dig into the chain to figure
+%%    out the current channel state. Remove txes from the tx_log that have
+%%    been returned to the mempool.
+%% 4. No fork switch, no channel tx in the top block, and no depth watch:
+%%    Do nothing.
+handle_info({gproc_ps_event, top_changed, #{info := Hash}}, #st{} = St) ->
+    lager:debug("(Fsm = ~p) top_changed: ~p", [St#st.parent, Hash]),
+    {noreply, check_status(Hash, St)};
+handle_info({gproc_ps_event, {tx_event, {channel, ChId}},
+             #{info := #{ block_hash := _BlockHash
+                        , tx_hash    := _TxHash
+                        , type       := _Type } = I}}, #st{chan_id = ChId} = St) ->
+    lager:debug("tx_event: I = ~p", [I]),
+    {noreply, log_tx(I, St)};
 handle_info({'DOWN', _, process, Parent, _}, #st{parent = Parent} = St) ->
     {stop, normal, St};
 handle_info(check_status, St) ->
-    {noreply, check_status(St)};
+    {noreply, check_status(top, St)};
 handle_info(_Msg, St) ->
     lager:debug("got unknown Msg: ~p", [_Msg]),
     {noreply, St}.
 
-handle_call(#{mode := _, callback_mod := _, parent := _} = Req, From,
+handle_call(#{ mode := _
+             , info := #{ type := _
+                        , callback_mod := _
+                        , parent := _}} = Req, From,
             #st{requests = Reqs} = St) ->
     case maps:find(tx_hash, Req) of
         {ok, TxHash} ->
@@ -84,16 +208,16 @@ handle_call(#{mode := _, callback_mod := _, parent := _} = Req, From,
                           TH =:= TxHash] of
                 [] ->
                     gen_server:reply(From, ok),
-                    {noreply, check_status(St#st{requests = Reqs ++ [Req]})};
+                    {noreply, check_status(top, St#st{requests = Reqs ++ [Req]})};
                 [_|_] ->
                     {reply, {error, {already_watching, TxHash}}, St}
             end;
         error ->
             gen_server:reply(From, ok),
-            {noreply, check_status(St#st{requests = [Req|Reqs]})}
+            {noreply, check_status(top, St#st{requests = [Req|Reqs]})}
     end;
-handle_call(_Req, _From, St) ->
-    {reply, {error, unknown_request}, St}.
+handle_call(Req, _From, St) ->
+    {reply, {error, {unknown_request, Req}}, St}.
 
 handle_cast(_Msg, St) ->
     {noreply, St}.
@@ -104,55 +228,169 @@ terminate(_Reason, _St) ->
 code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
 
-check_status(#st{requests = Reqs} = St) ->
-    check_status(Reqs, St, #{}, []).
+check_status(Hash, #st{ requests   = Reqs
+                      , last_block = LastBlock
+                      , last_top   = LastTop
+                      , tx_log     = TxLog
+                      , rpt_log    = RptLog
+                      , chan_vsn   = Vsn } = St) ->
+    lager:debug("Reqs = ~p", [Reqs]),
+    do_dirty(
+      fun() ->
+              C0 = #{ tx_log     => TxLog
+                    , rpt_log    => RptLog
+                    , last_block => LastBlock
+                    , last_top   => LastTop
+                    , chan_vsn   => Vsn},
+              C1 = case Hash of
+                      top ->
+                          {Top, C01} = top_hash(C0),
+                          C01#{ block_hash => Top };
+                      H ->
+                          C0#{ block_hash => H }
+                  end,
+              C2 = pick_scenario(Hash, St, C1),
+              lager:debug("scenario = ~p", [maps:get(scenario, C2)]),
+              check_status(Reqs, St, C2, [])
+      end).
 
+
+-spec pick_scenario(block_hash(), #st{}, cache()) -> cache().
+pick_scenario(BHash, #st{tx_log = TxLog} = St, C) ->
+    case aesc_window:info_find([{block_hash, BHash}], 2, TxLog) of
+        false ->
+            maybe_fork_switch(BHash, St, C);
+        LastTx ->
+            C#{scenario => {has_tx, LastTx}}
+    end.
+
+maybe_fork_switch(top, _St, C) ->
+    C#{scenario => top};
+maybe_fork_switch(BHash, #st{last_block = LastBlock}, C) ->
+    {Hdr, C1} = get_header(BHash, C),
+    S = case aec_headers:prev_hash(Hdr) of
+            LastBlock ->
+                next_block;
+            _ ->
+                fork_switch
+        end,
+    C1#{scenario => S}.
+
+
+do_dirty(F) ->
+    aec_db:transaction(
+      fun() ->
+              try F()
+              catch
+                  error:E ->
+                      lager:error("CAUGHT ~p / ~p", [E, erlang:get_stacktrace()]),
+                      error(E)
+              end
+      end).
+
+-spec check_status([req()], #st{}, cache(), [req()]) -> #st{}.
 check_status([Req|Reqs], St, Cache, Acc) ->
-    case check_status_(Req, St, Cache) of
+    lager:debug("Req = ~p", [Req]),
+    try check_status_(Req, St, Cache) of
         {done, Cache1} when is_map(Cache1) ->
             check_status(Reqs, St, Cache1, Acc);
-        {done, #st{} = St1, Cache1} when is_map(Cache1) ->
-            check_status(Reqs, St1, Cache1, Acc);
-        {Req1, Cache1} when is_map(Req1) ->
-            check_status(Reqs, St, Cache1, [Req1|Acc])
+        %% commented out to please dialyzer:
+        %% {done, #st{} = St1, Cache1} when is_map(Cache1) ->
+        %%     check_status(Reqs, St1, Cache1, Acc);
+        {Req1, Cache1} when is_map(Req1), is_map(Cache1) ->
+            check_status(Reqs, St, Cache1, [Req1|Acc]);
+        Other ->
+            lager:error("BAD return ~p from Req = ~p", [Other, Req]),
+            error({bad_return, Other})
+        %% {Req1, #st{} = St1, Cache1} when is_map(Req1), is_map(Cache1) ->
+        %%     check_status(Reqs, St1, Cache1, [Req1|Acc])
+    catch
+        error:E ->
+            lager:error("CAUGHT ~p / ~p", [E, erlang:get_stacktrace()]),
+            error(E)
     end;
-check_status([], St, _, Acc) ->
-    St#st{requests = lists:reverse(Acc)}.
+check_status([], St, Cache, Acc) ->
+    St1 = update_chan_vsn(Cache, St),
+    St1#st{requests = lists:reverse(Acc),
+           tx_log = maps:get(tx_log, Cache),
+           rpt_log = maps:get(rpt_log, Cache)}.
 
 check_status_(#{mode := close, locked_until := H, min_depth := Min} = R,
-              #st{chan_id = ChId}, Cache) ->
-    {HasDepth, Cache1} = determine_depth_(H, Min, Cache),
-    case HasDepth of
-        true ->
-            #{callback_mod := Mod, parent := Parent} = R,
-            Mod:minimum_depth_achieved(Parent, ChId, close, undefined),
-            {done, Cache1};
-        _ ->
-            {R, Cache1}
+              #st{chan_id = ChId, chan_vsn = Vsn}, Cache) ->
+    if Vsn =/= undefined ->
+            {HasDepth, Cache1} = determine_depth_(H, Min, Cache),
+            case HasDepth of
+                true ->
+                    #{callback_mod := Mod, parent := Parent} = R,
+                    Mod:minimum_depth_achieved(Parent, ChId, close, undefined),
+                    {done, Cache1};
+                _ ->
+                    {R, Cache1}
+            end;
+       true ->
+            {R, Cache}
     end;
-check_status_(#{mode := close, parent := Parent} = R, #st{chan_id = ChId}, C) ->
-    lager:debug("check_status(type = close, parent = ~p)", [Parent]),
-    {TopHeight, C1} = top_height(C),
-    {Status, C2} = channel_status(ChId, C1),
-    case Status of
-        #{ is_active := true } ->
-            {R, C2};
-        #{ locked_until := LockedUntil } ->
-            {R#{ locked_until => LockedUntil }, C2};
-        undefined ->
-            %% Set closing time to current top height, wait for min_depth
-            {R#{ locked_until => TopHeight }, C2}
+check_status_(#{mode := close} = R, #st{chan_id = ChId, chan_vsn = Vsn}, C) ->
+    if Vsn =/= undefined ->
+            #{info := #{parent := Parent}} = R,
+            lager:debug("check_status(type = close, parent = ~p)", [Parent]),
+            {TopHeight, C1} = top_height(C),
+            {Status, C2} = channel_status(ChId, C1),
+            case Status of
+                #{ is_active := true } ->
+                    {R, C2};
+                #{ locked_until := LockedUntil } ->
+                    {R#{ locked_until => LockedUntil }, C2};
+                undefined ->
+                    %% Set closing time to current top height, wait for min_depth
+                    {R#{ locked_until => TopHeight }, C2}
+            end;
+       true ->
+            {R, C}
     end;
-check_status_(#{mode := watch} = R, St, C) ->
-    watch_for_channel_closing(R, St, C);
-check_status_(#{mode := tx_hash, tx_hash := TxHash, parent := Parent,
-                type := Type, min_depth := MinDepth} = R,
-              #st{chan_id = ChanId}, C) ->
+check_status_(#{mode := unlock} = R, #st{chan_id = ChId, chan_vsn = Vsn} = St, C) ->
+    if Vsn =/= undefined ->
+            lager:debug("checking", []),
+            case get_basic_ch_status_(ChId, C) of
+                {#{locked_until := 0} = Ch, C1} ->
+                    lager:debug("locked_until = 0", []),
+                    report_channel_unlocked(R, Ch, St, C1),
+                    {done, C1};
+                {#{locked_until := LockedUntil} = Ch, C1} ->
+                    {Height, C2} = top_height(C1),
+                    lager:debug("LockedUntil = ~p, Height = ~p", [LockedUntil, Height]),
+                    case LockedUntil < Height of
+                        true  ->
+                            lager:debug("locked_until expired", []),
+                            report_channel_unlocked(R, Ch, St, C2),
+                            {done, C2};
+                        false ->
+                            lager:debug("still locked", []),
+                            {R, C2}
+                    end;
+                {undefined, C1} ->
+                    lager:debug("couldn't find channel", []),
+                    {done, C1}
+            end;
+       true ->
+            lager:debug("Vsn = undefined", []),
+            {R, C}
+    end;
+check_status_(#{mode := watch} = R, #st{chan_vsn = Vsn} = St, C) ->
+    if Vsn =/= undefined ->
+            %% At least wait until there's a channel object
+            watch_for_channel_change(R, St, C);
+       true ->
+            {R, C}
+    end;
+check_status_(#{mode := tx_hash, tx_hash := TxHash, min_depth := MinDepth} = R,
+              #st{chan_id = ChanId} = St, C) ->
+    #{info := #{parent := Parent}} = R,
     lager:debug("check_status(tx_hash = ~p, parent = ~p)", [TxHash, Parent]),
-    case min_depth_achieved(TxHash, MinDepth, C) of
+    case min_depth_achieved(TxHash, MinDepth, St, C) of
         {true, C1} ->
             lager:debug("min_depth achieved", []),
-            #{ callback_mod := Mod } = R,
+            #{ info := #{callback_mod := Mod, type := Type} } = R,
             Mod:minimum_depth_achieved(Parent, ChanId, Type, TxHash),
             {done, C1};
         {_, C1} ->
@@ -160,66 +398,421 @@ check_status_(#{mode := tx_hash, tx_hash := TxHash, parent := Parent,
             {R, C1}
     end.
 
-watch_for_channel_closing(#{callback_mod := Mod, parent := Parent},
-                          #st{closing = true, chan_id = ChanId}, C) ->
-    Mod:channel_closing_on_chain(Parent, ChanId),
-    {done, C};
-watch_for_channel_closing(#{check_at_height := _} = R, St, C) ->
-    {CurHeight, C1} = top_height(C),
-    watch_for_channel_closing(CurHeight, R, St, C1);
-watch_for_channel_closing(R, St, C) ->
-    {CurHeight, C1} = top_height(C),
-    watch_for_channel_closing(
-      CurHeight, R#{check_at_height => CurHeight}, St, C1).
+%% watch_for_channel_change(#{callback_mod := Mod, parent := Parent},
+%%                           #st{closing = true, chan_id = ChanId}, C) ->
+%%     Mod:channel_closing_on_chain(Parent, ChanId),
+%%     {done, C};
+%% watch_for_channel_change(#{check_at_height := _} = R, St, C) ->
+%%     {CurHeight, C1} = top_height(C),
+%%     watch_for_channel_change(CurHeight, R, St, C1);
+watch_for_channel_change(R, St, #{ scenario   := Scenario } = C) ->
+    case Scenario of
+        next_block ->
+            lager:debug("Will not check channel", []),
+            {R, C};
+        _ ->
+            {CurHeight, C1} = top_height(C),
+            lager:debug("Will check channel on chain (~p)", [Scenario]),
+            watch_for_channel_change(CurHeight, R, St, C1)
+    end.
+%% watch_for_channel_change(R, St, C) ->
+%%     {CurHeight, C1} = top_height(C),
+%%     lager:debug("CurHeight = ~p", [CurHeight]),
+%%     watch_for_channel_change(
+%%       CurHeight, R#{check_at_height => CurHeight}, St, C1).
 
-watch_for_channel_closing(CurHeight, #{check_at_height := H} = R,
-                          #st{chan_id = ChanId} = St, C)
-  when CurHeight >= H ->
+watch_for_channel_change(CurHeight, R, #st{chan_id = ChanId} = St, C) ->
+    lager:debug("Will check channel status (V=~p)", [St#st.chan_vsn]),
     {Status, C1} = channel_status(ChanId, C),
+    lager:debug("Status = ~p", [Status]),
+    watch_for_change_in_ch_status(Status, CurHeight, R, St, C1).
+%% watch_for_channel_change(_, R, _, C) ->
+%%     lager:debug("Will not check now", []),
+%%     {R, C}.
+
+watch_for_change_in_ch_status(undefined, _CurHeight, R, _St, C) ->
+    lager:debug("No channel object yet", []),
+    {R, C};
+watch_for_change_in_ch_status(Status, _CurHeight, R, St, C) ->
     case Status of
-        #{is_active := true, lock_period := LP} ->
-            NextHeight = CurHeight + erlang:min(1, LP div 2),
-            {R#{check_at_height => NextHeight}, C1};
-        #{is_active := false} ->
-            #{callback_mod := Mod, parent := Parent} = R,
-            Mod:channel_closing_on_chain(Parent, ChanId),
-            {done, St#st{closing = true}, C1};
+        #{changed := true} ->
+            lager:debug("Channel has changed: ~p", [Status]),
+            %% NextHeight = calc_next_height(Status, CurHeight, St),
+            #{callback_mod := Mod, parent := Parent} = maps:get(info, R),
+            C1 = report_status_change(Status, Mod, Parent, St, C),
+            {R, C1};
+        _ ->
+            lager:debug("No change in channel: ~p", [Status]),
+            {R, C}
+    end.
+
+report_status_change(#{channel := Ch, is_active := IsActive,
+                       tx := SignedTx}, Mod, Parent, St, C) ->
+    Event = if IsActive -> changed_on_chain;
+               true     -> closing_on_chain
+            end,
+    BlockHash = maps:get(block_hash, C),
+    RptKey = {Event, aetx_sign:hash(SignedTx)},
+    Info = #{ chan_id => St#st.chan_id
+            , tx => SignedTx
+            , channel => Ch
+            , block_hash => BlockHash },
+    maybe_report(
+      RptKey, Info,
+      fun() ->
+              case Event of
+                  changed_on_chain ->
+                      Mod:channel_changed_on_chain(Parent, Info);
+                  closing_on_chain ->
+                      Mod:channel_closing_on_chain(Parent, Info)
+              end
+      end, C).
+
+maybe_report(RptKey, Info, Rpt, C) when is_function(Rpt, 0) ->
+    RptLog = maps:get(rpt_log, C),
+    case aesc_window:keyfind(RptKey, 1, RptLog) of
+        false ->
+            Rpt(),
+            C#{rpt_log => aesc_window:add({RptKey, Info}, RptLog)};
+        _ ->
+            C
+    end.
+
+report_channel_unlocked(#{info := #{callback_mod := Mod, parent := Parent}}, Ch, St, C) ->
+    BlockHash = maps:get(block_hash, C),
+    Mod:channel_unlocked(Parent, #{ chan_id => St#st.chan_id
+                                  , channel => Ch
+                                  , block_hash => BlockHash }).
+
+%% calc_next_height(Status, CurHeight, #st{opts = Opts}) ->
+%%     Incr = case maps:find(skip_blocks, Opts) of
+%%                {ok, false} -> 1;
+%%                {ok, N} when is_integer(N), N >= 0 -> 1+N;
+%%                {ok, auto} -> auto_skip(Status);
+%%                error      -> auto_skip(Status)
+%%            end,
+%%     CurHeight + Incr.
+
+%% auto_skip(#{lock_period := LP}) ->
+%%     erlang:max(1, LP div 2);
+%% auto_skip(_) ->
+%%     1.
+
+
+channel_status(ChId, #{block_hash := Hash} = C) ->
+    cached_get({ch_status, Hash}, C, fun(C1) -> get_ch_status(ChId, Hash, C1) end).
+
+channel_status_changed(V, #{chan_vsn := V0}) ->
+    lager:debug("(~p) V = ~p; V0 = ~p", [V =/= V0, V, V0]),
+    V =/= V0.
+
+update_chan_vsn(#{block_hash := Hash} = Cache, #st{} = St) ->
+    case maps:find({channel, Hash}, Cache) of
+        {ok, #{vsn := Vsn, changed := true}} ->
+            lager:debug("Update Vsn = ~p", [Vsn]),
+            St#st{chan_vsn = Vsn,
+                  last_block = Hash};
+        _ ->
+            St
+    end.
+
+get_ch_status(ChId, Hash, C) ->
+    case get_basic_ch_status_(ChId, Hash, C) of
+        {#{changed := Changed} = Status, C1} ->
+            case Changed of
+                true ->
+                    lager:debug("status has changed", []),
+                    handle_ch_status_changed(ChId, C1);
+                false ->
+                    lager:debug("status hasn't changed", []),
+                    {Status, C1}
+            end;
+        Other ->
+            lager:debug("Other = ~p", [Other]),
+            Other
+    end.
+
+handle_ch_status_changed(ChId, #{ last_block := Last
+                                , block_hash := Hash } = C) ->
+    lager:debug("channel status changed, Hash=~p, Last=~p", [Hash,Last]),
+    {TxLog, C1} = get_txs_since({any_after_block, Last}, Hash, ChId, C),
+    lager:debug("New TxLog: ~p", [TxLog]),
+    #{tx_hash := Tx, block_hash := BlockHash} = get_latest_tx(TxLog),
+    lager:debug("Latest Tx = ~p, Hash = ~p", [Tx, BlockHash]),
+    {Status, C2} = get_basic_ch_status_(ChId, BlockHash, C1),
+    lager:debug("ChStatus(~p) = ~p", [BlockHash, Status]),
+    %% Assert that this is really a changed channel object
+    true = channel_status_changed(maps:get(vsn, Status), C2),
+    lager:debug("asserted status changed", []),
+    Status1 = Status#{tx => Tx},
+    {Status1, C2#{{channel, BlockHash} => Status1}}.
+
+get_basic_ch_status_(ChId, #{ block_hash := Hash } = C) ->
+    get_basic_ch_status_(ChId, Hash, C).
+
+get_basic_ch_status_(ChId, BlockHash, C) ->
+    {Ch, C1} = get_channel(ChId, BlockHash, C),
+    case Ch of
         undefined ->
-            {R, C1}
+            {undefined, C1};
+        _ ->
+            Vsn = channel_vsn(Ch),
+            Changed = channel_status_changed(Vsn, C1),
+            {#{ is_active    => aesc_channels:is_active(Ch)
+              , vsn          => Vsn
+              , changed      => Changed
+              , channel      => Ch
+              , lock_period  => aesc_channels:lock_period(Ch)
+              , locked_until => aesc_channels:locked_until(Ch) },
+             C1}
+    end.
+
+get_channel(ChId, Hash, C) ->
+    cached_get({channel, Hash}, C, fun() -> get_channel_(ChId, Hash) end).
+
+get_channel_(ChId, Hash) ->
+    case aec_chain:get_block_state(Hash) of
+        {ok, Trees} ->
+            case aec_chain:get_channel(ChId, Trees) of
+                {ok, Ch} ->
+                    Ch;
+                {error, _} ->
+                    undefined
+            end;
+        error ->
+            undefined
+    end.
+
+cached_get(Key, C, Get) ->
+    case maps:find(Key, C) of
+        {ok, V} ->
+            {V, C};
+        error ->
+            get_and_cache(Get, Key, C)
+    end.
+
+get_and_cache(F, Key, C) when is_function(F, 0) ->
+    V = F(),
+    {V, C#{ Key => V }};
+get_and_cache(F, Key, C) when is_function(F, 1) ->
+    {V, C1} = F(C),
+    {V, C1#{ Key => V }}.
+
+log_tx(#{ tx_hash      := TxHash
+        , block_hash   := BlockHash
+        , block_origin := _Origin
+        , type         := _Type } = Info, #st{tx_log = TxLog} = St) ->
+    Key = {TxHash, BlockHash},
+    case aesc_window:keymember(Key, 1, TxLog) of
+        true ->
+            St;
+        false ->
+            TxLog1 = aesc_window:add({{TxHash, BlockHash}, Info}, TxLog),
+            St#st{tx_log = TxLog1}
+    end.
+
+get_latest_tx(Log) ->
+    {{{_TxHash, _BlockHash}, Tx}, _TxLog1} = aesc_window:pop(Log),
+    lager:debug("Tx = ~p", [Tx]),
+    Tx.
+
+%% Find recent txs. Two different stop conditions:
+%% - {any_after_block, BlockHash}: Stop as soon as a block is found with
+%%   relevant txs in it, or when BlockHash is reached.
+%% - {all_after_tx, TxHash}: Find all txs after TxHash. Note that we must
+%%   first verify that TxHash exists on chain.
+%% Find recent txs related to ChId since LastBlock (not including those in
+%% LastBlock) up until, and including those in, Hash.
+%% This is like aec_chain:get_transactions_between/2, except it ignores all
+%% txs other than channel txs related to ChId, groups by block, etc.
+%%
+get_txs_since(StopCond, Hash, ChId, C) ->
+    case verify_stop_cond(StopCond, C) of
+        {ok, C1} ->
+            lager:debug("StopCond = ~p", [StopCond]),
+            TxLog = maps:get(tx_log, C1),
+            {Found, C2} = get_txs_since(StopCond, Hash, ChId, C1, []),
+            TxLog1 =
+                lists:foldl(
+                  fun({BlockHash, Txs}, Acc) ->
+                          lists:foldl(
+                            fun(TxHash, Acc1) ->
+                                    aesc_window:add(
+                                      { {TxHash, BlockHash},
+                                        #{ tx_hash      => TxHash
+                                         , block_hash => BlockHash
+                                         , block_origin => chain } }, Acc1)
+                            end, Acc, Txs)
+                  end, TxLog, Found),
+            {TxLog1, C2};
+        {{error, Error}, _} ->
+            lager:error("Bad StopCond (~p): ~p", [StopCond, Error]),
+            error(bad_stop_condition)
+    end.
+
+verify_stop_cond({any_after_block, _}, C) ->
+    %% assume this is ok (it will be as long as the watcher uses it correctly)
+    {ok, C};
+verify_stop_cond({all_after_tx, TxHash}, C) ->
+    case tx_location(TxHash, C) of
+        {BlockHash, C1} when is_binary(BlockHash) ->
+            {ok, C1};
+        {_, C1} ->
+            {{error, tx_not_on_chain}, C1}
+    end.
+
+
+%% The iteration checks most recent block first, but the accumulator is
+%% not reversed, so the result will be grouped by block in chronological order,
+%% with txs sorted by nonce (so in the order in which they were processed).
+%%
+get_txs_since({any_after_block, Hash}, Hash, _, C, Acc) ->
+    {Acc, C};
+get_txs_since(StopCond, Hash, ChId, C, Acc) ->
+    {Hdr, C1} = get_header(Hash, C),
+    case Hdr of
+        undefined ->
+            lager:debug("No header for ~p", [Hash]),
+            {Acc, C1};
+        _ ->
+            {Found, C2} = txs_for_chid(ChId, Hash, Hdr, C1),
+            Sorted = sort_txs(Found),
+            lager:debug("txs in ~p: ~p", [Hash, Found]),
+            PrevHash = aec_headers:prev_hash(Hdr),
+            case stop_cond(StopCond, PrevHash, Sorted) of
+                {true, Sorted1} ->
+                    {[{Hash, Sorted1}|Acc], C2};
+                false ->
+                    get_txs_since(
+                      StopCond, PrevHash, ChId, C2, [{Hash, Sorted}|Acc])
+            end
+    end.
+
+stop_cond({all_after_tx, TxHash}, _PrevHash, Found) ->
+    case Found of
+        [] -> false;
+        [_|_] ->
+            tail_after_tx(TxHash, Found)
     end;
-watch_for_channel_closing(_, R, _, C) ->
-    {R, C}.
+stop_cond({any_after_block, Hash}, PrevHash, Found) ->
+    if Hash == PrevHash ->
+            {true, Found};
+       true ->
+            has_create_tx(Found)
+    end.
+
+%% Safety. If a create_tx exists in Found, it must be the first one.
+has_create_tx([]) ->
+    false;
+has_create_tx([SignedTx|_] = Found) ->
+    case aetx:specialize_type(aetx_sign:tx(SignedTx)) of
+        {channel_create_tx, _} ->
+            {true, Found};
+        _ ->
+            false
+    end.
+
+tail_after_tx(_, []) ->
+    false;
+tail_after_tx(Hash, [H|T]) ->
+    case aetx_sign:hash(H) of
+        Hash ->
+            {true, T};
+        _ ->
+            tail_after_tx(Hash, T)
+    end.
+
+tx_hashes(BlockHash, BlockHdr, C) ->
+    cached_get({tx_hashes, BlockHash}, C,
+               fun() -> tx_hashes_(BlockHash, BlockHdr) end).
+
+tx_hashes_(Hash, Hdr) ->
+    case aec_headers:type(Hdr) of
+        key -> [];
+        micro ->
+            case aec_db:find_block_tx_hashes(Hash) of
+                {value, TxHashes} ->
+                    TxHashes;
+                not_found ->
+                    []
+            end
+    end.
+
+txs_for_chid(ChId, Hash, Hdr, C) ->
+    {TxHashes, C1} = tx_hashes(Hash, Hdr, C),
+    lists:foldl(
+      fun(TxHash, {Acc, Cx}) ->
+              {SignedTx, Cx1} = get_signed_tx(TxHash, Cx),
+              lager:debug("SignedTx = ~p", [SignedTx]),
+              case is_tx_for_chid(SignedTx, ChId) of
+                  true  -> {[SignedTx|Acc], Cx1};
+                  false -> {Acc, Cx1}
+              end
+      end, {[], C1}, TxHashes).
+
+get_signed_tx(TxHash, C) ->
+    cached_get({signed_tx, TxHash}, C, fun() -> get_signed_tx_(TxHash) end).
+
+get_signed_tx_(TxHash) ->
+    case aec_db:find_signed_tx(TxHash) of
+        {value, STx} ->
+            STx;
+        none ->
+            undefined
+    end.
 
 
-channel_status(ChId, C) ->
-    channel_status(maps:find({status, ChId}, C), ChId, C).
+sort_txs(Txs) ->
+    lists:sort(fun compare_txs/2, Txs).
 
-channel_status({ok, S}, _, C) -> {S, C};
-channel_status(error, ChId, C) ->
-    St = case aec_chain:get_channel(ChId) of
-             {ok, Ch} ->
-                 #{ is_active    => aesc_channels:is_active(Ch)
-                  , lock_period  => aesc_channels:lock_period(Ch)
-                  , locked_until => aesc_channels:locked_until(Ch) };
-             _ ->
-                 undefined
-         end,
-    {St, C#{ {status, ChId} => St }}.
+%% See lists:sort/2: The fun Comp(A,B) should return true if A =< B
+compare_txs(SignedA, SignedB) ->
+    aetx:nonce(aetx_sign:tx(SignedA)) =< aetx:nonce(aetx_sign:tx(SignedB)).
 
-min_depth_achieved(TxHash, MinDepth, C) ->
+is_tx_for_chid(undefined, _) -> false;
+is_tx_for_chid(SignedTx, ChId) ->
+    %% Likely only channel txs have a channel_id/1 callback, so prepare for
+    %% 'undef' exceptions.
+    {CB, Tx} = aetx:specialize_callback(aetx_sign:tx(SignedTx)),
+    PK = try CB:channel_pubkey(Tx)
+         catch error:_ -> error end,
+    lager:debug("Pubkey(Tx) = ~p", [PK]),
+    R = case PK of
+            ChId -> true;
+            _    -> false
+        end,
+    lager:debug("(~p) Tx=~p ChId=~p", [R,Tx,ChId]),
+    R.
+
+
+-spec channel_vsn(aesc_channels:channel()) -> chan_vsn().
+channel_vsn(Ch) ->
+    { aesc_channels:round(Ch)
+    , aesc_channels:solo_round(Ch)
+    , aesc_channels:is_active(Ch)
+    , aesc_channels:locked_until(Ch)
+    , aesc_channels:state_hash(Ch) }.
+
+
+min_depth_achieved(TxHash, MinDepth, #st{chan_id = ChId, chan_vsn = Vsn}, C) ->
     {L, C1} = tx_location(TxHash, C),
     case L of
         undefined ->
             {undefined, C1};
-        _ ->
-            determine_depth(L, MinDepth, C1)
+        _ when is_binary(L) ->
+            %% If the tx is on chain, perhaps fetch an initial channel object
+            C2 = if Vsn == undefined ->
+                         {_Status, C2_} = channel_status(ChId, C1),
+                         C2_;
+                    true -> C1
+                 end,
+            determine_depth(L, MinDepth, C2)
     end.
 
 tx_location(TxHash, C) ->
-    tx_location(maps:find({location,TxHash}, C), TxHash, C).
+    cached_get({location, TxHash}, C, fun(C1) -> tx_location_(TxHash, C1) end).
 
-tx_location({ok, L}, _, C) -> {L, C};
-tx_location(error, TxHash, C) ->
+tx_location_(TxHash, C) ->
     L = case aec_chain:find_tx_with_location(TxHash) of
             none ->
                 lager:debug("couldn't find tx hash", []),
@@ -231,7 +824,17 @@ tx_location(error, TxHash, C) ->
                 lager:debug("tx in Block ~p", [BlockHash]),
                 BlockHash
         end,
-    {L, C#{ {location, TxHash} => L }}.
+    {L, update_tx_log(TxHash, L, C)}.
+
+update_tx_log(TxHash, BlockHash, #{tx_log := TxLog} =C)
+  when is_binary(BlockHash) ->
+    C#{tx_log => aesc_window:add(
+                   { {TxHash, BlockHash},
+                     #{ tx_hash      => TxHash
+                      , block_hash   => BlockHash
+                      , block_origin => chain } }, TxLog)};
+update_tx_log(_, _, C) ->
+    C.
 
 determine_depth(BHash, MinDepth, C) ->
     {H, C1} = height(BHash, C),
@@ -242,30 +845,35 @@ determine_depth(BHash, MinDepth, C) ->
             determine_depth_(H, MinDepth, C1)
     end.
 
-top_height(#{top_height := H} = C) -> {H, C};
 top_height(C) ->
-    TopHeight = case aec_chain:top_header() of
-                    undefined ->
-                        undefined;
-                    TopHdr ->
-                        aec_headers:height(TopHdr)
-                end,
-    {TopHeight, C#{ top_height => TopHeight }}.
+    cached_get(top_height, C, fun(C1) -> top_height_(C1) end).
+
+top_height_(C) ->
+    {TopHash, C1} = top_hash(C),
+    height(TopHash, C1).
+
+top_hash(C) ->
+    cached_get(top_hash, C, fun aec_chain:top_block_hash/0).
+
 
 height(BHash, C) ->
-    height(maps:find({height, BHash}, C), BHash, C).
+    cached_get({height, BHash}, C, fun(C1) -> height_(BHash, C1) end).
 
-height({ok, H}, _BHash, C) -> {H, C};
-height(error, BHash, C) ->
-    Height = case aec_chain:get_header(BHash) of
-                 {ok, Hdr} ->
-                     H = aec_headers:height(Hdr),
-                     lager:debug("tx at height ~p", [H]),
-                     H;
-                 error ->
-                     undefined
-             end,
-    {Height, C#{ {height, BHash} => Height }}.
+height_(BHash, C) ->
+    {Hdr, C1} = get_header(BHash, C),
+    case Hdr of
+        undefined -> {undefined, C1};
+        _ -> {aec_headers:height(Hdr), C1}
+    end.
+
+get_header(BHash, C) ->
+    cached_get({header, BHash}, C, fun() -> get_header_(BHash) end).
+
+get_header_(BHash) ->
+    case aec_chain:get_header(BHash) of
+        {ok, Hdr} -> Hdr;
+        error     -> undefined
+    end.
 
 determine_depth_(Height, MinDepth, C) ->
     case top_height(C) of
@@ -273,4 +881,3 @@ determine_depth_(Height, MinDepth, C) ->
         {TopHeight, C1} ->
             {(TopHeight - Height) >= MinDepth, C1}
     end.
-

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -40,6 +40,14 @@
          prune_calls/1
         ]).
 
+-export([record_fields/1]).
+
+%% ==================================================================
+%% Tracing support
+record_fields(state) -> record_info(fields, state);
+record_fields(Other) -> aec_trees:record_fields(Other).
+%% ==================================================================
+
 
 -spec new(map()) -> {ok, state()}.
 new(Opts) ->

--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -212,7 +212,7 @@ channel_pubkey(#channel_offchain_tx{channel_id = ChannelId}) ->
 channel_id(#channel_offchain_tx{channel_id = ChannelId}) ->
     ChannelId.
 
--spec round(tx()) -> aesc_channels:seq_number().
+-spec round(tx()) -> aesc_channels:round().
 round(#channel_offchain_tx{round = Round}) ->
     Round.
 

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -148,8 +148,9 @@ get_reconnect_params() ->
 
 
 handle_call(close, _From, #st{econn = EConn} = St) ->
+    lager:debug("got close request", []),
     close_econn(EConn),
-    {stop, shutdown, ok, St};
+    {stop, normal, ok, St};
 handle_call(_Req, _From, St) ->
     {reply, {error, unknown_call}, St}.
 

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -42,6 +42,9 @@
        , terminate/2
        , code_change/3]).
 
+-export([ patterns/0
+        , record_fields/1]).
+
 -record(st, {parent :: pid()
            , parent_mon_ref :: reference()
            , econn }).
@@ -77,10 +80,32 @@ shutdown_ack       (Session, Msg) -> cast(Session, {msg, ?SHUTDOWN_ACK , Msg}).
 close(Session) ->
     try call(Session, close)
     catch
-        error:_ -> ok
+        error:_ -> ok;
+        exit:R ->
+            lager:error("CAUGHT exit:~p, ~p", [R, erlang:get_stacktrace()]),
+            unlink(Session),
+            exit(Session, kill),
+            ok
     end.
 
 -define(GEN_SERVER_OPTS, []).
+
+%% ==================================================================
+%% for tracing
+-define(EXCEPTION_TRACE, {'_', [], [{exception_trace}]}).
+patterns() ->
+    exports(?MODULE).
+        %% ++ exports(gen_tcp)
+        %% ++ exports(enoise)
+        %% ++ exports(enoise_connection).
+
+exports(M) ->
+    [{M, F, A, [?EXCEPTION_TRACE]} || {F,A} <- M:module_info(exports)].
+
+
+record_fields(st) -> record_info(fields, st);
+record_fields(_ ) -> no.
+%% ==================================================================
 
 %% Connection establishment
 
@@ -110,6 +135,7 @@ establish({accept, Port, Opts}, St) ->
     lager:debug("listen: TcpOpts = ~p", [TcpOpts]),
     {ok, LSock} = gen_tcp:listen(Port, TcpOpts),
     {ok, TcpSock} = gen_tcp:accept(LSock),
+    lager:debug("Accept TcpSock = ~p", [TcpSock]),
     %% TODO: extract/check something from FinalState?
     EnoiseOpts = enoise_opts(accept, Opts),
     lager:debug("EnoiseOpts (accept) = ~p", [EnoiseOpts]),
@@ -119,7 +145,9 @@ establish({accept, Port, Opts}, St) ->
 establish({connect, Host, Port, Opts}, St) ->
     TcpOpts = tcp_opts(connect, Opts),
     lager:debug("connect: TcpOpts = ~p", [TcpOpts]),
-    {ok, TcpSock} = connect_tcp(Host, Port, TcpOpts),
+    {ok, TcpSock} =
+        connect_tcp(Host, Port, St#st.parent_mon_ref, TcpOpts),
+    lager:debug("Connect TcpSock = ~p", [TcpSock]),
     %% TODO: extract/check something from FinalState?
     EnoiseOpts = enoise_opts(connect, Opts),
     lager:debug("EnoiseOpts (connect) = ~p", [EnoiseOpts]),
@@ -127,24 +155,39 @@ establish({connect, Host, Port, Opts}, St) ->
     %% tell_fsm({accept, EConn}, St),
     St#st{econn = EConn}.
 
-connect_tcp(Host, Port, Opts) ->
+connect_tcp(Host, Port, Ref, Opts) ->
     {Timeout, Retries} = get_reconnect_params(),
-    connect_tcp(Retries, Host, Port, Opts, Timeout).
+    connect_tcp(Retries, Host, Port, Ref, Opts, Timeout).
 
-connect_tcp(0, _, _, _, _) ->
+connect_tcp(0, _, _, _, _, _) ->
     erlang:error(connect_timeout);
-connect_tcp(Retries, Host, Port, Opts, Timeout) when Retries > 0 ->
+connect_tcp(Retries, Host, Port, Ref, Opts, Timeout)
+  when Retries > 0 ->
     case gen_tcp:connect(Host, Port, Opts, Timeout) of
         {ok, _TcpSock} = Ok ->
             Ok;
         {error, _} ->
-            timer:sleep(1000),
-            connect_tcp(Retries-1, Host, Port, Opts, Timeout)
+            sleep(Timeout, Ref),
+            connect_tcp(Retries-1, Host, Port, Ref, Opts, Timeout)
     end.
+
+sleep(T, Ref) ->
+    receive
+        {'$gen_call', From, close} = Msg ->
+            lager:debug("Got ~p while sleeping", [Msg]),
+            gen:reply(From, ok),
+            exit(normal);
+        {'DOWN', Ref, _, _, _} = Msg ->
+            lager:debug("Got ~p while sleeping", [Msg]),
+            exit(shutdown)
+    after T ->
+            ok
+    end.
+
 
 get_reconnect_params() ->
     %% {ConnectTimeout, Retries}
-    {10000, 30}.
+    {3000, 40}.  %% total 2 minutes
 
 
 handle_call(close, _From, #st{econn = EConn} = St) ->
@@ -191,7 +234,7 @@ handle_info_({noise, EConn, Data}, #st{econn = EConn} = St) ->
     {noreply, St};
 handle_info_({tcp_closed, _Port}, #st{parent = Pid} = St) ->
     aesc_fsm:connection_died(Pid),
-    {stop, shutdown, St};
+    {stop, normal, St};
 handle_info_(_Msg, St) ->
     lager:debug("Unknown handle_info_(~p)", [_Msg]),
     {noreply, St}.

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -98,7 +98,7 @@ init({Parent, Op}) ->
     %%
     %% TODO: For some reason, trapping exits causes
     %% aehttp_integration_SUITE:sc_ws_open/1 to fail. Investigate why.
-    %% process_flag(trap_exit, true),
+    process_flag(trap_exit, true),
     proc_lib:init_ack(Parent, {ok, self()}),
     ParentMonRef = monitor(process, Parent),
     St = establish(Op, #st{parent = Parent,
@@ -149,7 +149,7 @@ get_reconnect_params() ->
 
 handle_call(close, _From, #st{econn = EConn} = St) ->
     close_econn(EConn),
-    {stop, normal, ok, St};
+    {stop, shutdown, ok, St};
 handle_call(_Req, _From, St) ->
     {reply, {error, unknown_call}, St}.
 
@@ -173,7 +173,7 @@ handle_info({'DOWN', Ref, process, Pid, _Reason},
             #st{parent_mon_ref=Ref, parent=Pid, econn=EConn}=St) ->
     lager:debug("Got DOWN from parent (~p)", [Pid]),
     close_econn(EConn),
-    {stop, normal, St};
+    {stop, shutdown, St};
 handle_info(Msg, St) ->
     try handle_info_(Msg, St)
     catch
@@ -190,7 +190,7 @@ handle_info_({noise, EConn, Data}, #st{econn = EConn} = St) ->
     {noreply, St};
 handle_info_({tcp_closed, _Port}, #st{parent = Pid} = St) ->
     aesc_fsm:connection_died(Pid),
-    {stop, normal, St};
+    {stop, shutdown, St};
 handle_info_(_Msg, St) ->
     lager:debug("Unknown handle_info_(~p)", [_Msg]),
     {noreply, St}.

--- a/apps/aechannel/src/aesc_settle_tx.erl
+++ b/apps/aechannel/src/aesc_settle_tx.erl
@@ -27,6 +27,10 @@
          valid_at_protocol/2
         ]).
 
+% aesc_signable_transaction callbacks
+-export([channel_id/1,
+         channel_pubkey/1]).
+
 %%%===================================================================
 %%% Types
 %%%===================================================================
@@ -101,6 +105,9 @@ from_pubkey(#channel_settle_tx{from_id = FromId}) ->
 
 channel_pubkey(#channel_settle_tx{channel_id = ChannelId}) ->
     aeser_id:specialize(ChannelId, channel).
+
+channel_id(#channel_settle_tx{channel_id = ChannelId}) ->
+    ChannelId.
 
 -spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_settle_tx{}, Trees,_Env) ->

--- a/apps/aechannel/src/aesc_signable_transaction.erl
+++ b/apps/aechannel/src/aesc_signable_transaction.erl
@@ -12,5 +12,5 @@
 
 -callback state_hash(aetx:tx_instance()) -> binary().
 
--callback round(aetx:tx_instance()) -> aesc_channels:seq_number().
+-callback round(aetx:tx_instance()) -> aesc_channels:round().
 

--- a/apps/aechannel/src/aesc_slash_tx.erl
+++ b/apps/aechannel/src/aesc_slash_tx.erl
@@ -27,6 +27,10 @@
          valid_at_protocol/2
         ]).
 
+% aesc_signable_transaction callbacks
+-export([channel_id/1,
+         channel_pubkey/1]).
+
 %%%===================================================================
 %%% Types
 %%%===================================================================
@@ -101,6 +105,9 @@ from_pubkey(#channel_slash_tx{from_id = FromId}) ->
 
 channel_pubkey(#channel_slash_tx{channel_id = ChannelId}) ->
     aeser_id:specialize(ChannelId, channel).
+
+channel_id(#channel_slash_tx{channel_id = ChannelId}) ->
+    ChannelId.
 
 -spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
 check(#channel_slash_tx{payload    = Payload,

--- a/apps/aechannel/src/aesc_snapshot_solo_tx.erl
+++ b/apps/aechannel/src/aesc_snapshot_solo_tx.erl
@@ -11,6 +11,7 @@
 %% Behavior API
 -export([new/1,
          type/0,
+         channel_pubkey/1,
          fee/1,
          gas/1,
          ttl/1,
@@ -26,6 +27,9 @@
          for_client/1,
          valid_at_protocol/2
         ]).
+
+% aesc_signable_transaction callbacks
+-export([channel_id/1]).
 
 %%%===================================================================
 %%% Types
@@ -95,6 +99,9 @@ origin(#channel_snapshot_solo_tx{} = Tx) ->
 
 channel_pubkey(#channel_snapshot_solo_tx{channel_id = ChannelId}) ->
     aeser_id:specialize(ChannelId, channel).
+
+channel_id(#channel_snapshot_solo_tx{channel_id = ChannelId}) ->
+    ChannelId.
 
 from_pubkey(#channel_snapshot_solo_tx{from_id = FromId}) ->
     aeser_id:specialize(FromId, account).

--- a/apps/aechannel/src/aesc_ttb.erl
+++ b/apps/aechannel/src/aesc_ttb.erl
@@ -1,0 +1,46 @@
+-module(aesc_ttb).
+-behavior(tr_ttb).
+
+-export([ on_nodes/2
+        , stop/0
+        , stop_nofetch/0
+        , format/2
+        , format/3 ]).
+
+-export([ patterns/0
+        , flags/0 ]).
+
+-export([event/1]).
+
+-include_lib("trace_runner/include/trace_runner.hrl").
+
+%% This function is also traced. Can be used to insert markers in the trace log.
+event(E) ->
+    event(?LINE, E, none).
+
+event(_, _, _) ->
+    ok.
+
+on_nodes(Ns, File) ->
+    tr_ttb:on_nodes(Ns, File, ?MODULE).
+
+patterns() ->
+    sc_ws_api:patterns()
+        ++ aesc_fsm:patterns()
+        ++ aesc_session_noise:patterns()
+        ++ tr_ttb:default_patterns().
+
+flags() ->
+    {all, call}.
+
+stop() ->
+    tr_ttb:stop().
+
+stop_nofetch() ->
+    tr_ttb:stop_nofetch().
+
+format(Dir, Out) ->
+    tr_ttb:format(Dir, Out).
+
+format(Dir, Out, Opts) ->
+    tr_ttb:format(Dir, Out, Opts).

--- a/apps/aechannel/src/aesc_window.erl
+++ b/apps/aechannel/src/aesc_window.erl
@@ -1,0 +1,108 @@
+-module(aesc_window).
+
+-export([new/0, new/1,
+         change_keep/2,
+         add/2,
+         pop/1,
+         keyfind/3,
+         keymember/3,
+         info_find/3,
+         to_list/1]).
+
+-export_type([window/0]).
+
+-define(KEEP, 10).
+
+-type size()   :: non_neg_integer().
+-type entry()  :: any().
+
+-record(w, { n = 0         :: non_neg_integer()
+           , keep = ?KEEP  :: size()
+           , a = []        :: [entry()]
+           , b = []        :: [entry()]
+           }).
+
+-type window() :: #w{}.
+
+-spec new() -> window().
+new() ->
+    #w{}.
+
+-spec new(size()) -> window().
+new(Sz) when is_integer(Sz), Sz >= 0 ->
+    #w{keep = Sz}.
+
+-spec change_keep(size(), window()) -> window().
+change_keep(Keep, #w{} = W) when is_integer(Keep), Keep >= 0 ->
+    W#w{keep = Keep}.
+
+-spec add(entry(), window()) -> window().
+add(Item, #w{n = N, a = A, keep = Keep} = W) when N < Keep ->
+    W#w{n = N+1, a = [Item|A]};
+add(Item, #w{a = A} = W) ->
+    W#w{n = 1, a = [Item], b = A}.
+
+-spec pop(window()) -> {entry(), window()} | error.
+pop(#w{a = [], b = []}) ->
+    error;
+pop(#w{a = [], b = [H|T], n = N} = W) ->
+    {H, W#w{n = N-1, b = T}};
+pop(#w{a = [H|T], n = N} = W) ->
+    {H, W#w{n = N-1, a = T}}.
+
+-spec to_list(window()) -> [entry()].
+to_list(#w{a = A, b = B}) ->
+    A ++ B.
+
+%% Like lists:keyfind/3. Finds the most recent match (if any),
+%% since items are essentially stored in LIFO fashion.
+-spec keyfind(any(), non_neg_integer(), window()) -> false | entry().
+keyfind(K, Pos, #w{a = A, b = B}) ->
+    case lists:keyfind(K, Pos, A) of
+        false ->
+            lists:keyfind(K, Pos, B);
+        Other ->
+            Other
+    end.
+
+-spec keymember(any(), non_neg_integer(), window()) -> boolean().
+keymember(K, Pos, #w{a = A, b = B}) ->
+    lists:keymember(K, Pos, A)
+        orelse lists:keymember(K, Pos, B).
+
+%% Like keyfind/3, but instead of `Key', A list of `{Key, Value}' pairs is
+%% matched against map values in position `Pos' (entries where the `Pos'th
+%% element is not a map are skipped). If a value in the `KVL' is `undefined',
+%% this will match either the value `undefined' or the key being missing.
+%%
+-spec info_find([{any(), any()}], non_neg_integer(), window()) ->
+                       false | entry().
+info_find(KVL, Pos, #w{a = A, b = B}) when is_list(KVL) ->
+    case info_find_(KVL, Pos, A) of
+        false ->
+            info_find_(KVL, Pos, B);
+        Other ->
+            Other
+    end.
+
+info_find_(KVL, Pos, [H|T]) when is_map(element(Pos, H)) ->
+    case match_info(KVL, element(Pos, H)) of
+        true ->
+            H;
+        false ->
+            info_find_(KVL, Pos, T)
+    end;
+info_find_(KVL, Pos, [_|T]) ->
+    info_find_(KVL, Pos, T);
+info_find_(_, _, []) ->
+    false.
+
+match_info([{K, V}|T], Map) when is_map(Map) ->
+    case maps:get(K, Map, undefined) of
+        V -> match_info(T, Map);
+        _ -> false
+    end;
+match_info([], _) ->
+    true;
+match_info(_, _) ->
+    false.

--- a/apps/aechannel/src/aesc_window.erl
+++ b/apps/aechannel/src/aesc_window.erl
@@ -9,6 +9,8 @@
          info_find/3,
          to_list/1]).
 
+-export([record_fields/1]).
+
 -export_type([window/0]).
 
 -define(KEEP, 10).
@@ -23,6 +25,13 @@
            }).
 
 -type window() :: #w{}.
+
+%% ==================================================================
+%% Tracing support
+record_fields(w) -> record_info(fields, w);
+record_fields(_) -> no.
+%% ==================================================================
+
 
 -spec new() -> window().
 new() ->

--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -4924,11 +4924,6 @@ test_both_payload_from_different_channel(Cfg, Fun) ->
     [Test(Role) || Role <- ?ROLES],
     ok.
 
-%% test_both_old_round(Cfg, Fun) ->
-%%     test_both_old_round(Cfg, Fun, #{}).
-
-%% test_both_old_round(Cfg, Fun, Props) ->
-%%     test_both_old_round(Cfg, Fun, Props, same_round).
 
 test_both_old_round(Cfg, Fun, Props, Reason) ->
     Test0 =

--- a/apps/aecontract/src/aect_call_state_tree.erl
+++ b/apps/aecontract/src/aect_call_state_tree.erl
@@ -26,6 +26,8 @@
         , serialize_to_client/1
         ]).
 
+-export([record_fields/1]).
+
 -ifdef(TEST).
 -export([to_list/1]).
 -endif.
@@ -46,6 +48,13 @@
 
 -define(VSN, 1).
 -define(PUB_SIZE, 32).
+
+%% ==================================================================
+%% Tracing support
+record_fields(call_tree) -> record_info(fields, call_tree);
+record_fields(_        ) -> no.
+%% ==================================================================
+
 
 %%%===================================================================
 %%% API

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -34,6 +34,8 @@
         , to_binary_without_backend/1
         ]).
 
+-export([record_fields/1]).
+
 -export_type([tree/0]).
 
 %%%===================================================================
@@ -49,6 +51,13 @@
 -opaque tree() :: #contract_tree{}.
 
 -define(VSN, 1).
+
+%% ==================================================================
+%% Tracing support
+record_fields(contract_tree) -> record_info(fields, contract_tree);
+record_fields(_            ) -> no.         
+%% ==================================================================
+
 
 %%%===================================================================
 %%% API

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -136,6 +136,14 @@ insert_block(Block, _Origin) ->
     do_insert_block(Block, undefined).
 
 do_insert_block(Block, Origin) ->
+    T1 = erlang:monotonic_time(),
+    R = do_insert_block_(Block, Origin),
+    T2 = erlang:monotonic_time(),
+    Time = erlang:convert_time_unit(T2 - T1, native, microsecond),
+    lager:debug("[t: ~p us]", [Time]),
+    R.
+
+do_insert_block_(Block, Origin) ->
     aec_blocks:assert_block(Block),
     Node = wrap_block(Block),
     try internal_insert(Node, Block, Origin)

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -81,6 +81,7 @@
         , get_n_key_headers_backward_from/2
         , hash_is_connected_to_genesis/1
         , hash_is_in_main_chain/1
+        , hash_is_in_main_chain/2
         , insert_block/1
         , insert_block/2
         , gossip_allowed_height_from_top/0

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1009,6 +1009,12 @@ ok({ok, Value}) ->
     Value.
 
 
+ok({ok, Value}) ->
+    Value;
+ok(Other) ->
+    Other.
+
+
 handle_add_block(Block, #state{} = State, Origin) ->
     Header = aec_blocks:to_header(Block),
     handle_add_block(Header, Block, State, Origin).

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1008,13 +1008,6 @@ handle_signed_block(Block, State) ->
 ok({ok, Value}) ->
     Value.
 
-
-ok({ok, Value}) ->
-    Value;
-ok(Other) ->
-    Other.
-
-
 handle_add_block(Block, #state{} = State, Origin) ->
     Header = aec_blocks:to_header(Block),
     handle_add_block(Header, Block, State, Origin).

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -18,6 +18,7 @@
         ]).
 
 -export([transaction/1,
+         dirty/1,
          ensure_transaction/1,
          write/2,
          delete/2,
@@ -242,6 +243,9 @@ backend_mode(<<"mnesia">> , #{persist := true } = M) -> M#{module => mnesia,
 
 transaction(Fun) when is_function(Fun, 0) ->
     mnesia:activity(transaction, Fun).
+
+dirty(Fun) when is_function(Fun, 0) ->
+    mnesia:activity(async_dirty, Fun).
 
 ensure_transaction(Fun) when is_function(Fun, 0) ->
     %% TODO: actually, some non-transactions also have an activity state

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -59,6 +59,8 @@
          verify_poi/4
         ]).
 
+-export([record_fields/1]).
+
 -ifdef(TEST).
 -export([internal_serialize_poi_fields/1,
          internal_serialize_poi_from_fields/1
@@ -98,6 +100,19 @@
              ]).
 
 -define(VERSION, 1).
+
+%% ==================================================================
+%% Tracing support
+record_fields(trees) -> record_info(fields, trees);
+record_fields(poi  ) -> record_info(fields, poi);
+record_fields(_    ) -> {check_mods, [ aeu_mp_trees
+                                     , aec_accounts_trees
+                                     , aect_state_tree
+                                     , aect_call_state_tree
+                                     , aec_state_tree
+                                     , aens_state_tree
+                                     , aeo_state_tree ]}.
+%% ==================================================================
 
 %%%%=============================================================================
 %% API

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -27,6 +27,8 @@
          mine_blocks/4,
          mine_all_txs/2,
          mine_blocks_until_txs_on_chain/3,
+         mine_blocks_until_txs_on_chain/4,
+         mine_blocks_until_txs_on_chain/5,
          mine_key_blocks/2,
          mine_key_blocks/3,
          mine_micro_blocks/2,
@@ -279,12 +281,15 @@ mine_blocks_until_txs_on_chain(Node, TxHashes, MaxBlocks) ->
     mine_blocks_until_txs_on_chain(Node, TxHashes, ?DEFAULT_CUSTOM_EXPECTED_MINE_RATE, MaxBlocks).
 
 mine_blocks_until_txs_on_chain(Node, TxHashes, MiningRate, Max) ->
+    mine_blocks_until_txs_on_chain(Node, TxHashes, MiningRate, Max, #{}).
+
+mine_blocks_until_txs_on_chain(Node, TxHashes, MiningRate, Max, Opts) ->
     ok = rpc:call(
            Node, application, set_env, [aecore, expected_mine_rate, MiningRate],
            5000),
     [] = flush_new_blocks(),
     aecore_suite_utils:subscribe(Node, block_created),
-    StartRes = rpc:call(Node, aec_conductor, start_mining, [], 5000),
+    StartRes = rpc:call(Node, aec_conductor, start_mining, [Opts], 5000),
     ct:log("aec_conductor:start_mining() (~p) -> ~p", [Node, StartRes]),
     Res = mine_blocks_until_txs_on_chain_loop(Node, TxHashes, Max, []),
     StopRes = rpc:call(Node, aec_conductor, stop_mining, [], 5000),

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -154,7 +154,7 @@ process_fsm_(#{type := sign,
                                    orelse Tag =:= update_ack
                                    orelse Tag =:= slash_tx
                                    orelse Tag =:= close_solo_tx
-                                   orelse TAG =:= settle_tx ->
+                                   orelse Tag =:= settle_tx ->
     EncTx = aeser_api_encoder:encode(transaction, aetx:serialize_to_binary(Tx)),
     SerializedUpdates = [aesc_offchain_update:for_client(U) || U <- Updates],
     Tag1 =

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -14,6 +14,11 @@
          process_from_fsm/3
         ]).
 
+-export([patterns/0]).
+
+-include_lib("trace_runner/include/trace_runner.hrl").
+
+
 %%%===================================================================
 %%% Behaviour definition
 %%%===================================================================
@@ -33,6 +38,20 @@
 
 -callback process_incoming(Msg :: map() | list(map()), FsmPid :: pid()) ->
     {reply, map()} | no_reply | stop.
+
+
+%%%==================================================================
+%%% Trace settings
+%%%==================================================================
+
+patterns() ->
+    [{sc_ws_handler, init, 2, []} |
+     [{?MODULE, F, A, []} || {F, A} <- [ {protocol, 0}
+                                       , {response, 0}
+                                       , {process_from_client, 4}
+                                       , {process_from_fsm, 3}
+                                       ]]].
+
 
 %%%===================================================================
 %%% API

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -132,7 +132,9 @@ process_fsm_(#{type := sign,
                                    orelse Tag =:= shutdown_ack
                                    orelse Tag =:= funding_created
                                    orelse Tag =:= update
-                                   orelse Tag =:= update_ack ->
+                                   orelse Tag =:= update_ack
+                                   orelse Tag =:= slash_tx
+                                   orelse Tag =:= close_solo_tx ->
     EncTx = aeser_api_encoder:encode(transaction, aetx:serialize_to_binary(Tx)),
     SerializedUpdates = [aesc_offchain_update:for_client(U) || U <- Updates],
     Tag1 =
@@ -165,10 +167,11 @@ process_fsm_(#{type := report,
         case {Tag, Event} of
             {info, {died, _}} -> #{event => <<"died">>};
             {info, _} when is_atom(Event) -> #{event => atom_to_binary(Event, utf8)};
-            {on_chain_tx, Tx} ->
-                EncodedTx = aeser_api_encoder:encode(transaction,
-                                               aetx_sign:serialize_to_binary(Tx)),
-                #{tx => EncodedTx};
+            {on_chain_tx, #{tx := Tx} = Info} ->
+                EncodedTx = aeser_api_encoder:encode(
+                              transaction,
+                              aetx_sign:serialize_to_binary(Tx)),
+                Info#{tx => EncodedTx};
             {_, NewState} when Tag == update; Tag == leave ->
                 Bin = aeser_api_encoder:encode(transaction,
                                          aetx_sign:serialize_to_binary(NewState)),

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -134,7 +134,8 @@ process_fsm_(#{type := sign,
                                    orelse Tag =:= update
                                    orelse Tag =:= update_ack
                                    orelse Tag =:= slash_tx
-                                   orelse Tag =:= close_solo_tx ->
+                                   orelse Tag =:= close_solo_tx
+                                   orelse TAG =:= settle_tx ->
     EncTx = aeser_api_encoder:encode(transaction, aetx:serialize_to_binary(Tx)),
     SerializedUpdates = [aesc_offchain_update:for_client(U) || U <- Updates],
     Tag1 =

--- a/apps/aehttp/src/sc_ws_api_jsonrpc.erl
+++ b/apps/aehttp/src/sc_ws_api_jsonrpc.erl
@@ -27,7 +27,9 @@
                                Method =:= <<"channels.shutdown_sign">>;
                                Method =:= <<"channels.shutdown_sign_ack">>;
                                Method =:= <<"channels.update">>;
-                               Method =:= <<"channels.update_ack">>).
+                               Method =:= <<"channels.update_ack">>;
+                               Method =:= <<"channels.solo_close_tx">>;
+                               Method =:= <<"channels.slash_tx">>).
 -define(METHOD_TAG(Method), case Method of
                                 <<"channels.initiator_sign">>    -> create_tx;
                                 <<"channels.deposit_tx">>        -> deposit_tx;
@@ -39,7 +41,9 @@
                                 <<"channels.update_ack">>        -> update_ack;
                                 <<"channels.shutdown_sign">>     -> shutdown;
                                 <<"channels.shutdown_sign_ack">> -> shutdown_ack;
-                                <<"channels.leave">>             -> leave
+                                <<"channels.leave">>             -> leave;
+                                <<"channels.solo_close_tx">>     -> solo_close_tx;
+                                <<"channels.slash_tx">>          -> slash_tx
                             end).
 
 unpack(Msg) when is_map(Msg) ->

--- a/apps/aehttp/src/sc_ws_api_jsonrpc.erl
+++ b/apps/aehttp/src/sc_ws_api_jsonrpc.erl
@@ -29,7 +29,8 @@
                                Method =:= <<"channels.update">>;
                                Method =:= <<"channels.update_ack">>;
                                Method =:= <<"channels.solo_close_tx">>;
-                               Method =:= <<"channels.slash_tx">>).
+                               Method =:= <<"channels.slash_tx">>;
+                               Method =:= <<"channels.settle_tx">>).
 -define(METHOD_TAG(Method), case Method of
                                 <<"channels.initiator_sign">>    -> create_tx;
                                 <<"channels.deposit_tx">>        -> deposit_tx;
@@ -43,7 +44,8 @@
                                 <<"channels.shutdown_sign_ack">> -> shutdown_ack;
                                 <<"channels.leave">>             -> leave;
                                 <<"channels.solo_close_tx">>     -> solo_close_tx;
-                                <<"channels.slash_tx">>          -> slash_tx
+                                <<"channels.slash_tx">>          -> slash_tx;
+                                <<"channels.settle_tx">>         -> settle_tx
                             end).
 
 unpack(Msg) when is_map(Msg) ->
@@ -496,6 +498,18 @@ process_request(#{<<"method">> := <<"channels.leave">>}, FsmPid) ->
 process_request(#{<<"method">> := <<"channels.shutdown">>}, FsmPid) ->
     lager:warning("Channel WS: closing channel message received"),
     aesc_fsm:shutdown(FsmPid),
+    no_reply;
+process_request(#{<<"method">> := <<"channels.close_solo">>}, FsmPid) ->
+    lager:debug("Channel WS: close_solo message received"),
+    aesc_fsm:close_solo(FsmPid),
+    no_reply;
+process_request(#{<<"method">> := <<"channels.slash">>}, FsmPid) ->
+    lager:debug("Channel WS: slash message received"),
+    aesc_fsm:slash(FsmPid),
+    no_reply;
+process_request(#{<<"method">> := <<"channels.settle">>}, FsmPid) ->
+    lager:debug("Channel WS: settle message received"),
+    aesc_fsm:settle(FsmPid),
     no_reply;
 process_request(#{<<"method">> := _} = Unhandled, _FsmPid) ->
     lager:warning("Channel WS: unhandled action received ~p", [Unhandled]),

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -22,6 +22,7 @@
 
 init(Req, _Opts) ->
     lager:debug("init(~p, ~p)", [Req, _Opts]),
+    process_flag(trap_exit, true),
     {cowboy_websocket, Req,
      maps:from_list(cowboy_req:parse_qs(Req))}.
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3778,13 +3778,21 @@ sc_ws_deposit_(Config, Origin) when Origin =:= initiator
     {ok, #{<<"event">> := <<"deposit_created">>}} = wait_for_channel_event(AckConnPid, info, Config),
     {UnsignedStateTx, Updates} = channel_sign_tx(AckConnPid, AckPrivkey, <<"channels.deposit_ack">>, Config),
     ct:log("Unsigned state tx ~p", [UnsignedStateTx]),
-    {ok, #{<<"tx">> := EncodedSignedDepositTx}} = wait_for_channel_event(SenderConnPid, on_chain_tx, Config),
-    {ok, #{<<"tx">> := EncodedSignedDepositTx}} = wait_for_channel_event(AckConnPid, on_chain_tx, Config),
+    {ok, #{<<"tx">> := EncodedSignedDepositTx} = E1} = wait_for_channel_event(SenderConnPid, on_chain_tx, Config),
+    ok = match_info(E1, #{<<"info">> => <<"deposit_signed">>}),
+    {ok, #{<<"tx">> := EncodedSignedDepositTx} = E2} = wait_for_channel_event(AckConnPid, on_chain_tx, Config),
+    ok = match_info(E2, #{<<"info">> => <<"deposit_created">>}),
 
     {ok, SSignedDepositTx} = aeser_api_encoder:safe_decode(transaction,
                                                      EncodedSignedDepositTx),
     SignedDepositTx = aetx_sign:deserialize_from_binary(SSignedDepositTx),
     ok = wait_for_signed_transaction_in_block(SignedDepositTx),
+
+    {ok, #{<<"tx">> := EncodedSignedWTx} = Cc1} = wait_for_channel_event(SenderConnPid, on_chain_tx, Config),
+    ok = match_info(Cc1, #{<<"info">> => <<"channel_changed">>}),
+    {ok, #{<<"tx">> := EncodedSignedWTx} = Cc2} = wait_for_channel_event(AckConnPid, on_chain_tx, Config),
+    ok = match_info(Cc2, #{<<"info">> => <<"channel_changed">>}),
+
     % assert acknowledger balance have not changed
     {SStartB1, AStartB} = channel_participants_balances(SenderPubkey, AckPubkey),
     % assert sender balance has changed
@@ -3833,12 +3841,24 @@ sc_ws_withdraw_(Config, Origin) when Origin =:= initiator
     {ok, #{<<"event">> := <<"withdraw_created">>}} = wait_for_channel_event(AckConnPid, info, Config),
     {UnsignedStateTx, Updates} = channel_sign_tx(AckConnPid, AckPrivkey, <<"channels.withdraw_ack">>, Config),
     ct:log("Unsigned state tx ~p", [UnsignedStateTx]),
-    {ok, #{<<"tx">> := EncodedSignedWTx}} = wait_for_channel_event(SenderConnPid, on_chain_tx, Config),
-    {ok, #{<<"tx">> := EncodedSignedWTx}} = wait_for_channel_event(AckConnPid, on_chain_tx, Config),
+    {ok, #{<<"tx">> := EncodedSignedWTx} = E1} = wait_for_channel_event(SenderConnPid, on_chain_tx, Config),
+    ok = match_info(E1, #{<<"info">> => <<"withdraw_signed">>}),
+    {ok, #{<<"tx">> := EncodedSignedWTx} = E2} = wait_for_channel_event(AckConnPid, on_chain_tx, Config),
+    ok = match_info(E2, #{<<"info">> => <<"withdraw_created">>}),
+
+    ct:log("Got on_chain_tx from both"),
 
     {ok, SSignedWTx} = aeser_api_encoder:safe_decode(transaction, EncodedSignedWTx),
     SignedWTx = aetx_sign:deserialize_from_binary(SSignedWTx),
     ok = wait_for_signed_transaction_in_block(SignedWTx),
+
+    ct:log("Found signed transaction in block"),
+
+    {ok, #{<<"tx">> := EncodedSignedWTx} = Cc1} = wait_for_channel_event(SenderConnPid, on_chain_tx, Config),
+    ok = match_info(Cc1, #{<<"info">> => <<"channel_changed">>}),
+    {ok, #{<<"tx">> := EncodedSignedWTx} = Cc2} = wait_for_channel_event(AckConnPid, on_chain_tx, Config),
+    ok = match_info(Cc2, #{<<"info">> => <<"channel_changed">>}),
+
     % assert acknowledger balance have not changed
     {SStartB1, AStartB} = channel_participants_balances(SenderPubkey, AckPubkey),
     % assert sender balance has changed
@@ -3846,12 +3866,17 @@ sc_ws_withdraw_(Config, Origin) when Origin =:= initiator
     {SStartB1, _, _} = {SStartB + 2 - Fee, SStartB1, SStartB},
 
     aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
-                                   ?DEFAULT_MIN_DEPTH),
+                                   ?DEFAULT_MIN_DEPTH, #{strictly_follow_top => true}),
     {ok, #{<<"event">> := <<"own_withdraw_locked">>}} = wait_for_channel_event(SenderConnPid, info, Config),
     {ok, #{<<"event">> := <<"own_withdraw_locked">>}} = wait_for_channel_event(AckConnPid, info, Config),
 
+    ct:log("own_withdraw_locked from both"),
+
     {ok, #{<<"event">> := <<"withdraw_locked">>}} = wait_for_channel_event(SenderConnPid, info, Config),
     {ok, #{<<"event">> := <<"withdraw_locked">>}} = wait_for_channel_event(AckConnPid, info, Config),
+
+    ct:log("withdraw_locked from both"),
+
     ok = ?WS:unregister_test_for_channel_events(SenderConnPid, [sign, info, on_chain_tx,
                                                                 error]),
     ok = ?WS:unregister_test_for_channel_events(AckConnPid, [sign, info, on_chain_tx,
@@ -4957,12 +4982,28 @@ wait_for_signed_transaction_in_pool(SignedTx) ->
     ok = WaitForTx(30). % 30 attempts * 10ms
 
 wait_for_signed_transaction_in_block(SignedTx) ->
-    TxHash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(SignedTx)),
-    wait_for_tx_hash_on_chain(TxHash).
+    Node = aecore_suite_utils:node_name(?NODE),
+    TxHash = aeser_api_encoder:encode(tx_hash, Hash = aetx_sign:hash(SignedTx)),
+    case rpc:call(Node, aec_chain, find_tx_location, [Hash]) of
+        BHash when is_binary(BHash) ->
+            case rpc:call(Node, aec_chain, hash_is_in_main_chain, [BHash]) of
+                true ->
+                    ct:log("Tx is already on chain (BHash = ~p)", [BHash]),
+                    ok;
+                false ->
+                    ct:log("Tx found in a block off-chain (BHash = ~p)", [BHash]),
+                    wait_for_tx_hash_on_chain(TxHash)
+            end;
+        _Other ->
+            ct:log("Current Tx location: ~p", [_Other]),
+            wait_for_tx_hash_on_chain(TxHash)
+    end.
 
 wait_for_tx_hash_on_chain(TxHash) ->
+    Rate = aecore_suite_utils:expected_mine_rate(),
+    Opts = #{strictly_follow_top => true},
     case aecore_suite_utils:mine_blocks_until_txs_on_chain(
-            aecore_suite_utils:node_name(?NODE), [TxHash], ?MAX_MINED_BLOCKS) of
+           aecore_suite_utils:node_name(?NODE), [TxHash], Rate, ?MAX_MINED_BLOCKS, Opts) of
         {ok, _Blocks} -> ok;
         {error, _Reason} -> did_not_mine
     end.
@@ -5939,6 +5980,21 @@ wait_for_channel_event_(Event, ConnPid, Action, <<"json-rpc">>) ->
     {ok, #{ <<"data">> := #{ <<"event">> := Event } }} =
         wait_for_json_rpc_action(ConnPid, Action),
     ok.
+
+match_info(Info, Match) ->
+    maps:fold(fun(K,V,Acc) ->
+                      case maps:find(K, Info) of
+                          {ok, V} ->
+                              Acc;
+                          {ok, V1} when is_map(V), is_map(V1) ->
+                              match_info(V, V1);
+                          {ok, Other} ->
+                              error({info_mismatch, {K, [V, Other]}});
+                          error ->
+                              error({no_such_key, K})
+                      end
+              end, ok, Match).
+
 
 wait_for_channel_leave_msg(ConnPid, Config) ->
     wait_for_channel_leave_msg_(ConnPid, sc_ws_protocol(Config)).

--- a/apps/aehttp/test/aehttp_ws_test_utils.erl
+++ b/apps/aehttp/test/aehttp_ws_test_utils.erl
@@ -426,7 +426,7 @@ maybe_inform(Origin, Action, Tag, Msg, Register) ->
       RegisteredPids),
     %% for easier debugging
     case RegisteredPids == [] of
-        true -> ct:log("No test registered for this event");
+        true -> ct:log("No test registered for this event (Msg = ~p)", [Msg]);
         false -> pass
     end.
 

--- a/apps/aens/src/aens_state_tree.erl
+++ b/apps/aens/src/aens_state_tree.erl
@@ -27,6 +27,8 @@
         , to_binary_without_backend/1
         ]).
 
+-export([record_fields/1]).
+
 %% Export for test
 -ifdef(TEST).
 -export([ name_list/1
@@ -57,6 +59,13 @@
 -export_type([tree/0]).
 
 -define(VSN, 1).
+
+%% ==================================================================
+%% Tracing support
+record_fields(ns_tree) -> record_info(fields, ns_tree);
+record_fields(_      ) -> no.
+%% ==================================================================
+
 %%%===================================================================
 %%% API
 %%%===================================================================

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -33,6 +33,8 @@
         , to_binary_without_backend/1
         ]).
 
+-export([record_fields/1]).
+
 -ifdef(TEST).
 -export([ query_list/1
         , oracle_list/1
@@ -74,6 +76,13 @@
 -define(HASH_SIZE, 32).
 
 -define(VSN, 1).
+
+%% ==================================================================
+%% Tracing support
+record_fields(oracle_tree) -> record_info(fields, oracle_tree);
+record_fields(_          ) -> no.
+%% ==================================================================
+
 %%%===================================================================
 %%% API
 %%%===================================================================

--- a/apps/aeutils/src/aeu_mp_trees.erl
+++ b/apps/aeutils/src/aeu_mp_trees.erl
@@ -39,6 +39,8 @@
         , dict_db_put/3
         ]).
 
+-export([record_fields/1]).
+
 -export_type([ tree/0
              , iterator/0
              , iterator_opts/0
@@ -97,6 +99,14 @@
 
 -type unfold_leaf() :: {leaf, path()}.
 -type unfold_node() :: {node, path(), enc_node()}.
+
+%% ==================================================================
+%% Tracing support
+record_fields(mpt ) -> record_info(fields, mpt);
+record_fields(iter) -> record_info(fields, iter);
+record_fields(db  ) -> aeu_mp_trees_db:record_fields(db);
+record_fields(_   ) -> no.
+%% ==================================================================
 
 %%%===================================================================
 %%% API

--- a/apps/aeutils/src/aeu_mp_trees_db.erl
+++ b/apps/aeutils/src/aeu_mp_trees_db.erl
@@ -24,6 +24,8 @@
         , unsafe_write_to_backend/3
         ]).
 
+-export([record_fields/1]).
+
 -export_type([ db/0
              , db_spec/0
              ]).
@@ -59,6 +61,12 @@
 
 %% fun((cache()) -> cache()).
 -type drop_cache_mf() :: {module(), atom()}.
+
+%% ==================================================================
+%% Trace support
+record_fields(db) -> record_info(fields, db);
+record_fields(_ ) -> no.
+%% ==================================================================
 
 %%%===================================================================
 %%% API

--- a/docs/release-notes/next/PT-159406473-continuous_chain_monitoring.md
+++ b/docs/release-notes/next/PT-159406473-continuous_chain_monitoring.md
@@ -1,0 +1,6 @@
+* The state channel chain watcher now watches the chain continuously
+* The state channel FSM stays open during the closing phase
+* Client WS API for solo-closing, slash and settle
+* SC FSM automatically detects when a slash is needed
+* SC FSM reports to client any time the on-chain channel state changes
+* The SC watcher is now fork-aware

--- a/rebar.config
+++ b/rebar.config
@@ -89,7 +89,12 @@
 
         % waiting for https://github.com/szktty/erlang-lz4/pull/12 to be merged
         {lz4, {git, "https://github.com/aeternity/erlang-lz4.git",
-              {ref, "1ff9f36"}}}
+              {ref, "1ff9f36"}}},
+
+        % for lightweight trace-based debugging
+        {trace_runner, {git, "git://github.com/uwiger/trace_runner.git",
+                        {ref, "303ef2f"}}}
+
        ]}.
 
 {plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "ac38525ba55e8eefc00fb4fc0ec697ec3b2c26cf"}}}]}.
@@ -263,5 +268,5 @@
 {dialyzer, [
             {warnings, [unknown]},
             {plt_apps, all_deps},
-            {base_plt_apps, [erts, kernel, stdlib, crypto, mnesia]}
+            {base_plt_apps, [erts, kernel, stdlib, crypto, mnesia, trace_runner]}
            ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -110,6 +110,10 @@
   {git,"https://github.com/aeternity/erlang-sha3",
       {ref,"c818ddc20004ab26e09900e35608a58b5c8429a5"}},
   0},
+ {<<"trace_runner">>,
+  {git,"git://github.com/uwiger/trace_runner.git",
+      {ref,"303ef2f8a85748daa3852c8342b55c61de0f62d3"}},
+  0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},1},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0}]}.
 [

--- a/scripts/log_xtract.escript
+++ b/scripts/log_xtract.escript
@@ -1,0 +1,65 @@
+#!/usr/bin/env escript
+%% -*- mode:erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
+
+
+main([Re | Path]) ->
+    {Pids, Ps} = lists:foldl(
+                   fun(P, Acc) ->
+                           grep(Re, P, Acc)
+                   end, {ordsets:new(), ordsets:new()}, Path),
+    PidPats = pid_patterns(Pids),
+    [find_pids(P, PidPats) || P <- Ps],
+    halt(0).
+
+grep(Re, P, {Acc, PAcc}) ->
+    x(os:cmd("grep " ++ Re ++ " " ++ P), P, Acc, PAcc).
+
+find_pids(File, Pids) ->
+    {ok, Bin} = file:read_file(File),
+    Lines = string:lexemes(Bin, [$\n]),
+    io:fwrite("*** ~s ***~n", [File]),
+    Matches = [L || L <- Lines,
+                    match_pids(L, Pids)],
+    [io:fwrite("~s~n", [M]) || M <- Matches].
+
+pid_patterns(Pids) ->
+    [list_to_binary(pid_to_list(P)) || P <- Pids].
+
+match_pids(L, PidPats) ->
+    binary:matches(L, PidPats) =/= [].
+
+x([], _, Acc, PAcc) ->
+    {Acc, PAcc};
+x(Out, P, Acc, PAcc) ->
+    PAcc1 = ordsets:add_element(P, PAcc),
+    NewAcc = extract_pids(Out, Acc),
+    case NewAcc -- Acc of
+        [] ->
+            {Acc, PAcc1};
+        New ->
+            lists:foldl(
+              fun(Pid, AccX) ->
+                      grep("'" ++ pid_to_list(Pid) ++ "'", P, AccX)
+              end, {NewAcc, PAcc1}, New)
+    end.
+    
+
+
+extract_pids(String, Acc) ->
+    case re:run(String, "<[0-9]+\\.[0-9]+\\.[0-9]+>",
+                [global,{capture,all,list}]) of
+        {match, Matches} ->
+            lists:foldl(
+              fun(M, Acc1) ->
+                      lists:foldl(
+                        fun(P, Acc2) ->
+                                try ordsets:add_element(list_to_pid(P), Acc2)
+                                catch error:_ -> Acc2
+                                end
+                        end, Acc1, M)
+              end, Acc, Matches);
+        _ ->
+            []
+    end.
+
+


### PR DESCRIPTION
Rebased on top of latest changes.

Addresses:
* [#159406473 SC Watcher: listen for on-chain txs](https://www.pivotaltracker.com/story/show/159406473)
* [#159406302 SC WS: Solo closing](https://www.pivotaltracker.com/story/show/159406302)

Of particular note, the FSM now stays up during the closing phase, allowing the client to request `close_solo`, `slash` or `settle`. The FSM may also automatically slash if configured to do so (no tests exist for this). Documentation remains to be written. Also, http integration tests for the solo-closing phase.