### PR TITLE
Channels system test failure

### DIFF
--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -179,6 +179,14 @@ simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, C
     {ok, CloseTxHash, IChange, RChange} = sc_close_mutual(Chan, initiator),
 
     SplitOpenFee = 10000 * aest_nodes:gas_price(),
+    ct:log("IAmt = ~p~n"
+           "RAmt = ~p~n"
+           "Gas price    = ~p~n"
+           "SplitOpenFee = ~p~n"
+           "PushAmount   = ~p~n"
+           "IChange      = ~p~n"
+           "RChange      = ~p~n", [IAmt, RAmt, aest_nodes:gas_price(),
+                                   SplitOpenFee, PushAmount, IChange, RChange]),
     ?assertEqual(IAmt - 20 * aest_nodes:gas_price() - SplitOpenFee - PushAmount, IChange),
     ?assertEqual(RAmt - 50 * aest_nodes:gas_price() - SplitOpenFee + PushAmount, RChange),
 

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -176,19 +176,24 @@ simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, C
     wait_for_value({balance, maps:get(pubkey, IAccount), 200000 * aest_nodes:gas_price() - IAmt - OpenFee + 20 * aest_nodes:gas_price() - WFee1}, NodeNames, 10000, Cfg),
     wait_for_value({balance, maps:get(pubkey, RAccount), 200000 * aest_nodes:gas_price() - RAmt + 50 * aest_nodes:gas_price() - WFee2}, NodeNames, 10000, Cfg),
 
-    {ok, CloseTxHash, IChange, RChange} = sc_close_mutual(Chan, initiator),
+    {ok, CloseTxHash, CloseFee, IChange, RChange} = sc_close_mutual(Chan, initiator),
 
-    SplitOpenFee = 10000 * aest_nodes:gas_price(),
+    wait_for_value({txs_on_chain, [CloseTxHash]}, NodeNames, 5000, Cfg),
+
+    SplitCloseFee = CloseFee div 2,
+    ISplitCloseFee = trunc(math:ceil(CloseFee / 2)),
+    RSplitCloseFee = trunc(math:floor(CloseFee / 2)),
     ct:log("IAmt = ~p~n"
            "RAmt = ~p~n"
-           "Gas price    = ~p~n"
-           "SplitOpenFee = ~p~n"
-           "PushAmount   = ~p~n"
-           "IChange      = ~p~n"
-           "RChange      = ~p~n", [IAmt, RAmt, aest_nodes:gas_price(),
-                                   SplitOpenFee, PushAmount, IChange, RChange]),
-    ?assertEqual(IAmt - 20 * aest_nodes:gas_price() - SplitOpenFee - PushAmount, IChange),
-    ?assertEqual(RAmt - 50 * aest_nodes:gas_price() - SplitOpenFee + PushAmount, RChange),
+           "Gas price      = ~p~n"
+           "ISplitCloseFee = ~p~n"
+           "RSplitCloseFee = ~p~n"
+           "PushAmount     = ~p~n"
+           "IChange        = ~p~n"
+           "RChange        = ~p~n", [IAmt, RAmt, aest_nodes:gas_price(),
+                                     ISplitCloseFee, RSplitCloseFee, PushAmount, IChange, RChange]),
+    ?assertEqual(IAmt - 20 * aest_nodes:gas_price() - ISplitCloseFee - PushAmount, IChange),
+    ?assertEqual(RAmt - 50 * aest_nodes:gas_price() - RSplitCloseFee + PushAmount, RChange),
 
     wait_for_value({txs_on_chain, [CloseTxHash]}, NodeNames, 5000, Cfg),
     wait_for_value({balance, maps:get(pubkey, IAccount), 200000 - IAmt - OpenFee + 20 - WFee1 + IChange}, NodeNames, 10000, Cfg),

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -180,7 +180,6 @@ simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, C
 
     wait_for_value({txs_on_chain, [CloseTxHash]}, NodeNames, 5000, Cfg),
 
