### PR TITLE
PT-165853843 Properly encode binary JSON-content

### DIFF
--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -212,7 +212,7 @@ for_client(#spend_tx{sender_id    = SenderId,
       <<"fee">>          => Fee,
       <<"ttl">>          => TTL,
       <<"nonce">>        => Nonce,
-      <<"payload">>      => Payload}.
+      <<"payload">>      => aeser_api_encoder:encode(bytearray, Payload)}.
 
 -spec version(tx()) -> non_neg_integer().
 version(_) ->

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -110,7 +110,7 @@
               "properties" : {
                 "hash" : {
                   "type" : "string",
-                  "description" : "Hash"
+                  "description" : "Key block hash"
                 }
               }
             }
@@ -614,8 +614,7 @@
           "in" : "path",
           "description" : "The hash of the block",
           "required" : true,
-          "type" : "string",
-          "minimum" : 0
+          "type" : "string"
         } ],
         "responses" : {
           "200" : {
@@ -1125,7 +1124,7 @@
               "type" : "object",
               "properties" : {
                 "pubkey" : {
-                  "type" : "string"
+                  "$ref" : "#/definitions/EncodedPubkey"
                 }
               }
             }
@@ -2021,8 +2020,35 @@
     }
   },
   "definitions" : {
+    "UInt" : {
+      "type" : "integer",
+      "minimum" : 0
+    },
+    "UInt32" : {
+      "type" : "integer",
+      "minimum" : 0,
+      "maximum" : 4294967295
+    },
+    "UInt64" : {
+      "type" : "integer",
+      "minimum" : 0,
+      "maximum" : 18446744073709551615
+    },
     "EncodedHash" : {
-      "type" : "string"
+      "type" : "string",
+      "description" : "Base58Check encoded tagged hash"
+    },
+    "EncodedPubkey" : {
+      "type" : "string",
+      "description" : "Base58Check encoded tagged pubkey"
+    },
+    "EncodedValue" : {
+      "type" : "string",
+      "description" : "Base58Check encoded tagged value"
+    },
+    "EncodedByteArray" : {
+      "type" : "string",
+      "description" : "Base64Check encoded tagged byte array"
     },
     "Pow" : {
       "type" : "array",
@@ -2057,10 +2083,10 @@
           "$ref" : "#/definitions/EncodedHash"
         },
         "miner" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "beneficiary" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "target" : {
           "type" : "integer",
@@ -2088,6 +2114,7 @@
       "example" : {
         "nonce" : 1,
         "version" : 5,
+        "miner" : { },
         "target" : 6,
         "pow" : "",
         "time" : 5,
@@ -2108,8 +2135,8 @@
           "format" : "int64"
         },
         "pof_hash" : {
-          "type" : "string",
-          "description" : "\"no_fraud\" | api encoded Proof of Fraud hash"
+          "description" : "\"no_fraud\" | api encoded Proof of Fraud hash",
+          "$ref" : "#/definitions/EncodedHash"
         },
         "prev_hash" : {
           "$ref" : "#/definitions/EncodedHash"
@@ -2124,7 +2151,7 @@
           "$ref" : "#/definitions/EncodedHash"
         },
         "signature" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         },
         "time" : {
           "type" : "integer",
@@ -2136,7 +2163,7 @@
         }
       },
       "example" : {
-        "pof_hash" : "pof_hash",
+        "signature" : { },
         "time" : 7,
         "version" : 9,
         "height" : 2
@@ -2154,7 +2181,7 @@
       },
       "example" : {
         "micro_block" : {
-          "pof_hash" : "pof_hash",
+          "signature" : { },
           "time" : 7,
           "version" : 9,
           "height" : 2
@@ -2162,6 +2189,7 @@
         "key_block" : {
           "nonce" : 1,
           "version" : 5,
+          "miner" : { },
           "target" : 6,
           "pow" : "",
           "time" : 5,
@@ -2190,7 +2218,7 @@
           },
           "block_hash" : { },
           "block_height" : 6,
-          "signatures" : [ "signatures", "signatures" ]
+          "signatures" : [ { }, { } ]
         }, {
           "tx" : {
             "type" : "type",
@@ -2198,7 +2226,7 @@
           },
           "block_hash" : { },
           "block_height" : 6,
-          "signatures" : [ "signatures", "signatures" ]
+          "signatures" : [ { }, { } ]
         } ]
       }
     },
@@ -2208,7 +2236,7 @@
       "properties" : {
         "id" : {
           "description" : "Public key",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "balance" : {
           "type" : "integer",
@@ -2228,7 +2256,7 @@
         },
         "contract_id" : {
           "description" : "Id of authorization contract for generalized account",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "auth_fun" : {
           "type" : "string",
@@ -2248,11 +2276,11 @@
       "required" : [ "tx" ],
       "properties" : {
         "tx" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       },
       "example" : {
-        "tx" : "tx"
+        "tx" : { }
       }
     },
     "RegisteredOracle" : {
@@ -2260,7 +2288,7 @@
       "required" : [ "abi_version", "id", "query_fee", "query_format", "response_format", "ttl" ],
       "properties" : {
         "id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "query_format" : {
           "type" : "string"
@@ -2295,10 +2323,10 @@
       "required" : [ "fee", "id", "oracle_id", "query", "response", "response_ttl", "sender_id", "sender_nonce", "ttl" ],
       "properties" : {
         "id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         },
         "sender_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "sender_nonce" : {
           "type" : "integer",
@@ -2306,7 +2334,7 @@
           "minimum" : 0
         },
         "oracle_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "query" : {
           "type" : "string"
@@ -2336,7 +2364,8 @@
         "fee" : 5,
         "sender_nonce" : 0,
         "id" : { },
-        "ttl" : 6
+        "ttl" : 6,
+        "sender_id" : { }
       }
     },
     "OracleQueries" : {
@@ -2361,7 +2390,8 @@
           "fee" : 5,
           "sender_nonce" : 0,
           "id" : { },
-          "ttl" : 6
+          "ttl" : 6,
+          "sender_id" : { }
         }, {
           "response_ttl" : {
             "type" : "delta",
@@ -2372,7 +2402,8 @@
           "fee" : 5,
           "sender_nonce" : 0,
           "id" : { },
-          "ttl" : 6
+          "ttl" : 6,
+          "sender_id" : { }
         } ]
       }
     },
@@ -2381,7 +2412,7 @@
       "required" : [ "amount", "fee", "payload", "recipient_id", "sender_id" ],
       "properties" : {
         "recipient_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "amount" : {
           "type" : "integer",
@@ -2397,19 +2428,19 @@
           "format" : "int64"
         },
         "sender_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
           "format" : "int64"
         },
         "payload" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       },
       "example" : {
         "amount" : 0,
-        "payload" : "payload",
+        "payload" : { },
         "fee" : 6,
         "ttl" : 1,
         "nonce" : 5,
@@ -2434,7 +2465,7 @@
           "$ref" : "#/definitions/TTL"
         },
         "account_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2481,7 +2512,7 @@
           "$ref" : "#/definitions/RelativeTTL"
         },
         "oracle_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2508,7 +2539,7 @@
       "required" : [ "fee", "oracle_id", "query", "query_fee", "query_ttl", "response_ttl", "sender_id" ],
       "properties" : {
         "oracle_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "query" : {
           "type" : "string"
@@ -2532,7 +2563,7 @@
           "format" : "int64"
         },
         "sender_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2562,7 +2593,7 @@
       "required" : [ "fee", "oracle_id", "query_id", "response", "response_ttl" ],
       "properties" : {
         "query_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         },
         "response" : {
           "type" : "string"
@@ -2579,7 +2610,7 @@
           "format" : "int64"
         },
         "oracle_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2592,6 +2623,7 @@
           "type" : "delta",
           "value" : 1
         },
