### PR TITLE
PT 165082649 FSM clean up

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -425,7 +425,7 @@ awaiting_leave_ack(cast, {?LEAVE_ACK, Msg}, D) ->
             close(Err, D)
     end;
 awaiting_leave_ack(timeout, awaiting_leave_ack = T, D) ->
-    close({timeout, T}, D);
+    close({normal, T}, D);
 awaiting_leave_ack(cast, {?LEAVE, Msg}, D) ->
     case check_leave_msg(Msg, D) of
         {ok, D1} ->
@@ -845,7 +845,7 @@ dep_signed(cast, {?DEP_LOCKED, Msg}, #data{latest = {deposit, SignedTx,
             close(Error, D)
     end;
 dep_signed(timeout, dep_signed = T, D) ->
-    close({timeout, T}, D);
+    close({normal, T}, D);
 dep_signed(cast, {?SHUTDOWN, _Msg}, D) ->
     next_state(mutual_closing, D);
 dep_signed(Type, Msg, D) ->
@@ -3343,7 +3343,7 @@ handle_common_event(E, Msg, M, #data{cur_statem_state = St} = D) ->
     handle_common_event_(E, Msg, St, M, D).
 
 handle_common_event_(timeout, St = T, St, _, D) ->
-    close({timeout, T}, D);
+    close({normal, T}, D);
 handle_common_event_(cast, {?DISCONNECT, _} = Msg, _St, _, D) ->
     D1 = log(rcv, ?DISCONNECT, Msg, D),
     case D1#data.channel_status of

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -108,7 +108,8 @@
 %% -include_lib("trace_runner/include/trace_runner.hrl").
 
 -ifdef(TEST).
--export([strict_checks/2]).
+-export([strict_checks/2,
+         stop/1]).
 -endif.
 
 %% ==================================================================
@@ -363,6 +364,11 @@ channel_unlocked(Fsm, Info) ->
 -spec strict_checks(pid(), boolean()) -> ok.
 strict_checks(Fsm, Strict) when is_boolean(Strict) ->
     gen_statem:call(Fsm, {strict_checks, Strict}).
+
+-spec stop(pid()) -> ok.
+stop(Fsm) ->
+    lager:debug("Gracefully stopping the FSM", [Fsm]),
+    stop_ok(catch gen_statem:stop(Fsm)).
 -endif.
 
 %% ======================================================================

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -367,7 +367,7 @@ strict_checks(Fsm, Strict) when is_boolean(Strict) ->
 
 -spec stop(pid()) -> ok.
 stop(Fsm) ->
-    lager:debug("Gracefully stopping the FSM", [Fsm]),
+    lager:debug("Gracefully stopping the FSM ~p", [Fsm]),
     stop_ok(catch gen_statem:stop(Fsm)).
 -endif.
 

--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -66,6 +66,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 init([]) ->
+    process_flag(trap_exit, true),
     {ok, #st{}}.
 
 

--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -66,7 +66,6 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 init([]) ->
-    process_flag(trap_exit, true),
     {ok, #st{}}.
 
 

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1822,7 +1822,7 @@ fsm_relay_(#{ fsm := Fsm } = Map, Parent, Debug) ->
             Parent ! Msg;
         {Parent, die} ->
             ct:log("Got 'die' from parent", []),
-            exit(Fsm, die),
+            aesc_fsm:stop(Fsm),
             ct:log("relay stopping (die)", []),
             exit(normal);
         Other ->

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -2316,6 +2316,7 @@ sc_ws_timeout_open_(Config) ->
                                   #{timeout_accept => 500}, Config),
     {ok, IConnPid} = channel_ws_start(initiator, maps:put(host, <<"localhost">>, ChannelOpts), Config),
     ok = ?WS:register_test_for_channel_event(IConnPid, info),
+    ok = wait_for_channel_event(<<"timeout">>, IConnPid, info, Config),
     ok = wait_for_channel_event(<<"died">>, IConnPid, info, Config),
     ok = ?WS:unregister_test_for_channel_event(IConnPid, info),
     ok.
@@ -2367,7 +2368,9 @@ sc_ws_min_depth_not_reached_timeout_(Config) ->
     aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                        ?DEFAULT_MIN_DEPTH - 2),
 
+    ok = wait_for_channel_event(<<"timeout">>, IConnPid, info, Config),
     ok = wait_for_channel_event(<<"died">>, IConnPid, info, Config),
+    ok = wait_for_channel_event(<<"timeout">>, RConnPid, info, Config),
     ok = wait_for_channel_event(<<"died">>, RConnPid, info, Config),
     ok.
 

--- a/docs/release-notes/next/PT-165082649_SC_WS_improve_timeout_msgs
+++ b/docs/release-notes/next/PT-165082649_SC_WS_improve_timeout_msgs
@@ -1,3 +1,6 @@
-* Sends a more descriptive message to the client if the FSM dies because of a
-  timeout. Old message used to have an info "died" while the new ones have
-  "timeout" instead
+* The process that handles the state for the State Channel client in the node
+  has a list of different timeouts. They define different time frames for
+  certain events to be completed. Running out of time is a violation of the
+  off-chain protocol so if it happens - the connection is closed and it is up
+  to the State Channel client how to proceed next. This enhances user
+  experience adding a new info message for the timeouts.

--- a/docs/release-notes/next/PT-165082649_SC_WS_improve_timeout_msgs
+++ b/docs/release-notes/next/PT-165082649_SC_WS_improve_timeout_msgs
@@ -1,0 +1,3 @@
+* Sends a more descriptive message to the client if the FSM dies because of a
+  timeout. Old message used to have an info "died" while the new ones have
+  "timeout" instead


### PR DESCRIPTION
[State channel FSM integration test failed on CI hanging](https://www.pivotaltracker.com/story/show/165082649)

Although I could not trace the hanging issue to the channel's FSM and the failed test in particular, this PR:
* changes FSM process not to crash in case of a timeout
* cleans up a test not to kill the FSM process by an exit message but rather to gently stop it
* improves a bit min dept watcher messages processing regarding detection of a solo closing from the other party

It is not really client visible, hence no line in release notes. The need of it is debateable.