### PR TITLE
SC port multiplexing

### DIFF
--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -1,0 +1,202 @@
+-module(aesc_listeners).
+-behaviour(gen_server).
+
+-export([
+          start_link/0
+        , listen/3
+        , close/1
+        ]).
+
+-export([
+          init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
+
+-export([ patterns/0
+        , record_fields/1]).
+
+-record(st, {
+              ports = new_tab(aesc_listeners_ports)
+            , socks = new_tab(aesc_listener_socks)
+            , refs  = new_tab(aesc_listeners_refs)
+            }).
+-record(port, {key, responder, mref, lsock}).
+-record(sock, {key, port}).
+-record(ref , {mref, port, lsock, pid}).
+
+-define(SERVER, ?MODULE).
+
+%% ==================================================================
+%% for tracing
+-define(EXCEPTION_TRACE, {'_', [], [{exception_trace}]}).
+patterns() ->
+    exports(?MODULE).
+
+exports(M) ->
+    %% [{M, F, A, [?EXCEPTION_TRACE]} || {F,A} <- M:module_info(exports)].
+    [{M,'_','_', [?EXCEPTION_TRACE]}].
+
+
+record_fields(st) -> record_info(fields, st);
+record_fields(_ ) -> no.
+%% ==================================================================
+
+
+listen(Port, Responder, Opts) ->
+    call({listen, Port, Responder, Opts}).
+
+close(Port) ->
+    call({close, Port}).
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, #st{}}.
+
+
+handle_call({listen, Port, Responder, Opts}, {Pid,_Ref}, #st{ ports = Ports
+                                                            , socks = Socks
+                                                            , refs = Refs} = St) ->
+    case db_lookup(Ports, {Port,0}) of
+        [#port{responder = Responder, lsock = LSock}] ->
+            MRef = erlang:monitor(process, Pid),
+            Ports1 = db_insert(Ports, #port{key = {Port, Pid},
+                                            responder = Responder, mref = MRef}),
+            Refs1 = db_insert(Refs, #ref{mref = MRef, port = Port,
+                                         lsock = LSock, pid = Pid}),
+            {reply, {ok, LSock}, St#st{ ports = Ports1
+                                      , refs  = Refs1 }};
+        [#port{responder = OtherResponder}] ->
+            {reply, {error, {listen_port_busy, OtherResponder}}, St};
+        [] ->
+            try gen_tcp:listen(Port, Opts) of
+                {ok, LSock} ->
+                    MRef = erlang:monitor(process, Pid),
+                    Ports1 = db_insert(
+                               Ports, [#port{key = {Port,0},
+                                             responder = Responder, lsock = LSock},
+                                       #port{key = {Port,Pid}, responder = Responder,
+                                             lsock = LSock, mref = MRef}]),
+                    Socks1 = db_insert(Socks, #sock{key = LSock, port = Port}),
+                    Refs1 = db_insert(Refs, #ref{mref = MRef, port = Port,
+                                                 lsock = LSock, pid = Pid}),
+                    {reply, {ok, LSock}, St#st{ ports = Ports1
+                                              , socks = Socks1
+                                              , refs  = Refs1 }};
+                {error, _} = Error ->
+                    {reply, Error, St}
+            catch
+                error:Reason ->
+                    {reply, {exception, Reason}, St}
+            end
+    end;
+handle_call({close, LSock}, {Pid,_Ref}, #st{ socks = Socks
+                                           , ports = Ports
+                                           , refs  = Refs} = St) ->
+    case db_lookup(Socks, LSock) of
+        [#sock{port = Port}] ->
+            case db_lookup(Ports, {Port, Pid}) of
+                [#port{mref = MRef}] ->
+                    erlang:demonitor(MRef),
+                    Refs1 = db_delete(Refs, MRef),
+                    Ports1 = db_delete(Ports, {Port, Pid}),
+                    {reply, ok, maybe_close_lsock(
+                                  Port, LSock, St#st{ refs  = Refs1
+                                                    , ports = Ports1 })};
+                [] ->
+                    {reply, {exception, not_found}, St}
+            end;
+        [] ->
+            {reply, {exception, not_found}, St}
+    end;
+handle_call(_Req, _From, St) ->
+    {reply, {exception, {unknown_call, _Req}}, St}.
+
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+handle_info({'DOWN', MRef, process, Pid, _Reason}, #st{ refs = Refs
+                                                      , ports = Ports} = St) ->
+    case db_lookup(Refs, MRef) of
+        [#ref{port = Port, lsock = LSock, pid = Pid}] ->
+            Refs1  = db_delete(Refs, MRef),
+            Ports1 = db_delete(Ports, {Port,Pid}),
+            {noreply, maybe_close_lsock(Port, LSock, St#st{ refs  = Refs1
+                                                          , ports = Ports1 })};
+        [] ->
+            {noreply, St}
+    end;
+handle_info(_, St) ->
+    {noreply, St}.
+
+terminate(_Reason, _St) ->
+    ok.
+
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
+
+call(Req) ->
+    case gen_server:call(?SERVER, Req) of
+        {exception, Reason} ->
+            erlang:error(Reason);
+        Other ->
+            Other
+    end.
+
+maybe_close_lsock(Port, LSock, #st{ ports = Ports, socks = Socks } = St) ->
+    case db_next(Ports, {Port,0}) of
+        {Port,_}        -> St;
+        '$end_of_table' -> St;
+        {_OtherPort, _} ->
+            %% no more references to LSock
+            ok = gen_tcp:close(LSock),
+            Socks1 = db_delete(Socks, LSock),
+            Ports1 = db_delete(Ports, {Port, 0}),
+            St#st{ ports = Ports1
+                 , socks = Socks1 }
+    end.
+
+
+new_tab(Name) ->
+    db_new(Name, [{keypos, 2}, ordered_set, public, named_table]).
+
+db_new(Name, Opts) ->
+    {_, P} = lists:keyfind(keypos, 1, Opts),
+    #{name => Name, keypos => P, db => []}.
+
+db_lookup(#{db := L, keypos := P}, Key) ->
+    case lists:keyfind(Key, P, L) of
+        false ->
+            [];
+        Other ->
+            [Other]
+    end.
+
+db_delete(#{db := L, keypos := P} = Db, Key) ->
+    Db#{db => lists:keydelete(Key, P, L)}.
+
+db_insert(#{keypos := P, db := L} = Db, Objs) when is_list(Objs) ->
+    Db#{db => lists:foldl(fun(O, Lx) ->
+                                  lists:keystore(element(P, O), P, Lx, O)
+                          end, L, Objs)};
+db_insert(#{db := L, keypos := P} = Db, Obj) ->
+    K = element(P, Obj),
+    Db#{db => lists:keystore(K, P, L, Obj)}.
+
+db_next(#{db := L, keypos := P}, Key) ->
+    db_next_(L, P, Key).
+
+db_next_([H|T], P, K) when element(P, H) =:= K ->
+    case T of
+        [] -> '$end_of_table';
+        [Next|_] -> element(P, Next)
+    end;
+db_next_([_|T], P, K) ->
+    db_next_(T, P, K);
+db_next_([], _, _) ->
+    '$end_of_table'.

--- a/apps/aechannel/src/aesc_sessions_sup.erl
+++ b/apps/aechannel/src/aesc_sessions_sup.erl
@@ -10,7 +10,9 @@
 -define(SUPERVISOR, ?MODULE).
 -define(CHILD_MOD, aesc_session_noise).
 
--define(CHILD(Mod,N,Type), {Mod,{Mod,start_link,[]},permanent,N,Type,[Mod]}).
+%% Noise sessions have restart type 'temporary', since it makes no sense to
+%% restart them.
+-define(CHILD(Mod,N,Type), {Mod,{Mod,start_link,[]},temporary,N,Type,[Mod]}).
 
 start_child(Args) when is_list(Args) ->
     supervisor:start_child(?SUPERVISOR, Args).

--- a/apps/aechannel/src/aesc_sessions_sup.erl
+++ b/apps/aechannel/src/aesc_sessions_sup.erl
@@ -1,0 +1,22 @@
+-module(aesc_sessions_sup).
+-behaviour(supervisor).
+
+-export([
+          start_child/1
+        , start_link/0
+        , init/1
+        ]).
+
+-define(SUPERVISOR, ?MODULE).
+-define(CHILD_MOD, aesc_session_noise).
+
+-define(CHILD(Mod,N,Type), {Mod,{Mod,start_link,[]},permanent,N,Type,[Mod]}).
+
+start_child(Args) when is_list(Args) ->
+    supervisor:start_child(?SUPERVISOR, Args).
+
+start_link() ->
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+
+init([]) ->
+    {ok, {{simple_one_for_one, 5, 10}, [?CHILD(?CHILD_MOD, 5000, worker)]}}.

--- a/apps/aechannel/src/aesc_sup.erl
+++ b/apps/aechannel/src/aesc_sup.erl
@@ -14,4 +14,7 @@ start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 init([]) ->
-    {ok, {{one_for_one, 5, 10}, [?CHILD(aesc_state_cache, 5000, worker)]}}.
+    {ok, {{one_for_one, 5, 10}, [ ?CHILD(aesc_state_cache, 5000, worker)
+                                , ?CHILD(aesc_sessions_sup, 5000, supervisor)
+                                , ?CHILD(aesc_listeners, 5000, worker)
+                                ]}}.

--- a/apps/aechannel/src/aesc_ttb.erl
+++ b/apps/aechannel/src/aesc_ttb.erl
@@ -27,6 +27,7 @@ on_nodes(Ns, File) ->
 patterns() ->
     sc_ws_api:patterns()
         ++ aesc_fsm:patterns()
+        ++ aesc_listeners:patterns()
         ++ aesc_session_noise:patterns()
         ++ sc_ws_api:patterns()
         ++ tr_ttb:default_patterns().

--- a/docs/release-notes/next/PT-161143845-reuse-sc-listeners.md
+++ b/docs/release-notes/next/PT-161143845-reuse-sc-listeners.md
@@ -1,0 +1,1 @@
+* State Channels responders can use the same listen port for different channels (only one responder Id per listen port).


### PR DESCRIPTION
See [PT #161143845](https://www.pivotaltracker.com/story/show/161143845)

Existing test suites pass. No test case to test the "server scenario" where the responder sets `initiator => any`. There might be corner cases where responders terminate, leaving lingering acceptor processes; looking into ways to prevent that.