+        "oracle_id" : { },
         "query_id" : { },
         "response" : "response",
         "fee" : 0,
@@ -2642,7 +2674,7 @@
       "required" : [ "id", "pointers", "ttl" ],
       "properties" : {
         "id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "ttl" : {
           "type" : "integer",
@@ -2670,7 +2702,7 @@
       "required" : [ "account_id", "commitment_id", "fee" ],
       "properties" : {
         "commitment_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         },
         "fee" : {
           "type" : "integer",
@@ -2681,7 +2713,7 @@
           "format" : "int64"
         },
         "account_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2709,7 +2741,7 @@
           "format" : "int64"
         },
         "account_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2722,7 +2754,7 @@
       "required" : [ "account_id", "client_ttl", "fee", "name_id", "name_ttl", "pointers" ],
       "properties" : {
         "name_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         },
         "name_ttl" : {
           "type" : "integer",
@@ -2747,7 +2779,7 @@
           "format" : "int64"
         },
         "account_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2760,10 +2792,10 @@
       "required" : [ "account_id", "fee", "name_id", "recipient_id" ],
       "properties" : {
         "name_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         },
         "recipient_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "fee" : {
           "type" : "integer",
@@ -2774,7 +2806,7 @@
           "format" : "int64"
         },
         "account_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2787,7 +2819,7 @@
       "required" : [ "account_id", "fee", "name_id" ],
       "properties" : {
         "name_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         },
         "fee" : {
           "type" : "integer",
@@ -2798,7 +2830,7 @@
           "format" : "int64"
         },
         "account_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -2811,7 +2843,7 @@
       "required" : [ "commitment_id" ],
       "properties" : {
         "commitment_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         }
       },
       "example" : {
@@ -2823,7 +2855,7 @@
       "required" : [ "name_id" ],
       "properties" : {
         "name_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedValue"
         }
       }
     },
@@ -2835,7 +2867,7 @@
           "type" : "string"
         },
         "id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         }
       },
       "example" : {
@@ -2847,13 +2879,13 @@
       "required" : [ "channel_amount", "channel_reserve", "delegate_ids", "id", "initiator_amount", "initiator_id", "lock_period", "locked_until", "responder_amount", "responder_id", "round", "solo_round", "state_hash" ],
       "properties" : {
         "id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "initiator_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "responder_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "channel_amount" : {
           "type" : "integer",
@@ -2878,7 +2910,7 @@
         "delegate_ids" : {
           "type" : "array",
           "items" : {
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           }
         },
         "state_hash" : {
@@ -2911,6 +2943,7 @@
         "responder_amount" : 0,
         "initiator_amount" : 0,
         "round" : 0,
+        "state_hash" : { },
         "id" : { },
         "solo_round" : 0,
         "channel_amount" : 0,
@@ -2922,7 +2955,7 @@
       "required" : [ "channel_reserve", "fee", "initiator_amount", "initiator_id", "lock_period", "push_amount", "responder_amount", "responder_id", "state_hash" ],
       "properties" : {
         "initiator_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "initiator_amount" : {
           "type" : "integer",
@@ -2930,7 +2963,7 @@
           "minimum" : 0
         },
         "responder_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "responder_amount" : {
           "type" : "integer",
@@ -2978,10 +3011,10 @@
       "required" : [ "amount", "channel_id", "fee", "from_id", "nonce", "round", "state_hash" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "from_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "amount" : {
           "type" : "integer",
@@ -3020,10 +3053,10 @@
       "required" : [ "amount", "channel_id", "fee", "nonce", "round", "state_hash", "to_id" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "to_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "amount" : {
           "type" : "integer",
@@ -3062,13 +3095,13 @@
       "required" : [ "channel_id", "fee", "from_id", "payload", "round", "state_hash", "update" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "from_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "payload" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedByteArray"
         },
         "round" : {
           "type" : "integer",
@@ -3101,7 +3134,7 @@
         },
         "offchain_trees" : {
           "description" : "The whole set of off-chain state trees",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       }
     },
@@ -3110,10 +3143,10 @@
       "required" : [ "channel_id", "fee", "from_id", "initiator_amount_final", "nonce", "responder_amount_final" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "from_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "initiator_amount_final" : {
           "type" : "integer",
@@ -3147,13 +3180,13 @@
       "required" : [ "channel_id", "fee", "from_id", "payload", "poi" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "from_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "payload" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedByteArray"
         },
         "ttl" : {
           "type" : "integer",
@@ -3171,8 +3204,8 @@
           "minimum" : 0
         },
         "poi" : {
-          "type" : "string",
-          "description" : "Proof of inclusion containing information for closing the channel"
+          "description" : "Proof of inclusion containing information for closing the channel",
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       }
     },
@@ -3181,13 +3214,13 @@
       "required" : [ "channel_id", "fee", "from_id", "payload", "poi" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "from_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "payload" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedByteArray"
         },
         "ttl" : {
           "type" : "integer",
@@ -3205,8 +3238,8 @@
           "minimum" : 0
         },
         "poi" : {
-          "type" : "string",
-          "description" : "Proof of inclusion containing information for closing the channel"
+          "description" : "Proof of inclusion containing information for closing the channel",
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       }
     },
@@ -3215,10 +3248,10 @@
       "required" : [ "channel_id", "fee", "from_id", "initiator_amount_final", "nonce", "responder_amount_final" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "from_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "initiator_amount_final" : {
           "type" : "integer",
@@ -3252,13 +3285,13 @@
       "required" : [ "channel_id", "fee", "from_id", "payload" ],
       "properties" : {
         "channel_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "from_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "payload" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedByteArray"
         },
         "ttl" : {
           "type" : "integer",
@@ -3282,11 +3315,11 @@
       "required" : [ "pub_key" ],
       "properties" : {
         "pub_key" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedPubkey"
         }
       },
       "example" : {
-        "pub_key" : "pub_key"
+        "pub_key" : { }
       }
     },
     "Status" : {
@@ -3405,7 +3438,7 @@
           "type" : "array",
           "description" : "signatures required unless for Generalized Account Meta transactions",
           "items" : {
-            "type" : "string"
+            "$ref" : "#/definitions/EncodedValue"
           },
           "minItems" : 1
         }
@@ -3417,7 +3450,7 @@
         },
         "block_hash" : { },
         "block_height" : 6,
-        "signatures" : [ "signatures", "signatures" ]
+        "signatures" : [ { }, { } ]
       }
     },
     "GenericTx" : {
@@ -3628,7 +3661,7 @@
       "required" : [ "caller_id", "caller_nonce", "contract_id", "gas_price", "gas_used", "height", "log", "return_type", "return_value" ],
       "properties" : {
         "caller_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "caller_nonce" : {
           "type" : "integer"
@@ -3637,7 +3670,7 @@
           "type" : "integer"
         },
         "contract_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "gas_price" : {
           "type" : "integer"
@@ -3680,7 +3713,7 @@
       "required" : [ "caller_id", "gas_price", "gas_used", "height", "return_type", "return_value" ],
       "properties" : {
         "caller_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "height" : {
           "type" : "integer"
@@ -3715,7 +3748,7 @@
       "properties" : {
         "address" : {
           "description" : "Contract address",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "topics" : {
           "type" : "array",
@@ -3748,10 +3781,10 @@
       "required" : [ "abi_version", "active", "deposit", "id", "log", "owner_id", "referrer_ids", "vm_version" ],
       "properties" : {
         "id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "owner_id" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "vm_version" : {
           "type" : "integer",
@@ -3773,7 +3806,7 @@
         "referrer_ids" : {
           "type" : "array",
           "items" : {
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           }
         },
         "deposit" : {
@@ -3816,11 +3849,11 @@
       "required" : [ "bytecode" ],
       "properties" : {
         "bytecode" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       },
       "example" : {
-        "bytecode" : "bytecode"
+        "bytecode" : { }
       }
     },
     "DryRunInput" : {
@@ -3828,7 +3861,7 @@
       "required" : [ "txs" ],
       "properties" : {
         "top" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedHash"
         },
         "accounts" : {
           "type" : "array",
@@ -3841,12 +3874,12 @@
           "type" : "array",
           "description" : "Txs",
           "items" : {
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedByteArray"
           }
         }
       },
       "example" : {
-        "top" : "top",
+        "top" : { },
         "accounts" : [ {
           "amount" : 0,
           "pub_key" : { }
@@ -3854,7 +3887,7 @@
           "amount" : 0,
           "pub_key" : { }
         } ],
-        "txs" : [ null, null ]
+        "txs" : [ { }, { } ]
       }
     },
     "DryRunAccount" : {
@@ -3862,7 +3895,7 @@
       "required" : [ "amount", "pub_key" ],
       "properties" : {
         "pub_key" : {
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "amount" : {
           "type" : "integer"
@@ -3965,9 +3998,6 @@
         }
       }
     },
-    "EncodedByteArray" : {
-      "type" : "string"
-    },
     "Peer" : {
       "type" : "string",
       "description" : "Aeternity node"
@@ -4002,15 +4032,15 @@
       "properties" : {
         "owner_id" : {
           "description" : "Contract owner pub_key",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
           "description" : "Owner's nonce"
         },
         "code" : {
-          "type" : "string",
-          "description" : "Contract's code"
+          "description" : "Contract's code",
+          "$ref" : "#/definitions/EncodedByteArray"
         },
         "vm_version" : {
           "type" : "integer",
@@ -4063,8 +4093,7 @@
         "gas_price" : 0,
         "vm_version" : 39500,
         "amount" : 0,
-        "code" : "code",
-        "call_data" : { },
+        "code" : { },
         "owner_id" : { },
         "fee" : 0,
         "gas" : 0,
@@ -4080,7 +4109,7 @@
       "properties" : {
         "caller_id" : {
           "description" : "Contract caller pub_key",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "nonce" : {
           "type" : "integer",
@@ -4088,7 +4117,7 @@
         },
         "contract_id" : {
           "description" : "Contract's pub_key",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedPubkey"
         },
         "abi_version" : {
           "type" : "integer",
@@ -4144,7 +4173,7 @@
       "properties" : {
         "tx" : {
           "description" : "Unsigned transaction object",
-          "$ref" : "#/definitions/EncodedHash"
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       },
       "example" : {
@@ -4173,7 +4202,7 @@
         "properties" : {
           "contract_id" : {
             "description" : "Address of the contract to be created",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           }
         }
       } ]
@@ -4183,12 +4212,12 @@
       "required" : [ "poi" ],
       "properties" : {
         "poi" : {
-          "type" : "string",
-          "description" : "Proof of inclusion"
+          "description" : "Proof of inclusion",
+          "$ref" : "#/definitions/EncodedByteArray"
         }
       },
       "example" : {
-        "poi" : "poi"
+        "poi" : { }
       }
     },
     "Generation" : {
@@ -4201,7 +4230,7 @@
         "micro_blocks" : {
           "type" : "array",
           "items" : {
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           }
         }
       },
@@ -4210,6 +4239,7 @@
         "key_block" : {
           "nonce" : 1,
           "version" : 5,
+          "miner" : { },
           "target" : 6,
           "pow" : "",
           "time" : 5,
@@ -4238,11 +4268,11 @@
         "properties" : {
           "from" : {
             "description" : "Sender of tokens",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           },
           "to" : {
             "description" : "Receiver of tokens",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           },
           "amount" : {
             "type" : "integer",
@@ -4261,7 +4291,7 @@
         "properties" : {
           "to" : {
             "description" : "Withdrawer of tokens",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           },
           "amount" : {
             "type" : "integer",
@@ -4280,7 +4310,7 @@
         "properties" : {
           "from" : {
             "description" : "Depositor of tokens",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           },
           "amount" : {
             "type" : "integer",
@@ -4299,7 +4329,7 @@
         "properties" : {
           "owner" : {
             "description" : "Contract owner",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           },
           "vm_version" : {
             "type" : "integer",
@@ -4337,11 +4367,11 @@
         "properties" : {
           "caller" : {
             "description" : "Contract caller",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           },
           "contract" : {
             "description" : "Contract address",
-            "$ref" : "#/definitions/EncodedHash"
+            "$ref" : "#/definitions/EncodedPubkey"
           },
           "vm_version" : {
             "type" : "integer",
@@ -4428,7 +4458,7 @@
       "properties" : {
         "hash" : {
           "type" : "string",
-          "description" : "Hash"
+          "description" : "Key block hash"
         }
       },
       "example" : {
@@ -4463,11 +4493,11 @@
     "inline_response_200_3" : {
       "properties" : {
         "pubkey" : {
-          "type" : "string"
+          "$ref" : "#/definitions/EncodedPubkey"
         }
       },
       "example" : {
-        "pubkey" : "pubkey"
+        "pubkey" : { }
       }
     },
     "ContractStore_store" : {

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -1121,12 +1121,7 @@
           "200" : {
             "description" : "Successful operation",
             "schema" : {
-              "type" : "object",
-              "properties" : {
-                "pubkey" : {
-                  "$ref" : "#/definitions/EncodedPubkey"
-                }
-              }
+              "$ref" : "#/definitions/PeerPubKey"
             }
           }
         }
@@ -2020,20 +2015,6 @@
     }
   },
   "definitions" : {
-    "UInt" : {
-      "type" : "integer",
-      "minimum" : 0
-    },
-    "UInt32" : {
-      "type" : "integer",
-      "minimum" : 0,
-      "maximum" : 4294967295
-    },
-    "UInt64" : {
-      "type" : "integer",
-      "minimum" : 0,
-      "maximum" : 18446744073709551615
-    },
     "EncodedHash" : {
       "type" : "string",
       "description" : "Base58Check encoded tagged hash"
@@ -3310,6 +3291,18 @@
         }
       }
     },
+    "PeerPubKey" : {
+      "type" : "object",
+      "required" : [ "pubkey" ],
+      "properties" : {
+        "pubkey" : {
+          "$ref" : "#/definitions/EncodedPubkey"
+        }
+      },
+      "example" : {
+        "pubkey" : { }
+      }
+    },
     "PubKey" : {
       "type" : "object",
       "required" : [ "pub_key" ],
@@ -4488,16 +4481,6 @@
       },
       "example" : {
         "count" : 1
-      }
-    },
-    "inline_response_200_3" : {
-      "properties" : {
-        "pubkey" : {
-          "$ref" : "#/definitions/EncodedPubkey"
-        }
-      },
-      "example" : {
-        "pubkey" : { }
       }
     },
     "ContractStore_store" : {

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -73,7 +73,7 @@ handle_request_('PostSpend', #{'SpendTx' := Req}, _Context) ->
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{sender_id, sender_id, {id_hash, [account_pubkey]}},
                              {recipient_id, recipient_id, {id_hash, AllowedRecipients}}]),
-                 api_optional_decode([{payload, generic_bytearray}]),
+                 api_optional_decode([{payload, bytearray}]),
                  get_nonce_from_account_id(sender_id),
                  unsigned_tx_response(fun aec_spend_tx:new/1)
                 ],
@@ -230,7 +230,7 @@ handle_request_('PostChannelSnapshotSolo', #{'ChannelSnapshotSoloTx' := Req}, _C
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{channel_id, channel_id, {id_hash, [channel]}},
                              {from_id, from_id, {id_hash, [account_pubkey]}},
-                             {payload, payload, generic_bytearray}]),
+                             {payload, payload, bytearray}]),
                  get_nonce_from_account_id(from_id),
                  unsigned_tx_response(fun aesc_snapshot_solo_tx:new/1)
                 ],
@@ -256,7 +256,7 @@ handle_request_('PostChannelCloseSolo', #{'ChannelCloseSoloTx' := Req}, _Context
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{channel_id, channel_id, {id_hash, [channel]}},
                              {from_id, from_id, {id_hash, [account_pubkey]}},
-                             {poi, poi, poi}, {payload, payload, generic_bytearray}]),
+                             {poi, poi, poi}, {payload, payload, bytearray}]),
                  get_nonce_from_account_id(from_id),
                  poi_decode(poi),
                  unsigned_tx_response(fun aesc_close_solo_tx:new/1)
@@ -270,7 +270,7 @@ handle_request_('PostChannelSlash', #{'ChannelSlashTx' := Req}, _Context) ->
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{channel_id, channel_id, {id_hash, [channel]}},
                              {from_id, from_id, {id_hash, [account_pubkey]}},
-                             {poi, poi, poi}, {payload, payload, generic_bytearray}]),
+                             {poi, poi, poi}, {payload, payload, bytearray}]),
                  get_nonce_from_account_id(from_id),
                  poi_decode(poi),
                  unsigned_tx_response(fun aesc_slash_tx:new/1)

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -8,6 +8,8 @@
                         , read_required_params/1
                         , read_optional_params/1
                         , api_decode/1
+                        , api_optional_decode/1
+                        , api_conditional_decode/1
                         , get_nonce_from_account_id/1
                         , get_contract_code/2
                         , verify_name/1
@@ -67,13 +69,11 @@ handle_request_('PostKeyBlock', #{'KeyBlock' := Data}, _Context) ->
 handle_request_('PostSpend', #{'SpendTx' := Req}, _Context) ->
     AllowedRecipients = [account_pubkey, name, oracle_pubkey, contract_pubkey],
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([sender_id,
-                                       {recipient_id, recipient_id},
-                                        amount, fee, payload]),
+                 read_required_params([sender_id, recipient_id, amount, fee, payload]),
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{sender_id, sender_id, {id_hash, [account_pubkey]}},
-                                {recipient_id, recipient_id,
-                                 {id_hash, AllowedRecipients}}]),
+                             {recipient_id, recipient_id, {id_hash, AllowedRecipients}}]),
+                 api_optional_decode([{payload, generic_bytearray}]),
                  get_nonce_from_account_id(sender_id),
                  unsigned_tx_response(fun aec_spend_tx:new/1)
                 ],
@@ -229,7 +229,8 @@ handle_request_('PostChannelSnapshotSolo', #{'ChannelSnapshotSoloTx' := Req}, _C
                                        payload, fee]),
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{channel_id, channel_id, {id_hash, [channel]}},
-                                {from_id, from_id, {id_hash, [account_pubkey]}}]),
+                             {from_id, from_id, {id_hash, [account_pubkey]}},
+                             {payload, payload, generic_bytearray}]),
                  get_nonce_from_account_id(from_id),
                  unsigned_tx_response(fun aesc_snapshot_solo_tx:new/1)
                 ],
