### PR TITLE
Improve building scripts for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
     WIN_MSYS2_ROOT: C:\msys64
     WIN_MSYS2_CACHE: C:\msys64\var\cache\pacman\pkg
     WIN_OTP_PATH: C:\Program Files\erl
+    WIN_JDK_PATH: C:\Program Files\Java\jdk11
     BUILD_PATH: /c/projects/aeternity
     ERL_EPMD_ADDRESS: 127.0.0.1
   matrix:

--- a/ci/appveyor/build.bat
+++ b/ci/appveyor/build.bat
@@ -18,13 +18,18 @@ IF "%BUILD_STEP%"=="" SET "BUILD_STEP=build"
 IF "%BUILD_PATH%"=="" GOTO :BUILDABORT_MISSINGBUILDPATH
 
 @echo Current time: %time%
-rem Set the paths appropriately
 
+rem SET the appropriate MSVC_VERSION
+IF NOT "%MSVC_VERSION%"=="" GOTO MSVC_VERSION_SET
 @FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" Microsoft.VCToolsVersion.default.txt`) DO SET "ToolsVerFile=%%F"
 @FOR /F "tokens=* USEBACKQ delims=" %%F IN (`type "%ToolsVerFile%"`) DO SET MSVC_VERSION=%%F
+:MSVC_VERSION_SET
+
+rem Find and execute the VS env preparation script
 @FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" vcvarsall`) DO SET vcvarsall="%%F"
 call %vcvarsall% %PLATFORM%
 
+rem Set the paths appropriately
 SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
 :BUILDSTART

--- a/ci/appveyor/build.bat
+++ b/ci/appveyor/build.bat
@@ -12,28 +12,30 @@ cd %APPVEYOR_BUILD_FOLDER%
 
 rem Set required vars defaults
 IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
-IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
+IF "%WIN_MSYS2_ROOT%"=="" FOR /F %%F IN ('where msys2') DO SET "WIN_MSYS2_ROOT=%%~dpF"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 IF "%BUILD_STEP%"=="" SET "BUILD_STEP=build"
 IF "%BUILD_PATH%"=="" GOTO :BUILDABORT_MISSINGBUILDPATH
-SET BASH_BIN="%WIN_MSYS2_ROOT%\usr\bin\bash"
 
 @echo Current time: %time%
 rem Set the paths appropriately
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
-@echo on
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" Microsoft.VCToolsVersion.default.txt`) DO SET "ToolsVerFile=%%F"
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`type "%ToolsVerFile%"`) DO SET MSVC_VERSION=%%F
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" vcvarsall`) DO SET vcvarsall="%%F"
+call %vcvarsall% %PLATFORM%
+
 SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
 :BUILDSTART
-GOTO BUILD_%BUILD_STEP%
+@GOTO BUILD_%BUILD_STEP%
 
 :BUILD_build
 @echo Current time: %time%
 rem Run build: build
-%BASH_BIN% -lc "cd %BUILD_PATH% && make KIND=test local-build"
+bash -lc "cd %BUILD_PATH% && make KIND=test local-build"
 
-GOTO BUILD_DONE
+@GOTO BUILD_DONE
 
 :BUILD_
 :BUILD_DONE

--- a/ci/appveyor/package.bat
+++ b/ci/appveyor/package.bat
@@ -11,60 +11,68 @@ SETLOCAL ENABLEEXTENSIONS
 
 rem Set required vars defaults
 IF "%PACKAGE_PATH%"=="" SET "PACKAGE_PATH=/tmp/win_package_build"
-IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
+IF "%WIN_MSYS2_ROOT%"=="" FOR /F %%F IN ('where msys2') DO SET "WIN_MSYS2_ROOT=%%~dpF"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 IF "%BUILD_PATH%"=="" GOTO :PACKAGEABORT_MISSINGBUILDPATH
-SET BASH_BIN="%WIN_MSYS2_ROOT%\usr\bin\bash"
+
 SET RELEASE_PATH=%BUILD_PATH%/_build/prod/rel/aeternity
 
 @echo Current time: %time%
