### PR TITLE
Support multiple SC responder keys per port

### DIFF
--- a/apps/aechannel/src/aesc_codec.erl
+++ b/apps/aechannel/src/aesc_codec.erl
@@ -98,7 +98,8 @@ dec(<<?c(?ID_INBAND_MSG)   , B/bytes>>) -> {?INBAND_MSG  , dec_inband_msg(B)}.
                        , initiator_amount     := amount()
                        , responder_amount     := amount()
                        , channel_reserve      := amount()
-                       , initiator            := pubkey()}.
+                       , initiator            := pubkey()
+                       , responder            := pubkey()}.
 
 -spec enc_ch_open(ch_open_msg()) -> binary().
 enc_ch_open(#{chain_hash := ChainHash

--- a/apps/aechannel/src/aesc_codec.erl
+++ b/apps/aechannel/src/aesc_codec.erl
@@ -108,7 +108,8 @@ enc_ch_open(#{chain_hash := ChainHash
             , initiator_amount     := InitiatorAmt
             , responder_amount     := ResponderAmt
             , channel_reserve      := ChanReserve
-            , initiator            := InitiatorPubkey}) ->
+            , initiator            := InitiatorPubkey
+            , responder            := ResponderPubkey}) ->
     << ?ID_CH_OPEN    :1 /unit:8
      , ChainHash      :32/binary
      , ChanId         :32/binary
@@ -117,7 +118,8 @@ enc_ch_open(#{chain_hash := ChainHash
      , InitiatorAmt   :8 /unit:8
      , ResponderAmt   :8 /unit:8
      , ChanReserve    :8 /unit:8
-     , InitiatorPubkey:32/binary >>.
+     , InitiatorPubkey:32/binary
+     , ResponderPubkey:32/binary >>.
 
 -spec dec_ch_open(binary()) -> ch_open_msg().
 dec_ch_open(<< ChainHash      :32/binary
@@ -127,7 +129,8 @@ dec_ch_open(<< ChainHash      :32/binary
              , InitiatorAmt   :8 /unit:8
              , ResponderAmt   :8 /unit:8
              , ChanReserve    :8 /unit:8
-             , InitiatorPubkey:32/binary >>) ->
+             , InitiatorPubkey:32/binary
+             , ResponderPubkey:32/binary>>) ->
     #{ chain_hash           => ChainHash
      , temporary_channel_id => ChanId
      , lock_period          => LockPeriod
@@ -135,7 +138,8 @@ dec_ch_open(<< ChainHash      :32/binary
      , initiator_amount     => InitiatorAmt
      , responder_amount     => ResponderAmt
      , channel_reserve      => ChanReserve
-     , initiator            => InitiatorPubkey}.
+     , initiator            => InitiatorPubkey
+     , responder            => ResponderPubkey }.
 
 
 -type ch_accept_msg() :: #{ chain_hash           := hash()
@@ -144,6 +148,7 @@ dec_ch_open(<< ChainHash      :32/binary
                           , initiator_amount     := amount()
                           , responder_amount     := amount()
                           , channel_reserve      := amount()
+                          , initiator            := pubkey()
                           , responder            := pubkey()}.
 
 -spec enc_ch_accept(ch_accept_msg()) -> binary().
@@ -153,6 +158,7 @@ enc_ch_accept(#{ chain_hash           := ChainHash
                , initiator_amount     := InitiatorAmt
                , responder_amount     := ResponderAmt
                , channel_reserve      := ChanReserve
+               , initiator            := Initiator
                , responder            := Responder}) ->
     << ?ID_CH_ACCEPT  :1 /unit:8
      , ChainHash      :32/binary
@@ -161,6 +167,7 @@ enc_ch_accept(#{ chain_hash           := ChainHash
      , InitiatorAmt   :8 /unit:8
      , ResponderAmt   :8 /unit:8
      , ChanReserve    :8 /unit:8
+     , Initiator      :32/binary
      , Responder      :32/binary >>.
 
 -spec dec_ch_accept(binary()) -> ch_accept_msg().
@@ -170,6 +177,7 @@ dec_ch_accept(<< ChainHash      :32/binary
                , InitiatorAmt   :8 /unit:8
                , ResponderAmt   :8 /unit:8
                , ChanReserve    :8 /unit:8
+               , Initiator      :32/binary
                , Responder      :32/binary >>) ->
     #{ chain_hash           => ChainHash
      , temporary_channel_id => ChanId
@@ -177,6 +185,7 @@ dec_ch_accept(<< ChainHash      :32/binary
      , initiator_amount     => InitiatorAmt
      , responder_amount     => ResponderAmt
      , channel_reserve      => ChanReserve
+     , initiator            => Initiator
      , responder            => Responder}.
 
 

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1983,6 +1983,7 @@ send_open_msg(#data{opts       = Opts,
            , responder_amount     => ResponderAmount
            , channel_reserve      => ChannelReserve
            , initiator            => Initiator
+           , responder            => Responder
            },
     aesc_session_noise:channel_open(Sn, Msg),
     Data#data{ channel_id = ChannelPubKey
@@ -1995,7 +1996,8 @@ check_open_msg(#{ chain_hash           := ChainHash
                 , initiator_amount     := InitiatorAmt
                 , responder_amount     := ResponderAmt
                 , channel_reserve      := ChanReserve
-                , initiator            := InitiatorPubkey} = Msg,
+                , initiator            := InitiatorPubkey
+                , responder            := ResponderPubkey } = Msg,
                #data{opts = Opts} = Data) ->
     %% TODO: Implement more checks
     case aec_chain:genesis_hash() of
