### PR TITLE
HTTP API cache

### DIFF
--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -20,11 +20,7 @@
     validator :: jesse_state:state()
 }).
 
--ifdef(TEST).
--define(DEFAULT_HTTP_CACHE_ENABLED, true).
--else.
 -define(DEFAULT_HTTP_CACHE_ENABLED, false).
--endif.
 
 init(Req, {OperationId, AllowedMethod, LogicHandler}) ->
     %% TODO: make this validator a proper service.

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -10,6 +10,8 @@
 -export([delete_resource/2]).
 -export([forbidden/2]).
 -export([handle_request_json/2]).
+-export([generate_etag/2]).
+-export([expires/2]).
 
 -record(state, {
     operation_id :: atom(),
@@ -50,6 +52,12 @@ content_types_provided(Req, State) ->
 
 delete_resource(Req, State) ->
     handle_request_json(Req, State).
+
+generate_etag(Req, State = #state{operation_id = OperationId}) ->
+    aehttp_cache_etag:generate(OperationId, Req, State).
+
+expires(Req, State = #state{operation_id = OperationId}) ->
+    aehttp_cache_expires:expires(OperationId, Req, State).
 
 handle_request_json(Req0, State = #state{
         operation_id = OperationId,

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -108,7 +108,7 @@ to_error({Reason, Name, Info}) ->
        parameter => Name,
        info => Info }.
 
--spec cache_enabled() -> non_neg_integer().
+-spec cache_enabled() -> boolean().
 cache_enabled() ->
     aeu_env:user_config_or_env([<<"http">>, <<"cache">>, <<"enabled">>],
                                aehttp, [cache, enabled], ?DEFAULT_HTTP_CACHE_ENABLED).

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -20,6 +20,12 @@
     validator :: jesse_state:state()
 }).
 
+-ifdef(TEST).
+-define(DEFAULT_HTTP_CACHE_ENABLED, true).
+-else.
+-define(DEFAULT_HTTP_CACHE_ENABLED, false).
+-endif.
+
 init(Req, {OperationId, AllowedMethod, LogicHandler}) ->
     %% TODO: make this validator a proper service.
     JsonSpec = aehttp_api_validate:json_spec(),
@@ -105,4 +111,4 @@ to_error({Reason, Name, Info}) ->
 -spec cache_enabled() -> non_neg_integer().
 cache_enabled() ->
     aeu_env:user_config_or_env([<<"http">>, <<"cache">>, <<"enabled">>],
-                               aehttp, [cache, enabled], false).
+                               aehttp, [cache, enabled], ?DEFAULT_HTTP_CACHE_ENABLED).

--- a/apps/aehttp/src/aehttp_cache_etag.erl
+++ b/apps/aehttp/src/aehttp_cache_etag.erl
@@ -1,0 +1,103 @@
+%% Implements generate/3 similar to cowboy_rest generate_etag/2 callback
+%% customized with additional OperationId (first) argument for easy switching
+
+-module(aehttp_cache_etag).
+
+-export([generate/3]).
+
+%%%===================================================================
+%%% External API
+
+generate('GetTopBlock', Req, State) ->
+    case aec_chain:top_block() of
+        undefined ->
+            {undefined, Req, State};
+        Block ->
+            ETag = etag_block(Block),
+            {{strong, ETag}, Req, State}
+    end;
+
+generate('GetCurrentKeyBlock', Req, State) ->
+    case aec_chain:top_key_block() of
+        {ok, Block} ->
+            ETag = etag_block(Block),
+            {{strong, ETag}, Req, State};
+        _ ->
+            {undefined, Req, State}
+    end;
+
+generate('GetKeyBlockByHash', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate('GetKeyBlockByHeight', Req, State) ->
+    handle_block_height(Req, State);
+
+generate('GetMicroBlockHeaderByHash', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate('GetMicroBlockTransactionsByHash', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate('GetMicroBlockTransactionByHashAndIndex', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate('GetMicroBlockTransactionsCountByHash', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate('GetGenerationByHash', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate('GetGenerationByHeight', Req, State) ->
+    handle_block_height(Req, State);
+
+generate('GetTransactionByHash', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate('GetTransactionInfoByHash', Req, State) ->
+    Hash = cowboy_req:binding(hash, Req),
+    {{strong, Hash}, Req, State};
+
+generate(_OperationId, Req, State) ->
+    {undefined, Req, State}.
+
+%%%===================================================================
+%%% Private functions
+
+handle_block_height(Req, State) ->
+    Height0 = cowboy_req:binding(height, Req),
+    case to_int(Height0) of
+        {ok, Height} ->
+            ETag = etag_block_height(Height),
+            {{strong, ETag}, Req, State};
+        _ ->
+            {undefined, Req, State}
+    end.
+
+etag_block_height(Height) ->
+    case aehttp_logic:get_key_header_by_height(Height) of
+        {ok, Header} -> etag_block_header(Header);
+        _ -> undefined
+    end.
+
+etag_block(Block) ->
+    Header = aec_blocks:to_header(Block),
+    etag_block_header(Header).
+
+etag_block_header(Header) ->
+    {ok, Hash} = aec_headers:hash_header(Header),
+    Hex = aeu_hex:bin_to_hex(Hash),
+    list_to_binary(Hex).
+
+to_int(Data) ->
+    try {ok, binary_to_integer(Data)}
+    catch
+        error:badarg ->
+            error
+    end.

--- a/apps/aehttp/src/aehttp_cache_etag.erl
+++ b/apps/aehttp/src/aehttp_cache_etag.erl
@@ -156,6 +156,7 @@ etag_generation_hash(Hash) ->
         _ ->
             undefined
     end.
+
 -spec etag_generation(aec_blocks:key_block(), [aec_blocks:micro_block()]) -> binary().
 etag_generation(KeyBlock, []) ->
     etag_block(KeyBlock);

--- a/apps/aehttp/src/aehttp_cache_etag.erl
+++ b/apps/aehttp/src/aehttp_cache_etag.erl
@@ -53,11 +53,10 @@ generate('GetMicroBlockTransactionsCountByHash', Req, State) ->
     {{strong, Hash}, Req, State};
 
 generate('GetGenerationByHash', Req, State) ->
-    Hash = cowboy_req:binding(hash, Req),
-    {{strong, Hash}, Req, State};
+    handle_generation_hash(Req, State);
 
 generate('GetGenerationByHeight', Req, State) ->
-    handle_block_height(Req, State);
+    handle_generation_height(Req, State);
 
 generate('GetTransactionByHash', Req, State) ->
     Hash = cowboy_req:binding(hash, Req),
@@ -88,7 +87,37 @@ handle_block_height(Req, State) ->
             {undefined, Req, State}
     end.
 
--spec etag_block_height(integer()) -> {ok, aec_headers:header()} | undefined.
+-spec handle_generation_hash(cowboy_req:req(), any()) -> cowboy_etag_res().
+handle_generation_hash(Req, State) ->
+    Hash0 = cowboy_req:binding(hash, Req),
+    case aeser_api_encoder:safe_decode(key_block_hash, Hash0) of
+        {ok, Hash} ->
+            case etag_generation_hash(Hash) of
+                {ok, ETag} ->
+                    {{strong, ETag}, Req, State};
+                _ ->
+                    {undefined, Req, State}
+            end;
+        _ ->
+            {undefined, Req, State}
+    end.
+
+-spec handle_generation_height(cowboy_req:req(), any()) -> cowboy_etag_res().
+handle_generation_height(Req, State) ->
+    Height0 = cowboy_req:binding(height, Req),
+    case to_int(Height0) of
+        {ok, Height} ->
+            case etag_generation_height(Height) of
+                {ok, ETag} ->
+                    {{strong, ETag}, Req, State};
+                _ ->
+                    {undefined, Req, State}
+            end;
+        _ ->
+            {undefined, Req, State}
+    end.
+
+-spec etag_block_height(integer()) -> {ok, binary()} | undefined.
 etag_block_height(Height) ->
     case aehttp_logic:get_key_header_by_height(Height) of
         {ok, Header} ->
@@ -107,6 +136,33 @@ etag_block_header(Header) ->
     {ok, Hash} = aec_headers:hash_header(Header),
     Hex = aeu_hex:bin_to_hex(Hash),
     list_to_binary(Hex).
+
+-spec etag_generation_height(non_neg_integer()) -> {ok, binary()} | undefined.
+etag_generation_height(Height) ->
+    case aec_chain:get_generation_by_height(Height, forward) of
+        {ok, #{key_block := KeyBlock, micro_blocks := MBs}} ->
+            ETag = etag_generation(KeyBlock, MBs),
+            {ok, ETag};
+        _ ->
+            undefined
+    end.
+
+-spec etag_generation_hash(binary()) -> {ok, binary()} | undefined.
+etag_generation_hash(Hash) ->
+    case aec_chain:get_generation_by_hash(Hash, forward) of
+        {ok, #{key_block := KeyBlock, micro_blocks := MBs}} ->
+            ETag = etag_generation(KeyBlock, MBs),
+            {ok, ETag};
+        _ ->
+            undefined
+    end.
+-spec etag_generation(aec_blocks:key_block(), [aec_blocks:micro_block()]) -> binary().
+etag_generation(KeyBlock, []) ->
+    etag_block(KeyBlock);
+
+etag_generation(_KeyBlock, MBs) ->
+    Block = lists:last(MBs),
+    etag_block(Block).
 
 -spec to_int(binary()) -> {ok, integer()} | error.
 to_int(Data) ->

--- a/apps/aehttp/src/aehttp_cache_etag.erl
+++ b/apps/aehttp/src/aehttp_cache_etag.erl
@@ -74,15 +74,21 @@ handle_block_height(Req, State) ->
     Height0 = cowboy_req:binding(height, Req),
     case to_int(Height0) of
         {ok, Height} ->
-            ETag = etag_block_height(Height),
-            {{strong, ETag}, Req, State};
+            case etag_block_height(Height) of
+                {ok, ETag} ->
+                    {{strong, ETag}, Req, State};
+                undefined ->
+                    {undefined, Req, State}
+            end;
         _ ->
             {undefined, Req, State}
     end.
 
 etag_block_height(Height) ->
     case aehttp_logic:get_key_header_by_height(Height) of
-        {ok, Header} -> etag_block_header(Header);
+        {ok, Header} ->
+            ETag = etag_block_header(Header),
+            {ok, ETag};
         _ -> undefined
     end.
 

--- a/apps/aehttp/src/aehttp_cache_expires.erl
+++ b/apps/aehttp/src/aehttp_cache_expires.erl
@@ -1,0 +1,192 @@
+%% Implements expires/3 similar to cowboy_rest expires/2 callback
+%% customized with additional OperationId (first) argument for easy switching
+%%
+%% Get the top block (either key or micro block)
+%% Cannot be cached for more than MICRO_BLOCK_CYCLE (3s)
+%%
+%% Get a micro block
+%% Can be cached aggressively, however micro-blocks of last X key blocks can be reorganized by forks,
+%% thus their cache time should not exceed EXPECTED_BLOCK_MINE_RATE_MINUTES (3 min.)
+%% Expires = ExpectedNextBlockTime() -> TopBlockTime + InterBlockTime
+%%
+%% Also micro blocks can be reorganized because of micro-forks,
+%% so micro-blocks of current generation cannot be cached for more than MICRO_BLOCK_CYCLE (3s)
+%% Expires = ExpectedNextMicroBlockTime() -> TopMicroBlockTime + InterMicroBlockTime
+%%
+%% Get a key block
+%% Can be cached for long period of time, however last X key blocks can be reorganized by forks,
+%% thus their cache time should not exceed EXPECTED_BLOCK_MINE_RATE_MINUTES (3 min.)
+%% Expires = ExpectedNextBlockTime() -> TopBlockTime + InterBlockTime
+%%
+%% Get a generation by hash
+%% Same as micro block endpoints cache requirements - older generations can be cached aggressively.
+%%
+%% Transaction can be cached based on age of it's generation
+
+-module(aehttp_cache_expires).
+
+-export([expires/3]).
+
+-define(AGED_BLOCKS_TIME, 24*60*60). % Time to consider a block as aged (1d)
+-define(AGED_BLOCKS_CACHE_TIME, 24*60*60). % Cache aged key blocks for a day
+
+%%%===================================================================
+%%% External API
+
+expires('GetTopBlock', Req, State) ->
+    CacheTime = expected_next_micro_block_time(),
+    Exp = unixtime_to_datetime(CacheTime),
+    {Exp, Req, State};
+
+expires('GetCurrentKeyBlock', Req, State) ->
+    case aec_chain:top_key_block() of
+        {ok, Block} ->
+            Header = aec_blocks:to_header(Block),
+            Exp = expires_block_header(Header),
+            {Exp, Req, State};
+        _ ->
+            {undefined, Req, State}
+    end;
+
+expires('GetKeyBlockByHash', Req, State) ->
+    handle_key_block_hash(Req, State);
+
+expires('GetKeyBlockByHeight', Req, State) ->
+    handle_key_block_height(Req, State);
+
+expires('GetMicroBlockHeaderByHash', Req, State) ->
+    handle_micro_block_hash(Req, State);
+
+expires('GetMicroBlockTransactionsByHash', Req, State) ->
+    handle_micro_block_hash(Req, State);
+
+expires('GetMicroBlockTransactionByHashAndIndex', Req, State) ->
+    handle_micro_block_hash(Req, State);
+
+expires('GetMicroBlockTransactionsCountByHash', Req, State) ->
+    handle_micro_block_hash(Req, State);
+
+expires('GetGenerationByHash', Req, State) ->
+    handle_key_block_hash(Req, State);
+
+expires('GetGenerationByHeight', Req, State) ->
+    handle_key_block_height(Req, State);
+
+expires('GetTransactionByHash', Req, State) ->
+    handle_transaction_hash(Req, State);
+
+expires('GetTransactionInfoByHash', Req, State) ->
+    handle_transaction_hash(Req, State);
+
+expires(_OperationId, Req, State) ->
+    {undefined, Req, State}.
+
+%%%===================================================================
+%%% Private functions
+
+handle_key_block_hash(Req, State) ->
+    Hash0 = cowboy_req:binding(hash, Req),
+    case aeser_api_encoder:safe_decode(key_block_hash, Hash0) of
+        {ok, Hash} ->
+            Exp = expires_block_hash(Hash),
+            {Exp, Req, State};
+        _ -> {undefined, Req, State}
+    end.
+
+handle_key_block_height(Req, State) ->
+    Height0 = cowboy_req:binding(height, Req),
+    case to_int(Height0) of
+        {ok, Height} ->
+            Exp = expires_block_height(Height),
+            {Exp, Req, State};
+        _ ->
+            {undefined, Req, State}
+    end.
+
+handle_micro_block_hash(Req, State) ->
+    Hash0 = cowboy_req:binding(hash, Req),
+    case aeser_api_encoder:safe_decode(micro_block_hash, Hash0) of
+        {ok, Hash} ->
+            Exp = expires_block_hash(Hash),
+            {Exp, Req, State};
+        _ -> {undefined, Req, State}
+    end.
+
+handle_transaction_hash(Req, State) ->
+    Hash0 = cowboy_req:binding(hash, Req),
+    case aeser_api_encoder:safe_decode(tx_hash, Hash0) of
+        {ok, Hash} ->
+            case aec_chain:find_tx_with_location(Hash) of
+                {BlockHash, _Tx} when is_binary(BlockHash) ->
+                    Exp = expires_block_hash(BlockHash),
+                    {Exp, Req, State};
+                _ ->
+                    {undefined, Req, State}
+            end;
+        _ ->
+            {undefined, Req, State}
+    end.
+
+expires_block_height(Height) ->
+    case aehttp_logic:get_key_header_by_height(Height) of
+        {ok, Header} -> expires_block_header(Header);
+        _ -> undefined
+    end.
+
+expires_block_hash(Hash) ->
+    case aehttp_logic:get_header_by_hash(Hash) of
+        {ok, Header} -> expires_block_header(Header);
+        _ -> undefined
+    end.
+
+expires_block_header(Header) ->
+    case block_header_cache_time(Header) of
+        CacheTime when is_integer(CacheTime) ->
+            unixtime_to_datetime(CacheTime);
+        _ -> error
+    end.
+
+block_header_cache_time(Header) ->
+    Now = aeu_time:now_in_secs(),
+    BlockTimestamp = aec_headers:time_in_secs(Header),
+    Diff = Now - BlockTimestamp,
+    if Diff > ?AGED_BLOCKS_TIME ->
+            Now + ?AGED_BLOCKS_CACHE_TIME;
+       true ->
+            expected_next_key_block_time()
+    end.
+
+expected_next_key_block_time() ->
+    case top_key_block_header() of
+        {ok, Header} ->
+            BlockTimestamp = aec_headers:time_in_secs(Header),
+            Rate = aeu_time:msecs_to_secs(aec_governance:expected_block_mine_rate()),
+            BlockTimestamp + Rate;
+        _ -> error
+    end.
+
+top_key_block_header() ->
+    case aec_chain:top_key_block() of
+        {ok, Block} ->
+            {ok, aec_blocks:to_key_header(Block)};
+        _ ->
+            error
+    end.
+
+expected_next_micro_block_time() ->
+    TopHeader = aec_chain:top_header(),
+    BlockTimestamp = aec_headers:time_in_secs(TopHeader),
+    Rate = aeu_time:msecs_to_secs(aec_governance:micro_block_cycle()),
+    BlockTimestamp + Rate.
+
+to_int(Data) ->
+    try {ok, binary_to_integer(Data)}
+    catch
+        error:badarg ->
+            error
+    end.
+
+unixtime_to_datetime(Unixtime) ->
+    BaseDate = calendar:datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}}),
+    Seconds  = BaseDate + Unixtime,
+    calendar:gregorian_seconds_to_datetime(Seconds).

--- a/apps/aehttp/src/aehttp_cache_expires.erl
+++ b/apps/aehttp/src/aehttp_cache_expires.erl
@@ -205,12 +205,11 @@ block_rate(key) ->
 block_rate(micro) ->
     aec_governance:micro_block_cycle().
 
--spec to_int(binary()) -> integer() | error.
+-spec to_int(binary()) -> {ok, integer()} | error.
 to_int(Data) ->
     try {ok, binary_to_integer(Data)}
     catch
-        error:badarg ->
-            error
+        error:badarg -> error
     end.
 
 -spec unixtime_to_datetime(non_neg_integer()) -> calendar:datetime().

--- a/apps/aehttp/src/aehttp_cache_expires.erl
+++ b/apps/aehttp/src/aehttp_cache_expires.erl
@@ -31,49 +31,46 @@
 -define(DEFAULT_AGED_BLOCKS_CACHE_TIME, 24*60*60). % Cache aged key blocks for a day by default
 
 -type cowboy_expires_res() :: {calendar:datetime() | undefined, cowboy_req:req(), any()}.
+-type expire_type() :: key | micro.
+-type hash_param() :: key_block_hash | micro_block_hash.
 
 %%%===================================================================
 %%% External API
 
 -spec expires(atom(), cowboy_req:req(), any()) -> cowboy_expires_res().
 expires('GetTopBlock', Req, State) ->
-    CacheTime = expected_next_micro_block_time(),
+    CacheTime = expected_next_block_time(micro),
     Exp = unixtime_to_datetime(CacheTime),
     {Exp, Req, State};
 
 expires('GetCurrentKeyBlock', Req, State) ->
-    case aec_chain:top_key_block() of
-        {ok, Block} ->
-            Header = aec_blocks:to_header(Block),
-            Exp = expires_block_header(Header),
-            {Exp, Req, State};
-        _ ->
-            {undefined, Req, State}
-    end;
+    Header = top_key_block_header(),
+    Exp = expires_datetime(Header, key),
+    {Exp, Req, State};
 
 expires('GetKeyBlockByHash', Req, State) ->
-    handle_key_block_hash(Req, State);
+    handle_block_hash(key_block_hash, key, Req, State);
 
 expires('GetKeyBlockByHeight', Req, State) ->
-    handle_key_block_height(Req, State);
+    handle_block_height(key, Req, State);
 
 expires('GetMicroBlockHeaderByHash', Req, State) ->
-    handle_micro_block_hash(Req, State);
+    handle_block_hash(micro_block_hash, micro, Req, State);
 
 expires('GetMicroBlockTransactionsByHash', Req, State) ->
-    handle_micro_block_hash(Req, State);
+    handle_block_hash(micro_block_hash, micro, Req, State);
 
 expires('GetMicroBlockTransactionByHashAndIndex', Req, State) ->
-    handle_micro_block_hash(Req, State);
+    handle_block_hash(micro_block_hash, micro, Req, State);
 
 expires('GetMicroBlockTransactionsCountByHash', Req, State) ->
-    handle_micro_block_hash(Req, State);
+    handle_block_hash(micro_block_hash, micro, Req, State);
 
 expires('GetGenerationByHash', Req, State) ->
-    handle_key_block_hash(Req, State);
+     handle_block_hash(key_block_hash, micro, Req, State);
 
 expires('GetGenerationByHeight', Req, State) ->
-    handle_key_block_height(Req, State);
+    handle_block_height(micro, Req, State);
 
 expires('GetTransactionByHash', Req, State) ->
     handle_transaction_hash(Req, State);
@@ -97,35 +94,25 @@ aged_blocks_cache_time() ->
     aeu_env:user_config_or_env([<<"http">>, <<"cache">>, <<"aged_blocks_cache_time">>],
                                aehttp, [cache, aged_blocks_cache_time], ?DEFAULT_AGED_BLOCKS_CACHE_TIME).
 
--spec handle_key_block_hash(cowboy_req:req(), any()) -> cowboy_expires_res().
-handle_key_block_hash(Req, State) ->
+-spec handle_block_hash(hash_param(), expire_type(), cowboy_req:req(), any()) -> cowboy_expires_res().
+handle_block_hash(Param, CacheType, Req, State) ->
     Hash0 = cowboy_req:binding(hash, Req),
-    case aeser_api_encoder:safe_decode(key_block_hash, Hash0) of
+    case aeser_api_encoder:safe_decode(Param, Hash0) of
         {ok, Hash} ->
-            Exp = expires_block_hash(Hash),
+            Exp = expires_block_hash(Hash, CacheType),
             {Exp, Req, State};
         _ -> {undefined, Req, State}
     end.
 
--spec handle_key_block_height(cowboy_req:req(), any()) -> cowboy_expires_res().
-handle_key_block_height(Req, State) ->
+-spec handle_block_height(expire_type(), cowboy_req:req(), any()) -> cowboy_expires_res().
+handle_block_height(CacheType, Req, State) ->
     Height0 = cowboy_req:binding(height, Req),
     case to_int(Height0) of
         {ok, Height} ->
-            Exp = expires_block_height(Height),
+            Exp = expires_block_height(Height, CacheType),
             {Exp, Req, State};
         _ ->
             {undefined, Req, State}
-    end.
-
--spec handle_micro_block_hash(cowboy_req:req(), any()) -> cowboy_expires_res().
-handle_micro_block_hash(Req, State) ->
-    Hash0 = cowboy_req:binding(hash, Req),
-    case aeser_api_encoder:safe_decode(micro_block_hash, Hash0) of
-        {ok, Hash} ->
-            Exp = expires_block_hash(Hash),
-            {Exp, Req, State};
-        _ -> {undefined, Req, State}
     end.
 
 -spec handle_transaction_hash(cowboy_req:req(), any()) -> cowboy_expires_res().
@@ -135,7 +122,7 @@ handle_transaction_hash(Req, State) ->
         {ok, Hash} ->
             case aec_chain:find_tx_with_location(Hash) of
                 {BlockHash, _Tx} when is_binary(BlockHash) ->
-                    Exp = expires_block_hash(BlockHash),
+                    Exp = expires_block_hash(BlockHash, micro),
                     {Exp, Req, State};
                 _ ->
                     {undefined, Req, State}
@@ -144,66 +131,81 @@ handle_transaction_hash(Req, State) ->
             {undefined, Req, State}
     end.
 
--spec expires_block_height(non_neg_integer()) -> {ok, aec_headers:header()} | undefined.
-expires_block_height(Height) ->
+-spec expires_block_height(non_neg_integer(), expire_type()) -> calendar:datetime() | undefined.
+expires_block_height(Height, Type) ->
     case aehttp_logic:get_key_header_by_height(Height) of
-        {ok, Header} -> expires_block_header(Header);
+        {ok, Header} -> expires_datetime(Header, Type);
         _ -> undefined
     end.
 
--spec expires_block_hash(binary()) -> {ok, aec_headers:header()} | undefined.
-expires_block_hash(Hash) ->
+-spec expires_block_hash(binary(), expire_type()) -> calendar:datetime() | undefined.
+expires_block_hash(Hash, Type) ->
     case aehttp_logic:get_header_by_hash(Hash) of
-        {ok, Header} -> expires_block_header(Header);
+        {ok, Header} -> expires_datetime(Header, Type);
         _ -> undefined
     end.
 
--spec expires_block_header(aec_headers:header()) -> non_neg_integer() | error.
-expires_block_header(Header) ->
-    case block_header_cache_time(Header) of
-        CacheTime when is_integer(CacheTime) ->
-            unixtime_to_datetime(CacheTime);
-        _ -> error
+-spec expires_datetime(aec_headers:header(), expire_type()) -> calendar:datetime().
+expires_datetime(Header, Type) ->
+    unixtime_to_datetime(cache_time(Header, Type)).
+
+-spec cache_time(aec_headers:header(), key | micro ) -> non_neg_integer().
+cache_time(Header, key) ->
+    case is_aged(Header) of
+        true  ->
+            lager:info("Aged block."),
+            aeu_time:now_in_secs() + aged_blocks_cache_time();
+        false -> expected_next_block_time(key)
+    end;
+
+cache_time(Header, micro) ->
+    case is_top_generation(Header) of
+        true ->
+            lager:info("Part of top generation."),
+            expected_next_block_time(micro);
+        false -> cache_time(Header, key)
     end.
 
--spec block_header_cache_time(aec_headers:header()) -> non_neg_integer() | error.
-block_header_cache_time(Header) ->
+-spec is_aged(aec_headers:header()) -> boolean().
+is_aged(Header) ->
     Now = aeu_time:now_in_secs(),
     BlockTimestamp = aec_headers:time_in_secs(Header),
     Diff = Now - BlockTimestamp,
-    case Diff > aged_blocks_time() of
-        true ->
-            Now + aged_blocks_cache_time();
-        false ->
-            expected_next_key_block_time()
-    end.
+    Diff > aged_blocks_time().
 
--spec expected_next_key_block_time() -> non_neg_integer() | error.
-expected_next_key_block_time() ->
-    case top_key_block_header() of
-        {ok, Header} ->
-            BlockTimestamp = aec_headers:time_in_secs(Header),
-            Rate = aeu_time:msecs_to_secs(aec_governance:expected_block_mine_rate()),
-            BlockTimestamp + Rate;
-        _ -> error
-    end.
+-spec is_top_generation(aec_headers:header()) -> boolean().
+is_top_generation(Header) ->
+    TopKeyHeader = top_key_block_header(),
+    {ok, TopKeyHash} = aec_headers:hash_header(TopKeyHeader),
+    KeyHash = case aec_headers:type(Header) of
+        micro ->
+            aec_headers:prev_key_hash(Header);
+        key ->
+            {ok, Hash} = aec_headers:hash_header(Header),
+            Hash
+    end,
+    lager:info("Compare: ~p =:= ~p", [TopKeyHash, KeyHash]),
+    TopKeyHash =:= KeyHash.
 
--spec top_key_block_header() -> {ok, aec_headers:header()} | error.
+-spec top_key_block_header() -> aec_headers:header().
 top_key_block_header() ->
-    case aec_chain:top_key_block() of
-        {ok, Block} ->
-            {ok, aec_blocks:to_key_header(Block)};
-        _ ->
-            error
-    end.
+    {ok, Block} = aec_chain:top_key_block(),
+    aec_blocks:to_key_header(Block).
 
--spec expected_next_micro_block_time() -> non_neg_integer().
-expected_next_micro_block_time() ->
+-spec expected_next_block_time(key | micro) -> non_neg_integer().
+expected_next_block_time(Type) ->
     TopHeader = aec_chain:top_header(),
     BlockTimestamp = aec_headers:time_in_secs(TopHeader),
-    Rate = aeu_time:msecs_to_secs(aec_governance:micro_block_cycle()),
+    Rate = aeu_time:msecs_to_secs(block_rate(Type)),
     BlockTimestamp + Rate.
 
+-spec block_rate(key|micro) -> non_neg_integer().
+block_rate(key) ->
+    aec_governance:expected_block_mine_rate();
+block_rate(micro) ->
+    aec_governance:micro_block_cycle().
+
+-spec to_int(binary()) -> integer() | error.
 to_int(Data) ->
     try {ok, binary_to_integer(Data)}
     catch

--- a/apps/aehttp/src/aehttp_spec_handler.erl
+++ b/apps/aehttp/src/aehttp_spec_handler.erl
@@ -9,6 +9,7 @@
 -export([init/2]).
 -export([content_types_accepted/2]).
 -export([content_types_provided/2]).
+-export([generate_etag/2]).
 -export([handle_request_json/2]).
 
 -record(state, {
@@ -35,10 +36,13 @@ content_types_accepted(Req, State) ->
 content_types_provided(Req, State) ->
     {[{<<"application/json">>, handle_request_json}], Req, State}.
 
+generate_etag(Req, State = #state{spec = Spec}) ->
+    Etag = aeu_hex:bin_to_hex(crypto:hash(sha, Spec)),
+    {{strong, list_to_binary(Etag)}, Req, State}.
+
 handle_request_json(Req, State = #state{
         operation_id = 'Api',
         spec = Spec
     }) ->
     Repl = cowboy_req:reply(200, #{}, Spec, Req),
     {stop, Repl, State}.
-

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -168,7 +168,9 @@
     cors_returned_on_get_request/1]).
 
 %% test case exports for HTTP cache headers
--export([cache_headers/1]).
+-export([
+    expires_cache_header/1,
+    etag_cache_header/1]).
 
 %% test case exports
 %% for Cowboy handler tests
@@ -516,7 +518,8 @@ groups() ->
        cors_returned_on_get_request]},
 
      {http_cache, [],
-      [cache_headers]},
+      [expires_cache_header,
+       etag_cache_header]},
 
      {cowboy_handler, [],
       [charset_param_in_content_type]},
@@ -6050,13 +6053,12 @@ cors_returned_on_get_request(_Config) ->
 %% Test HTTP cache headers
 %% ============================================================
 
-cache_headers(_Config) ->
+expires_cache_header(_Config) ->
     Host = external_address(),
     {ok, {{_, 200, _}, Headers, _Body}} =
         httpc_request(get, {Host ++ "/v2/blocks/top", []}, [], []),
 
     true = proplists:is_defined("expires", Headers),
-    true = proplists:is_defined("etag", Headers),
     Blocktime = case get_top_sut() of
         {ok, 200, #{<<"key_block">> := Block}} -> maps:get(<<"time">>, Block);
         {ok, 200, #{<<"micro_block">> := MicroBlock}} -> maps:get(<<"time">>, MicroBlock)
@@ -6064,6 +6066,18 @@ cache_headers(_Config) ->
     ExpiresStr = proplists:get_value("expires", Headers),
     Expires = http_datetime_to_unixtime(ExpiresStr) * 1000, % to msecs
     true = Expires - Blocktime =< aec_governance:micro_block_cycle(),
+    ok.
+
+etag_cache_header(_Config) ->
+    Host = external_address(),
+    {ok, {{_, 200, _}, Headers, _Body}} =
+        httpc_request(get, {Host ++ "/v2/key-blocks/height/0", []}, [], []),
+
+    true = proplists:is_defined("etag", Headers),
+    ETag = proplists:get_value("etag", Headers),
+
+    {ok, {{_, 304, _}, _, []}} =
+        httpc_request(get, {Host ++ "/v2/key-blocks/height/0", [{"if-none-match", ETag}]}, [], []),
     ok.
 
 %% ============================================================

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -167,6 +167,9 @@
     cors_returned_on_preflight_request/1,
     cors_returned_on_get_request/1]).
 
+%% test case exports for HTTP cache headers
+-export([cache_headers/1]).
+
 %% test case exports
 %% for Cowboy handler tests
 -export([
@@ -511,6 +514,9 @@ groups() ->
       [cors_not_returned_when_origin_not_sent,
        cors_returned_on_preflight_request,
        cors_returned_on_get_request]},
+
+     {http_cache, [],
+      [cache_headers]},
 
      {cowboy_handler, [],
       [charset_param_in_content_type]},
@@ -6038,6 +6044,19 @@ cors_returned_on_get_request(_Config) ->
         httpc_request(get, {Host ++ "/v2/blocks/top", [{"origin", "example.com"}]}, [], []),
 
     "example.com" = proplists:get_value("access-control-allow-origin", Headers),
+    ok.
+
+%% ============================================================
+%% Test HTTP cache headers
+%% ============================================================
+
+cache_headers(_Config) ->
+    Host = external_address(),
+    {ok, {{_, 200, _}, Headers, _Body}} =
+        httpc_request(get, {Host ++ "/v2/blocks/top", []}, [], []),
+
+    true = proplists:is_defined("expires", Headers),
+    true = proplists:is_defined("etag", Headers),
     ok.
 
 %% ============================================================

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -276,7 +276,7 @@
                         "type" : "boolean"
                     },
                     "dev" : {
-                        "description" : "Development only API - for validation of client implementations. Should not be used in real life scenrios",
+                        "description" : "Development only API - for validation of client implementations. Should not be used in real life scenarios",
                         "type" : "boolean"
                     },
                     "debug" : {
@@ -291,6 +291,27 @@
                 "debug" : {
                     "description" : "Deprecated. See also 'http > internal > debug_endpoints'",
                     "type" : "boolean"
+                },
+                "cache": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable HTTP cache headers (ETag and Expire)",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "aged_blocks_time" : {
+                            "description" : "Time (in seconds) after a block is considered aged. That is an Expire header is generated for such blocks API endpoints.",
+                            "type" : "integer",
+                            "default" : 86400
+                        },
+                        "aged_blocks_cache_time" : {
+                            "description" : "Time (in seconds) to cache aged blocks, the Expire header time relative to block creation time.",
+                            "type" : "integer",
+                            "default" : 86400
+                        }
+                    }
                 }
             }
         },

--- a/apps/aeutils/src/aeu_time.erl
+++ b/apps/aeutils/src/aeu_time.erl
@@ -2,11 +2,16 @@
 
 %% API
 -export([now_in_msecs/0,
+         now_in_secs/0,
          msecs_to_secs/1]).
 
 now_in_msecs() ->
     {Megasecs, Secs, Microsecs} = os:timestamp(),
     Megasecs * 1000000000 + Secs * 1000 + Microsecs div 1000.
+
+now_in_secs() ->
+    {Megasecs, Secs, _} = os:timestamp(),
+    Megasecs * 1000000 + Secs.
 
 msecs_to_secs(Msecs) ->
     Msecs div 1000.

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -90,6 +90,13 @@ http:
         acceptors: 10
         # Enable (true) debug api. Disabled (false) by default
         debug_endpoints: false
+    cache:
+        # Enable HTTP cache headers (ETag and Expire)
+        enabled: false
+        # Time (in seconds) after a block is considered aged. That is an Expire header is generated for such blocks API endpoints.
+        aged_blocks_time: 86400
+        # Time (in seconds) to cache aged blocks, the Expire header time relative to block creation time.
+        aged_blocks_cache_time: 86400
 
 websocket:
     channel:

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -20,7 +20,10 @@
                         {handlers, 100},
                         {listen_address, <<"127.0.0.1">>}
                       ]}