-rem Set the paths appropriately
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
-@echo on
+rem SET the appropriate MSVC_VERSION
+IF NOT "%MSVC_VERSION%"=="" GOTO MSVC_VERSION_SET
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" Microsoft.VCToolsVersion.default.txt`) DO SET "ToolsVerFile=%%F"
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`type "%ToolsVerFile%"`) DO SET MSVC_VERSION=%%F
+:MSVC_VERSION_SET
+
+rem Find and execute the VS env preparation script
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" vcvarsall`) DO SET vcvarsall="%%F"
+call %vcvarsall% %PLATFORM%
+
+rem Set the paths appropriately
 SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
 :PACKAGESTART
 
 @echo Current time: %time%
 rem Build production release
-%BASH_BIN% -lc "cd %BUILD_PATH% && make prod-build"
+bash -lc "cd %BUILD_PATH% && make prod-build"
 
 @echo Current time: %time%
 rem Remove erl.ini files from release
-%BASH_BIN% -lc "find \"%RELEASE_PATH%\" -name erl.ini -type f -delete"
+bash -lc "find \"%RELEASE_PATH%\" -name erl.ini -type f -delete"
 
 @echo Current time: %time%
 rem Remove any previous package environment
-%BASH_BIN% -lc "rm -rf \"%PACKAGE_PATH%\""
+bash -lc "rm -rf \"%PACKAGE_PATH%\""
 
 @echo Current time: %time%
 rem Build package environment
-%BASH_BIN% -lc "/mingw64/bin/styrene -o \"%PACKAGE_PATH%\" \"%BUILD_PATH%/ci/appveyor/package.cfg\""
+bash -lc "/mingw64/bin/styrene -o \"%PACKAGE_PATH%\" \"%BUILD_PATH%/ci/appveyor/package.cfg\""
 
 @echo Current time: %time%
 rem Copy release into package environment
-%BASH_BIN% -lc "mkdir -p \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib\""
-%BASH_BIN% -lc "cp -R \"%RELEASE_PATH%\" \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib/\""
-%BASH_BIN% -lc "mv -f \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib/aeternity/REVISION\" \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib/aeternity/VERSION\" \"%PACKAGE_PATH%/aeternity-windows-w64/\""
-%BASH_BIN% -lc "mkdir -p \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
+bash -lc "mkdir -p \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib\""
+bash -lc "cp -R \"%RELEASE_PATH%\" \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib/\""
+bash -lc "mv -f \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib/aeternity/REVISION\" \"%PACKAGE_PATH%/aeternity-windows-w64/usr/lib/aeternity/VERSION\" \"%PACKAGE_PATH%/aeternity-windows-w64/\""
+bash -lc "mkdir -p \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
 
 @echo Current time: %time%
 rem Copy genisis and hard-fork account migrations into top-level data folder
-%BASH_BIN% -lc "cp -R \"%RELEASE_PATH%/data/aecore/.genesis\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
-%BASH_BIN% -lc "cp -R \"%RELEASE_PATH%/data/aecore/.minerva\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
-%BASH_BIN% -lc "cp -R \"%RELEASE_PATH%/data/aecore/.fortuna\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
-%BASH_BIN% -lc "cp -R \"%RELEASE_PATH%/data/aecore/.lima\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
+bash -lc "cp -R \"%RELEASE_PATH%/data/aecore/.genesis\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
+bash -lc "cp -R \"%RELEASE_PATH%/data/aecore/.minerva\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
+bash -lc "cp -R \"%RELEASE_PATH%/data/aecore/.fortuna\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
+bash -lc "cp -R \"%RELEASE_PATH%/data/aecore/.lima\" \"%PACKAGE_PATH%/aeternity-windows-w64/data/aecore\""
 
 @echo Current time: %time%
 rem Build packages