@@ -2003,6 +2005,7 @@ check_open_msg(#{ chain_hash           := ChainHash
             Opts1 =
                 Opts#{ lock_period        => LockPeriod
                      , initiator          => InitiatorPubkey
+                     , responder          => ResponderPubkey
                      , push_amount        => PushAmt
                      , initiator_amount   => InitiatorAmt
                      , responder_amount   => ResponderAmt
@@ -2147,9 +2150,10 @@ send_channel_accept(#data{opts          = Opts,
                           session       = Sn,
                           channel_id    = ChanId} = Data) ->
     #{ minimum_depth      := MinDepth
-     , responder        := Responder
+     , initiator          := Initiator
+     , responder          := Responder
      , initiator_amount   := InitiatorAmt
-     , responder_amount := ResponderAmt
+     , responder_amount   := ResponderAmt
      , channel_reserve    := ChanReserve } = Opts,
     ChainHash = aec_chain:genesis_hash(),
     Msg = #{ chain_hash           => ChainHash
@@ -2158,6 +2162,7 @@ send_channel_accept(#data{opts          = Opts,
            , initiator_amount     => InitiatorAmt
            , responder_amount     => ResponderAmt
            , channel_reserve      => ChanReserve
+           , initiator            => Initiator
            , responder            => Responder
            },
     aesc_session_noise:channel_accept(Sn, Msg),
@@ -2169,6 +2174,7 @@ check_accept_msg(#{ chain_hash           := ChainHash
                   , initiator_amount     := _InitiatorAmt
                   , responder_amount     := _ResponderAmt
                   , channel_reserve      := _ChanReserve
+                  , initiator            := Initiator
                   , responder            := Responder} = Msg,
                  #data{channel_id = ChanId,
                        opts = Opts} = Data) ->
@@ -2177,6 +2183,7 @@ check_accept_msg(#{ chain_hash           := ChainHash
         ChainHash ->
             Log1 = log_msg(rcv, ?CH_ACCEPT, Msg, Data#data.log),
             {ok, Data#data{ opts = Opts#{ minimum_depth => MinDepth
+                                        , initiator     => Initiator
                                         , responder     => Responder}
                           , log = Log1 }};
         _ ->

--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -232,5 +232,5 @@ get_lsock_info(Items, I, St) when is_list(Items) ->
               get_lsock_info(Item, Acc, St)
       end, I, Items);
 get_lsock_info(all, I, St) ->
-    get_lsock_info([pids, responder], I, St).
+    get_lsock_info([pids, responders], I, St).
 

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -362,8 +362,10 @@ create_channel(Cfg) ->
 
 multiple_responder_keys_per_port(Cfg) ->
     Slogan = ?SLOGAN,
-    Debug = get_debug(Cfg),
+    %% Debug = get_debug(Cfg),
+    Debug = true,
     {_, Responder2} = lists:keyfind(responder2, 1, Cfg),
+    ct:log("Responder2 = ~p", [Responder2]),
     Cfg2 = lists:keyreplace(responder, 1, Cfg, {responder, Responder2}),
     Me = self(),
     Initiator = maps:get(pub, ?config(initiator, Cfg)),
@@ -373,7 +375,7 @@ multiple_responder_keys_per_port(Cfg) ->
                                 {nonce, Nonce + N - 1},
                                 {minimum_depth, 0},
                                 {slogan, {Slogan, N}} | CfgX], #{mine_blocks => {ask, Me},
-                                                                 debug => Debug})
+                                                                 debug => Debug}, false)
           || {N, CfgX} <- [{1, Cfg}, {2, Cfg2}]],
     ct:log("channels spawned", []),
     CsAcks = collect_acks_w_payload(Cs, mine_blocks, 2),
@@ -1520,12 +1522,18 @@ collect_acks_w_payload([], _Tag, _) ->
 
 
 create_multi_channel(Cfg, Debug) ->
+    create_multi_channel(Cfg, Debug, true).
+
+create_multi_channel(Cfg, Debug, UseAny) ->
     spawn_link(fun() ->
-                       create_multi_channel_(Cfg, Debug)
+                       create_multi_channel_(Cfg, Debug, UseAny)
                end).
 
-create_multi_channel_(Cfg, Debug) ->
-    #{i := I, r := R} = create_channel_([multi | Cfg], Debug),
+create_multi_channel_(Cfg0, Debug, UseAny) when is_boolean(UseAny) ->
+    Cfg = if UseAny -> [ use_any | Cfg0 ];
+             true   -> Cfg0
+          end,
+    #{i := I, r := R} = create_channel_(Cfg, Debug),
     Parent = ?config(ack_to, Cfg),
     Parent ! {self(), channel_ack},
     ch_loop(I, R, Parent, Cfg).