-          ]}
+          ]},
+      {cache, [
+        {enabled, true}
+      ]}
   ]},
 
   {jobs, [

--- a/docs/release-notes/next/PT-165271539_http_api_cache.md
+++ b/docs/release-notes/next/PT-165271539_http_api_cache.md
@@ -1,0 +1,2 @@
+* Add support for HTTP API cache headers (Expires and ETag). It can be enabled by setting 
+    `http` -> `cache` -> `enabled` to `true`. Refer to the configuration schema for more options.


### PR DESCRIPTION
Since the blockchain data is immutable (after certain period of time), it could be cached very aggressively at the **clients** and intermediaries (e.g. HTTP proxies) level. This would drastically improve the **clients** performance and implicitly lower the node load.

This PR implements [HTTP caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching) headers in the node HTTP API. It utilize  [HTTP Expires header](https://tools.ietf.org/html/rfc7234#section-5.3) to control the resource [freshness](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Freshness) and [ETag HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#ETags) for effective cache revalidation.

This has been implemented as callbacks for [cowboy rest behaviour](https://ninenines.eu/docs/en/cowboy/2.2/guide/rest_handlers/).

Expires header has been chosen over Cache-Control because of former cowboy support. There shouldn't be any functional differences between the two.

This is not about HTTP API backend cache.

PT: https://www.pivotaltracker.com/story/show/165271539

- [x] Add PR description
- [x] Add release notes

