### PR TITLE
API URLs of Localnet compatibility with swagger schema

### DIFF
--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -1,16 +1,30 @@
 server {
     listen 3001;
 
+    # External API
     location / {
         include cors.conf;
         proxy_pass http://node1:3013/;
     }
 
+    # Internal API
     location /internal/ {
+        # Backward compatibility
         include cors.conf;
         proxy_pass http://node1:3113/;
     }
 
+    location /v2/debug {
+        include cors.conf;
+        proxy_pass http://node1:3113/v2/debug;
+    }
+
+    location /v2/key-blocks {
+        include cors.conf;
+        proxy_pass http://node1:3113/v2/key-blocks;
+    }
+
+    # State Channels Web Sockets
     location /channel {
         include cors.conf;
         include ws.conf;
@@ -21,16 +35,30 @@ server {
 server {
     listen 3002;
 
+    # External API
     location / {
         include cors.conf;
         proxy_pass http://node2:3013/;
     }
 
+    # Internal API
     location /internal/ {
+        # Backward compatibility
         include cors.conf;
         proxy_pass http://node2:3113/;
     }
 
+    location /v2/debug {
+        include cors.conf;
+        proxy_pass http://node2:3113/v2/debug;
+    }
+
+    location /v2/key-blocks {
+        include cors.conf;
+        proxy_pass http://node2:3113/v2/key-blocks;
+    }
+
+    # State Channels Web Sockets
     location /channel {
         include cors.conf;
         include ws.conf;
@@ -41,16 +69,30 @@ server {
 server {
     listen 3003;
 
+    # External API
     location / {
         include cors.conf;
         proxy_pass http://node3:3013/;
     }
 
+    # Internal API
     location /internal/ {
+        # Backward compatibility
         include cors.conf;
         proxy_pass http://node3:3113/;
     }
 
+    location /v2/debug {
+        include cors.conf;
+        proxy_pass http://node3:3113/v2/debug;
+    }
+
+    location /v2/key-blocks {
+        include cors.conf;
+        proxy_pass http://node3:3113/v2/key-blocks;
+    }
+
+    # State Channels Web Sockets
     location /channel {
         include cors.conf;
         include ws.conf;

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -1,3 +1,7 @@
+# Assumptions:
+# - The set of paths tagged as `internal` and the set of paths tagged as `external` are disjoint.
+# - The set of paths tagged as `internal` is equal to the union of: the set of paths with prefix `/v2/debug`; and the exact path `/v2/key-blocks` (beware that if you do not consider "exact" here, additional constraints need to be considered).
+
 server {
     listen 3001;
 
@@ -19,7 +23,7 @@ server {
         proxy_pass http://node1:3113/v2/debug;
     }
 
-    location /v2/key-blocks {
+    location = /v2/key-blocks {
         include cors.conf;
         proxy_pass http://node1:3113/v2/key-blocks;
     }
@@ -53,7 +57,7 @@ server {
         proxy_pass http://node2:3113/v2/debug;
     }
 
-    location /v2/key-blocks {
+    location = /v2/key-blocks {
         include cors.conf;
         proxy_pass http://node2:3113/v2/key-blocks;
     }
@@ -87,7 +91,7 @@ server {
         proxy_pass http://node3:3113/v2/debug;
     }
 
-    location /v2/key-blocks {
+    location = /v2/key-blocks {
         include cors.conf;
         proxy_pass http://node3:3113/v2/key-blocks;
     }

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -20,12 +20,12 @@ server {
 
     location /v2/debug {
         include cors.conf;
-        proxy_pass http://node1:3113/v2/debug;
+        proxy_pass http://node1:3113;
     }
 
     location = /v2/key-blocks {
         include cors.conf;
-        proxy_pass http://node1:3113/v2/key-blocks;
+        proxy_pass http://node1:3113;
     }
 
     # State Channels Web Sockets
@@ -54,12 +54,12 @@ server {
 
     location /v2/debug {
         include cors.conf;
-        proxy_pass http://node2:3113/v2/debug;
+        proxy_pass http://node2:3113;
     }
 
     location = /v2/key-blocks {
         include cors.conf;
-        proxy_pass http://node2:3113/v2/key-blocks;
+        proxy_pass http://node2:3113;
     }
 
     # State Channels Web Sockets
@@ -88,12 +88,12 @@ server {
 
     location /v2/debug {
         include cors.conf;
-        proxy_pass http://node3:3113/v2/debug;
+        proxy_pass http://node3:3113;
     }
 
     location = /v2/key-blocks {
         include cors.conf;
-        proxy_pass http://node3:3113/v2/key-blocks;
+        proxy_pass http://node3:3113;
     }
 
     # State Channels Web Sockets

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -123,11 +123,8 @@ All local network nodes are configured with the same beneficiary account (for mo
 - private key secret: `secret`
 - key-pair binaries can be found [here](/docker/keys/beneficiary)
 
-Both external and internal API are exposed to the docker host, the URL pattern is as follows:
-- external API - http://$DOCKER_HOST_ADDRESS:$NODE_PORT/
-- internal API - http://$DOCKER_HOST_ADDRESS:$NODE_PORT/internal
-
-Websocket API is exposed to the docker host with following URL pattern:
+All APIs (external, internal and state channels websocket) are exposed to the docker host, the URL pattern is as follows:
+- external/internal API - http://$DOCKER_HOST_ADDRESS:$NODE_PORT/
 - channels API - ws://$DOCKER_HOST_ADDRESS:$NODE_PORT/channel
 
 Node ports:

--- a/docs/release-notes/next/PT-0-localnet-api.md
+++ b/docs/release-notes/next/PT-0-localnet-api.md
@@ -1,0 +1,2 @@
+- Localnet setup (docker-compose) has been improved by adding node API compatibility of the internal endpoints,
+    e.g. `/v2/debug` is now available without prefix. The `/internal` prefix is now deprecated.


### PR DESCRIPTION
Swagger schema expects /v2/debug prefix, while current configuration is adding additional /internal prefix. While SDKs have support to configure 2 different URLs for internal and external endpoints, the additional compatibility configuration in this PR should make the user lives easier