### PR TITLE
Introduce a ping-pong mechanism in WebSocket data messages

### DIFF
--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -4,7 +4,8 @@
 
 %TODO type -> opaque
 -opaque protocol() :: jsonrpc.
--type response() :: {reply, map()} | no_reply | stop.
+-type reply() :: {{error, atom()}, map()} | map().
+-type response() :: {reply, reply() | [reply()]} | no_reply | stop.
 
 -export_type([protocol/0,
               response/0]).
@@ -37,8 +38,7 @@
     {reply, map()}.
 
 -callback process_incoming(Msg :: map() | list(map()), FsmPid :: pid()) ->
-    {reply, map()} | no_reply | stop.
-
+    response().
 
 %%%==================================================================
 %%% Trace settings

--- a/apps/aehttp/src/sc_ws_api_jsonrpc.erl
+++ b/apps/aehttp/src/sc_ws_api_jsonrpc.erl
@@ -234,6 +234,9 @@ process_incoming(Msg, FsmPid) ->
     end.
 
 -spec process_request(map(), pid()) -> no_reply | {reply, map()} | {error, term()}.
+process_request(#{<<"method">> := <<"channels.system">>,
+                  <<"params">> := #{<<"action">> := <<"ping">>}}, _FsmPid) ->
+    {reply, #{action => system, tag => pong}};
 process_request(#{<<"method">> := <<"channels.update.new">>,
                    <<"params">> := #{<<"from">>    := FromB,
                                      <<"to">>      := ToB,

--- a/apps/aehttp/test/aehttp_ws_test_utils.erl
+++ b/apps/aehttp/test/aehttp_ws_test_utils.erl
@@ -236,8 +236,8 @@ register_test_for_channel_events(ConnPid, Actions) when is_list(Actions)->
     register_test_for_events(ConnPid, ?CHANNEL, Actions).
 
 register_test_for_all_channel_events(ConnPid) ->
-    Actions = aesc_fsm:report_tags(),
-    register_test_for_events(ConnPid, ?CHANNEL, Actions).
+    FSMActions = aesc_fsm:report_tags(),
+    register_test_for_events(ConnPid, ?CHANNEL, [system | FSMActions]).
 
 
 unregister_test_for_channel_event(ConnPid, Action) ->

--- a/docs/release-notes/next/PT-166433992_ping_pong.md
+++ b/docs/release-notes/next/PT-166433992_ping_pong.md
@@ -1,0 +1,4 @@
+* Adds support for responding of `ping` messages in State Channels' WebSocket
+  protocol. Because of browser compatibility issues, the keep alive
+  functionality is being built on data frames instead of using the control
+  frames.


### PR DESCRIPTION
[SC WS: ping-pong events](https://www.pivotaltracker.com/story/show/166433992)


WebSocket protocol does not detect abrupt disconnects so this must be implemented on both sides. The node timeouts in 1 minute if no messages had been sent or received and is protected from leaking connections. In order for the client to be safe it will send ping messages and will receive pongs.

For browser compatibility, the ping-pong mechanism is implemented via data frames.. 