@@ -254,8 +255,8 @@ handle_request_('PostChannelCloseSolo', #{'ChannelCloseSoloTx' := Req}, _Context
                                        payload, poi, fee]),
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{channel_id, channel_id, {id_hash, [channel]}},
-                                {from_id, from_id, {id_hash, [account_pubkey]}},
-                                {poi, poi, poi}]),
+                             {from_id, from_id, {id_hash, [account_pubkey]}},
+                             {poi, poi, poi}, {payload, payload, generic_bytearray}]),
                  get_nonce_from_account_id(from_id),
                  poi_decode(poi),
                  unsigned_tx_response(fun aesc_close_solo_tx:new/1)
@@ -268,8 +269,8 @@ handle_request_('PostChannelSlash', #{'ChannelSlashTx' := Req}, _Context) ->
                                        payload, poi, fee]),
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{channel_id, channel_id, {id_hash, [channel]}},
-                                {from_id, from_id, {id_hash, [account_pubkey]}},
-                                {poi, poi, poi}]),
+                             {from_id, from_id, {id_hash, [account_pubkey]}},
+                             {poi, poi, poi}, {payload, payload, generic_bytearray}]),
                  get_nonce_from_account_id(from_id),
                  poi_decode(poi),
                  unsigned_tx_response(fun aesc_slash_tx:new/1)
