### PR TITLE
Fix loading of FP transactions from old Database format #166184378

### DIFF
--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -69,24 +69,27 @@
 
 %% Record introduced temporarily during Fortuna development, shipped in releases 2.4.0 and 2.5.0, and potentially stored in DB.
 -record(v2_db_record, {	
-          channel_id    :: aeser_id:id(),	
-          from_id       :: aeser_id:id(),	
-          payload       :: binary(),	
-          update        :: tuple(),	
-          state_hash    :: binary(),	
-          round         :: aesc_channels:seq_number(),	
-          offchain_trees:: aec_trees:trees(),	
-          ttl           :: aetx:tx_ttl(),	
-          fee           :: non_neg_integer(),	
+          channel_id    :: aeser_id:id(),
+          from_id       :: aeser_id:id(),
+          payload       :: binary(),
+          update        :: tuple(),
+          state_hash    :: binary(),
+          round         :: aesc_channels:seq_number(),
+          offchain_trees:: aec_trees:trees(),
+          ttl           :: aetx:tx_ttl(),
+          fee           :: non_neg_integer(),
           nonce         :: non_neg_integer(),
-					block_hash    :: binary()
+          block_hash    :: binary()
          }).
 %%%===================================================================
 %%% Conversion of old db format
 
 -spec from_db_format(tx()) -> tx().
-from_db_format(#channel_force_progress_tx{} = Tx) ->
-    Tx;
+from_db_format(#channel_force_progress_tx{update = Update} = Tx) ->
+    case aesc_offchain_update:from_db_format(Update) of
+        Update -> Tx; % update is already in new serialization
+        NewSUpdate -> Tx#channel_force_progress_tx{update = NewSUpdate}
+    end;
 from_db_format(Tuple) ->
     case setelement(1, Tuple, v2_db_record) of
         #v2_db_record{

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -73,7 +73,7 @@
 -export([from_db_format/1
         ]).
 
--spec from_db_format(tuple()) -> update().
+-spec from_db_format(update() | tuple()) -> update().
 from_db_format(#transfer{} = U) ->
     U;
 from_db_format(#withdraw{} = U) ->

--- a/docs/release-notes/next/PT-164328475_fix_loading_of_FPs.md
+++ b/docs/release-notes/next/PT-164328475_fix_loading_of_FPs.md
@@ -1,0 +1,2 @@
+* Solves an issue with loading old serialization of
+  `channel_force_progress_tx` and updating it to the new serialization format


### PR DESCRIPTION
PT [Bad function clause match causing process crash](https://www.pivotaltracker.com/story/show/166184378)