### PR TITLE
jsonrpc: always reply to requests that have an 'id'

### DIFF
--- a/apps/aehttp/src/sc_ws_api_jsonrpc.erl
+++ b/apps/aehttp/src/sc_ws_api_jsonrpc.erl
@@ -54,6 +54,7 @@
                                 <<"channels.settle_sign">>       -> settle_tx
                             end).
 
+
 unpack(Msg) when is_map(Msg) ->
     unpack([Msg]);
 unpack(Msg) ->
@@ -81,7 +82,12 @@ notify(Msg, ChannelId) ->
                                 , <<"channel_id">> => ChannelId} }
     }.
 
-reply(no_reply, _, _) -> no_reply;
+reply(no_reply, Msgs, ChannelId) ->
+    case [{#{ payload => <<"ok">>}, M} || #{<<"id">> := _} = M <- Msgs] of
+        [] -> no_reply;
+        [_|_] = Replies ->
+            reply({reply, Replies}, Msgs, ChannelId)
+    end;
 reply(stop, _, _)     -> stop;
 reply({reply,  L}, WholeMsg, ChannelId) when is_list(L) ->
     case [reply({reply, Reply}, WholeMsg, ChannelId) || Reply <- L] of

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3345,7 +3345,7 @@ channel_sign_tx(ConnPid, Privkey, Method, Config) ->
     SignedCreateTx = aec_test_utils:sign_tx(Tx, Privkey),
     EncSignedCreateTx = aeser_api_encoder:encode(transaction,
                                   aetx_sign:serialize_to_binary(SignedCreateTx)),
-    ws_send_tagged(ConnPid, Method, #{tx => EncSignedCreateTx}, Config),
+    ws_call_async_method(ConnPid, Method, #{tx => EncSignedCreateTx}, Config),
     #{tx => Tx, signed_tx => SignedCreateTx, updates => Updates}.
 
 sc_ws_open_(Config) ->
@@ -6364,6 +6364,16 @@ method_pfx(Action) ->
 
 ws_send_tagged(ConnPid, Method, Payload, Config) ->
     ws_send_tagged_(ConnPid, Method, Payload, sc_ws_protocol(Config)).
+
+ws_call_async_method(ConnPid, Method, Payload, Config) ->
+    ws_call_async_method(ConnPid, Method, Payload, sc_ws_protocol(Config), Config).
+
+ws_call_async_method(ConnPid, Method, Payload, <<"json-rpc">>, Config) ->
+    <<"ok">> = ?WS:json_rpc_call(
+                  ConnPid, #{ <<"method">> => Method
+                            , <<"params">> => Payload }),
+    ok.
+
 
 ws_send_tagged_(ConnPid, Method, Payload, <<"json-rpc">>) ->
     ?WS:json_rpc_notify(

--- a/docs/release-notes/next/PT-166537135-synchronous-jsonrpc.md
+++ b/docs/release-notes/next/PT-166537135-synchronous-jsonrpc.md
@@ -1,0 +1,1 @@
+* Ensure that synchronous jsonrpc calls to asynchronous methods get an "ok" response instead of timing out


### PR DESCRIPTION
See [PT #166537135](https://www.pivotaltracker.com/story/show/166537135)

In JSON-RPC, the client indicates that a request is synchronous by including an `"id"` (some locally unique number). In this case, even if the method callback returns `no_reply`, the handler should reply _something_, or the client is likely to block 'forever'. We choose to reply `"ok"`.

To test this change, the signing reply operation in `aehttp_integration_SUITE` was changed into a synchronous call. This made tests time out and fail before this fix was applied.