### PR TITLE
Add type checking of tail call return values in FATE

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -5200,9 +5200,18 @@ call_wrong_type(_Cfg) ->
     Contract1 = ?call(create_contract, Acc1, remote_type_check, {}),
     Contract2 = ?call(create_contract, Acc1, remote_type_check, {}),
     42        = ?call(call_contract, Acc1, Contract1, remote_id, word, {?cid(Contract2), 42}),
-    {error, Error} = ?call(call_contract, Acc1, Contract1, remote_wrong_type, word,
-                           {?cid(Contract2), <<"hello">>}),
-    ?assertMatchVM(<<"out_of_gas">>, <<"Type error on call:", _/binary>>, Error),
+    {error, Error1} = ?call(call_contract, Acc1, Contract1, remote_wrong_arg, string,
+                            {?cid(Contract2), <<"hello">>}),
+    ?assertMatchVM(<<"out_of_gas">>, <<"Type error on call:", _/binary>>, Error1),
+    {error, Error2} = ?call(call_contract, Acc1, Contract1, remote_wrong_ret, {tuple, [string]},
+                            {?cid(Contract2), <<"hello">>}),
+    ?assertMatchVM(<<"out_of_gas">>, <<"Type error on return:", _/binary>>, Error2),
+    {error, Error3} = ?call(call_contract, Acc1, Contract1, remote_wrong_ret_tailcall, word,
+                            {?cid(Contract2), <<"hello">>}),
+    ?assertMatchVM(<<"out_of_gas">>, <<"Type error on return:", _/binary>>, Error3),
+    {error, Error4} = ?call(call_contract, Acc1, Contract1, remote_wrong_ret_tailcall_type_vars, word,
+                            {?cid(Contract2), <<"hello">>}),
+    ?assertMatchVM(<<"out_of_gas">>, <<"Type error on return:", _/binary>>, Error4),
     ok.
 
 %%%===================================================================

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -258,7 +258,7 @@ all() ->
 
 groups() ->
     [ {aevm, [], ?ALL_TESTS ++ ?AEVM_SPECIFIC}
-    , {fate, [], [{group, sophia}]}%%?ALL_TESTS ++ ?FATE_SPECIFIC}
+    , {fate, [], ?ALL_TESTS ++ ?FATE_SPECIFIC}
     , {protocol_interaction, [], [ sophia_vm_interaction
                                  , create_contract_init_error_no_create_account
                                  ]}

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -200,6 +200,7 @@ push_call_stack(#es{ current_bb = BB
 %% TODO: Make better types for all these things
 -spec pop_call_stack(state()) ->
                             'empty' |
+                            {'return_check', map(), aeb_fate_data:fate_type_type(), state()} |
                             {'local', _, map(), non_neg_integer(), state()} |
                             {'remote', aeb_fate_data:fate_contract(), _, map(), non_neg_integer(), state()}.
 pop_call_stack(#es{call_stack = Stack,

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -209,7 +209,7 @@ push_call_stack(#es{ current_bb = BB
 pop_call_stack(#es{call_stack = Stack,
                    current_contract = Current} = ES) ->
     case Stack of
-        [] -> empty;
+        [] -> {empty, ES};
         [{return_check, TVars, ReturnType}| Rest] ->
             {return_check, TVars, ReturnType, ES#es{ call_stack = Rest}};
         [{gas_store, StoredGas}| Rest] ->

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -202,7 +202,7 @@ push_call_stack(#es{ current_bb = BB
 
 %% TODO: Make better types for all these things
 -spec pop_call_stack(state()) ->
-                            'empty' |
+                            {'empty', state()} |
                             {'return_check', map(), aeb_fate_data:fate_type_type(), state()} |
                             {'local', _, map(), non_neg_integer(), state()} |
                             {'remote', aeb_fate_data:fate_contract(), _, map(), non_neg_integer(), state()}.

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -66,6 +66,7 @@
         , push_arguments/2
         , push_call_stack/1
         , push_gas_cap/2
+        , push_return_type_check/3
         , spend_gas/2
         , update_for_remote_call/3
         ]).
@@ -205,6 +206,8 @@ pop_call_stack(#es{call_stack = Stack,
                    current_contract = Current} = ES) ->
     case Stack of
         [] -> empty;
+        [{return_check, TVars, ReturnType}| Rest] ->
+            {return_check, TVars, ReturnType, ES#es{ call_stack = Rest}};
         [{gas_store, StoredGas}| Rest] ->
             ES1 = ES#es{ gas = StoredGas + gas(ES)
                        , call_stack = Rest
@@ -242,6 +245,13 @@ push_gas_cap(GasCap, #es{ gas = AvailableGas
     ES#es{ call_stack = [{gas_store, AvailableGas - GasCap}|Stack]
          , gas        = GasCap
          }.
+
+-spec push_return_type_check(aeb_fate_data:fate_type_type(), #{}, state()) -> state().
+push_return_type_check(RetType, TVars, #es{ call_stack = Stack} = ES) ->
+    %% Note that the TVars must correspond to the bindings for the
+    %% return type.  Typically, the current_tvars corresponds to the
+    %% next function in the call stack.
+    ES#es{ call_stack = [{return_check, TVars, RetType}|Stack]}.
 
 -spec push_accumulator(aeb_fate_data:fate_type(), state()) -> state().
 push_accumulator(V, #es{ accumulator = ?FATE_VOID

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -564,8 +564,8 @@ push_gas_cap(Gas, ES) when ?IS_FATE_INTEGER(Gas) ->
 
 pop_call_stack(ES) ->
     case aefa_engine_state:pop_call_stack(ES) of
-        empty ->
-            {stop, ES};
+        {empty, ES1} ->
+            {stop, ES1};
         {return_check, TVars, RetType, ES1} ->
             ES2 = check_return_type(RetType, TVars, ES1),
             pop_call_stack(ES2);

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -205,8 +205,8 @@ call_gtr(Arg0, Arg1, Arg2, Arg3, EngineState) ->
     Caller = aefa_engine_state:current_function(EngineState),
     CallerSignature = aefa_fate:get_function_signature(Caller, EngineState),
     CallerTvars = aefa_engine_state:current_tvars(EngineState),
-    ES5 = aefa_fate:push_return_type_check(Signature, CallerSignature, CallerTvars, ES4),
-    ES6 = aefa_fate:push_gas_cap(GasCap, ES5),
+    ES5 = aefa_fate:push_gas_cap(GasCap, ES4),
+    ES6 = aefa_fate:push_return_type_check(Signature, CallerSignature, CallerTvars, ES5),
     {jump, 0, ES6}.
 
 remote_call_common(Contract, Function, Value, EngineState) ->

--- a/apps/aefate/test/aefate_engine_test.erl
+++ b/apps/aefate/test/aefate_engine_test.erl
@@ -273,9 +273,7 @@ fail() ->
       || {F, A, R} <-
             [ {<<"bad_poly_return">>,       [1, <<"string">>], {error, <<"Type error on return: <<\"string\">> is not of type integer">>}}
             , {<<"bad_return_after_call">>, [false], {error, <<"Type error on return: 3 is not of type boolean">>}}
-            , {<<"bad_tail_call_return">>,  [false], 1}
-                %% TODO: currently type checks on tail calls are not working (no check that inner return type and outer return type match)
-                %% {error, <<"Type error on return: 1 is not of type boolean">>}}
+            , {<<"bad_tail_call_return">>,  [false], {error, <<"Type error on return: 1 is not of type boolean">>}}
             ]
     ].
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1146,7 +1146,7 @@ remote_gas_test_contract(Config) ->
     call_get(APub, APriv, EncC2Pub, Contract, 100),
     force_fun_calls(Node),
     Balance1 = get_balance(APub),
-    ?assertMatchVM(1600476, 1600010, (Balance0 - Balance1) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(1600596, 1600010, (Balance0 - Balance1) div ?DEFAULT_GAS_PRICE),
 
     %% Test remote call with limited gas
     %% Call contract remote set function with limited gas
@@ -1154,13 +1154,13 @@ remote_gas_test_contract(Config) ->
     call_get(APub, APriv, EncC2Pub, Contract, 1),
     force_fun_calls(Node),
     Balance2 = get_balance(APub),
-    ?assertMatchVM(1610687, 1600034, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(1610855, 1600034, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
 
     %% Test remote call with limited gas (3) that fails (out of gas).
     [] = call_func(APub, APriv, EncC1Pub, Contract, "call", [EncC2Pub, "2", "3"], error),
     force_fun_calls(Node),
     Balance3 = get_balance(APub),
-    ?assertMatchVM(809933, 800019, (Balance2 - Balance3) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(809981, 800019, (Balance2 - Balance3) div ?DEFAULT_GAS_PRICE),
 
     %% Check that store/state not changed (we tried to write 2).
     call_get(APub, APriv, EncC2Pub, Contract, 1),

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1154,7 +1154,7 @@ remote_gas_test_contract(Config) ->
     call_get(APub, APriv, EncC2Pub, Contract, 1),
     force_fun_calls(Node),
     Balance2 = get_balance(APub),
-    ?assertMatchVM(1610687, 1620018, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(1610687, 1600034, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
 
     %% Test remote call with limited gas (3) that fails (out of gas).
     [] = call_func(APub, APriv, EncC1Pub, Contract, "call", [EncC2Pub, "2", "3"], error),

--- a/test/contracts/remote_gas_test.aes
+++ b/test/contracts/remote_gas_test.aes
@@ -1,10 +1,16 @@
 contract Remote1 =
   entrypoint set : (int) => int
+  entrypoint bogus_return : (int) => string
 
 contract RemoteCall =
     record state = { i : int }
 
     entrypoint init(x) = { i = x }
+
+    entrypoint bogus_return(x) = x
+
+    entrypoint bogus_remote(r : Remote1, x : int, g : int) =
+       r.bogus_return(gas = g, x)
 
     stateful entrypoint set( x : int) : int =
         let old = state.i

--- a/test/contracts/remote_type_check.aes
+++ b/test/contracts/remote_type_check.aes
@@ -1,15 +1,23 @@
 contract Remote =
   entrypoint id : ('a) => 'a
   entrypoint missing : ('a) => 'a
-  entrypoint wrong_type : (string) => string
+  entrypoint bogus_string_string_arg : (string) => string
+  entrypoint bogus_string_string_ret : (string) => string
+  entrypoint bogus_id : ('a) => ('a)
 
 contract Main =
 
   entrypoint id(x : int) =
     x
 
-  entrypoint wrong_type(x : int) =
-    x
+  entrypoint bogus_id(x) =
+    (x, x)
+
+  entrypoint bogus_string_string_arg(x : int) =
+    "hello"
+
+  entrypoint bogus_string_string_ret(x : string) =
+    42
 
   entrypoint remote_id(r : Remote, x) =
     r.id(x)
@@ -17,6 +25,14 @@ contract Main =
   entrypoint remote_missing(r : Remote, x) =
     r.missing(x)
 
-  entrypoint remote_wrong_type(r : Remote, x) =
-    r.wrong_type(x)
+  entrypoint remote_wrong_arg(r : Remote, x) =
+    r.bogus_string_string_arg(x)
 
+  entrypoint remote_wrong_ret(r : Remote, x) =
+    (r.bogus_string_string_ret(x), r.bogus_string_string_ret(x))
+
+  entrypoint remote_wrong_ret_tailcall(r : Remote, x) : string =
+    r.bogus_string_string_ret(x)
+
+  entrypoint remote_wrong_ret_tailcall_type_vars(r : Remote, x) =
+    r.bogus_id(x)

--- a/test/contracts/sophia_2/remote_gas_test.aes
+++ b/test/contracts/sophia_2/remote_gas_test.aes
@@ -1,10 +1,16 @@
 contract Remote1 =
   function set : (int) => int
+  function bogus_return : (int) => string
 
 contract RemoteCall =
     record state = { i : int }
 
     function init(x) = { i = x }
+
+    function bogus_return(x) = x
+
+    function bogus_remote(r : Remote1, x : int, g : int) =
+       r.bogus_return(gas = g, x)
 
     stateful function set( x : int) : int =
         let old = state.i

--- a/test/contracts/sophia_2/remote_type_check.aes
+++ b/test/contracts/sophia_2/remote_type_check.aes
@@ -1,15 +1,23 @@
 contract Remote =
   function id : ('a) => 'a
   function missing : ('a) => 'a
-  function wrong_type : (string) => string
+  function bogus_string_string_arg : (string) => string
+  function bogus_string_string_ret : (string) => string
+  function bogus_id : ('a) => ('a)
 
 contract Main =
 
   function id(x : int) =
     x
 
-  function wrong_type(x : int) =
-    x
+  function bogus_id(x) =
+    (x, x)
+
+  function bogus_string_string_arg(x : int) =
+    "hello"
+
+  function bogus_string_string_ret(x : string) =
+    42
 
   function remote_id(r : Remote, x) =
     r.id(x)
@@ -17,6 +25,14 @@ contract Main =
   function remote_missing(r : Remote, x) =
     r.missing(x)
 
-  function remote_wrong_type(r : Remote, x) =
-    r.wrong_type(x)
+  function remote_wrong_arg(r : Remote, x) =
+    r.bogus_string_string_arg(x)
 
+  function remote_wrong_ret(r : Remote, x) =
+    (r.bogus_string_string_ret(x), r.bogus_string_string_ret(x))
+
+  function remote_wrong_ret_tailcall(r : Remote, x) : string =
+    r.bogus_string_string_ret(x)
+
+  function remote_wrong_ret_tailcall_type_vars(r : Remote, x) =
+    r.bogus_id(x)


### PR DESCRIPTION
This is a crude solution of the problem stated in https://www.pivotaltracker.com/story/show/164302162
In particular, it reduces the tail call constant stack optimization.

We should tackle this in a more sophisticated way, but now at least it works. Creating a new PT ticket to make this properly.