### PR TITLE
Improve FSM in order to compute fees dynamically

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1285,7 +1285,7 @@ new_onchain_tx_for_signing(Type, Opts, D) ->
 new_onchain_tx_for_signing_(Type, Opts, D) ->
     Defaults = tx_defaults(Type, Opts, D),
     Opts1 = maps:merge(Defaults, Opts),
-    CurrHeight = cur_height(),
+    CurrHeight = curr_height(),
     {ok, Tx, Updates} = new_onchain_tx(Type, Opts1, D, CurrHeight),
     case {aetx:min_fee(Tx, CurrHeight), aetx:fee(Tx)} of
         {MinFee, Fee} when MinFee =< Fee ->
@@ -1580,10 +1580,10 @@ get_nonce(Pubkey) ->
 %% we have an actual transaction record (required by aetx:min_fee/2).
 %% The default should err on the side of being too low.
 default_fee(_Tx) ->
-    CurHeight = aec_headers:height(aec_chain:top_header()),
+    CurrHeight = aec_headers:height(aec_chain:top_header()),
     %% this could be fragile on hard fork height if one participant's node had
     %% already forked and the other had not yet
-    20000 * max(aec_governance:minimum_gas_price(CurHeight),
+    20000 * max(aec_governance:minimum_gas_price(CurrHeight),
                 aec_tx_pool:minimum_miner_gas_price()).
 
 default_ttl(_Type, Opts, #data{opts = DOpts}) ->
@@ -1591,12 +1591,12 @@ default_ttl(_Type, Opts, #data{opts = DOpts}) ->
     Opts#{ttl => adjust_ttl(TTL)}.
 
 adjust_ttl(undefined) ->
-    CurHeight = aec_headers:height(aec_chain:top_header()),
-    CurHeight + 100;
+    CurrHeight = aec_headers:height(aec_chain:top_header()),
+    CurrHeight + 100;
 adjust_ttl(TTL) when is_integer(TTL), TTL >= 0 ->
     TTL.
 
-cur_height() ->
+curr_height() ->
     aec_headers:height(aec_chain:top_header()).
 
 
@@ -2962,7 +2962,7 @@ has_gproc_key(Fsm, #{gproc_key := K}) ->
 
 is_channel_locked(0) -> false;
 is_channel_locked(LockedUntil) ->
-    LockedUntil >= cur_height().
+    LockedUntil >= curr_height().
 
 withdraw_locked_complete(SignedTx, Updates, #data{state = State, opts = Opts} = D) ->
     {OnChainEnv, OnChainTrees} =
@@ -3443,4 +3443,4 @@ init_checks(Opts) ->
 
 is_fork_active(ProtocolVSN) ->
     %% Enable a new fork only after MINIMUM_DEPTH generations in order to avoid fork changes
-    ProtocolVSN == aec_hard_forks:protocol_effective_at_height(max(cur_height() - ?MINIMUM_DEPTH, aec_block_genesis:height())).
+    ProtocolVSN == aec_hard_forks:protocol_effective_at_height(max(curr_height() - ?MINIMUM_DEPTH, aec_block_genesis:height())).

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1458,15 +1458,15 @@ new_onchain_tx_(Mod, Opts, CurrHeight) ->
         true -> % use preset fee
             apply(Mod, new, [Opts]);
         false ->
-            create_with_minuimum_fee(Mod, Opts#{fee => 0}, CurrHeight)
+            create_with_minimum_fee(Mod, Opts#{fee => 0}, CurrHeight)
     end.
 
-create_with_minuimum_fee(Mod, Opts, CurrHeight) ->
-    create_with_minuimum_fee(Mod, Opts, CurrHeight, 5).
+create_with_minimum_fee(Mod, Opts, CurrHeight) ->
+    create_with_minimum_fee(Mod, Opts, CurrHeight, 5).
 
-create_with_minuimum_fee(_, _, _, Attempts) when Attempts < 1 ->
+create_with_minimum_fee(_, _, _, Attempts) when Attempts < 1 ->
     erlang:error(could_not_compute_fee);
-create_with_minuimum_fee(Mod, Opts, CurrHeight, Attempts) ->
+create_with_minimum_fee(Mod, Opts, CurrHeight, Attempts) ->
     {ok, Tx} = apply(Mod, new, [Opts]),
     MinTxFee = aetx:min_fee(Tx, CurrHeight),
     MinGas = aetx:min_gas(Tx, CurrHeight),
@@ -1478,7 +1478,7 @@ create_with_minuimum_fee(Mod, Opts, CurrHeight, Attempts) ->
         true ->
             {ok, Tx};
         false ->
-            create_with_minuimum_fee(Mod, Opts#{fee => MinFee}, CurrHeight,
+            create_with_minimum_fee(Mod, Opts#{fee => MinFee}, CurrHeight,
                                      Attempts - 1)
     end.
 

--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -204,3 +204,8 @@
                       TxHash :: binary(), aetx_sign:signed_tx(),
                       [aesc_offchain_update:update()]}
                    | {reestablish, OffChainTx :: aetx_sign:signed_tx()}.
+
+-define(DEFAULT_FSM_TX_GAS, 20000).
+
+-define(DEFAULT_FSM_TX_TTL_DELTA, 100).
+

--- a/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
+++ b/apps/aechannel/src/aesc_fsm_min_depth_watcher.erl
@@ -575,25 +575,25 @@ watch_for_channel_change(R, St, #{ scenario := Scenario } = C)
             lager:debug("Will not check channel", []),
             {R, C};
         _ ->
-            {CurHeight, C1} = top_height(C),
+            {CurrHeight, C1} = top_height(C),
             lager:debug("Will check channel on chain (~p)", [Scenario]),
-            watch_for_channel_change(CurHeight, R, St, C1)
+            watch_for_channel_change(CurrHeight, R, St, C1)
     end.
 
-watch_for_channel_change(CurHeight, R, #st{chan_id = ChanId} = St, C) ->
+watch_for_channel_change(CurrHeight, R, #st{chan_id = ChanId} = St, C) ->
     lager:debug("Will check channel status (V=~p)", [St#st.chan_vsn]),
     {Status, C1} = channel_status(ChanId, C),
     lager:debug("Status = ~p", [Status]),
-    watch_for_change_in_ch_status(Status, CurHeight, R, St, C1).
+    watch_for_change_in_ch_status(Status, CurrHeight, R, St, C1).
 
-watch_for_change_in_ch_status(undefined, _CurHeight, R, _St, C) ->
+watch_for_change_in_ch_status(undefined, _CurrHeight, R, _St, C) ->
     lager:debug("No channel object yet", []),
     {R, C};
-watch_for_change_in_ch_status(Status, _CurHeight, R, St, C) ->
+watch_for_change_in_ch_status(Status, _CurrHeight, R, St, C) ->
     case Status of
         #{changed := true} ->
             lager:debug("Channel has changed: ~p", [Status]),
-            %% NextHeight = calc_next_height(Status, CurHeight, St),
+            %% NextHeight = calc_next_height(Status, CurrHeight, St),
             #{callback_mod := Mod, parent := Parent} = maps:get(info, R),
             C1 = report_status_change(Status, Mod, Parent, St, C),
             {R, C1};

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -299,6 +299,7 @@ min_gas_price(AETx = #aetx{ type = Type, cb = CB, tx = Tx, size = Size }, Height
 min_fee(#aetx{} = AeTx, Height) ->
     min_gas(AeTx, Height) * aec_governance:minimum_gas_price(Height).
 
+-spec min_gas(Tx :: tx(), Height :: aec_blocks:height()) -> Gas :: non_neg_integer().
 min_gas(#aetx{ type = Type, size = Size }, Height) when ?IS_CONTRACT_TX(Type) ->
     base_gas(Type, Height) + size_gas(Size);
 min_gas(#aetx{} = Tx, Height) ->

--- a/docs/release-notes/next/PT-167254422_fix_fee_in_FSM.md
+++ b/docs/release-notes/next/PT-167254422_fix_fee_in_FSM.md
@@ -1,0 +1,2 @@
+* Improves State Channel FSM to compute transaction fees in a dynamic manner.
+  This will usually result in smaller fees being paid by participants.


### PR DESCRIPTION
[Integration test plain.sc_ws_slash failed on CI -- max_reached](https://www.pivotaltracker.com/story/show/167254422)
The issue was caused by FSM using hardcoded fee of `30 000 * local gas price` (or 33 000) for all transactions. In certain cases this was insufficant and transaction was rejected.

This PR introduces computing the fee according the transaction instead. The only transaction type that still uses hardcoded fee is `channel_mutual_close_tx` as the fee is important component in participant amounts' computation.