@@ -290,12 +291,14 @@ handle_request_('PostChannelSettle', #{'ChannelSettleTx' := Req}, _Context) ->
     process_request(ParseFuns, Req);
 
 handle_request_('PostOracleRegister', #{'OracleRegisterTx' := Req}, _Context) ->
+    IsVmABI = fun(Data) -> maps:get(abi_version, Data, 0) == ?ABI_AEVM_SOPHIA_1 end,
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([account_id, {query_format, query_format},
-                                       {response_format, response_format},
+                 read_required_params([account_id, query_format, response_format,
                                        query_fee, oracle_ttl, fee]),
                  read_optional_params([{ttl, ttl, '$no_value'}, {abi_version, abi_version, 0}]),
                  api_decode([{account_id, account_id, {id_hash, [account_pubkey]}}]),
+                 api_conditional_decode([{query_format, {contract_bytearray, IsVmABI}},
+                                         {response_format, {contract_bytearray, IsVmABI}}]),
                  get_nonce_from_account_id(account_id),
                  ttl_decode(oracle_ttl),
                  unsigned_tx_response(fun aeo_register_tx:new/1)
@@ -321,6 +324,7 @@ handle_request_('PostOracleQuery', #{'OracleQueryTx' := Req}, _Context) ->
                  api_decode([{sender_id, sender_id, {id_hash, [account_pubkey]}},
                                 {oracle_id, oracle_id, {id_hash, [oracle_pubkey]}}]),
                  get_nonce_from_account_id(sender_id),
+                 api_optional_decode([{query, contract_bytearray}]),
                  ttl_decode(query_ttl),
                  relative_ttl_decode(response_ttl),
                  verify_oracle_existence(oracle_id),
@@ -334,6 +338,7 @@ handle_request_('PostOracleRespond', #{'OracleRespondTx' := Req}, _Context) ->
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{oracle_id, oracle_id, {id_hash, [oracle_pubkey]}},
                                 {query_id, query_id, oracle_query_id}]),
+                 api_optional_decode([{response, contract_bytearray}]),
                  get_nonce_from_account_id(oracle_id),
                  relative_ttl_decode(response_ttl),
                  verify_oracle_query_existence(oracle_id, query_id),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2584,13 +2584,15 @@ state_channels_withdrawal(ChannelId, MinerPubkey) ->
 
 state_channels_snapshot_solo(ChannelId, MinerPubkey) ->
     _PoI = aec_trees:new_poi(aec_trees:new_without_backend()),
+    Payload = <<"hejsan svejsan">>, %%TODO proper payload
     Encoded = #{channel_id => aeser_api_encoder:encode(channel, ChannelId),
                 from_id => aeser_api_encoder:encode(account_pubkey, MinerPubkey),
-                payload => <<"hejsan svejsan">>, %%TODO proper payload
+                payload => aeser_api_encoder:encode(bytearray, Payload),
                 fee => 100000 * aec_test_utils:min_gas_price()},
     Decoded = maps:merge(Encoded,
                         #{from_id => aeser_id:create(account, MinerPubkey),
-                          channel_id => aeser_id:create(channel, ChannelId)}),
+                          channel_id => aeser_id:create(channel, ChannelId),
+                          payload => Payload}),
     unsigned_tx_positive_test(Decoded, Encoded,
                                fun get_channel_snapshot_solo/1,
                                fun aesc_snapshot_solo_tx:new/1, MinerPubkey),
