### PR TITLE
Improve visited handling in mempool

### DIFF
--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -42,7 +42,8 @@ init_per_suite(Config) ->
         },
         <<"mining">> => #{
             <<"micro_block_cycle">> => MicroBlockCycle
-        }
+        },
+        <<"mempool">> => #{ <<"invalid_tx_ttl">> => 2 }
     },
     Config1 = aecore_suite_utils:init_per_suite([dev1, dev2], DefCfg, [{symlink_name, "latest.txs"}, {test_module, ?MODULE}, {micro_block_cycle, MicroBlockCycle}] ++ Config),
     [{nodes, [aecore_suite_utils:node_tuple(dev1),


### PR DESCRIPTION
This should lower the probability of https://www.pivotaltracker.com/story/show/165788429 and similar errors significantly. There is still a small chance that we get an inconsistent set of `visited` transactions due to a race between rolling back a micro fork and getting another candidate set - but we would need a major refactoring to solve this completely I think...