### PR TITLE
Introduce mempool gas cap for GAMetaTx authentication function

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -36,6 +36,7 @@
         , get_candidate/2
         , get_max_nonce/1
         , minimum_miner_gas_price/0
+        , maximum_auth_fun_gas/0
         , new_sync_top_target/1
         , peek/1
         , peek/2
@@ -128,6 +129,7 @@
 -define(DEFAULT_NONCE_BASELINE, 1).
 -define(DEFAULT_NONCE_OFFSET, 5).
 -define(DEFAULT_MIN_MINER_GAS_PRICE, 1000000000).
+-define(DEFAULT_MAX_AUTH_FUN_GAS, 50000).
 
 %%%===================================================================
 %%% API
@@ -810,16 +812,22 @@ int_check_nonce(Tx, Source, Event) ->
     end.
 
 int_check_meta_tx(0, MetaTx, Pubkey, Source) ->
-    case get_account(Pubkey, Source) of
-        {value, Account} ->
-            TotalAmount = aega_meta_tx:gas(MetaTx) * aega_meta_tx:gas_price(MetaTx)
-                            + aega_meta_tx:fee(MetaTx),
-            case TotalAmount =< aec_accounts:balance(Account) of
-                true  -> ok;
-                false -> {error, insufficient_funds}
+    Gas    = aega_meta_tx:gas(MetaTx),
+    case Gas =< aec_tx_pool:maximum_auth_fun_gas() of
+        true ->
+            case get_account(Pubkey, Source) of
+                {value, Account} ->
+                    TotalAmount = Gas * aega_meta_tx:gas_price(MetaTx) +
+                                    aega_meta_tx:fee(MetaTx),
+                    case TotalAmount =< aec_accounts:balance(Account) of
+                        true  -> ok;
+                        false -> {error, insufficient_funds}
+                    end;
+                _ ->
+                    {error, authenticating_account_does_not_exist}
             end;
-        _ ->
-            {error, authenticating_account_does_not_exist}
+        false ->
+            {error, too_much_gas_for_auth_function}
     end;
 int_check_meta_tx(_, _, _, _) ->
     {error, illegal_nonce}.
@@ -895,3 +903,7 @@ nonce_offset() ->
 minimum_miner_gas_price() ->
     aeu_env:user_config_or_env([<<"mining">>, <<"min_miner_gas_price">>],
                                aecore, mining_min_miner_gas_price, ?DEFAULT_MIN_MINER_GAS_PRICE).
+
+maximum_auth_fun_gas() ->
+    aeu_env:user_config_or_env([<<"mining">>, <<"max_auth_fun_gas">>],
+                               aecore, mining_max_auth_fun_gas, ?DEFAULT_MAX_AUTH_FUN_GAS).

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -890,7 +890,7 @@ a_meta_tx(Sender, OuterFee, GasPrice, InnerFee) ->
         aega_meta_tx:new(#{ga_id       => aeser_id:create(account, Sender),
                            auth_data   => <<"">>,
                            abi_version => 1,
-                           gas         => 50000,
+                           gas         => 20000,
                            gas_price   => GasPrice,
                            fee         => OuterFee,
                            tx          => STx}),

--- a/apps/aega/test/aega_test_utils.erl
+++ b/apps/aega/test/aega_test_utils.erl
@@ -45,7 +45,7 @@ ga_meta_tx_default(PubKey) ->
     #{ fee         => 1000000 * aec_test_utils:min_gas_price()
      , ga_id       => aeser_id:create(account, PubKey)
      , abi_version => aect_test_utils:latest_sophia_abi_version()
-     , gas         => 50000
+     , gas         => 20000
      , gas_price   => 1000 * aec_test_utils:min_gas_price()
      , ttl         => 0
      }.

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -35,7 +35,6 @@
         , meta_meta_spend/1
         , attach_second/1
         , meta_4_fail/1
-        , large_meta/1
         , mempool/1
         ]).
 
@@ -65,7 +64,6 @@ groups() ->
       , meta_meta_fail
       , meta_meta_spend
       , meta_4_fail