-%BASH_BIN% -lc "/mingw64/bin/styrene -o \"%PACKAGE_PATH%\" \"%BUILD_PATH%/ci/appveyor/package.cfg\""
+bash -lc "/mingw64/bin/styrene -o \"%PACKAGE_PATH%\" \"%BUILD_PATH%/ci/appveyor/package.cfg\""
 
 @echo Current time: %time%
 rem Copy packages
 SET /p PACKAGE_VERSION=<%~dp0%\..\..\REVISION
-%BASH_BIN% -lc "cp \"%PACKAGE_PATH%\"/*.zip \"%BUILD_PATH%/aeternity-%PACKAGE_VERSION%-windows-x86_64.zip\""
-%BASH_BIN% -lc "cp \"%PACKAGE_PATH%\"/*.exe \"%BUILD_PATH%/aeternity-%PACKAGE_VERSION%-windows-x86_64.exe\""
+bash -lc "cp \"%PACKAGE_PATH%\"/*.zip \"%BUILD_PATH%/aeternity-%PACKAGE_VERSION%-windows-x86_64.zip\""
+bash -lc "cp \"%PACKAGE_PATH%\"/*.exe \"%BUILD_PATH%/aeternity-%PACKAGE_VERSION%-windows-x86_64.exe\""
 
 :PACKAGEDONE
 

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -23,17 +23,18 @@ rem Set required vars defaults
 IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
 IF "%PACKAGE_TESTS_DIR%"=="" SET "PACKAGE_TESTS_DIR=/tmp/package_tests"
 IF "%PACKAGE_ZIPARCHIVE%"=="" SET "PACKAGE_ZIPARCHIVE=aeternity-%PACKAGE_VERSION%-windows-x86_64.zip"
-IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
+IF "%WIN_MSYS2_ROOT%"=="" FOR /F %%F IN ('where msys2') DO SET "WIN_MSYS2_ROOT=%%~dpF"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 IF "%TEST_STEPS%"=="" SET "TEST_STEPS=ct"
-
-SET BASH_BIN="%WIN_MSYS2_ROOT%\usr\bin\bash"
 
 @echo Current time: %time%
 rem Set the paths appropriately
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
-@echo on
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" Microsoft.VCToolsVersion.default.txt`) DO SET "ToolsVerFile=%%F"
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`type "%ToolsVerFile%"`) DO SET MSVC_VERSION=%%F
+@FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" vcvarsall`) DO SET vcvarsall="%%F"
+call %vcvarsall% %PLATFORM%
+
 SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
 :FIND_NEXT_STEP

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -28,13 +28,18 @@ IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 IF "%TEST_STEPS%"=="" SET "TEST_STEPS=ct"
 
 @echo Current time: %time%
-rem Set the paths appropriately
 
+rem SET the appropriate MSVC_VERSION
+IF NOT "%MSVC_VERSION%"=="" GOTO MSVC_VERSION_SET
 @FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" Microsoft.VCToolsVersion.default.txt`) DO SET "ToolsVerFile=%%F"
 @FOR /F "tokens=* USEBACKQ delims=" %%F IN (`type "%ToolsVerFile%"`) DO SET MSVC_VERSION=%%F
+:MSVC_VERSION_SET
+
+rem Find and execute the VS env preparation script
 @FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" vcvarsall`) DO SET vcvarsall="%%F"
 call %vcvarsall% %PLATFORM%
 
+rem Set the paths appropriately
 SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
 
 :FIND_NEXT_STEP

--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -4,36 +4,68 @@ This document describes how to build an Aeternity node from source on Windows us
 [MSYS2][msys2].
 
 NOTE: Only 64-bit versions of Windows 10 and Windows Server 2016 are supported and tested.
+ 
+Administrative privileges are required.
 
 ## Dependencies
 
+Note: You might consider easier to use [Chocolatey][chocolatey] package manager to
+install the requirements
+
 ### [MSYS2][msys2]
+
+Install Msys2 using [Chocolatey][chocolatey] 
+
+```
+cinst msys2 -y
+```
+
+or manually
 
 **Download:** [MSYS2 Windows Installer][msys2_dl]
 
 - Execute installer and follow instructions
 - Keep note of install folder
 
