### PR TITLE
Add crypto operators and improve FATE tests in aecontract_SUITE

### DIFF
--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -134,8 +134,8 @@ abort(hd_on_empty_list, ES) ->
     ?t("Head on empty list", [], ES);
 abort(tl_on_empty_list, ES) ->
     ?t("Tail on empty list", [], ES);
-abort({arithmetic_error, bits_sum_on_infinite_set}, ES) ->
-    ?t("Arithmetic error: bits_sum on infinite set", [], ES);
+abort({arithmetic_error, Reason}, ES) ->
+    ?t("Arithmetic error: ~p", [Reason], ES);
 abort(division_by_zero, ES) ->
     ?t("Arithmetic error: division by zero", [], ES);
 abort(mod_by_zero, ES) ->
@@ -433,6 +433,8 @@ terms_are_of_same_type(X, Y) when ?IS_FATE_BOOLEAN(X), ?IS_FATE_BOOLEAN(Y) -> tr
 terms_are_of_same_type(X, Y) when ?IS_FATE_BITS(X), ?IS_FATE_BITS(Y) -> true;
 terms_are_of_same_type(X, Y) when ?IS_FATE_ADDRESS(X), ?IS_FATE_ADDRESS(Y) -> true;
 terms_are_of_same_type(X, Y) when ?IS_FATE_CONTRACT(X), ?IS_FATE_CONTRACT(Y) -> true;
+terms_are_of_same_type(X, Y) when ?IS_FATE_HASH(X), ?IS_FATE_HASH(Y) -> true;
+terms_are_of_same_type(X, Y) when ?IS_FATE_SIGNATURE(X), ?IS_FATE_SIGNATURE(Y) -> true;
 terms_are_of_same_type(X, Y) when ?IS_FATE_ORACLE(X), ?IS_FATE_ORACLE(Y) -> true;
 terms_are_of_same_type(X, Y) when ?IS_FATE_NAME(X), ?IS_FATE_NAME(Y) -> true;
 terms_are_of_same_type(X, Y) when ?IS_FATE_STRING(X), ?IS_FATE_STRING(Y) -> true;

--- a/apps/aefate/test/aefate_test_utils.erl
+++ b/apps/aefate/test/aefate_test_utils.erl
@@ -46,6 +46,8 @@ encode({channel, S}) when is_list(S)  ->
     aeb_fate_data:make_channel(encode_address(channel, S));
 encode({variant, Arities, Tag, Values}) ->
     aeb_fate_data:make_variant(Arities, Tag, list_to_tuple([encode(V) || V <- tuple_to_list(Values)]));
+encode(none)      -> aeb_fate_data:make_variant([0, 1], 0, {});
+encode({some, X}) -> aeb_fate_data:make_variant([0, 1], 1, {encode(X)});
 encode(Term) when is_integer(Term) -> aeb_fate_data:make_integer(Term);
 encode(Term) when is_boolean(Term) -> aeb_fate_data:make_boolean(Term);
 encode(Term) when is_list(Term) -> aeb_fate_data:make_list([encode(E) || E <- Term]);

