### PR TITLE
Reject normal TXs signed by GA in mempool

### DIFF
--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -76,7 +76,7 @@ tx_pool_test_() ->
 
                %% Add it again and see that it is not added twice
                ?assertEqual(ok, aec_tx_pool:push(STx1, tx_received)),
-               ?assertEqual({ok, [STx1]}, aec_tx_pool:peek(1)),
+               ?assertEqual({ok, [STx1]}, aec_tx_pool:peek(2)),
 
                %% Other tx received from a peer.
                STx2 = a_signed_tx(new_pubkey(), me, 1, 20000),
@@ -89,7 +89,7 @@ tx_pool_test_() ->
       {"ensure nonce limit for sender without account in state",
        fun() ->
             PK0 = new_pubkey(),
-            ?assertEqual(none, aec_chain:get_account(PK0)),
+            ?assertEqual(none,                   aec_chain:get_account(PK0)),
             ?assertEqual(ok,                     aec_tx_pool:push( a_signed_tx(PK0, me, 1, 20000) )),
             ?assertEqual({error,nonce_too_high}, aec_tx_pool:push( a_signed_tx(PK0, me, 2, 20000) )),
 

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -36,6 +36,7 @@
         , attach_second/1
         , meta_4_fail/1
         , mempool/1
+        , mempool_rejects_normal_tx/1
         ]).
 
 -define(NODE, dev1).
@@ -74,7 +75,8 @@ groups() ->
 
      {ga_mempool, [sequence],
       [ attach
-      , mempool ]}
+      , mempool
+      , mempool_rejects_normal_tx ]}
     ].
 
 suite() ->
@@ -394,6 +396,16 @@ mempool(Config) ->
 
     %% Test with exactly the lowest possible fee... Note that there isn't any size gas!
     #{tx_hash := _MetaTx} = post_ga_spend_tx(APub, APriv, ["1"], BPub, 10001, MGP * 15000, MetaFee),
+
+    ok.
+
+mempool_rejects_normal_tx(Config) ->
+    #{acc_a := #{pub_key := APub, priv_key := APriv},
+      acc_b := #{pub_key := BPub}} = proplists:get_value(accounts, Config),
+    MGP     = aec_test_utils:min_gas_price(),
+    SpendTx = spend_tx(APub, APriv, 2, BPub, 10000, 20000 * MGP),
+    SignTx  = aec_test_utils:sign_tx(SpendTx, [APriv]),
+    ?assertEqual(not_accepted, post_aetx(SignTx)),
 
     ok.
 

--- a/apps/aetx/test/aetx_sign_tests.erl
+++ b/apps/aetx/test/aetx_sign_tests.erl
@@ -47,10 +47,10 @@ sign_txs_test_() ->
       end},
       {"Broken priv key does not produce signatures",
        fun() ->
-               BrokenKey = <<0:32/unit:8>>,
-               {ok, SpendTx} = make_spend_tx(BrokenKey),
-               ?_assertException(error, {invalid_priv_key, [BrokenKey]},
-                                 aec_test_utils:sign_tx(SpendTx, <<0:42/unit:8>>)),
+               BrokenPrivKey = <<0:65/unit:8>>,
+               {ok, SpendTx} = make_spend_tx(<<0:32/unit:8>>),
+               ?assertException(error, {invalid_priv_key, [BrokenPrivKey]},
+                                aec_test_utils:sign_tx(SpendTx, BrokenPrivKey)),
                ok
       end},
       {"Missing channel does not validate",

--- a/docs/release-notes/next/PT-166793190-filter_ga_txs_in_mempool.md
+++ b/docs/release-notes/next/PT-166793190-filter_ga_txs_in_mempool.md
@@ -1,0 +1,2 @@
+* Adds an extra check to reject normal TX signed by GA in mempool. The check is
+  cheap so let's avoid cluttering the mempool with bad transactions.


### PR DESCRIPTION
The check is cheap, let's not clutter the mempool unnecessarily!

Requested by @velzevur 