-### [Visual Studio 2017][vs2017]
+### [Visual Studio 2017/2019][vs2017]
 
-Install Vistual Studio 2017 and make sure to include the following components:
+Install only the required components of Visual Studio 2019 using [Chocolatey][chocolatey]
+
+```
+cinst visualstudio2019-workload-vctools -y --params "--add Microsoft.VisualStudio.Component.VC.CLI.Support --locale en-US"
+```
+
+or manually
+
+**Download:** [Visual Studio 2019 Installer][vs2019_dl]
+
+Make sure to include the following components (use the VCTools workload as base):
 
 - Command-line compiler support
-- Windows OS Kit 10
+- Windows 10 SDK
+
+Alternatively can use [vs_buildtools.exe][vs_buildtools] to reduce install size.
 
 ### [Erlang/OTP 20.3][otp] (optional)
 
-If you don't want to install [Erlang/OTP][otp] manually, the preparation script will do it automatically for you.
+If you don't want to install [Erlang/OTP][otp] manually, the preparation script
+will do it automatically for you.
 
 **Download:** [Erlang/OTP 20.3 Windows Installer][otp203_dl]
 
 - Execute installer and follow instructions
 - Keep note of install folder
 
+### [Java Development Kit 11][jdk] (optional)
+
+If you don't want to install Open JDK manually, the preparation script will do
+it automatically for you.
+
 ## Setup
 
-Now the [MSYS2][msys2] environment needs to be prepared. This can be done
-automatically through the helper script `scripts/windows/msys2_prepare.bat`.
+Now the [MSYS2][msys2] environment needs to be prepared. This can be done 
+automatically by the helper script `scripts/windows/msys2_prepare.bat`.
+
 This script uses the following environment variable default values. If your
 local setup differs, you need to set these variables yourself.
 
@@ -44,27 +76,36 @@ JDK_URL=https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64
 OTP_VERSION=20.3
 PLATFORM=x64
 WIN_JDK_BASEPATH=C:\Program Files\Java
-WIN_JDK_PATH=C:\Program Files\Java\jdk11
-WIN_MSYS2_ROOT=C:\msys64
-WIN_OTP_PATH=C:\Program Files\erl
+WIN_JDK_PATH=C:\Program Files\Java\jdk-11.0.2
+WIN_OTP_PATH=C:\Program Files\erl9.3
+JAVA_VERSIOIN=11.0.2
 
+```
+
+Note: The helper scripts will try to detect where `msys2` is installed.
+If this fails, you can set `WIN_MSYS2_ROOT` environment variable with the proper path, i.e.:
+
+```
+WIN_MSYS2_ROOT=C:\msys64
 ```
 
 You can execute the script directly in a `cmd` window.
 
 ## Building
 
-Open a [MSYS2][msys2] shell with the proper paths set. You can use the helper
-script `scripts/windows/msys2_shell.bat` to do so.
+Open a [MSYS2][msys2] shell with the proper paths set. 
 
-That script uses the following environment variables:
+Use the helper script `scripts/windows/msys2_shell.bat` to do so.
+
+That script uses the following environment variables (defaults):
 
 ```
 PLATFORM=x64
-WIN_MSYS2_ROOT=C:\msys64
+ERTS_VERSION=9.3
+JAVA_VERSION=11.0.2
 ```
 
-In the opened shell go into your build directory and build the system like on
+In the opened shell (MinGW64) go into your build directory and build the system like on
 any other UNIX system:
 
 ```bash