@@ -1558,7 +1566,7 @@ create_channel_(Cfg, Debug) ->
     {I, R, Spec} = channel_spec(Cfg),
     log(Debug, "channel_spec: ~p", [{I, R, Spec}]),
     Port = proplists:get_value(port, Cfg, 9325),
-    create_channel_from_spec(I, R, Spec, Port, proplists:get_bool(multi, Cfg),
+    create_channel_from_spec(I, R, Spec, Port, proplists:get_bool(use_any, Cfg),
                              Debug, Cfg).
 
 channel_spec(Cfg) ->
@@ -1606,8 +1614,8 @@ slogan(Cfg) ->
 create_channel_from_spec(I, R, Spec, Port, Debug, Cfg) ->
     create_channel_from_spec(I, R, Spec, Port, false, Debug, Cfg).
 
-create_channel_from_spec(I, R, Spec, Port, Multi, Debug, Cfg) ->
-    RProxy = spawn_responder(Port, Spec, R, Multi, Debug),
+create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
+    RProxy = spawn_responder(Port, Spec, R, UseAny, Debug),
     IProxy = spawn_initiator(Port, Spec, I, Debug),
     log("RProxy = ~p, IProxy = ~p", [RProxy, IProxy]),
     #{ i := #{ fsm := FsmI } = I1
@@ -1655,19 +1663,18 @@ create_channel_from_spec(I, R, Spec, Port, Multi, Debug, Cfg) ->
     check_info(500, Debug),
     #{i => I5, r => R5, spec => Spec}.
 
-spawn_responder(Port, Spec, R, Multi, Debug) ->
+spawn_responder(Port, Spec, R, UseAny, Debug) ->
     Me = self(),
     spawn_link(fun() ->
                        log("responder spawned: ~p", [Spec]),
-                       Spec1 = maybe_multi(Multi, Spec#{ client => self()
-                                                       , initiator => any }),
+                       Spec1 = maybe_use_any(UseAny, Spec#{ client => self() }),
                        {ok, Fsm} = rpc(dev1, aesc_fsm, respond, [Port, Spec1], Debug),
                        responder_instance_(Fsm, Spec1, R, Me, Debug)
                end).
 
-maybe_multi(true, Spec) ->
+maybe_use_any(true, Spec) ->
     Spec#{initiator => any};
-maybe_multi(false, Spec) ->
+maybe_use_any(false, Spec) ->
     Spec.
 
 spawn_initiator(Port, Spec, I, Debug) ->
@@ -1693,6 +1700,7 @@ match_responder_and_initiator(RProxy, Debug) ->
 responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
     R = fsm_map(Fsm, Spec, R0),
     {ok, ChOpen} = receive_from_fsm(info, R, channel_open, ?TIMEOUT, Debug),
+    ct:log("Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
     #{data := #{temporary_channel_id := TmpChanId}} = ChOpen,
     gproc:reg({n,l,{?MODULE,TmpChanId,responder}}, #{ r => R#{ proxy => self()
                                                              , parent => Parent }}),
@@ -1708,6 +1716,7 @@ responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
 initiator_instance_(Fsm, Spec, I0, Parent, Debug) ->
     I = fsm_map(Fsm, Spec, I0),
     {ok, ChAccept} = receive_from_fsm(info, I, channel_accept, ?TIMEOUT, Debug),
+    ct:log("Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
     #{data := #{temporary_channel_id := TmpChanId}} = ChAccept,
     gproc:reg({n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I#{ proxy => self() }
                                                     , channel_accept => ChAccept}),
@@ -1836,8 +1845,9 @@ await_signing_request(Tag, #{fsm := Fsm} = Signer,
     await_signing_request(Tag, #{fsm := Fsm} = Signer,
                           Action, Timeout, Debug, Cfg, according_account).
 
-await_signing_request(Tag, #{fsm := Fsm} = Signer,
+await_signing_request(Tag, #{fsm := Fsm, pub := Pub} = Signer,
                       Action, Timeout, Debug, Cfg, SignatureType) ->
+    log("await_signing_request, Fsm = ~p (Pub = ~p)", [Fsm, Pub]),
     receive {aesc_fsm, Fsm, #{type := sign, tag := Tag,
                               info := #{signed_tx := SignedTx0,
                                         updates   := Updates}} = Msg} ->

--- a/docs/release-notes/next/PT-167194534-SC-multiple-responder-keys-per-port.md
+++ b/docs/release-notes/next/PT-167194534-SC-multiple-responder-keys-per-port.md
@@ -1,0 +1,3 @@
+* Multiple different State Channel responder pubkeys can now share the same listen port
+* The `channel_open` and `channel_accept` messages now contain both the initiator and
+  responder public keys. This is not backwards compatible for the `noise` protocol.


### PR DESCRIPTION
See [PT #167194534](https://www.pivotaltracker.com/story/show/167194534)

Note: at initial push, there are no test cases testing multiple responder keys listening on the same port. Nor are there tests for the logic that is supposed to kick in if an accept times out.