### PR TITLE
Preparation for miner signalled consensus upgrade

### DIFF
--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -157,7 +157,7 @@ check_update_tx(SignedTx, Updates, #state{signed_tx = OldSignedTx}=State,
     {Mod, TxI} = aetx:specialize_callback(aetx_sign:innermost_tx(SignedTx)),
     lager:debug("Tx = ~p", [TxI]),
     case Mod:valid_at_protocol(Protocol, TxI) of
-        false -> {error, invalid_at_height};
+        false -> {error, invalid_at_protocol};
         true ->
             case Mod of
                 aesc_close_mutual_tx -> ok; % no particular check for a close mutual

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -1120,7 +1120,16 @@ call(Fun, Xs) when is_function(Fun, 1 + length(Xs)) ->
 -define(call(Fun, X, Y, Z, U, V, W), call(Fun, fun Fun/7, [X, Y, Z, U, V, W])).
 
 perform_pre_transformations(Height, S) when Height > ?GENESIS_HEIGHT ->
-    Trees = aec_trees:perform_pre_transformations(aect_test_utils:trees(S), Height),
+    Vsn = aec_hard_forks:protocol_effective_at_height(Height),
+    %% Exploit assumption that no two commands at same height.
+    PrevVsn =
+        case Height - 1 of
+            ?GENESIS_HEIGHT ->
+                undefined;
+            PrevHeight ->
+                aec_hard_forks:protocol_effective_at_height(PrevHeight)
+        end,
+    Trees = aec_trees:perform_pre_transformations(aect_test_utils:trees(S), PrevVsn, Vsn, Height),
     {ok, aect_test_utils:set_trees(Trees, S)}.
 
 new_account(Balance, S) ->

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -3,8 +3,7 @@
 -export([check_env/0]).
 -export([protocols/0,
          check_protocol_version_validity/2,
-         protocol_effective_at_height/1,
-         is_fork_height/1
+         protocol_effective_at_height/1
         ]).
 
 -ifdef(TEST).
@@ -57,14 +56,6 @@ check_protocol_version_validity(Version, Height) ->
 -spec protocol_effective_at_height(aec_blocks:height()) -> version().
 protocol_effective_at_height(H) ->
     protocol_effective_at_height(H, protocols()).
-
--spec is_fork_height(aec_blocks:height()) -> false | {true, protocol_vsn()}.
-is_fork_height(Height) ->
-    Protocols = maps:filter(fun(_P, H) -> H =:= Height end, protocols()),
-    case map_size(Protocols) of
-        0 -> false;
-        1 -> {true, hd(maps:keys(Protocols))}
-    end.
 
 %%%===================================================================
 %%% Internal functions

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -770,7 +770,8 @@ check_tx_ttl(STx, _Hash, Height, _Event) ->
     end.
 
 check_valid_at_protocol(STx, _Hash, Height, _Event) ->
-    aetx:check_protocol_at_height(aetx_sign:tx(STx), Height).
+    Protocol = aec_hard_forks:protocol_effective_at_height(Height),
+    aetx:check_protocol(aetx_sign:tx(STx), Protocol).
 
 check_signature(Tx, Hash, Height, _Event) ->
     {ok, Trees} = aec_chain:get_top_state(),

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -1968,13 +1968,6 @@ hard_fork_inserts_new_accounts() ->
     ok.
 
 meck_minerva_fork_height(Height) ->
-    meck:expect(aec_hard_forks, is_fork_height,
-                fun(H) ->
-                    case H =:= Height of
-                        true -> {true, ?MINERVA_PROTOCOL_VSN};
-                        false -> false
-                    end
-                end),
     meck:expect(aec_hard_forks, protocol_effective_at_height,
                 fun(H) ->
                     case H >= Height of

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -376,7 +376,7 @@ create_keyblock_with_state([{PrevBlock, TreesIn} | _] = Chain, MinerAccount, Ben
     {ok, PrevBlockHash} = aec_blocks:hash_internal_representation(PrevBlock),
     Height = aec_blocks:height(PrevBlock) + 1,
     Version = aec_hard_forks:protocol_effective_at_height(Height),
-    Trees1 = aec_trees:perform_pre_transformations(TreesIn, Height),
+    Trees1 = aec_trees:perform_pre_transformations(TreesIn, aec_blocks:version(PrevBlock), Version, Height),
     Delay = aec_governance:beneficiary_reward_delay(),
     PrevKeyHash = case aec_blocks:type(PrevBlock) of
                       micro -> aec_blocks:prev_key_hash(PrevBlock);

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -34,7 +34,7 @@
         , specialize_callback/1
         , update_tx/2
         , valid_at_protocol/2
-        , check_protocol_at_height/2]).
+        , check_protocol/2]).
 
 -ifdef(TEST).
 -export([tx/1]).
