### PR TITLE
Names bidding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ eqc-lib
 eqc
 /docs/.tools/
 /docs/state-channels/*.svg
+*.iml

--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -2647,7 +2647,8 @@ fp_use_onchain_name_resolution(Cfg) ->
     FPRound = 20,
     LockPeriod = 10,
     FPHeight0 = 20,
-    Name = <<"lorem.test">>,
+    LongPrefix = <<"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">>,
+    Name = <<LongPrefix/binary, "lorem.test">>,
     ForceCallCheckName =
         fun(Forcer, K, Found) when is_binary(K) andalso is_boolean(Found) ->
             fun(Props) ->
@@ -5208,7 +5209,7 @@ register_name(Name, Pointers0) ->
             % claim
             fun(#{state := S, name_owner := NameOwner, height := Height0} = Props) ->
                 PrivKey = aesc_test_utils:priv_key(NameOwner, S),
-                Delta = aec_governance:name_claim_preclaim_delta(),
+                Delta = aec_governance:name_claim_preclaim_timeout(),
                 TxSpec = aens_test_utils:claim_tx_spec(NameOwner, Name, NameSalt, S),
                 {ok, Tx} = aens_claim_tx:new(TxSpec),
                 SignedTx = aec_test_utils:sign_tx(Tx, PrivKey),

--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -5215,8 +5215,13 @@ register_name(Name, Pointers0) ->
                 Delta = aec_governance:name_claim_preclaim_timeout(),
                 %% INFO: aeprimop checks what protocol we run
                 %%       checking the fee at Lima then
-                NameFee = aec_governance:name_claim_fee(?LIMA_PROTOCOL_VSN,
-                                                        aens_commitments:name_length(Name)),
+                NameFee = case aect_test_utils:latest_protocol_version() of
+                              Vsn when Vsn >= ?LIMA_PROTOCOL_VSN ->
+                                  aec_governance:name_claim_fee(
+                                    Vsn, aens_commitments:name_length(Name));
+                              _ ->
+                                  undefined
+                          end,
                 TxSpec = aens_test_utils:claim_tx_spec(NameOwner, Name, NameFee, NameSalt, S),
                 {ok, Tx} = aens_claim_tx:new(TxSpec),
                 SignedTx = aec_test_utils:sign_tx(Tx, PrivKey),
@@ -5483,4 +5488,3 @@ aevm_type(Type) -> Type.
 encode_sig(Sig) ->
     <<"0x", Hex/binary>> = aeu_hex:hexstring_encode(Sig),
     binary_to_list(<<"#", Hex/binary>>).
-

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -8,6 +8,8 @@
 %% common_test exports
 -export([ all/0
         , groups/0
+        , init_per_suite/1
+        , end_per_suite/1
         , init_per_group/2
         , end_per_group/2
         , init_per_testcase/2
@@ -424,6 +426,11 @@ init_tests(Release, VMName) ->
     Cfg = [{sophia_version, Sophia}, {vm_version, VM},
            {abi_version, ABI}, {protocol, Release}],
     init_per_testcase_common(interactive, Cfg).
+
+init_per_suite(Cfg) ->
+    [{protocol_vsn, aect_test_utils:latest_protocol_version()} | Cfg].
+end_per_suite(_) ->
+    ok.
 
 init_per_group(aevm, Cfg) ->
     aect_test_utils:init_per_group(aevm, Cfg, fun(X) -> X end);
@@ -3474,7 +3481,8 @@ sophia_signatures_aens(Cfg) ->
     Ct              = ?call(create_contract, NameAcc, aens, {}, #{ amount => 100000 }),
     LongPrefix      = <<"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">>,
     Name1           = <<LongPrefix/binary, "bla.test">>,
-    NameFee         = aec_governance:name_claim_fee(aens_commitments:name_length(Name1)),
+    NameFee         = aec_governance:name_claim_fee(?config(protocol_vsn, Cfg),
+                                                    aens_commitments:name_length(Name1)),
     Salt1           = rand:uniform(10000),
     {ok, NameAscii} = aens_utils:to_ascii(Name1),
     CHash           = ?hsh(aens_hash:commitment_hash(NameAscii, Salt1)),

--- a/apps/aecore/src/aec_aens_governance.erl
+++ b/apps/aecore/src/aec_aens_governance.erl
@@ -12,9 +12,12 @@
 
 -define(MULTIPLIER_14, 100000000000000).
 -define(MULTIPLIER_DAY, 480).
--define(BASE_FEE, 3).
 
-get_base_fee() -> ?BASE_FEE * ?MULTIPLIER_14.
+
+get_base_fee() ->
+    %% INFO: calling old governance, to make sure non-auction
+    %%       is compatible with pre-lima fees
+    aec_governance:name_claim_locked_fee() * ?MULTIPLIER_14.
 
 -spec init_fee_at_length(non_neg_integer()) -> non_neg_integer().
 init_fee_at_length(Length) when not is_integer(Length) orelse Length < 1 ->

--- a/apps/aecore/src/aec_aens_governance.erl
+++ b/apps/aecore/src/aec_aens_governance.erl
@@ -15,8 +15,6 @@
 
 
 get_base_fee() ->
-    %% INFO: calling old governance, to make sure non-auction
-    %%       is compatible with pre-lima fees
     aec_governance:name_claim_locked_fee() * ?MULTIPLIER_14.
 
 -spec init_fee_at_length(non_neg_integer()) -> non_neg_integer().

--- a/apps/aecore/src/aec_aens_governance.erl
+++ b/apps/aecore/src/aec_aens_governance.erl
@@ -1,0 +1,63 @@
+%%%-------------------------------------------------------------------
+%%% @doc Placeholder for functions instrumenting Naming auctions
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aec_aens_governance).
+
+%% API
+-export([init_fee_at_length/1,
+         bid_timeout_at_length/1,
+         get_base_fee/0]).
+
+-define(MULTIPLIER_14, 100000000000000).
+-define(MULTIPLIER_DAY, 480).
+-define(BASE_FEE, 3).
+
+get_base_fee() -> ?BASE_FEE * ?MULTIPLIER_14.
+
+-spec init_fee_at_length(non_neg_integer()) -> non_neg_integer().
+init_fee_at_length(Length) when not is_integer(Length) orelse Length < 1 ->
+    error({bad_height, Length});
+
+init_fee_at_length(Length) when Length > 31 -> get_base_fee();
+
+init_fee_at_length(31) -> 3 * ?MULTIPLIER_14;
+init_fee_at_length(30) -> 5 * ?MULTIPLIER_14;
+init_fee_at_length(29) -> 8 * ?MULTIPLIER_14;
+init_fee_at_length(28) -> 13 * ?MULTIPLIER_14;
+init_fee_at_length(27) -> 21 * ?MULTIPLIER_14;
+init_fee_at_length(26) -> 34 * ?MULTIPLIER_14;
+init_fee_at_length(25) -> 55 * ?MULTIPLIER_14;
+init_fee_at_length(24) -> 89 * ?MULTIPLIER_14;
+init_fee_at_length(23) -> 144 * ?MULTIPLIER_14;
+init_fee_at_length(22) -> 233 * ?MULTIPLIER_14;
+init_fee_at_length(21) -> 377 * ?MULTIPLIER_14;
+init_fee_at_length(20) -> 610 * ?MULTIPLIER_14;
+init_fee_at_length(19) -> 987 * ?MULTIPLIER_14;
+init_fee_at_length(18) -> 1597 * ?MULTIPLIER_14;
+init_fee_at_length(17) -> 2584 * ?MULTIPLIER_14;
+init_fee_at_length(16) -> 4181 * ?MULTIPLIER_14;
+init_fee_at_length(15) -> 6765 * ?MULTIPLIER_14;
+init_fee_at_length(14) -> 10946 * ?MULTIPLIER_14;
+init_fee_at_length(13) -> 17711 * ?MULTIPLIER_14;
+init_fee_at_length(12) -> 28657 * ?MULTIPLIER_14;
+init_fee_at_length(11) -> 46368 * ?MULTIPLIER_14;
+init_fee_at_length(10) -> 75025 * ?MULTIPLIER_14;
+init_fee_at_length(9) -> 121393 * ?MULTIPLIER_14;
+init_fee_at_length(8) -> 196418 * ?MULTIPLIER_14;
+init_fee_at_length(7) -> 317811 * ?MULTIPLIER_14;
+init_fee_at_length(6) -> 514229 * ?MULTIPLIER_14;
+init_fee_at_length(5) -> 832040 * ?MULTIPLIER_14;
+init_fee_at_length(4) -> 1346269 * ?MULTIPLIER_14;
+init_fee_at_length(3) -> 2178309 * ?MULTIPLIER_14;
+init_fee_at_length(2) -> 3524578 * ?MULTIPLIER_14;
+init_fee_at_length(1) -> 5702887 * ?MULTIPLIER_14.
+
+
+bid_timeout_at_length(Length) when not is_integer(Length) orelse Length < 1 ->
+    error({bad_height, Length});
+bid_timeout_at_length(Length) when Length > 32 -> 1;
+bid_timeout_at_length(Length) when Length > 8 -> 1 * ?MULTIPLIER_DAY;  %% 480 blocks
+bid_timeout_at_length(Length) when Length > 4 -> 31 * ?MULTIPLIER_DAY; %% 14880 blocks
+bid_timeout_at_length(Length) when Length > 0 -> 62 * ?MULTIPLIER_DAY. %% 29760 blocks

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -12,10 +12,13 @@
          locked_coins_holder_account/0,
          minimum_gas_price/1,
          name_preclaim_expiration/0,
-         name_claim_locked_fee/0,
+         name_claim_bid_increment/0,
+         name_claim_fee/1,
+         name_claim_fee_base/0,
          name_claim_max_expiration/0,
          name_protection_period/0,
-         name_claim_preclaim_delta/0,
+         name_claim_preclaim_timeout/0,
+         name_claim_bid_timeout/1,
          name_registrars/0,
          micro_block_cycle/0,
          accepted_future_block_time_shift/0,
@@ -201,8 +204,11 @@ primop_base_gas(?PRIM_CALL_ADDR_IS_ORACLE            ) -> 5000.
 name_preclaim_expiration() ->
     300.
 
-name_claim_locked_fee() ->
-    3.
+name_claim_fee_base() ->
+    aec_aens_governance:get_base_fee().
+
+name_claim_fee(Length) ->
+    aec_aens_governance:init_fee_at_length(Length).
 
 name_claim_max_expiration() ->
     50000.
@@ -210,8 +216,14 @@ name_claim_max_expiration() ->
 name_protection_period() ->
     2016.
 
-name_claim_preclaim_delta() ->
+name_claim_preclaim_timeout() ->
     1.
+
+name_claim_bid_timeout(Length) ->
+    aec_aens_governance:bid_timeout_at_length(Length).
+
+name_claim_bid_increment() ->
+    5. %% 5%
 
 -spec name_registrars() -> list(binary()).
 name_registrars() ->

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -14,7 +14,7 @@
          name_preclaim_expiration/0,
          name_claim_locked_fee/0,
          name_claim_bid_increment/0,
-         name_claim_fee/1,
+         name_claim_fee/2,
          name_claim_fee_base/0,
          name_claim_max_expiration/0,
          name_protection_period/0,
@@ -211,8 +211,10 @@ name_preclaim_expiration() ->
 name_claim_fee_base() ->
     aec_aens_governance:get_base_fee().
 
-name_claim_fee(Length) ->
-    aec_aens_governance:init_fee_at_length(Length).
+name_claim_fee(?LIMA_PROTOCOL_VSN, Length) ->
+    aec_aens_governance:init_fee_at_length(Length);
+name_claim_fee(_, _Length) ->
+    name_claim_locked_fee().
 
 name_claim_max_expiration() ->
     50000.

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -12,6 +12,7 @@
          locked_coins_holder_account/0,
          minimum_gas_price/1,
          name_preclaim_expiration/0,
+         name_claim_locked_fee/0,
          name_claim_bid_increment/0,
          name_claim_fee/1,
          name_claim_fee_base/0,
@@ -200,6 +201,9 @@ primop_base_gas(?PRIM_CALL_ADDR_IS_ORACLE            ) -> 5000.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Naming system variables
+
+name_claim_locked_fee() ->
+    3.
 
 name_preclaim_expiration() ->
     300.

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -4,12 +4,14 @@
 -export([protocols/0,
          check_protocol_version_validity/2,
          protocol_effective_at_height/1,
-         is_fork_height/1
+         is_fork_height/1,
+         is_valid_at_protocol/2
         ]).
 
 -ifdef(TEST).
 -export([check_protocol_version_validity/3,
-         sorted_protocol_versions/0
+         sorted_protocol_versions/0,
+         protocol_start_height/1
         ]).
 -endif.
 
@@ -66,15 +68,24 @@ is_fork_height(Height) ->
         1 -> {true, hd(maps:keys(Protocols))}
     end.
 
+is_valid_at_protocol(CurrentVer, MinimalVer) ->
+    CurrentVer >= MinimalVer.
+
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+protocol_start_height(VSN) ->
+    case maps:is_key(VSN, protocols()) of
+        true -> maps:get(VSN, protocols());
+        false -> undefined
+    end.
 
 protocols_from_network_id(<<"ae_mainnet">>) ->
     #{ ?ROMA_PROTOCOL_VSN     => 0
      , ?MINERVA_PROTOCOL_VSN  => 47800
      , ?FORTUNA_PROTOCOL_VSN => 90800
-%%%  , ?LIMA_PROTOCOL_VSN =>  Not yet decided
+     , ?LIMA_PROTOCOL_VSN =>  144000  %% not validated, from the hat, need it for Claim ver.
      };
 protocols_from_network_id(<<"ae_uat">>) ->
     #{ ?ROMA_PROTOCOL_VSN     => 0

--- a/apps/aecore/src/aec_spend_tx.erl
+++ b/apps/aecore/src/aec_spend_tx.erl
@@ -142,10 +142,10 @@ signers(#spend_tx{} = Tx, _) -> {ok, [sender_pubkey(Tx)]}.
 process(#spend_tx{} = SpendTx, Trees, Env) ->
     Instructions =
         aeprimop:spend_tx_instructions(sender_pubkey(SpendTx),
-                                               recipient_id(SpendTx),
-                                               amount(SpendTx),
-                                               fee(SpendTx),
-                                               nonce(SpendTx)),
+                                       recipient_id(SpendTx),
+                                       amount(SpendTx),
+                                       fee(SpendTx),
+                                       nonce(SpendTx)),
     aeprimop:eval(Instructions, Trees, Env).
 
 serialize(#spend_tx{sender_id    = SenderId,

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -249,7 +249,7 @@ gc_cache(Trees, TreesToGC) ->
 perform_pre_transformations(Trees, Height) ->
     Trees0 = aect_call_state_tree:prune(Height, Trees),
     Trees1 = aeo_state_tree:prune(Height, Trees0),
-    Trees2 = set_ns(Trees1, aens_state_tree:prune(Height, ns(Trees1))),
+    Trees2 = aens_state_tree:prune(Height, Trees1),
     case Height =:= aec_block_genesis:height() of
         true -> Trees2; % genesis block
         false ->

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -584,7 +584,7 @@ apply_txs_on_state_trees([SignedTx | Rest], ValidTxs, InvalidTxs, Trees, Env, Op
                     lager:debug("Tx ~p cannot be applied due to an error ~p", [Tx, Reason]),
                     {error, Reason};
                 {error, Reason} when not Strict ->
-                    lager:debug("Tx ~p cannot be applied due to an error ~p", [Tx, Reason]),
+                    lager:error("Tx ~p cannot be applied due to an error ~p", [Tx, Reason]),
                     Invalid1 = [SignedTx | InvalidTxs],
                     apply_txs_on_state_trees(Rest, ValidTxs, Invalid1, Trees, Env, Opts)
             catch
@@ -594,7 +594,7 @@ apply_txs_on_state_trees([SignedTx | Rest], ValidTxs, InvalidTxs, Trees, Env, Op
                     {error, Reason};
                 Type:What when not Strict ->
                     Reason = {Type, What},
-                    lager:debug("Tx ~p cannot be applied due to an error ~p", [Tx, Reason]),
+                    lager:error("Tx ~p cannot be applied due to a crash ~p", [Tx, Reason]),
                     Invalid1 = [SignedTx| InvalidTxs],
                     apply_txs_on_state_trees(Rest, ValidTxs, Invalid1, Trees, Env, Opts)
             end;

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -38,6 +38,7 @@
           aens_resolve/4,
           aens_preclaim_tx/3,
           aens_preclaim/3,
+          aens_claim_tx/4,
           aens_claim_tx/5,
           aens_claim/3,
           aens_transfer_tx/4,
@@ -574,6 +575,13 @@ aens_preclaim_(Tx, Signature, State) ->
         ok               -> apply_transaction(Tx, State);
         Err = {error, _} -> Err
     end.
+
+
+-spec aens_claim_tx(aec_keys:pubkey(), binary(), integer(), chain_state()) ->
+    {ok, aetx:tx()} | {error, term()}.
+aens_claim_tx(Addr, Name, Salt, State) ->
+    NameFee = aec_governance:name_claim_fee_base(),
+    on_chain_only(State, fun() -> aens_claim_tx_(Addr, Name, Salt, NameFee, State) end).
 
 -spec aens_claim_tx(aec_keys:pubkey(), binary(), integer(), integer(), chain_state()) ->
     {ok, aetx:tx()} | {error, term()}.

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -580,8 +580,7 @@ aens_preclaim_(Tx, Signature, State) ->
 -spec aens_claim_tx(aec_keys:pubkey(), binary(), integer(), chain_state()) ->
     {ok, aetx:tx()} | {error, term()}.
 aens_claim_tx(Addr, Name, Salt, State) ->
-    NameFee = aec_governance:name_claim_fee_base(),
-    on_chain_only(State, fun() -> aens_claim_tx_(Addr, Name, Salt, NameFee, State) end).
+    on_chain_only(State, fun() -> aens_claim_tx_(Addr, Name, Salt, undefined, State) end).
 
 -spec aens_claim_tx(aec_keys:pubkey(), binary(), integer(), integer(), chain_state()) ->
     {ok, aetx:tx()} | {error, term()}.

--- a/apps/aecore/src/aec_vm_chain.erl
+++ b/apps/aecore/src/aec_vm_chain.erl
@@ -38,7 +38,7 @@
           aens_resolve/4,
           aens_preclaim_tx/3,
           aens_preclaim/3,
-          aens_claim_tx/4,
+          aens_claim_tx/5,
           aens_claim/3,
           aens_transfer_tx/4,
           aens_transfer/3,
@@ -575,18 +575,19 @@ aens_preclaim_(Tx, Signature, State) ->
         Err = {error, _} -> Err
     end.
 
--spec aens_claim_tx(aec_keys:pubkey(), binary(), integer(), chain_state()) ->
+-spec aens_claim_tx(aec_keys:pubkey(), binary(), integer(), integer(), chain_state()) ->
     {ok, aetx:tx()} | {error, term()}.
-aens_claim_tx(Addr, Name, Salt, State) ->
-    on_chain_only(State, fun() -> aens_claim_tx_(Addr, Name, Salt, State) end).
+aens_claim_tx(Addr, Name, Salt, NameFee, State) ->
+    on_chain_only(State, fun() -> aens_claim_tx_(Addr, Name, Salt, NameFee, State) end).
 
-aens_claim_tx_(Addr, Name, Salt, State) ->
+aens_claim_tx_(Addr, Name, Salt, NameFee, State) ->
     Nonce = next_nonce(Addr, State),
     Spec =
         #{ account_id => aeser_id:create(account, Addr),
            nonce      => Nonce,
            name       => Name,
            name_salt  => Salt,
+           name_fee   => NameFee,
            fee        => 0
          },
     aens_claim_tx:new(Spec).

--- a/apps/aefate/src/aefa_chain_api.erl
+++ b/apps/aefate/src/aefa_chain_api.erl
@@ -40,7 +40,7 @@
         , oracle_check_query/5
         , is_oracle/2
         , is_contract/2
-        , aens_claim/4
+        , aens_claim/5
         , aens_preclaim/3
         , aens_resolve/3
         , aens_revoke/3
@@ -596,13 +596,8 @@ aens_resolve_from_pstate(NameString, Key, PState) ->
 aens_preclaim(Pubkey, Hash, #state{} = S) when ?IS_ONCHAIN(S) ->
     eval_primops([aeprimop:name_preclaim_op(Pubkey, Hash, 0)], S).
 
-aens_claim(Pubkey, NameBin, SaltInt, #state{} = S) when ?IS_ONCHAIN(S) ->
-    PreclaimDelta = aec_governance:name_claim_preclaim_delta(),
-    DeltaTTL = aec_governance:name_claim_max_expiration(),
-    LockedFee = aec_governance:name_claim_locked_fee(),
-    Instructions = [ aeprimop:lock_amount_op(Pubkey, LockedFee)
-                   , aeprimop:name_claim_op(Pubkey, NameBin, SaltInt,
-                                            DeltaTTL, PreclaimDelta)
+aens_claim(Pubkey, NameBin, SaltInt, NameFee, #state{} = S) when ?IS_ONCHAIN(S) ->
+    Instructions = [aeprimop:name_claim_op(Pubkey, NameBin, SaltInt, NameFee)
                    ],
     eval_primops(Instructions, S).
 

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2647,7 +2647,7 @@
     },
     "NameClaimTx" : {
       "type" : "object",
-      "required" : [ "account_id", "fee", "name", "name_salt" ],
+      "required" : [ "account_id", "fee", "name", "name_fee", "name_salt" ],
       "properties" : {
         "name" : {
           "type" : "string"

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2655,6 +2655,9 @@
         "name_salt" : {
           "$ref" : "#/definitions/UInt"
         },
+        "name_fee" : {
+          "$ref" : "#/definitions/UInt"
+        },
         "fee" : {
           "$ref" : "#/definitions/UInt"
         },

--- a/apps/aehttp/priv/swagger.json
+++ b/apps/aehttp/priv/swagger.json
@@ -2647,7 +2647,7 @@
     },
     "NameClaimTx" : {
       "type" : "object",
-      "required" : [ "account_id", "fee", "name", "name_fee", "name_salt" ],
+      "required" : [ "account_id", "fee", "name", "name_salt" ],
       "properties" : {
         "name" : {
           "type" : "string"

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -148,7 +148,7 @@ handle_request_('PostNameUpdate', #{'NameUpdateTx' := Req}, _Context) ->
 
 handle_request_('PostNameClaim', #{'NameClaimTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([account_id, name, name_salt, fee]),
+                 read_required_params([account_id, name, name_salt, name_fee, fee]),
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{account_id, account_id, {id_hash, [account_pubkey]}},
                                 {name, name, name}]),

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -148,8 +148,9 @@ handle_request_('PostNameUpdate', #{'NameUpdateTx' := Req}, _Context) ->
 
 handle_request_('PostNameClaim', #{'NameClaimTx' := Req}, _Context) ->
     ParseFuns = [parse_map_to_atom_keys(),
-                 read_required_params([account_id, name, name_salt, name_fee, fee]),
-                 read_optional_params([{ttl, ttl, '$no_value'}]),
+                 read_required_params([account_id, name, name_salt, fee]),
+                 read_optional_params([{name_fee, name_fee, '$no_value'},
+                                       {ttl, ttl, '$no_value'}]),
                  api_decode([{account_id, account_id, {id_hash, [account_pubkey]}},
                                 {name, name, name}]),
                  get_nonce_from_account_id(account_id),
@@ -407,4 +408,3 @@ handle_request_(OperationID, Req, Context) ->
       [{OperationID, Req, Context}]
      ),
     {501, [], #{}}.
-

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -1260,9 +1260,10 @@ random_unused_name() ->
 random_unused_name(Attempts) when Attempts < 1->
     {error, exhausted};
 random_unused_name(Attempts) ->
-    Size = 10,
+    Size = 32,
     RandStr = base58:binary_to_base58(crypto:strong_rand_bytes(Size)),
-    NameL = RandStr ++ ".test",
+    Namespace = hd(aec_governance:name_registrars()),
+    NameL = RandStr ++ <<".", Namespace/binary>>,
     Name = list_to_binary(NameL),
     case get_names_entry_by_name_sut(Name) of
         {ok, 404, _Error} -> Name; % name not used yet
@@ -1880,7 +1881,7 @@ preclaim_name(Owner, OwnerPrivKey, Name, Salt) ->
     ok.
 
 claim_name(Owner, OwnerPrivKey, Name, Salt) ->
-    Delta = aec_governance:name_claim_preclaim_delta(),
+    Delta = aec_governance:name_claim_preclaim_timeout(),
     Node = aecore_suite_utils:node_name(?NODE),
     aecore_suite_utils:mine_key_blocks(Node, Delta),
     {ok, Nonce} = rpc(aec_next_nonce, pick_for_account, [Owner]),

--- a/apps/aens/src/aens_claim_tx.erl
+++ b/apps/aens/src/aens_claim_tx.erl
@@ -177,6 +177,14 @@ serialization_template(?NAME_CLAIM_TX_VSN_1) ->
     , {nonce, int}
     , {name, binary}
     , {name_salt, int}
+    , {fee, int}
+    , {ttl, int}
+    ];
+serialization_template(?NAME_CLAIM_TX_VSN_2) ->
+    [ {account_id, id}
+    , {nonce, int}
+    , {name, binary}
+    , {name_salt, int}
     , {name_fee, int}
     , {fee, int}
     , {ttl, int}
@@ -226,7 +234,7 @@ account_pubkey(#ns_claim_tx{account_id = AccountId}) ->
 
 -spec version(tx()) -> non_neg_integer().
 version(_) ->
-    ?NAME_CLAIM_TX_VSN_1.
+    ?NAME_CLAIM_TX_VSN_2.
 
 -spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
 valid_at_protocol(_, _) ->

--- a/apps/aens/src/aens_commitments.erl
+++ b/apps/aens/src/aens_commitments.erl
@@ -9,6 +9,7 @@
 
 %% API
 -export([new/4,
+         update/6,
          serialize/1,
          deserialize/2,
          deserialize_from_fields/3,
@@ -16,21 +17,40 @@
          serialization_template/1
         ]).
 
+-export([is_auction_done_when_elapsed/1,
+         get_name_auction_state/2,
+         name_length/1]).
+
+-export([assert_commitment_owner/2,
+         assert_height_delta/3]).
+
 %% Getters
 -export([hash/1,
          owner_pubkey/1,
          ttl/1,
-         created/1]).
+         created/1,
+         auction/1,
+         name_fee/1,
+         name_hash/1]).
 
 -behavior(aens_cache).
 %%%===================================================================
 %%% Types
 %%%===================================================================
+-define(LEGACY, legacy).
+-define(PRECLAIM, preclaim).
+-define(CLAIM_ATTEMPT, claim_attempt).
+
+-type(auction_state() :: ?LEGACY | ?PRECLAIM | ?CLAIM_ATTEMPT).
+
 -record(commitment,
-        {id       :: aeser_id:id(),
-         owner_id :: aeser_id:id(),
-         created  :: aec_blocks:height(),
-         ttl      :: aec_blocks:height()
+        {id                :: aeser_id:id(),
+         owner_id          :: aeser_id:id(),
+         created           :: aec_blocks:height(),
+         auction           :: auction_state(),
+         name_fee          :: non_neg_integer(),
+         name_hash         :: hash() | undefined,
+         ttl               :: aec_blocks:height()
          }).
 
 -opaque commitment() :: #commitment{}.
@@ -45,7 +65,9 @@
               serialized/0]).
 
 -define(COMMITMENT_TYPE, name_commitment).
--define(COMMITMENT_VSN, 1).
+-define(COMMITMENT_ROMA, 1).
+-define(COMMITMENT_LIMA_PRECLAIM, 2).
+-define(COMMITMENT_LIMA_CLAIM, 3).
 
 %%%===================================================================
 %%% API
@@ -57,42 +79,126 @@ new(Id, OwnerId, DeltaTTL, BlockHeight) ->
     account    = aeser_id:specialize_type(OwnerId),
     #commitment{id       = Id,
                 owner_id = OwnerId,
+                auction = ?PRECLAIM,
                 created  = BlockHeight,
+                name_fee = 0,
                 ttl      = BlockHeight + DeltaTTL}.
 
+-spec update(commitment(), aeser_id:id(), non_neg_integer(), aec_blocks:height(),
+             non_neg_integer(), hash()) -> commitment().
+update(Commitment, NewOwnerId, BidDelta, BlockHeight, NameFee, NameHash) ->
+    NewOwnerIdSpec = aeser_id:create(account, NewOwnerId),
+    Commitment#commitment{
+      owner_id = NewOwnerIdSpec,
+      auction  = ?CLAIM_ATTEMPT,
+      name_fee = NameFee,
+      name_hash = NameHash,
+      ttl      = BlockHeight + BidDelta}.
+
 -spec serialize(commitment()) -> serialized().
+%% INFO: order of causes matters as legacy ones don't have auction field
 serialize(#commitment{owner_id = OwnerId,
-                      created  = Created,
-                      ttl      = TTL}) ->
+    created = Created,
+    auction = preclaim,
+    name_fee = 0,
+    ttl = TTL}) ->
+    aeser_chain_objects:serialize(
+        ?COMMITMENT_TYPE,
+        ?COMMITMENT_LIMA_PRECLAIM,
+        serialization_template(?COMMITMENT_LIMA_PRECLAIM),
+        [ {owner_id, OwnerId}
+        , {created, Created}
+        , {auction, <<"preclaim">>}
+        , {name_fee, 0}
+        , {ttl, TTL}]);
+serialize(#commitment{owner_id = OwnerId,
+                      created = Created,
+                      auction = claim_attempt,
+                      name_fee = NameFee,
+                      name_hash = NameHash,
+                      ttl = TTL}) ->
     aeser_chain_objects:serialize(
       ?COMMITMENT_TYPE,
-      ?COMMITMENT_VSN,
-      serialization_template(?COMMITMENT_VSN),
+      ?COMMITMENT_LIMA_CLAIM,
+      serialization_template(?COMMITMENT_LIMA_CLAIM),
       [ {owner_id, OwnerId}
       , {created, Created}
-      , {ttl, TTL}]).
+      , {auction, <<"claim_attempt">>}
+      , {name_fee, NameFee}
+      , {name_hash, NameHash}
+      , {ttl, TTL}]);
+serialize(#commitment{owner_id = OwnerId,
+    created  = Created,
+    ttl      = TTL}) ->
+    aeser_chain_objects:serialize(
+        ?COMMITMENT_TYPE,
+        ?COMMITMENT_ROMA,
+        serialization_template(?COMMITMENT_ROMA),
+        [ {owner_id, OwnerId}
+        , {created, Created}
+        , {ttl, TTL}]).
 
 -spec deserialize(hash(), binary()) -> commitment().
 deserialize(CommitmentHash, Bin) ->
-    Fields = aeser_chain_objects:deserialize(
-                  ?COMMITMENT_TYPE,
-                  ?COMMITMENT_VSN,
-                  serialization_template(?COMMITMENT_VSN),
-                  Bin),
-    deserialize_from_fields(?COMMITMENT_VSN, CommitmentHash, Fields).
+    {Type, Vsn, _Rest} = aeser_chain_objects:deserialize_type_and_vsn(Bin),
+    Fields = aeser_chain_objects:deserialize(Type, Vsn, serialization_template(Vsn), Bin),
+    deserialize_from_fields(Vsn, CommitmentHash, Fields).
 
-deserialize_from_fields(?COMMITMENT_VSN, CommitmentHash,
-    [ {owner_id, OwnerId}
-    , {created, Created}
-    , {ttl, TTL}]) ->
+deserialize_from_fields(?COMMITMENT_ROMA, CommitmentHash,
+                        [ {owner_id, OwnerId}
+                        , {created, Created}
+                        , {ttl, TTL}]) ->
     #commitment{id       = aeser_id:create(commitment, CommitmentHash),
                 owner_id = OwnerId,
                 created  = Created,
+                auction  = ?LEGACY,
+                name_fee = aec_governance:name_claim_fee_base(), %% base fee is equal to pre-lima fee
+                ttl      = TTL};
+deserialize_from_fields(?COMMITMENT_LIMA_PRECLAIM, CommitmentHash,
+                        [ {owner_id, OwnerId}
+                        , {created, Created}
+                        , {auction, <<"preclaim">>}
+                        , {name_fee, 0}
+                        , {ttl, TTL}]) ->
+    #commitment{id       = aeser_id:create(commitment, CommitmentHash),
+                owner_id = OwnerId,
+                created  = Created,
+                name_fee = 0,
+                auction = ?PRECLAIM,
+                ttl      = TTL};
+deserialize_from_fields(?COMMITMENT_LIMA_CLAIM, CommitmentHash,
+                        [ {owner_id, OwnerId}
+                        , {created, Created}
+                        , {auction, <<"claim_attempt">>}
+                        , {name_fee, NameFee}
+                        , {name_hash, NameHash}
+                        , {ttl, TTL}]) ->
+    #commitment{id       = aeser_id:create(commitment, CommitmentHash),
+                owner_id = OwnerId,
+                created  = Created,
+                auction = ?CLAIM_ATTEMPT,
+                name_fee = NameFee,
+                name_hash = NameHash,
                 ttl      = TTL}.
 
-serialization_template(?COMMITMENT_VSN) ->
+serialization_template(?COMMITMENT_ROMA) ->
     [ {owner_id, id}
     , {created, int}
+    , {ttl, int}
+    ];
+serialization_template(?COMMITMENT_LIMA_PRECLAIM) ->
+    [ {owner_id, id}
+    , {created, int}
+    , {auction, binary}
+    , {name_fee, int}
+    , {ttl, int}
+    ];
+serialization_template(?COMMITMENT_LIMA_CLAIM) ->
+    [ {owner_id, id}
+    , {created, int}
+    , {auction, binary}
+    , {name_fee, int}
+    , {name_hash, binary}
     , {ttl, int}
     ].
 
@@ -117,3 +223,87 @@ ttl(#commitment{ttl = TTL}) ->
 created(#commitment{created = Created}) ->
     Created.
 
+-spec auction(commitment()) -> auction_state().
+auction(#commitment{auction = AuctionState}) ->
+    AuctionState.
+
+-spec name_hash(commitment()) -> hash().
+name_hash(#commitment{name_hash = NameHash}) ->
+    NameHash.
+
+-spec name_fee(commitment()) -> non_neg_integer().
+name_fee(#commitment{name_fee = NameFee}) ->
+    NameFee.
+
+%%%===================================================================
+%%% Auction handling
+%%%===================================================================
+
+-spec is_auction_done_when_elapsed(commitment()) -> boolean().
+is_auction_done_when_elapsed(#commitment{auction = ?LEGACY}) ->
+    false;
+is_auction_done_when_elapsed(#commitment{auction = ?PRECLAIM}) ->
+    false;
+is_auction_done_when_elapsed(#commitment{auction = ?CLAIM_ATTEMPT}) ->
+    true.
+
+-spec get_name_auction_state(commitment(), binary()) ->
+                             no_auction | auction_ready | auction_ongoing.
+get_name_auction_state(#commitment{auction = Auction}, Name) ->
+    Length = name_length(Name),
+    %% If the time for the next bid is higher than 1 block, then we have an auction
+    BidTimeout = aec_governance:name_claim_bid_timeout(Length),
+    case {Auction, BidTimeout > 1} of
+        {?LEGACY, _} ->
+            no_auction;
+        {?PRECLAIM, false} ->
+            no_auction;
+        {?PRECLAIM, true} ->
+            auction_ready;
+        {?CLAIM_ATTEMPT, _} ->
+            auction_ongoing
+    end.
+
+
+-spec name_length(binary()) -> non_neg_integer().
+name_length(PlainName) ->
+    %% Works only for one namespace; improve when we have more
+    %% No reason to regex now
+    size(PlainName) - size(hd(aec_governance:name_registrars())) - 1.
+
+
+%%%===================================================================
+%%% Assertions
+%%%===================================================================
+
+assert_commitment_owner(Commitment, Pubkey) ->
+    OwnerId = aens_commitments:owner_pubkey(Commitment),
+    AuctionState = aens_commitments:auction(Commitment),
+    case {AuctionState, OwnerId =:= Pubkey} of
+        {?LEGACY, true} -> ok;
+        {?LEGACY, false} -> commitment_not_owned;
+        {?PRECLAIM, true}  -> ok;
+        {?PRECLAIM, false} -> commitment_not_owned;
+        {?CLAIM_ATTEMPT, true} -> commitment_already_owned;
+        {?CLAIM_ATTEMPT, false} -> ok
+    end.
+
+assert_height_delta(Commitment, PreclaimDelta, Height) ->
+    AuctionState = aens_commitments:auction(Commitment),
+    case AuctionState of
+        ?LEGACY -> assert_preclaim_delta(Commitment, PreclaimDelta, Height);
+        ?PRECLAIM -> assert_preclaim_delta(Commitment, PreclaimDelta, Height);
+        ?CLAIM_ATTEMPT ->  assert_bid_delta(Commitment, Height)
+    end.
+
+assert_preclaim_delta(Commitment, PreclaimDelta, Height) ->
+    case aens_commitments:created(Commitment) + PreclaimDelta =< Height of
+        true  -> ok;
+        false -> commitment_delta_too_small
+    end.
+
+assert_bid_delta(Commitment, Height) ->
+    case aens_commitments:ttl(Commitment) >= Height of
+        true  -> ok;
+        false -> too_late_for_bid
+    end.

--- a/apps/aens/src/aens_state_tree.erl
+++ b/apps/aens/src/aens_state_tree.erl
@@ -97,21 +97,21 @@ new_with_backend(RootHash, CacheRootHash) ->
     Cache = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:ns_cache_backend()),
     #ns_tree{mtree = MTree, cache = Cache}.
 
--spec prune(block_height(), tree()) -> tree().
-prune(NextBlockHeight, #ns_tree{} = Tree) ->
-    {Tree1, ExpiredActions} = int_prune(NextBlockHeight - 1, Tree),
-    run_elapsed(ExpiredActions, Tree1, NextBlockHeight).
+-spec prune(block_height(), aec_trees:trees()) -> aec_trees:trees().
+prune(NextBlockHeight, Trees) ->
+    {NSTree1, ExpiredActions} = int_prune(NextBlockHeight - 1, aec_trees:ns(Trees)),
+    run_elapsed(ExpiredActions, aec_trees:set_ns(Trees, NSTree1), NextBlockHeight).
 
-run_elapsed([], Tree, _) ->
-    Tree;
-run_elapsed([{aens_names, Id, Serialized}|Expired], Tree, Height) ->
+run_elapsed([], Trees, _) ->
+    Trees;
+run_elapsed([{aens_names, Id, Serialized}|Expired], Trees, Height) ->
     Name = aens_names:deserialize(Id, Serialized),
-    {ok, Tree1} = run_elapsed_name(Name, Tree, Height),
-    run_elapsed(Expired, Tree1, Height);
-run_elapsed([{aens_commitments, Id, Serialized}|Expired], Tree, Height) ->
+    {ok, Tree1} = run_elapsed_name(Name, aec_trees:ns(Trees), Height),
+    run_elapsed(Expired, aec_trees:set_ns(Trees, Tree1), Height);
+run_elapsed([{aens_commitments, Id, Serialized}|Expired], Trees, Height) ->
     Commitment = aens_commitments:deserialize(Id, Serialized),
-    {ok, Tree1} = run_elapsed_commitment(Commitment, Tree),
-    run_elapsed(Expired, Tree1, Height).
+    {ok, Trees1} = run_elapsed_commitment(Commitment, Trees, Height),
+    run_elapsed(Expired, Trees1, Height).
 
 -spec enter_commitment(commitment(), tree()) -> tree().
 enter_commitment(Commitment, Tree) ->
@@ -264,12 +264,43 @@ run_elapsed_name(Name, NamesTree0, NextBlockHeight) ->
             {ok, aens_state_tree:delete_name(NameHash, NamesTree0)}
     end.
 
-run_elapsed_commitment(Commitment, NamesTree0) ->
+
+run_elapsed_commitment(Commitment, Trees0, Height) ->
     %% INFO: We delete in both cases when name is claimed or not claimed
     %%       when it expires
+    NamesTree0 = aec_trees:ns(Trees0),
     CommitmentHash = aens_commitments:hash(Commitment),
+    {value, Commitment} = lookup_commitment(CommitmentHash, NamesTree0),
+
     NamesTree1 = aens_state_tree:delete_commitment(CommitmentHash, NamesTree0),
-    {ok, NamesTree1}.
+    case aens_commitments:is_auction_done_when_elapsed(Commitment) of
+        false ->
+            {ok, aec_trees:set_ns(Trees0, NamesTree1)};
+        true ->
+            NameHash = aens_commitments:name_hash(Commitment),
+            AccountPubkey = aens_commitments:owner_pubkey(Commitment),
+            NameRentTime = aec_governance:name_claim_max_expiration(),
+            case lookup_name(NameHash, NamesTree0) of
+                {value, _} ->
+                    AccountsTree0 = aec_trees:accounts(Trees0),
+                    AccountsTree1 = return_name_fee(AccountsTree0, Commitment),
+                    aec_trees:set_accounts(aec_trees:set_ns(Trees0, NamesTree1), AccountsTree1);
+                none ->
+                    Name = aens_names:new(NameHash, AccountPubkey, Height + NameRentTime),
+                    NamesTree2 = enter_name(Name, NamesTree1),
+                    Trees1 = aec_trees:set_ns(Trees0, NamesTree2),
+                    {ok, Trees1}
+            end
+    end.
+
+return_name_fee(AccountsTree0, Commitment) ->
+    ChargedNameFee = aens_commitments:name_fee(Commitment),
+    AccountsTree1 = aec_accounts_trees:lock_coins(-ChargedNameFee, AccountsTree0),
+
+    OwnerPubKey = aens_commitments:owner_pubkey(Commitment),
+    OwnerAccount0 = aec_accounts_tree:get(OwnerPubKey, AccountsTree0),
+    {ok, OwnerAccount1} = aec_accounts:earn(OwnerAccount0, ChargedNameFee),
+    aec_accounts_trees:enter(OwnerAccount1, AccountsTree1).
 
 %%%===================================================================
 %%% TTL Cache

--- a/apps/aens/test/aens_test_utils.erl
+++ b/apps/aens/test/aens_test_utils.erl
@@ -19,7 +19,6 @@
          revoke_name/2,
          preclaim_tx_spec/3,
          preclaim_tx_spec/4,
-         claim_tx_spec/4,
          claim_tx_spec/5,
          claim_tx_spec/6,
          claim_tx_defaul_fee/0,
@@ -143,10 +142,6 @@ preclaim_tx_default_spec(PubKey, State) ->
 %%%===================================================================
 %%% Claim tx
 %%%===================================================================
-
-claim_tx_spec(PubKey, Name, NameSalt, State) ->
-    NameFee = aec_governance:name_claim_fee_base(),
-    claim_tx_spec(PubKey, Name, NameFee, NameSalt, #{}, State).
 
 claim_tx_spec(PubKey, Name, NameFee, NameSalt, State) ->
     claim_tx_spec(PubKey, Name, NameFee, NameSalt, #{}, State).

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -433,6 +433,7 @@ check_ttl(AeTx, Env) ->
 
 check_protocol_at_height(AeTx, Height) ->
     Protocol = aec_hard_forks:protocol_effective_at_height(Height),
+    io:format("check proto ~p ~p ~p", [Protocol, Height, AeTx]),
     case valid_at_protocol(Protocol, AeTx) of
         true  -> ok;
         false -> {error, invalid_at_height}

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -133,7 +133,7 @@ is_local_primop(Data) ->
 %% the argument was built.
 
 types(?PRIM_CALL_AENS_CLAIM,_HeapValue,_Store,_State) ->
-    {[word, string, word, sign_t()], tuple0_t()};
+    {[word, string, word, word, sign_t()], tuple0_t()};
 types(?PRIM_CALL_AENS_PRECLAIM,_HeapValue,_Store,_State) ->
     {[word, word, sign_t()], tuple0_t()};
 types(?PRIM_CALL_AENS_RESOLVE, HeapValue, Store,_State) ->
@@ -535,8 +535,8 @@ aens_call_preclaim(Data, #chain{api = API, state = State} = Chain) ->
     end.
 
 aens_call_claim(Data, #chain{api = API, state = State} = Chain) ->
-    [Addr, Name, Salt, Sign0] = get_args([word, string, word, sign_t()], Data),
-    case API:aens_claim_tx(<<Addr:256>>, Name, Salt, State) of
+    [Addr, Name, Salt, NameFee, Sign0] = get_args([word, string, word, word, sign_t()], Data),
+    case API:aens_claim_tx(<<Addr:256>>, Name, Salt, NameFee, State) of
         {ok, Tx} ->
             SizeGas = size_gas(Tx),
             Callback = fun(ChainAPI, ChainState) -> ChainAPI:aens_claim(Tx, to_sign(Sign0), ChainState) end,

--- a/apps/aevm/src/aevm_chain_api.erl
+++ b/apps/aevm/src/aevm_chain_api.erl
@@ -176,6 +176,7 @@
 -callback aens_claim_tx(Addr :: pubkey(),
                         Name :: binary(),
                         Salt :: integer(),
+                        NameFee :: integer(),
                         ChainState :: chain_state()) ->
     {ok, aetx:tx()} | {error, term()}.
 

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2140,6 +2140,7 @@ definitions:
     required:
       - name
       - name_salt
+      - name_fee
       - fee
       - account_id
   NameUpdateTx:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2127,6 +2127,8 @@ definitions:
         type: string
       name_salt:
         $ref: '#/definitions/UInt'
+      name_fee:
+        $ref: '#/definitions/UInt'
       fee:
         $ref: '#/definitions/UInt'
       ttl:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -2140,7 +2140,6 @@ definitions:
     required:
       - name
       - name_salt
-      - name_fee
       - fee
       - account_id
   NameUpdateTx:
@@ -3200,4 +3199,3 @@ definitions:
 externalDocs:
   description: Find out more about Aeternity
   url: 'http://www.aeternity.com'
-

--- a/py/tests/integration/test_spend_tx.py
+++ b/py/tests/integration/test_spend_tx.py
@@ -118,8 +118,7 @@ def test_send_by_name():
     bob_name = bob_name_long + test_settings["name_register"]["name"]
 
     fee = test_settings["name_register"]["fee"]
-    register_name(bob_name, bob_address, ext_api, int_api, bob_private_key,
-                  fee)
+    register_name(bob_name, bob_address, ext_api, int_api, bob_private_key, fee)
 
     print("Bob has registered " + bob_name)
     bob_balance1 = common.get_account_balance(ext_api, bob_address)
@@ -169,8 +168,7 @@ def register_name(name, address, external_api, internal_api, private_key, fee):
     encoded_name = common.encode_name(name)
     unsigned_claim = common.api_decode(\
         internal_api.post_name_claim(\
-            NameClaimTx(name=encoded_name, name_salt=salt, fee=fee,
-                        name_fee=name_fee, ttl=100, account_id=address)).tx)
+            NameClaimTx(name=encoded_name, name_salt=salt, fee=fee, name_fee=name_fee, ttl=100, account_id=address)).tx)
     signed_claim = keys.sign_encode_tx(unsigned_claim, private_key)
     common.ensure_transaction_posted(external_api, signed_claim)
     name_entry0 = external_api.get_name_entry_by_name(name)

--- a/py/tests/integration/test_spend_tx.py
+++ b/py/tests/integration/test_spend_tx.py
@@ -113,7 +113,10 @@ def test_send_by_name():
     print("Bob balance is " + str(bob_balance0))
     print("Bob address is " + bob_address)
 
-    bob_name = test_settings["name_register"]["name"]
+    # escape auctions with long prefix
+    bob_name_long = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    bob_name = bob_name_long + test_settings["name_register"]["name"]
+
     fee = test_settings["name_register"]["fee"]
     register_name(bob_name, bob_address, ext_api, int_api, bob_private_key,
                   fee)
@@ -159,11 +162,15 @@ def register_name(name, address, external_api, internal_api, private_key, fee):
     signed_preclaim = keys.sign_encode_tx(unsigned_preclaim, private_key)
     common.ensure_transaction_posted(external_api, signed_preclaim)
 
+    # hardcoded name fee for non-auction name, minimum one
+    name_fee = 300000000000000
+
     # claim
     encoded_name = common.encode_name(name)
     unsigned_claim = common.api_decode(\
         internal_api.post_name_claim(\
-            NameClaimTx(name=encoded_name, name_salt=salt, fee=fee, ttl=100, account_id=address)).tx)
+            NameClaimTx(name=encoded_name, name_salt=salt, fee=fee,
+                        name_fee=name_fee, ttl=100, account_id=address)).tx)
     signed_claim = keys.sign_encode_tx(unsigned_claim, private_key)
     common.ensure_transaction_posted(external_api, signed_claim)
     name_entry0 = external_api.get_name_entry_by_name(name)

--- a/rebar.config
+++ b/rebar.config
@@ -66,7 +66,7 @@
                    {ref, "0a82f0f"}}},
 
         {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", 
-                      {ref,"86ce250"}}},
+                      {ref,"cee6316"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"4a07297"}}},
@@ -197,11 +197,7 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
-<<<<<<< HEAD
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"df12f6a"}}},
-=======
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"edf2439"}}},
->>>>>>> names bidding
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"6c0ea77"}}},
                             {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {tag, "v3.2.0"}}}
                            ]}
                    ]},

--- a/rebar.config
+++ b/rebar.config
@@ -65,8 +65,8 @@
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                    {ref, "0a82f0f"}}},
 
-        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", 
-                      {ref,"cee6316"}}},
+        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git",
+                      {ref,"adf3664"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"4a07297"}}},
@@ -197,7 +197,7 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"6c0ea77"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"d96f1a8"}}},
                             {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {tag, "v3.2.0"}}}
                            ]}
                    ]},

--- a/rebar.config
+++ b/rebar.config
@@ -197,7 +197,7 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"d96f1a8"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"451b363"}}},
                             {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {tag, "v3.2.0"}}}
                            ]}
                    ]},

--- a/rebar.config
+++ b/rebar.config
@@ -65,8 +65,8 @@
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                    {ref, "0a82f0f"}}},
 
-        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git",
-                      {ref, "2a9035d"}}},
+        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", 
+                      {ref,"86ce250"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"4a07297"}}},
@@ -197,7 +197,11 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
+<<<<<<< HEAD
                             {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"df12f6a"}}},
+=======
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"edf2439"}}},
+>>>>>>> names bidding
                             {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {tag, "v3.2.0"}}}
                            ]}
                    ]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"eff804a3861673a16b78d59fd208b94fd89eb89c"}},
+      {ref,"cee6316e846a9215521d6a31c668acb7626ad2aa"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"2a9035d5ef72bc65e51e4b9a1a958bb8ba2c6747"}},
+      {ref,"eff804a3861673a16b78d59fd208b94fd89eb89c"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"cee6316e846a9215521d6a31c668acb7626ad2aa"}},
+      {ref,"adf3664dd03626c115756f79fa0e602fda24318d"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",


### PR DESCRIPTION
Implemented according to protocol repository PR: 
https://github.com/aeternity/protocol/pull/379

DONE:
- whole backend adjusted including fate, aevm etc for new argument in claim transaction with bid value
- aens SUITE tests all versions:
   old names & old behaviour (skips auctions),
   old names & new behaviour
   new names & new behaviour
   utf8 on all heights 
- some tests edited to escape auction behaviour at all heights. Done that by extending name to non-auction length (over 31 chars now)

NOT DONE:

- Swagger has only new interface
- HTTP integration test tests only new interface
- aecontract SUITE not finished as top level /test templates are not adjusted for extra argument in claim. Need to revert it and write new test that is skipped in pre-lima
- couple tests around failing due to not adjusted contract templates in /test 


Depends on unmerged aebytecode and sophia PRs (they are pointed in this PR rebar.config). Pre-merge commit will need to fix rebar.config and rebar.lock with rebased aebytecode and sophia PRs.