@@ -2617,15 +2619,17 @@ state_channels_close_mutual(ChannelId, InitiatorPubkey) ->
     ok.
 
 state_channels_close_solo(ChannelId, MinerPubkey) ->
+    Payload = <<"hejsan svejsan">>, %%TODO proper payload
     PoI = aec_trees:new_poi(aec_trees:new_without_backend()),
     Encoded = #{channel_id => aeser_api_encoder:encode(channel, ChannelId),
                 from_id => aeser_api_encoder:encode(account_pubkey, MinerPubkey),
-                payload => <<"hejsan svejsan">>, %%TODO proper payload
+                payload => aeser_api_encoder:encode(bytearray, Payload),
                 poi => aeser_api_encoder:encode(poi, aec_trees:serialize_poi(PoI)),
                 fee => 100000 * aec_test_utils:min_gas_price()},
     Decoded = maps:merge(Encoded,
                         #{from_id => aeser_id:create(account, MinerPubkey),
                           channel_id => aeser_id:create(channel, ChannelId),
+                          payload => Payload,
                           poi => PoI}),
     unsigned_tx_positive_test(Decoded, Encoded,
                                fun get_channel_close_solo/1,
@@ -2642,15 +2646,17 @@ state_channels_close_solo(ChannelId, MinerPubkey) ->
     ok.
 
 state_channels_slash(ChannelId, MinerPubkey) ->
+    Payload = <<"hejsan svejsan">>, %%TODO proper payload
     PoI = aec_trees:new_poi(aec_trees:new_without_backend()),
     Encoded = #{channel_id => aeser_api_encoder:encode(channel, ChannelId),
                 from_id => aeser_api_encoder:encode(account_pubkey, MinerPubkey),
-                payload => <<"hejsan svejsan">>, %%TODO proper payload
+                payload => aeser_api_encoder:encode(bytearray, Payload),
                 poi => aeser_api_encoder:encode(poi, aec_trees:serialize_poi(PoI)),
                 fee => 100000 * aec_test_utils:min_gas_price()},
     Decoded = maps:merge(Encoded,
                         #{from_id => aeser_id:create(account, MinerPubkey),
                           channel_id => aeser_id:create(channel, ChannelId),
+                          payload => Payload,
                           poi => PoI}),
     unsigned_tx_positive_test(Decoded, Encoded,
                                fun get_channel_slash/1,
@@ -2693,20 +2699,28 @@ spend_transaction(_Config) ->
     MinerAddress = get_pubkey(),
     {ok, MinerPubkey} = aeser_api_encoder:safe_decode(account_pubkey, MinerAddress),
     RandAddress = random_hash(),
+    Payload = <<"hejsan svejsan">>,
     Encoded = #{sender_id => MinerAddress,
                 recipient_id => aeser_api_encoder:encode(account_pubkey, RandAddress),
                 amount => 2,
                 fee => 100000 * aec_test_utils:min_gas_price(),
                 ttl => 43,
-                payload => <<"hejsan svejsan">>},
+                payload => aeser_api_encoder:encode(bytearray, Payload)
+               },
     Decoded = maps:merge(Encoded,
                         #{sender_id => aeser_id:create(account, MinerPubkey),
-                          recipient_id => aeser_id:create(account, RandAddress)}),
+                          recipient_id => aeser_id:create(account, RandAddress),
+                          payload => Payload}),
     {ok, T} = unsigned_tx_positive_test(Decoded, Encoded,
                                   fun get_spend/1,
                                   fun aec_spend_tx:new/1, MinerPubkey),
     {spend_tx, SpendTx} = aetx:specialize_type(T),
-    <<"hejsan svejsan">> = aec_spend_tx:payload(SpendTx),
+    ?assertEqual(Payload, aec_spend_tx:payload(SpendTx)),
+
+    %% Test that we can also still pass unencoded payload.
+    {ok, _T2} = unsigned_tx_positive_test(Decoded, Encoded#{payload => Payload},
+                                  fun get_spend/1,
+                                  fun aec_spend_tx:new/1, MinerPubkey),
 
     test_invalid_hash({account_pubkey, MinerPubkey}, sender_id, Encoded, fun get_spend/1),
     test_invalid_hash({account_pubkey, MinerPubkey}, {recipient_id, recipient_id}, Encoded, fun get_spend/1),

--- a/apps/aeoracle/src/aeo_oracles.erl
+++ b/apps/aeoracle/src/aeo_oracles.erl
@@ -172,9 +172,14 @@ serialize_for_client(#oracle{id              = Id,
                              ttl             = TTL,
                              abi_version     = ABIVersion
                             }) ->
+    EncFormat = fun(F) -> if ABIVersion == ?ABI_AEVM_SOPHIA_1 ->
+                                 aeser_api_encoder:encode(contract_bytearray, F);
+                             true ->
+                                 F
+                          end end,
     #{ <<"id">>              => aeser_api_encoder:encode(id_hash, Id)
-     , <<"query_format">>    => QueryFormat
-     , <<"response_format">> => ResponseFormat
+     , <<"query_format">>    => EncFormat(QueryFormat)
+     , <<"response_format">> => EncFormat(ResponseFormat)
      , <<"query_fee">>       => QueryFee
      , <<"ttl">>             => TTL
      , <<"abi_version">>     => ABIVersion

--- a/apps/aeoracle/src/aeo_oracles.erl
+++ b/apps/aeoracle/src/aeo_oracles.erl
@@ -34,6 +34,7 @@
 -export([new/2]).
 -endif.
 
+-include("../../aecontract/include/aecontract.hrl").
 
 %%%===================================================================
 %%% Types

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -92,8 +92,9 @@ paths:
             type: object
             properties:
               hash:
+                description: 'Key block hash'
+                # Encoded key block hash 'kh_...'
                 type: string
-                description: 'Hash'
         '404':
           description: 'Block not found'
           schema:
@@ -157,7 +158,8 @@ paths:
           name: hash
           description: 'The hash of the block'
           required: true
-          type : string
+          # Encoded key block hash 'kh_...'
+          type: string
       responses:
         '200':
           description: 'Successful operation'
@@ -235,7 +237,8 @@ paths:
           name: hash
           description: 'The hash of the block'
           required: true
-          type : string
+          # Encoded micro block hash 'mh_...'
+          type: string
       responses:
         '200':
           description: 'Successful operation'
@@ -263,7 +266,8 @@ paths:
           name: hash
           description: 'The hash of the block'
           required: true
-          type : string
+          # Encoded micro block hash 'mh_...'
+          type: string
       responses:
         '200':
           description: 'Successful operation'
@@ -291,6 +295,7 @@ paths:
           name: hash
           description: 'The hash of the block'
           required: true
+          # Encoded micro block hash 'mh_...'
           type: string
         - in: path
           name: index
@@ -325,7 +330,8 @@ paths:
           name: hash
           description: 'The hash of the block'
           required: true
-          type : string
+          # Encoded micro block hash 'mh_...'
+          type: string
       responses:
         '200':
           description: 'Successful operation'
@@ -377,7 +383,8 @@ paths:
           name: hash
           description: 'The hash of the generation'
           required: true
