### PR TITLE
Allow dots in prelease identifiers

### DIFF
--- a/.circleci/set_package_path.sh
+++ b/.circleci/set_package_path.sh
@@ -14,7 +14,7 @@ PKG_SUFFIX="${PKG_TARGET_OS}-"`uname -m`
 
 
 VERSION=${CIRCLE_SHA1:-unknown}
-if [[ -n $CIRCLE_TAG && $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)*)$ ]]; then
+if [[ -n $CIRCLE_TAG && $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9\.]+)*)$ ]]; then
     VERSION=${BASH_REMATCH[1]}
 fi
 


### PR DESCRIPTION
```
$ bash -x .circleci/set_package_path.sh 
+ set -e
+ '[' -z '' ']'
++ uname -s
+ '[' Darwin == Darwin ']'
+ PKG_TARGET_OS=macos
++ uname -m
+ PKG_SUFFIX=macos-x86_64
+ VERSION=unknown
+ [[ -n v3.0.0-rc.1 ]]
+ [[ v3.0.0-rc.1 =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9\.]+)*)$ ]]
+ VERSION=3.0.0-rc.1
+ PACKAGE_TARBALL=/tmp/packages/aeternity-3.0.0-rc.1-macos-x86_64.tar.gz
```