### PR TITLE
Bump CI to recognize tag for v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ references:
           && ./configure && make -j$(nproc) && sudo make install && sudo ldconfig
 
   tag_regex: &tag_regex /^v.*$/
-  stable_tag_regex: &stable_tag_regex /^v3\..*$/
+  stable_tag_regex: &stable_tag_regex /^v4\..*$/
 
   rebar_cache_key: &rebar_cache_key rebar-cache-{{ checksum "rebar.lock" }}-{{ checksum "rebar.config" }}
   restore_rebar_cache: &restore_rebar_cache


### PR DESCRIPTION
In scope of https://www.pivotaltracker.com/story/show/167061956

See also #2442