-          type : string
+          # Encoded key block hash 'kh_...'
+          type: string
       responses:
         '200':
           description: 'Successful operation'
@@ -430,6 +437,7 @@ paths:
           name: pubkey
           description: 'The public key of the account'
           required: true
+          # Encoded account pubkey 'ak_...'
           type: string
       responses:
         '200':
@@ -458,6 +466,7 @@ paths:
           name: pubkey
           description: 'The public key of the account'
           required: true
+          # Encoded account pubkey 'ak_...'
           type: string
         - in: path
           name: height
@@ -492,13 +501,14 @@ paths:
           name: pubkey
           description: 'The public key of the account'
           required: true
+          # Encoded account pubkey 'ak_...'
           type: string
         - in: path
           name: hash
           description: 'The hash of the block'
           required: true
+          # Encoded block hash 'kh_...'/'mh_...'
           type: string
-          minimum: 0
       responses:
         '200':
           description: 'Successful operation'
@@ -526,6 +536,7 @@ paths:
           name: pubkey
           description: 'The public key of the account'
           required: true
+          # Encoded account pubkey 'ak_...'
           type: string
       responses:
         '200':
@@ -554,6 +565,7 @@ paths:
           name: hash
           description: 'The hash of the transaction'
           required: true
+          # Encoded account pubkey 'ak_...'
           type: string
       responses:
         '200':
@@ -581,6 +593,7 @@ paths:
           name: hash
           description: 'The hash of the transaction'
           required: true
+          # Encoded transaction hash 'th_...'
           type: string
       responses:
         '200':
@@ -636,6 +649,7 @@ paths:
           name: pubkey
           description: 'The pubkey of the contract'
           required: true
+          # Encoded contract pubkey 'ct_...'
           type: string
       responses:
         '200':
@@ -662,6 +676,7 @@ paths:
           name: pubkey
           description: 'The pubkey of the contract'
           required: true
+          # Encoded contract pubkey 'ct_...'
           type: string
       responses:
         '200':
@@ -690,6 +705,7 @@ paths:
           name: pubkey
           description: 'The pubkey of the contract'
           required: true
+          # Encoded contract pubkey 'ct_...'
           type: string
       responses:
         '200':
@@ -716,6 +732,7 @@ paths:
           name: pubkey
           description: 'Contract pubkey to get proof for'
           required: true
+          # Encoded contract pubkey 'ct_...'
           type: string
       responses:
         '200':
@@ -744,6 +761,7 @@ paths:
           name: pubkey
           description: 'The public key of the oracle'
           required: true
+          # Encoded oracle pubkey 'ok_...'
           type: string
       responses:
         '200':
@@ -772,11 +790,13 @@ paths:
           name: pubkey
           description: 'The public key of the oracle'
           required: true
+          # Encoded oracle pubkey 'ok_...'
           type: string
         - in: query
           name: from
           description: 'Last query id in previous page'
           required: false
+          # Encoded oracle query id 'oq_...'
           type: string
         - in: query
           name: limit
@@ -818,11 +838,13 @@ paths:
           name: pubkey
           description: 'The public key of the oracle'
           required: true
+          # Encoded oracle pubkey 'ok_...'
           type: string
         - in: path
           name: query-id
           description: 'The ID of the query'
           required: true
+          # Encoded oracle query id 'oq_...'
           type: string
       responses:
         '200':
@@ -879,6 +901,7 @@ paths:
           name: pubkey
           description: 'The pubkey of the channel'
           required: true
+          # Encoded channel id 'ch_...'
           type: string
       responses:
         '200':

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -929,10 +929,7 @@ paths:
         '200':
           description: 'Successful operation'
           schema:
-            type: object
-            properties:
-              pubkey:
-                $ref: '#/definitions/EncodedPubkey'
+            $ref: '#/definitions/PeerPubKey'
   /status:
     get:
       tags:
@@ -2638,6 +2635,13 @@ definitions:
       - from_id
       - payload
       - fee
+  PeerPubKey:
+    type: object
+    properties:
+      pubkey:
+        $ref: '#/definitions/EncodedPubkey'
+    required:
+      - pubkey
   PubKey:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -932,7 +932,7 @@ paths:
             type: object
             properties:
               pubkey:
-                type: string
+                $ref: '#/definitions/EncodedPubkey'
   /status:
     get:
       tags:
@@ -1675,8 +1675,28 @@ paths:
 ##
 
 definitions:
+  # Encoded values - this is binary/byte array data that is
+  # "typed" and Base58Check/Base64Check encoded
+  # (for details see aeserialization/aeser_api_encoder.erl)
   EncodedHash:
+    # Base58Check encoded 32-byte hash (key block hash, micro block hash,
+    # root hash, etc)
+    description: 'Base58Check encoded tagged hash'
     type: string
+  EncodedPubkey:
+    # Base58Check encoded 32-byte pubkey (account, contract, oracle, etc)
+    description: 'Base58Check encoded tagged pubkey'
+    type: string
+  EncodedValue:
+    # Base58Check encoded 32/64-byte value (signature, oracle query id, etc)
+    description: 'Base58Check encoded tagged value'
+    type: string
+
+  EncodedByteArray:
+    # Base64Check encoded byte array
+    description: 'Base64Check encoded tagged byte array'
+    type: string
+
   Pow:
     type: array
     items:
@@ -1702,9 +1722,9 @@ definitions:
       state_hash:
         $ref: '#/definitions/EncodedHash'
       miner:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       beneficiary:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       target:
         type: integer
         format: int64
@@ -1742,7 +1762,7 @@ definitions:
         type: integer
         format: int64
       pof_hash:
-        type: string
+        $ref: '#/definitions/EncodedHash'
         description: '"no_fraud" | api encoded Proof of Fraud hash'
       prev_hash:
         $ref: '#/definitions/EncodedHash'
@@ -1753,7 +1773,7 @@ definitions:
       txs_hash:
         $ref: '#/definitions/EncodedHash'
       signature:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
       time:
         type: integer
         format: int64
@@ -1791,7 +1811,7 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
         description: 'Public key'
       balance:
         type: integer
@@ -1808,7 +1828,7 @@ definitions:
         enum: [basic, generalized]
       contract_id:
         description: 'Id of authorization contract for generalized account'
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       auth_fun:
         description: 'Name of authorization function for generalized account'
         type: string
@@ -1820,17 +1840,19 @@ definitions:
     type: object
     properties:
        tx:
-         type: string
+         $ref: '#/definitions/EncodedByteArray'
     required:
       - tx
   RegisteredOracle:
     type: object
     properties:
       id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       query_format:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       response_format:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       query_fee:
         type: integer
@@ -1852,18 +1874,20 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
       sender_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       sender_nonce:
         type: integer
         format: int64
         minimum: 0
       oracle_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       query:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       response:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       ttl:
         type: integer
@@ -1896,7 +1920,7 @@ definitions:
     type: object
     properties:
       recipient_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       amount:
         type: integer
         format: int64
@@ -1908,12 +1932,12 @@ definitions:
         type: integer
         format: int64
       sender_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
       payload:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
     required:
       - recipient_id
       - amount
@@ -1924,8 +1948,10 @@ definitions:
     type: object
     properties:
       query_format:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       response_format:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       query_fee:
         type: integer
@@ -1933,7 +1959,7 @@ definitions:
       oracle_ttl:
         $ref: '#/definitions/TTL'
       account_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -1963,7 +1989,7 @@ definitions:
       oracle_ttl:
         $ref: '#/definitions/RelativeTTL'
       oracle_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -1978,8 +2004,9 @@ definitions:
     type: object
     properties:
       oracle_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       query:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       query_fee:
         type: integer