@@ -72,10 +113,16 @@ cd PATH_TO_REPO_CHECKOUT
 make
 ```
 
+NOTE: Disk drives are mounted in the root folder (i.e. `C:` is `/c`)
+
 Refer to `docs/build.md` for more information on how to build.
 
+[chocolatey]: https://chocolatey.org/docs/installation#installing-chocolatey
 [msys2]: https://www.msys2.org/
+[jdk]: https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip
 [msys2_dl]: http://repo.msys2.org/distrib/x86_64/msys2-x86_64-20180531.exe
 [otp]: http://www.erlang.org/
 [otp203_dl]: http://erlang.org/download/otp_win64_20.3.exe
 [vs2017]: https://docs.microsoft.com/en-us/visualstudio/install/install-visual-studio
+[vs2019_dl]: https://visualstudio.microsoft.com/downloads/
+[vs_buildtools]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019

--- a/scripts/windows/msys2_env_build.sh
+++ b/scripts/windows/msys2_env_build.sh
@@ -43,21 +43,20 @@ CPPFLAGS='-D _WIN32'
 MSYS2_ROOT=${MSYS2_ROOT:-"${C_DRV}/msys64"}
 WIN_MSYS2_ROOT=${WIN_MSYS2_ROOT:-"${WIN_C_DRV}\\msys64"}
 
-PRG_FLS64="${C_DRV}/Program Files"
-PRG_FLS32="${C_DRV}/Program Files (x86)"
-WIN_PRG_FLS64="${WIN_C_DRV}\\Program Files"
-WIN_PRG_FLS32="${WIN_C_DRV}\\Program Files (x86)"
+PRG_FLS64="$(make_upath "${PROGRAMFILES}")"
+WIN_PRG_FLS64="${PROGRAMFILES}"
 ERL_TOP="${PRG_FLS64}/erl${ERTS_VERSION}"
 WIN_ERL_TOP="${WIN_PRG_FLS64}\\erl${ERTS_VERSION}"
-JAVA_TOP="${JAVA_TOP:-${PRG_FLS64}/Java/jdk${JAVA_VERSION}}"
+JAVA_TOP="${JAVA_TOP:-${PRG_FLS64}/Java/jdk-${JAVA_VERSION}}"
 
-VISUAL_STUDIO_ROOT=${PRG_FLS32}/Microsoft\ Visual\ Studio/2017/Community
-WIN_VISUAL_STUDIO_ROOT="${WIN_PRG_FLS32}\\Microsoft Visual Studio\\2017\\Community"
+WIN_VISUAL_STUDIO_ROOT="${VSINSTALLDIR}"
+VISUAL_STUDIO_ROOT="$(make_upath "${WIN_VISUAL_STUDIO_ROOT}")"
 
-MSVC_ROOT=${VISUAL_STUDIO_ROOT}/VC/Tools/MSVC/${MSVC_VERSION}
-MSVC=${MSVC_ROOT}/bin/Hostx64/x64
-WIN_MSVC_ROOT=${WIN_VISUAL_STUDIO_ROOT}\\VC\\Tools\\MSVC\\${MSVC_VERSION}
-WIN_MSVC=${WIN_MSVC_ROOT}/bin\\Hostx64\\x64
+WIN_MSVC_ROOT=${VCToolsInstallDir}
+WIN_MSVC=${WIN_MSVC_ROOT}bin\\Hostx64\\x64
+
+MSVC_ROOT="$(make_upath "${WIN_MSVC_ROOT}")"
+MSVC="$(make_upath "${WIN_MSVC}")"
 
 PATH="/usr/local/bin:/usr/bin:/bin:/c/Windows/system32:/c/Windows:/c/Windows/System32/Wbem:${PATH}"
 PATH="${HOME}/.local/bin:${MSVC}:${ERL_TOP}/bin:${PATH}:${ERL_TOP}/erts-${ERTS_VERSION}/bin:${MSYS2_ROOT}/mingw64/bin"
@@ -66,5 +65,4 @@ PATH="${JAVA_TOP}/bin:${PATH}"
 INCLUDE="${INCLUDE};${WIN_MSYS2_ROOT}\\mingw64\\include;${WIN_MSYS2_ROOT}\\usr\\include"
 LIB="${LIB};${WIN_MSYS2_ROOT}\\mingw64\\lib;${WIN_MSYS2_ROOT}\\mingw64\\bin;${WIN_ERL_TOP}\\usr\\lib;"
 
-export INCLUDE LIB PATH ERL_TOP WIN_ERL_TOP COMSPEC
 export INCLUDE LIB PATH ERL_TOP WIN_ERL_TOP COMSPEC CPPFLAGS

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -1,4 +1,4 @@
-@echo on
+@echo off
 @rem Script to prepare msys2 environment for builds.
 @rem Required vars:
 @rem    ERTS_VERSION
@@ -7,6 +7,7 @@
 @rem    OTP_VERSION
 @rem    PLATFORM
 @rem    WIN_JDK_BASEPATH
+@rem    JAVA_VERSION
 @rem    WIN_JDK_PATH
 @rem    WIN_MSYS2_ROOT
 @rem    WIN_OTP_PATH
@@ -21,9 +22,10 @@ IF "%JDK_URL%"=="" SET "JDK_URL=https://download.java.net/java/GA/jdk11/9/GPL/op
 IF "%OTP_VERSION%"=="" SET "OTP_VERSION=20.3"
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
 IF "%WIN_JDK_BASEPATH%"=="" SET "WIN_JDK_BASEPATH=C:\Program Files\Java"
-IF "%WIN_JDK_PATH%"=="" SET "WIN_JDK_PATH=C:\Program Files\Java\jdk11"
-IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
-IF "%WIN_OTP_PATH%"=="" SET "WIN_OTP_PATH=C:\Program Files\erl"
+IF "%JAVA_VERSION%"=="" SET "JAVA_VERSION=11.0.2"
+IF "%WIN_JDK_PATH%"=="" SET "WIN_JDK_PATH=C:\Program Files\Java\jdk-%JAVA_VERSION%"
+IF "%WIN_MSYS2_ROOT%"=="" FOR /F %%F IN ('where msys2') DO SET "WIN_MSYS2_ROOT=%%~dpF"
+IF "%WIN_OTP_PATH%"=="" SET "WIN_OTP_PATH=C:\Program Files\erl%ERTS_VERSION%"
 
 SET "BASH_BIN=%WIN_MSYS2_ROOT%\usr\bin\bash"
 SET "PACMAN=pacman --noconfirm --needed -S"
@@ -65,49 +67,51 @@ mingw-w64-x86_64-python3-pip ^
 mingw-w64-x86_64-python3-pynacl ^
 mingw-w64-x86_64-python3-yaml
 
-@echo Current time: %time%
+echo Current time: %time%
+
+rem Find and execute the VS env preparation script
+FOR /F "usebackq delims=" %%F IN (`where /f /r "C:\Program Files (x86)\Microsoft Visual Studio" vcvarsall`) DO SET vcvarsall=%%F
+call %vcvarsall% %PLATFORM%
+
 rem Set the paths appropriately
+SET "PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%WIN_OTP_PATH%\bin;%WIN_OTP_PATH%\erts-%OTP_VERSION%;%PATH%"
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\\vcvarsall.bat" %PLATFORM%
-@echo on
-SET "PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%"
-
-@echo Current time: %time%
+echo Current time: %time%
 rem Set up msys2 env variables
 
 COPY %~dp0\msys2_env_build.sh %WIN_MSYS2_ROOT%\etc\profile.d\env_build.sh
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Remove 32-bit tools
 
-%BASH_BIN% -lc "pacman -Qet | grep i686 | awk '{ print $1; }' | xargs %PACMAN_RM% || true"
-%BASH_BIN% -lc "pacman -Qdt | grep i686 | awk '{ print $1; }' | xargs %PACMAN_RM% || true"
+bash -lc "pacman -Qet | grep i686 | awk '{ print $1; }' | xargs %PACMAN_RM% || true"
+bash -lc "pacman -Qdt | grep i686 | awk '{ print $1; }' | xargs %PACMAN_RM% || true"
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Remove breaking tools
 
-%BASH_BIN% -lc "%PACMAN_RM% %PACMAN_PACKAGES_REMOVE% || true"
+bash -lc "%PACMAN_RM% %PACMAN_PACKAGES_REMOVE% || true"
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Upgrade the MSYS2 platform
 
-%BASH_BIN% -lc "%PACMAN% -yuu"
+bash -lc "%PACMAN% -yuu"
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Install required tools
-%BASH_BIN% -lc "%PACMAN% %PACMAN_PACKAGES% %PACMAN_PYTHON_PACKAGES%"
+bash -lc "%PACMAN% %PACMAN_PACKAGES% %PACMAN_PYTHON_PACKAGES%"
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Ensure Erlang/OTP %OTP_VERSION% is installed
 
-IF EXIST "%WIN_OTP_PATH%%ERTS_VERSION%\bin\" GOTO OTPINSTALLED
+IF EXIST "%WIN_OTP_PATH%\bin\" GOTO OTPINSTALLED
 SET "OTP_PACKAGE=otp_win64_%OTP_VERSION%.exe"
 SET "OTP_URL=http://erlang.org/download/%OTP_PACKAGE%"
 PowerShell -Command "(New-Object System.Net.WebClient).DownloadFile(\"%OTP_URL%\", \"%TMP%\%OTP_PACKAGE%\")"
 START "" /WAIT "%TMP%\%OTP_PACKAGE%" /S
 :OTPINSTALLED
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Ensure JDK is installed
 
 IF EXIST "%WIN_JDK_PATH%\bin\" GOTO JDKINSTALLED
@@ -116,21 +120,21 @@ PowerShell -Command "(New-Object System.Net.WebClient).DownloadFile(\"%JDK_URL%\
 PowerShell -Command "Expand-Archive -LiteralPath \"%TMP%\%JDK_PACKAGE%\" -DestinationPath \"%WIN_JDK_BASEPATH%\""
 :JDKINSTALLED
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Ensure Styrene is installed
 
 IF EXIST "%WIN_STYRENE_PATH%" IF "%FORCE_STYRENE_REINSTALL%" NEQ "true" GOTO STYRENEINSTALLED
-%BASH_BIN% -lc "rm -rf \"${ORIGINAL_TEMP}/styrene\""
-%BASH_BIN% -lc "git clone https://github.com/achadwick/styrene.git \"${ORIGINAL_TEMP}/styrene\""
-%BASH_BIN% -lc "cd \"${ORIGINAL_TEMP}/styrene\" && git fetch origin && git checkout v0.3.0"
-%BASH_BIN% -lc "cd \"${ORIGINAL_TEMP}/styrene\" && %PIP% uninstall -y styrene"
-%BASH_BIN% -lc "cd \"${ORIGINAL_TEMP}/styrene\" && %PIP% install ."
+bash -lc "rm -rf \"${ORIGINAL_TEMP}/styrene\""
+bash -lc "git clone https://github.com/achadwick/styrene.git \"${ORIGINAL_TEMP}/styrene\""
+bash -lc "cd \"${ORIGINAL_TEMP}/styrene\" && git fetch origin && git checkout v0.3.0"
+bash -lc "cd \"${ORIGINAL_TEMP}/styrene\" && %PIP% uninstall -y styrene"
+bash -lc "cd \"${ORIGINAL_TEMP}/styrene\" && %PIP% install ."
 :STYRENEINSTALLED
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Remove link.exe from msys2, so it does not interfere with MSVC's link.exe
 
-%BASH_BIN% -lc "rm -f /bin/link.exe /usr/bin/link.exe"
+bash -lc "rm -f /bin/link.exe /usr/bin/link.exe"
 
-@echo Current time: %time%
+echo Current time: %time%
 rem Finished preparation

--- a/scripts/windows/msys2_prepare.bat
+++ b/scripts/windows/msys2_prepare.bat
@@ -27,7 +27,6 @@ IF "%WIN_JDK_PATH%"=="" SET "WIN_JDK_PATH=C:\Program Files\Java\jdk-%JAVA_VERSIO
 IF "%WIN_MSYS2_ROOT%"=="" FOR /F %%F IN ('where msys2') DO SET "WIN_MSYS2_ROOT=%%~dpF"
 IF "%WIN_OTP_PATH%"=="" SET "WIN_OTP_PATH=C:\Program Files\erl%ERTS_VERSION%"
 
-SET "BASH_BIN=%WIN_MSYS2_ROOT%\usr\bin\bash"
 SET "PACMAN=pacman --noconfirm --needed -S"
 SET "PACMAN_RM=pacman --noconfirm -Rsc"
 SET "PIP=/mingw64/bin/pip3"

--- a/scripts/windows/msys2_shell.bat
+++ b/scripts/windows/msys2_shell.bat
@@ -40,4 +40,4 @@ SET "PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%"
 echo Current time: %time%
 rem Open shell
 
-%WIN_MSYS2_ROOT%\mingw64.exe
+mingw64.exe

--- a/scripts/windows/msys2_shell.bat
+++ b/scripts/windows/msys2_shell.bat
@@ -1,23 +1,43 @@
-@echo on
+@echo off
 @rem Script to open a msys2 shell ready for building.
 @rem Required vars:
 @rem    PLATFORM
 @rem    WIN_MSYS2_ROOT
+@rem    ERTS_VERSION
+@rem    JAVA_VERSION
 
 SETLOCAL ENABLEEXTENSIONS
 
 rem Set required vars defaults
 IF "%PLATFORM%"=="" SET "PLATFORM=x64"
-IF "%WIN_MSYS2_ROOT%"=="" SET "WIN_MSYS2_ROOT=C:\msys64"
+IF "%WIN_MSYS2_ROOT%"=="" FOR /F %%F IN ('where msys2') DO SET "WIN_MSYS2_ROOT=%%~dpF"
+IF "%ERTS_VERSION%"=="" SET "ERTS_VERSION=9.3"
+IF "%JAVA_VERSION%"=="" SET "JAVA_VERSION=11.0.2"
 
-@echo Current time: %time%
+echo Current time: %time%
+
+rem SET the appropriate MSVC_VERSION
+IF NOT "%MSVC_VERSION%"=="" GOTO MSVC_VERSION_SET
+FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" Microsoft.VCToolsVersion.default.txt`) DO SET "ToolsVerFile=%%F"
+FOR /F "tokens=* USEBACKQ delims=" %%F IN (`type "%ToolsVerFile%"`) DO SET MSVC_VERSION=%%F
+:MSVC_VERSION_SET
+
+rem Find and execute the VS env preparation script
+IF NOT "%vcvarsall%"=="" GOTO VCVARSALLFOUND
+FOR /F "tokens=* USEBACKQ delims=" %%F IN (`where /r "C:\Program Files (x86)\Microsoft Visual Studio" vcvarsall`) DO SET vcvarsall="%%F"
+:VCVARSALLFOUND
+call %vcvarsall% %PLATFORM%
+
+echo MSVC_VERSION=%MSVC_VERSION%
+echo ERTS_VERSION=%ERTS_VERSION%
+echo JAVA_VERSION=%JAVA_VERSION%
+echo PLATFORM=%PLATFORM%
+echo WIN_MSYS2_ROOT=%WIN_MSYS2_ROOT%
+
 rem Set the paths appropriately
+SET "PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%"
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\\vcvarsall.bat" %PLATFORM%
-@echo on
-SET PATH=%WIN_MSYS2_ROOT%\mingw64\bin;%WIN_MSYS2_ROOT%\usr\bin;%PATH%
-
-@echo Current time: %time%
+echo Current time: %time%
 rem Open shell
 
 %WIN_MSYS2_ROOT%\mingw64.exe


### PR DESCRIPTION
+ Auto detect Visual studio version and paths (allow support of VS2019)
+ Auto detect msys2 and other tools paths
+ Improve docs

Background: Building from windows is very confusing and messy because many of the current tools versions and their installation paths are different. To match the expected environment users need to decode the scripts and scan for paths and version numbers. Older versions are no longer available from the official download links and users need to search for them.