### PR TITLE
add round in reconnect_tx to guard against replay attacks

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -2562,7 +2562,9 @@ check_tx_and_verify_signatures(SignedTx, Updates, Mod, Data, Pubkeys, ErrTypeMsg
                 {ChannelPubkey, MyRole, MyPubkey, Round}
                   when Round > Data#data.client_reconnect_nonce ->
                     verify_signatures_offchain(
-                      ChannelPubkey, Pubkeys, SignedTx)
+                      ChannelPubkey, Pubkeys, SignedTx);
+                _ ->
+                    {error, invalid}
             catch
                 error:_ ->
                     {error, invalid}

--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -131,6 +131,7 @@
               , client_mref                   :: reference() | undefined
               , client_connected = true       :: boolean()
               , client_may_disconnect = false :: boolean()
+              , client_reconnect_nonce = 0    :: non_neg_integer()
               , opts                          :: map()
               , channel_id                    :: undefined | binary()
               , on_chain_id                   :: undefined | binary()

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1615,13 +1615,17 @@ reconnect(Fsm, Role, #{} = R, Debug) ->
     end,
     R#{ proxy => NewProxy }.
 
-try_reconnect(Fsm, Role, #{ channel_id := ChId
-                          , fsm  := Fsm
-                          , pub  := Pub
-                          , priv := Priv}, Debug) ->
+try_reconnect(Fsm, Role, R, Debug) ->
+    try_reconnect(Fsm, 1, Role, R, Debug).
+
+try_reconnect(Fsm, Round, Role, #{ channel_id := ChId
+                                 , fsm  := Fsm
+                                 , pub  := Pub
+                                 , priv := Priv}, Debug) ->
     ChIdId = aeser_id:create(channel, ChId),
     PubId = aeser_id:create(account, Pub),
     {ok, Tx} = aesc_client_reconnect_tx:new(#{ channel_id => ChIdId
+                                             , round      => Round
                                              , role       => Role
                                              , pub_key    => PubId }),
     log(Debug, "Reconnect Tx = ~p", [Tx]),

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1571,6 +1571,7 @@ client_reconnect_(Role, Cfg) ->
     log(Debug, "Reconnecting before disconnecting failed: ~p", [Err]),
     unlink(Proxy),
     exit(Proxy, kill),
+    timer:sleep(100),  % give the above exit time to propagate
     ok = things_that_should_fail_if_no_client(Role, I, R, Debug),
     Res = reconnect(Fsm, Role, RoleI, Debug),
     ct:log("Reconnect req -> ~p", [Res]),

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -2488,11 +2488,15 @@ other_role(responder) -> initiator;
 other_role(initiator) -> responder.
 
 reconnect_client_(ChId, Role, Pub, Priv, Config) ->
+    reconnect_client_(ChId, 1, Role, Pub, Priv, Config).
+
+reconnect_client_(ChId, Round, Role, Pub, Priv, Config) ->
     ct:log("reconnecting ChId = ~p, Role = ~p, Pub = ~p", [ChId, Role, Pub]),
     {channel, ChIdDec} = aeser_api_encoder:decode(ChId),
     ChIdId = aeser_id:create(channel, ChIdDec),
     PubId = aeser_id:create(account, Pub),
     {ok, Tx} = aesc_client_reconnect_tx:new(#{ channel_id => ChIdId
+                                             , round      => Round
                                              , role       => Role
                                              , pub_key    => PubId }),
     SignedTx = aec_test_utils:sign_tx(Tx, Priv),


### PR DESCRIPTION
Proposed change to #2602 - adding `round` to the reconnect_tx in order to protect against replay attacks.