### PR TITLE
Hook aevm_data property-based test to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ eqc-test: eqc
 	env ERL_FLAGS="-eqc_testing_time_multiplier $(EQC_EUNIT_TESTING_TIME_MULTIPLIER)" $(REBAR) as test,eqc eunit $(EQC_EUNIT_TEST_FLAGS_FINAL)
 
 EQC_TEST_REPO = https://github.com/Quviq/epoch-eqc.git
-EQC_TEST_VERSION = 0a637d3
+EQC_TEST_VERSION = 658e16b
 
 .PHONY: eqc
 eqc: | eqc/.git

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ ST_CT_LOCALDIR = --dir system_test/only_local
 
 EQC_EUNIT_TEST_FLAGS ?=
 EQC_EUNIT_TESTING_TIME_MULTIPLIER ?= 1
+EQC_EUNIT_TEST_FLAGS_FINAL = $(EQC_EUNIT_TEST_FLAGS)
 
 SWAGGER_CODEGEN_CLI_V = 2.4.4
 SWAGGER_CODEGEN_CLI = swagger/swagger-codegen-cli-$(SWAGGER_CODEGEN_CLI_V).jar
@@ -67,10 +68,13 @@ endif
 ifdef TEST
 CT_TEST_FLAGS += --case=$(TEST)
 EUNIT_TEST_FLAGS += --module=$(TEST)
-EQC_EUNIT_TEST_FLAGS += --module=$(TEST)
 unexport TEST
+endif
+
+ifdef EQC_TEST
+EQC_EUNIT_TEST_FLAGS_FINAL += --module=$(EQC_TEST)
 else
-EQC_EUNIT_TEST_FLAGS += --app eqc_test
+EQC_EUNIT_TEST_FLAGS_FINAL += --app eqc_test
 endif
 
 ifdef VERBOSE
@@ -316,7 +320,7 @@ $(AEVM_EXTERNAL_TEST_DIR)/ethereum_tests:
 
 .PHONY: eqc-test
 eqc-test: eqc
-	env ERL_FLAGS="-eqc_testing_time_multiplier $(EQC_EUNIT_TESTING_TIME_MULTIPLIER)" $(REBAR) as test,eqc eunit $(EQC_EUNIT_TEST_FLAGS)
+	env ERL_FLAGS="-eqc_testing_time_multiplier $(EQC_EUNIT_TESTING_TIME_MULTIPLIER)" $(REBAR) as test,eqc eunit $(EQC_EUNIT_TEST_FLAGS_FINAL)
 
 EQC_TEST_REPO = https://github.com/Quviq/epoch-eqc.git
 EQC_TEST_VERSION = 0a637d3

--- a/eqc_test/src/aevm_data_eqc_tests.erl
+++ b/eqc_test/src/aevm_data_eqc_tests.erl
@@ -1,0 +1,8 @@
+-module(aevm_data_eqc_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+quickcheck_test_() ->
+    aeeqc_eunit:props_mod_test_repr(?MODULE_STRING, fun testing_time_ms/1).
+
+testing_time_ms(PropName) when is_atom(PropName) ->
+    aeeqc_eunit:testing_time_multiplier() * 500.

--- a/eqc_test/src/eqc_test_enabled_tests.erl
+++ b/eqc_test/src/eqc_test_enabled_tests.erl
@@ -3,7 +3,6 @@
 
 -define(DISABLED_PROPS_MODS,
         [ aec_sync_eqc
-        , aeso_data_eqc
         , aeu_mp_trees_eqc
         , fate_compiler_eqc
         , txs_eqc


### PR DESCRIPTION
Depends on https://github.com/Quviq/epoch-eqc/pull/28 for the commit hash to put in the makefile.