-    SplitCloseFee = CloseFee div 2,
     ISplitCloseFee = trunc(math:ceil(CloseFee / 2)),
     RSplitCloseFee = trunc(math:floor(CloseFee / 2)),
     ct:log("IAmt = ~p~n"

--- a/system_test/common/helpers/aest_api.erl
+++ b/system_test/common/helpers/aest_api.erl
@@ -78,8 +78,10 @@ sc_open(Params, Cfg) ->
     CrTx = sc_wait_and_sign(RConn, RPrivKey, <<"responder_sign">>),
     {ok, #{ <<"event">> := <<"funding_signed">>} } = sc_wait_for_channel_event(IConn, info),
     %% both of them receive the same co-signed channel_create_tx
-    {ok, #{ <<"tx">> := EncSignedCrTx} } = sc_wait_for_channel_event(IConn, on_chain_tx),
-    {ok, #{ <<"tx">> := EncSignedCrTx} } = sc_wait_for_channel_event(RConn, on_chain_tx),
+    {ok, #{ <<"info">> := <<"funding_signed">>
+          , <<"tx">> := EncSignedCrTx} } = sc_wait_for_channel_event(IConn, on_chain_tx),
+    {ok, #{ <<"info">> := <<"funding_created">>
+          , <<"tx">> := EncSignedCrTx} } = sc_wait_for_channel_event(RConn, on_chain_tx),
 
     {ok, BinSignedCrTx} = aeser_api_encoder:safe_decode(transaction, EncSignedCrTx),
     SignedCrTx = aetx_sign:deserialize_from_binary(BinSignedCrTx),
@@ -91,6 +93,8 @@ sc_open(Params, Cfg) ->
     IPubKey = aesc_create_tx:initiator_pubkey(Tx),
     RPubKey = aesc_create_tx:responder_pubkey(Tx),
     Fee = aesc_create_tx:fee(Tx),
+
+    ok = sc_wait_channel_changed(IConn, RConn, <<"channel_create_tx">>),
 
     ok = sc_wait_funding_locked(IConn, RConn),
 
@@ -189,6 +193,8 @@ sc_withdraw(SenderConn, SenderPrivKey, Amount, AckConn, AckPrivKey) ->
     WTx = aetx_sign:tx(SignedWTx),
     Fee = aetx:fee(WTx),
 
+    ok = sc_wait_channel_changed(SenderConn, AckConn, <<"channel_withdraw_tx">>),
+
     ok = sc_wait_withdraw_locked(SenderConn, AckConn),
 
     TxHash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(SignedWTx)),
@@ -209,6 +215,15 @@ sc_wait_and_sign(Conn, Privkey, Tag) ->
     EncSignedTx = aeser_api_encoder:encode(transaction, BinSignedTx),
     ws_send(Conn, Tag, #{tx => EncSignedTx}),
     Tx.
+
+sc_wait_channel_changed(InitiatorConn, ResponderConn, Type) ->
+    {ok, #{ <<"info">> := <<"channel_changed">>
+          , <<"type">> := Type }}
+        = sc_wait_for_channel_event(InitiatorConn, on_chain_tx),
+    {ok, #{ <<"info">> := <<"channel_changed">>
+          , <<"type">> := Type }}
+        = sc_wait_for_channel_event(ResponderConn, on_chain_tx),
+    ok.
 
 sc_wait_funding_locked(InitiatorConn, ResponderConn) ->
     {ok, #{ <<"event">> := <<"own_funding_locked">> }} = sc_wait_for_channel_event(InitiatorConn, info),

--- a/system_test/common/helpers/aest_api.erl
+++ b/system_test/common/helpers/aest_api.erl
@@ -144,10 +144,11 @@ sc_close_mutual(Channel, Closer)
 
     IChange = aesc_close_mutual_tx:initiator_amount_final(MutualTx),
     RChange = aesc_close_mutual_tx:responder_amount_final(MutualTx),
+    Fee     = aesc_close_mutual_tx:fee(MutualTx),
 
     TxHash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(SignedMutualTx)),
 
-    {ok, TxHash, IChange, RChange}.
+    {ok, TxHash, Fee, IChange, RChange}.
 
 %--- NODE FUNCTIONS ------------------------------------------------------------
 


### PR DESCRIPTION
See [PT #166493847](https://www.pivotaltracker.com/story/show/166493847)

Matching of `channel_changed` events added to the flow. Test still fails locally on amount mismatch after `close_mutual`

**EDIT Jun 12** Tests now pass. Code has been added to consume new "channel_changed" messages sent by the state channel fsm, and hard-coded assumptions about the `close_mutual` fee (confusingly represented as `SplitOpenFee` in the code) were removed; instead, the actual fee is fetched from the generated tx.