-      , large_meta
       ]},
 
      {ga_info, [sequence],
@@ -376,36 +374,6 @@ meta_4_fail(Config) ->
     ?assertEqual(ABal1, ABal0 - 3*(MetaFee + 4711 * 1000 * MGP)),
     ok.
 
-large_meta(Config) ->
-    %% Get account information.
-    #{acc_a := #{pub_key := APub, priv_key := APriv}} = proplists:get_value(accounts, Config),
-
-    MGP = aec_test_utils:min_gas_price(),
-    MetaFee = (5 * 15000 + 30000) * MGP,
-
-    %% Prepare MetaTx1 to barely fit in a microblock (wouldn't fit if we counted size twice!)
-    SizeMetaSpend = 380, %% roughly...
-    GasRemain = aec_governance:block_gas_limit() - 5 * 15000 - 15000 - SizeMetaSpend * 20,
-    #{tx_hash := MetaTx1} = post_ga_spend_tx(APub, APriv, ["11"], APub, 10000, 15000 * MGP, MetaFee, GasRemain),
-
-    %% Prepare MetaTx2 to be too big to fit in a microblock
-    #{tx_hash := MetaTx2} = post_ga_spend_tx(APub, APriv, ["12"], APub, 10000, 15000 * MGP, MetaFee, GasRemain + 1000),
-
-    ?MINE_TXS([MetaTx1]),
-
-    {ok, 200, #{<<"tx">> := #{<<"type">> := <<"GAMetaTx">>},
-                <<"block_height">> := BH1} = JSONTx1} = get_tx(MetaTx1),
-    ct:log("Transaction: ~p", [JSONTx1]),
-
-    {ok, 200, #{<<"tx">> := #{<<"type">> := <<"GAMetaTx">>},
-                <<"block_height">> := BH2} = JSONTx2} = get_tx(MetaTx2),
-    ct:log("Transaction: ~p", [JSONTx2]),
-
-    ?assertMatch(BH when BH > 0, BH1),
-    ?assertEqual(-1, BH2),
-
-    ok.
-
 %% Test the minimum gas price check
 mempool(Config) ->
     %% Get account information.
@@ -419,6 +387,10 @@ mempool(Config) ->
     not_accepted = post_ga_spend_tx(APub, APriv, ["1"], BPub, 10001, MGP * 15000, TooLowMetaFee),
     %% Test with too low fee in inner Tx
     not_accepted = post_ga_spend_tx(APub, APriv, ["1"], BPub, 10001, MGP * 10000, MetaFee),
+
+    %% Test with too much gas for auth function
+    not_accepted = post_ga_spend_tx(APub, APriv, ["1"], APub, 10001, 15000 * MGP,
+                                    MetaFee, aec_tx_pool:maximum_auth_fun_gas() + 1),
 
     %% Test with exactly the lowest possible fee... Note that there isn't any size gas!
     #{tx_hash := _MetaTx} = post_ga_spend_tx(APub, APriv, ["1"], BPub, 10001, MGP * 15000, MetaFee),
@@ -497,7 +469,7 @@ spend_tx (AccPK, _AccSK, Nonce, Recipient, Amount, Fee) ->
     SpendTx.
 
 post_ga_spend_tx(AccPK, AccSK, Nonces, Recipient, Amount, Fee, MetaFee) ->
-    post_ga_spend_tx(AccPK, AccSK, Nonces, Recipient, Amount, Fee, MetaFee, 50000).
+    post_ga_spend_tx(AccPK, AccSK, Nonces, Recipient, Amount, Fee, MetaFee, 20000).
 
 post_ga_spend_tx(AccPK, AccSK, Nonces, Recipient, Amount, Fee, MetaFee, AuthGas) ->
     InnerTx = spend_tx(AccPK, AccSK, 0, Recipient, Amount, Fee),

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -427,6 +427,12 @@
                     "default" : 1000000000,
                     "minimum" : 1
                 },
+                "max_auth_fun_gas" : {
+                    "description" : "Maximum gas allowed for GAMetaTx authentication function",
+                    "type" : "integer",
+                    "default" : 50000,
+                    "minimum" : 1
+                },
                 "beneficiary_reward_delay" : {
                     "description" : "Delay (in key blocks / generations) for getting mining rewards. Used in governance.",
                     "type" : "integer",

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -124,6 +124,8 @@ mining:
     expected_mine_rate: 180000
     micro_block_cycle: 3000
     min_miner_gas_price: 1000000000
+    # Maximum gas allowed for GAMetaTx authentication function
+    max_auth_fun_gas: 50000
     # Public key of beneficiary account that will receive fees from mining on a node.
     beneficiary: "ak_DummyPubKeyDoNotEverUse999999999999999999999999999"
     cuckoo:

--- a/docs/release-notes/next-fortuna/cap_auth_gas_v2.md
+++ b/docs/release-notes/next-fortuna/cap_auth_gas_v2.md
@@ -1,0 +1,2 @@
+* Added a mining configuration parameter `max_auth_fun_gas` - that limits the amount of gas that can be provided
+  to the authentication function in a GAMetaTx.


### PR DESCRIPTION
Not part of consensus, instead checking this when pushing to the mempool.