### PR TITLE
GA always authorizing test

### DIFF
--- a/test/contracts/auth_true.aes
+++ b/test/contracts/auth_true.aes
@@ -1,0 +1,7 @@
+// Contract replicating "normal" Aeternity authentication by always returning true
+contract AuthTrue =
+
+  entrypoint init() = ()
+
+  entrypoint authorize() : bool =
+    true


### PR DESCRIPTION
Making a Generalized account that always authenticates will result in possibility for same transaction posted twice. However, we must have unique transaction hashes. Added a test that shows that indeed same transaction is refused.