--- a/apps/aeutils/src/aeu_crypto.erl
+++ b/apps/aeutils/src/aeu_crypto.erl
@@ -1,0 +1,57 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2019, Aeternity Anstalt
+%%% @doc
+%%% Some crypto related helper functions.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aeu_crypto).
+
+-export([ ecdsa_from_der_pk/1
+        , ecdsa_from_der_sig/1
+        , ecdsa_to_der_pk/1
+        , ecdsa_to_der_sig/1
+
+        , ecverify/3
+        , ecverify/4
+        ]).
+
+%% Convert from OpenSSL/Erlang crypto formats...
+ecdsa_from_der_pk(<<16#04, PK:64/binary>>) ->
+    PK.
+
+ecdsa_from_der_sig(<<16#30, _Len0:8, 16#02, Len1:8, Rest/binary>>) ->
+    <<R:Len1/binary, 16#02, Len2:8, S/binary>> = Rest,
+    <<(der_part_trunc(Len1, R)):32/binary, (der_part_trunc(Len2, S)):32/binary>>.
+
+%% Convert to OpenSSL expected formats...
+ecdsa_to_der_pk(Pubkey = <<_:64/binary>>) ->
+    <<16#04, Pubkey:64/binary>>.
+
+ecdsa_to_der_sig(<<R0:32/binary, S0:32/binary>>) ->
+    {R1, S1} = {der_sig_part(R0), der_sig_part(S0)},
+    {LR, LS} = {byte_size(R1), byte_size(S1)},
+    <<16#30, (4 + LR + LS), 16#02, LR, R1/binary, 16#02, LS, S1/binary>>.
+
+%% ECVERIFY
+ecverify(Msg, PK, Sig) -> ecverify(curve25519, Msg, PK, Sig).
+
+ecverify(curve25519, Msg, PK, Sig) ->
+    case enacl:sign_verify_detached(Sig, Msg, PK) of
+        {ok, _}    -> true;
+        {error, _} -> false
+    end;
+ecverify(secp256k1, Msg, PK0, Sig0) ->
+    PK  = ecdsa_to_der_pk(PK0),
+    Sig = ecdsa_to_der_sig(Sig0),
+    %% Note that `sha256` is just there to indicate the length (32 bytes) of
+    %% the digest, nothing is hashed with SHA256!
+    crypto:verify(ecdsa, sha256, {digest, Msg}, Sig, [PK, secp256k1]).
+
+%% Internal functions
+der_part_trunc(33, <<0, Rest/binary>>)   -> Rest;
+der_part_trunc(Len, Part) when Len =< 32 -> <<0:((32-Len)*8), Part/binary>>.
+
+der_sig_part(P = <<1:1, _/bitstring>>) -> <<0:8, P/binary>>;
+der_sig_part(<<0, Rest/binary>>)       -> der_sig_part(Rest);
+der_sig_part(P)                        -> P.
+

--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,7 @@
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                    {ref, "9ff46af"}}},
 
-        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref,"53a055b"}}},
+        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref,"29b5ee3"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"3416ff5"}}},
@@ -191,7 +191,7 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"093a5ff"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"ab6d7fb"}}},
                             {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {ref, "8c73107"}}}
                            ]}
                    ]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"53a055b90a7201761ab7bc2c55d6ddf5a1f38f27"}},
+      {ref,"29b5ee3e68086e0f0170d3c70e92bbfa210cbae6"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",

--- a/test/contracts/chain.aes
+++ b/test/contracts/chain.aes
@@ -11,3 +11,5 @@ contract ChainTest =
 
   stateful function save_coinbase() =
     put(state{last_bf = Chain.coinbase})
+
+  function last_bf() = state.last_bf

--- a/test/contracts/crypto.aes
+++ b/test/contracts/crypto.aes
@@ -15,3 +15,9 @@ contract CryptoTest =
   function sha256  (x : complex) : hash = Crypto.sha256(x)
   function blake2b (x : complex) : hash = Crypto.blake2b(x)
 
+  function test_verify_secp256k1(msg : hash, pk : bytes(64), sig : signature) =
+    Crypto.ecverify_secp256k1(msg, pk, sig)
+
+  function test_string_verify_secp256k1(x : string, pk : bytes(64), sig : signature) =
+    Crypto.ecverify_secp256k1(String.sha3(x), pk, sig)
+


### PR DESCRIPTION
- Test addr_to_str and int_to_str in FATE

- Implement hash operations in FATE

- Tests for FATE hash instructions

- Implement ecverify(_secp256k1) for FATE

- introduce `aeu_crypto` as a utility module for (ECDSA) crypto.

- Use Map-result from Sophia-compiler for FATE

- Add contract_to_address to FATE and enable test

- Rename AEVM specific tests in aecontract_SUITE

- Adjust savecoinbase test to work also for FATE

- Adjust sophia_operators test to work also for FATE

- Fix Bits errors and adjust test for FATE

- Fix safe_math test and implement POW for FATE