@@ -395,7 +395,7 @@ check_tx(#aetx{ cb = CB, tx = Tx } = AeTx, Trees, Env) ->
         [fun() -> check_minimum_fee(AeTx, Env) end,
          fun() -> check_minimum_gas_price(AeTx, aetx_env:height(Env)) end,
          fun() -> check_ttl(AeTx, Env) end,
-         fun() -> check_protocol_at_height(AeTx, aetx_env:height(Env)) end
+         fun() -> check_protocol(AeTx, aetx_env:consensus_version(Env)) end
         ],
     case aeu_validation:run(Checks) of
         ok             -> CB:check(Tx, Trees, Env);
@@ -441,11 +441,10 @@ check_ttl(AeTx, Env) ->
         false -> {error, ttl_expired}
     end.
 
-check_protocol_at_height(AeTx, Height) ->
-    Protocol = aec_hard_forks:protocol_effective_at_height(Height),
+check_protocol(AeTx, Protocol) ->
     case valid_at_protocol(Protocol, AeTx) of
         true  -> ok;
-        false -> {error, invalid_at_height}
+        false -> {error, invalid_at_protocol}
     end.
 
 %%%===================================================================

--- a/test/measure_gas_SUITE.erl
+++ b/test/measure_gas_SUITE.erl
@@ -204,8 +204,11 @@ init(Accounts) ->
 
 %% Mine at height Height
 mine(Height, Trees) ->
-    Trees1 = aec_trees:perform_pre_transformations(Trees, Height + 1),
-    {Trees1, aetx_env:tx_env(Height + 1)}.
+    Vsn = aec_hard_forks:protocol_effective_at_height(Height),
+    NextH = Height + 1,
+    NextVsn = aec_hard_forks:protocol_effective_at_height(NextH),
+    Trees1 = aec_trees:perform_pre_transformations(Trees, Vsn, NextVsn, NextH),
+    {Trees1, aetx_env:tx_env(NextH)}.
 
 contract_create(Trees, Sender, CompiledContract, Init, Args, Backend) ->
     #{contract_source := Contract} = CompiledContract,


### PR DESCRIPTION
Prepared while designing https://www.pivotaltracker.com/story/show/166642114

Supersedes #2618 (fixes `aec_block_key_candidate_tests `)

TODO:
* [x] Relax from `aec_headers:deserialize_key_from_binary` the check of the consensus based on the height.
* [x] `aec_headers:validate_key_block_header` has a consensus-height check `validate_version`, such `aec_headers:validate_key_block_header` is called only from `aec_conductor:post_block` and `aec_conductor:add_synced_block`, and in both points the block being added is meant to be connected to genesis. Restructure code so to rely on miner signalling having ended already.
* [x] `aec_headers:validate_micro_block_header` has a consensus-height check `validate_version`, and is called from the following points:
  -  `aec_conductor:post_block` and `aec_conductor:add_synced_block`, and in both points the block being added is meant to be connected to genesis. Restructure code so to rely on miner signalling having ended already.
  - `aec_peer_connection:handle_new_micro_block`: function `pre_assembly_check` already has assumption - in a check - that previous key block is present, and that hence the micro block signature can be checked. Such assumption of knowledge of key block may be exploited, relying on consensus meant to change only at key blocks.
* [x] In `aec_chain_state:calculate_state_for_new_keyblock`, in line `fake_key_node` compute consensus version considering user config and miner signalling. This is possible because this function is called from two points:
  - `create_key_block_candidate` in `aec_conductor`. This bases the candidate on the top block.
  - `get_pending_key_block` in `aec_conductor`. This bases the candidate on the top block.
    - Orthogonal question: is this function needed at all?
* [ ] ...