### PR TITLE
Fix AppVeyor build failures

### DIFF
--- a/ci/appveyor/build.bat
+++ b/ci/appveyor/build.bat
@@ -15,6 +15,7 @@ IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
 IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 IF "%BUILD_STEP%"=="" SET "BUILD_STEP=build"
+IF "%BUILD_PATH%"=="" GOTO :BUILDABORT_MISSINGBUILDPATH
 SET BASH_BIN="%WIN_MSYS2_ROOT%\usr\bin\bash"
 
 @echo Current time: %time%
@@ -39,3 +40,8 @@ GOTO BUILD_DONE
 
 @echo Current time: %time%
 rem Finished build phase
+exit /B 0
+
+:BUILDABORT_MISSINGBUILDPATH
+@echo ERROR: Missing environment variable BUILD_PATH
+exit /B 1

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -90,9 +90,7 @@ rem Remove breaking tools
 @echo Current time: %time%
 rem Upgrade the MSYS2 platform
 
-%BASH_BIN% -lc "%PACMAN% -y pacman"
-@echo Current time: %time%
-%BASH_BIN% -lc "%PACMAN% -u"
+%BASH_BIN% -lc "%PACMAN% -yuu"
 
 @echo Current time: %time%
 rem Install required tools


### PR DESCRIPTION
`pacman` breaks during AppVeyor preparation, leaving some important deps uninstalled and breaking the build. This change tries to fix the `pacman` upgrade procedure.