@@ -1995,7 +2022,7 @@ definitions:
         type: integer
         format: int64
       sender_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -2012,8 +2039,9 @@ definitions:
     type: object
     properties:
       query_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
       response:
+        # Depending on ABI version it might be a EncodedByteArray
         type: string
       response_ttl:
         $ref: '#/definitions/RelativeTTL'
@@ -2024,7 +2052,7 @@ definitions:
         type: integer
         format: int64
       oracle_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -2065,7 +2093,7 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       ttl:
         type: integer
         format: int64
@@ -2081,8 +2109,7 @@ definitions:
     type: object
     properties:
       commitment_id:
-        type: string
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
       fee:
         type: integer
         format: int64
@@ -2090,7 +2117,7 @@ definitions:
         type: integer
         format: int64
       account_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -2113,7 +2140,7 @@ definitions:
         type: integer
         format: int64
       account_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -2126,8 +2153,7 @@ definitions:
     type: object
     properties:
       name_id:
-        $ref: '#/definitions/EncodedHash'
-        type: string
+        $ref: '#/definitions/EncodedValue'
       name_ttl:
         type: integer
         format: int64
@@ -2145,7 +2171,7 @@ definitions:
         type: integer
         format: int64
       account_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -2160,9 +2186,9 @@ definitions:
     type: object
     properties:
       name_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
       recipient_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       fee:
         type: integer
         format: int64
@@ -2170,7 +2196,7 @@ definitions:
         type: integer
         format: int64
       account_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -2183,7 +2209,7 @@ definitions:
     type: object
     properties:
       name_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
       fee:
         type: integer
         format: int64
@@ -2191,7 +2217,7 @@ definitions:
         type: integer
         format: int64
       account_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       nonce:
         type: integer
         format: int64
@@ -2203,14 +2229,14 @@ definitions:
     type: object
     properties:
       commitment_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
     required:
       - commitment_id
   NameHash:
     type: object
     properties:
       name_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedValue'
     required:
       - name_id
   NamePointer:
@@ -2219,7 +2245,7 @@ definitions:
       key:
         type: string
       id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
     required:
       - key
       - id
@@ -2227,11 +2253,11 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       initiator_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       responder_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       channel_amount:
         type: integer
         format: int64
@@ -2251,7 +2277,7 @@ definitions:
       delegate_ids:
         type: array
         items:
-          $ref: '#/definitions/EncodedHash'
+          $ref: '#/definitions/EncodedPubkey'
       state_hash:
         $ref: '#/definitions/EncodedHash'
       round:
@@ -2287,13 +2313,13 @@ definitions:
     type: object
     properties:
       initiator_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       initiator_amount:
         type: integer
         format: int64
         minimum: 0
       responder_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       responder_amount:
         type: integer
         format: int64
@@ -2339,9 +2365,9 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       from_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       amount:
         type: integer
         format: int64
@@ -2378,9 +2404,9 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       to_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       amount:
         type: integer
         format: int64
@@ -2417,11 +2443,11 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       from_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       payload:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
       round:
         type: integer
         format: int64
@@ -2446,7 +2472,7 @@ definitions:
         format: int64
         minimum: 0
       offchain_trees:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedByteArray'
         description: 'The whole set of off-chain state trees'
     required:
       - channel_id
@@ -2462,9 +2488,9 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       from_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       initiator_amount_final:
         type: integer
         format: int64
@@ -2496,11 +2522,11 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       from_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       payload:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
       ttl:
         type: integer
         format: int64
@@ -2514,7 +2540,7 @@ definitions:
         format: int64
         minimum: 0
       poi:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
         description: 'Proof of inclusion containing information for closing the channel'
     required:
       - channel_id
@@ -2526,11 +2552,11 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       from_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       payload:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
       ttl:
         type: integer
         format: int64
@@ -2544,7 +2570,7 @@ definitions:
         format: int64
         minimum: 0
       poi:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
         description: 'Proof of inclusion containing information for closing the channel'
     required:
       - channel_id
@@ -2556,9 +2582,9 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       from_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       initiator_amount_final:
         type: integer
         format: int64
@@ -2590,11 +2616,11 @@ definitions:
     type: object
     properties:
       channel_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       from_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       payload:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
       ttl:
         type: integer
         format: int64
@@ -2616,7 +2642,7 @@ definitions:
     type: object
     properties:
       pub_key:
-        type: string
+        $ref: '#/definitions/EncodedPubkey'
     required:
       - pub_key
   Status:
@@ -2701,7 +2727,7 @@ definitions:
         type: array
         minItems: 1
         items:
-          type: string
+          $ref: '#/definitions/EncodedValue'
     required:
       - tx
       - block_height
@@ -2816,13 +2842,13 @@ definitions:
     type: object
     properties:
       caller_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       caller_nonce:
         type: integer
       height:
         type: integer
       contract_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       gas_price:
         type: integer
       gas_used:
@@ -2850,7 +2876,7 @@ definitions:
     type: object
     properties:
       caller_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       height:
         type: integer
       gas_price:
@@ -2876,7 +2902,7 @@ definitions:
     properties:
       address:
         description: Contract address
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       topics:
         description: Event topics
         type: array
@@ -2900,9 +2926,9 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       owner_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       vm_version:
         type: integer
         minimum: 0
@@ -2919,7 +2945,7 @@ definitions:
       referrer_ids:
         type: array
         items:
-          $ref: '#/definitions/EncodedHash'
+          $ref: '#/definitions/EncodedPubkey'
       deposit:
         type: integer
     required:
@@ -2943,21 +2969,20 @@ definitions:
               type: string
             value:
               $ref: '#/definitions/EncodedByteArray'
-              type: string
     required:
       - store
   ByteCode:
     type: object
     properties:
       bytecode:
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
     required:
       - bytecode
   DryRunInput:
     type: object
     properties:
       top:
-        type: string
+        $ref: '#/definitions/EncodedHash'
       accounts:
         type: array
         description: Accounts
@@ -2967,14 +2992,14 @@ definitions:
         type: array
         description: Txs
         items:
-          $ref: '#/definitions/EncodedHash'
+          $ref: '#/definitions/EncodedByteArray'
     required:
       - txs
   DryRunAccount:
     type: object
     properties:
       pub_key:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
       amount:
         type: integer
     required:
@@ -3004,8 +3029,6 @@ definitions:
     required:
       - type
       - result
-  EncodedByteArray:
-    type: string
   Peer:
     type: string
     description: 'Aeternity node'
@@ -3029,14 +3052,14 @@ definitions:
     type: object
     properties:
       owner_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
         description: Contract owner pub_key
       nonce:
         description: 'Owner''s nonce'
         type: integer
       code:
         description: 'Contract''s code'
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
       vm_version:
         description: 'Virtual machine''s version'
         type: integer
@@ -3089,13 +3112,13 @@ definitions:
     type: object
     properties:
       caller_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
         description: Contract caller pub_key
       nonce:
         description: 'Caller''s nonce'
         type: integer
       contract_id:
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedPubkey'
         description: 'Contract''s pub_key'
       abi_version:
         description: 'ABI version'
@@ -3139,7 +3162,7 @@ definitions:
     properties:
       tx:
         description: Unsigned transaction object
-        $ref: '#/definitions/EncodedHash'
+        $ref: '#/definitions/EncodedByteArray'
     required:
       - tx
   PostTxResponse:
@@ -3156,7 +3179,7 @@ definitions:
       - type: object
         properties:
           contract_id:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Address of the contract to be created
         required:
           - contract_id
@@ -3165,7 +3188,7 @@ definitions:
     properties:
       poi:
         description: Proof of inclusion
-        type: string
+        $ref: '#/definitions/EncodedByteArray'
     required:
       - poi
   Generation:
@@ -3176,7 +3199,7 @@ definitions:
       micro_blocks:
         type: array
         items:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
     required:
       - key_block
       - micro_blocks
@@ -3194,10 +3217,10 @@ definitions:
       - type: object
         properties:
           from:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Sender of tokens
           to:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Receiver of tokens
           amount:
             type: integer
@@ -3213,7 +3236,7 @@ definitions:
       - type: object
         properties:
           to:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Withdrawer of tokens
           amount:
             type: integer
@@ -3228,7 +3251,7 @@ definitions:
       - type: object
         properties:
           from:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Depositor of tokens
           amount:
             type: integer
@@ -3243,7 +3266,7 @@ definitions:
       - type: object
         properties:
           owner:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Contract owner
           vm_version:
             type: integer
@@ -3277,10 +3300,10 @@ definitions:
       - type: object
         properties:
           caller:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Contract caller
           contract:
-            $ref: '#/definitions/EncodedHash'
+            $ref: '#/definitions/EncodedPubkey'
             description: Contract address
           # vm_version kept for backwards compatibility, should be removed
           vm_version:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -49,7 +49,6 @@ paths:
       description: 'Get the top block (either key or micro block)'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -59,7 +58,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /key-blocks/current:
     get:
       tags:
@@ -69,7 +67,6 @@ paths:
       description: 'Get the current key block'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -79,7 +76,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /key-blocks/current/hash:
     get:
       tags:
@@ -89,7 +85,6 @@ paths:
       description: 'Get the hash of the current key block'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -103,7 +98,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /key-blocks/current/height:
     get:
       tags:
@@ -113,7 +107,6 @@ paths:
       description: 'Get the height of the current key block'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -128,7 +121,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /key-blocks/pending:
     get:
       tags:
@@ -138,7 +130,6 @@ paths:
       description: 'Get the pending key block'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -152,7 +143,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /key-blocks/hash/{hash}:
     get:
       tags:
@@ -181,7 +171,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /key-blocks/height/{height}:
     get:
       tags:
@@ -207,7 +196,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /key-blocks:
     post:
       tags:
@@ -233,7 +221,6 @@ paths:
           description: 'Invalid block'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /micro-blocks/hash/{hash}/header:
     get:
       tags:
@@ -262,7 +249,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /micro-blocks/hash/{hash}/transactions:
     get:
       tags:
@@ -291,7 +277,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /micro-blocks/hash/{hash}/transactions/index/{index}:
     get:
       tags:
@@ -326,7 +311,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /micro-blocks/hash/{hash}/transactions/count:
     get:
       tags:
@@ -361,7 +345,6 @@ paths:
           description: 'Block not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /generations/current:
     get:
       tags:
@@ -371,7 +354,6 @@ paths:
       description: 'Get the current generation'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -381,7 +363,6 @@ paths:
           description: 'Generation not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /generations/hash/{hash}:
     get:
       tags:
@@ -410,7 +391,6 @@ paths:
           description: 'Generation not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /generations/height/{height}:
     get:
       tags:
@@ -436,7 +416,6 @@ paths:
           description: 'Generation not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /accounts/{pubkey}:
     get:
       tags:
@@ -465,7 +444,6 @@ paths:
           description: 'Account not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /accounts/{pubkey}/height/{height}:
     get:
       tags:
@@ -500,7 +478,6 @@ paths:
           description: 'Account not found or height not available'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /accounts/{pubkey}/hash/{hash}:
     get:
       tags:
@@ -535,7 +512,6 @@ paths:
           description: 'Account not found or hash not available'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /accounts/{pubkey}/transactions/pending:
     get:
       tags:
@@ -564,7 +540,6 @@ paths:
           description: 'Account not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /transactions/{hash}:
     get:
       tags:
@@ -593,7 +568,6 @@ paths:
           description: 'Transaction not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /transactions/{hash}/info:
     get:
       tags:
@@ -621,7 +595,6 @@ paths:
           description: 'Transaction not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /transactions:
     post:
       tags:
@@ -649,7 +622,6 @@ paths:
           description: 'Invalid transaction'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /contracts/{pubkey}:
     get:
       tags:
@@ -786,7 +758,6 @@ paths:
           description: 'Oracle not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /oracles/{pubkey}/queries:
     get:
       tags:
@@ -833,7 +804,6 @@ paths:
           description: 'Oracle not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /oracles/{pubkey}/queries/{query-id}:
     get:
       tags:
@@ -867,7 +837,6 @@ paths:
           description: 'Oracle query not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /names/{name}:
     get:
       tags:
@@ -896,7 +865,6 @@ paths:
           description: 'Name not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /channels/{pubkey}:
     get:
       tags:
@@ -925,7 +893,6 @@ paths:
           description: 'Channel not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /peers/pubkey:
     get:
       tags:
@@ -935,7 +902,6 @@ paths:
       description: 'Get peer public key'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -944,7 +910,6 @@ paths:
             properties:
               pubkey:
                 type: string
-      security:
   /status:
     get:
       tags:
@@ -954,13 +919,11 @@ paths:
       description: 'Get the status of a node'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/Status'
-      security:
 
   /debug/contracts/create:
     post:
@@ -1539,7 +1502,6 @@ paths:
       description: 'Get pending transactions'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -1575,7 +1537,6 @@ paths:
           description: 'Invalid name'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /debug/accounts/beneficiary:
     get:
       tags:
@@ -1586,7 +1547,6 @@ paths:
       description: 'Get node''s beneficiary public key'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -1596,7 +1556,6 @@ paths:
           description: 'Beneficiary error'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /debug/accounts/node:
     get:
       tags:
@@ -1607,7 +1566,6 @@ paths:
       description: 'Get node''s public key'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: 'Successful operation'
@@ -1617,7 +1575,6 @@ paths:
           description: 'Public key not found'
           schema:
             $ref: '#/definitions/Error'
-      security:
   /debug/peers:
     get:
       tags:
@@ -1628,7 +1585,6 @@ paths:
       description: 'Get node Peers'
       produces:
         - application/json
-      parameters:
       responses:
         '200':
           description: successful operation
@@ -1638,7 +1594,6 @@ paths:
           description: Info not enabled
           schema:
             $ref: '#/definitions/Error'
-      security:
   /debug/transactions/dry-run:
     post:
       tags:

--- a/docs/release-notes/next/PT-165853843-encode_binary_json_content.md
+++ b/docs/release-notes/next/PT-165853843-encode_binary_json_content.md
@@ -1,0 +1,1 @@
+* Changed some HTTP API fields from plain `string` to encoded strings. See `swagger.yaml` for details.

--- a/rebar.config
+++ b/rebar.config
@@ -65,7 +65,7 @@
                      {ref,"08a09b0"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                           {ref,"816bf99"}}},
+                          {ref,"3416ff5"}}},
 
         %% forks
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"816bf994ffb5cee218c3f22dc5fea296c9e0882e"}},
+      {ref,"3416ff5c1b4f6401bc211106063717ea1bbb1bd2"}},
   0},
  {<<"base58">>,
   {git,"https://github.com/aeternity/erl-base58.git",


### PR DESCRIPTION
Some fields in our HTTP APIs are really generic binary data (byte arrays); in some places (especially fields called `payload`) we use an ordinary JSON string to transfer these. This does not work well, since the strings are interpreted as UTF8, and not all bytes/byte combinations are valid UTF8...

This PR fixes this, and also adds a level of granularity to the Swagger-file distinguishing public keys from hashes, and from other encoded values.