### PR TITLE
Add meta update object to SC offchain updates

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -2258,15 +2258,15 @@ handle_upd_transfer(FromPub, ToPub, Amount, From, UOpts, #data{ state = State
                                                               , opts = Opts
                                                               , on_chain_id = ChannelId
                                                               } = D) ->
-    Updates = [aesc_offchain_update:op_transfer(aeser_id:create(account, FromPub),
-                                                aeser_id:create(account, ToPub), Amount)
-              | meta_updates(UOpts)],
     {OnChainEnv, OnChainTrees} = tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     %% TODO PT-165214367: maybe set block_hash
     BlockHash = ?NOT_SET_BLOCK_HASH,
     ActiveProtocol = aec_hard_forks:protocol_effective_at_height(Height),
     try
+        Updates = [aesc_offchain_update:op_transfer(aeser_id:create(account, FromPub),
+                                                    aeser_id:create(account, ToPub), Amount)
+                   | meta_updates(UOpts)],
         Tx1 = aesc_offchain_state:make_update_tx(Updates, State, ChannelId, ActiveProtocol,
                                                  OnChainTrees, OnChainEnv, Opts),
         case request_signing(?UPDATE, Tx1, Updates, BlockHash, D, defer) of

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -263,7 +263,7 @@ upd_deposit(Fsm, #{amount := Amt} = Opts) when is_integer(Amt) ->
 upd_transfer(Fsm, From, To, Amount) ->
     upd_transfer(Fsm, From, To, Amount, #{}).
 
-upd_transfer(_Fsm, _From, _To, Amount, Opts) when Amount < 0 ->
+upd_transfer(_Fsm, _From, _To, Amount, _Opts) when Amount < 0 ->
     {error, negative_amount};
 upd_transfer(Fsm, From, To, Amount, Opts) when is_integer(Amount), is_map(Opts) ->
     lager:debug("upd_transfer(~p, ~p, ~p, ~p, ~p)", [Fsm, From, To, Amount, Opts]),

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -49,6 +49,7 @@
         , upd_create_contract/2   %%
         , upd_deposit/2           %% (fsm() , map())
         , upd_transfer/4          %% (fsm() , from(), to(), amount())
+        , upd_transfer/5          %% (fsm() , from(), to(), amount(), #{})
         , upd_withdraw/2          %% (fsm() , map())
         , where/2
         ]).
@@ -259,11 +260,14 @@ upd_deposit(Fsm, #{amount := Amt} = Opts) when is_integer(Amt) ->
     lager:debug("upd_deposit(~p)", [Opts]),
     gen_statem:call(Fsm, {upd_deposit, Opts}).
 
-upd_transfer(_Fsm, _From, _To, Amount) when Amount < 0 ->
+upd_transfer(Fsm, From, To, Amount) ->
+    upd_transfer(Fsm, From, To, Amount, #{}).
+
+upd_transfer(_Fsm, _From, _To, Amount, Opts) when Amount < 0 ->
     {error, negative_amount};
-upd_transfer(Fsm, From, To, Amount) when is_integer(Amount) ->
-    lager:debug("upd_transfer(~p, ~p, ~p, ~p)", [Fsm, From, To, Amount]),
-    gen_statem:call(Fsm, {upd_transfer, From, To, Amount}).
+upd_transfer(Fsm, From, To, Amount, Opts) when is_integer(Amount), is_map(Opts) ->
+    lager:debug("upd_transfer(~p, ~p, ~p, ~p, ~p)", [Fsm, From, To, Amount, Opts]),
+    gen_statem:call(Fsm, {upd_transfer, From, To, Amount, Opts}).
 
 upd_withdraw(_Fsm, #{amount := Amt}) when Amt < 0 ->
     {error, negative_amount};
@@ -2246,12 +2250,13 @@ check_update_ack_(SignedTx, HalfSignedTx) ->
     lager:debug("Txes are the same", []),
     ok.
 
-handle_upd_transfer(FromPub, ToPub, Amount, From, #data{ state = State
-                                                       , opts = Opts
-                                                       , on_chain_id = ChannelId
-                                                       } = D) ->
+handle_upd_transfer(FromPub, ToPub, Amount, From, UOpts, #data{ state = State
+                                                              , opts = Opts
+                                                              , on_chain_id = ChannelId
+                                                              } = D) ->
     Updates = [aesc_offchain_update:op_transfer(aeser_id:create(account, FromPub),
-                                                aeser_id:create(account, ToPub), Amount)],
+                                                aeser_id:create(account, ToPub), Amount)
+              | meta_updates(UOpts)],
     {OnChainEnv, OnChainTrees} = tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     %% TODO PT-165214367: maybe set block_hash
@@ -2274,6 +2279,11 @@ handle_upd_transfer(FromPub, ToPub, Amount, From, #data{ state = State
         error:Reason ->
             process_update_error(Reason, From, D)
     end.
+
+meta_updates(Opts) when is_map(Opts) ->
+    L = maps:get(meta, Opts, []),
+    [aesc_offchain_update:op_meta(D) || D <- L,
+                                        is_binary(D)].
 
 send_leave_msg(#data{ on_chain_id = ChId
                     , session     = Session} = Data) ->
@@ -3491,11 +3501,11 @@ handle_call_(_AnyState, {inband_msg, ToPub, Msg}, From, #data{} = D) ->
         _ ->
             keep_state(D, [{reply, From, {error, unknown_recipient}}])
     end;
-handle_call_(open, {upd_transfer, FromPub, ToPub, Amount}, From,
+handle_call_(open, {upd_transfer, FromPub, ToPub, Amount, Opts}, From,
             #data{opts = #{initiator := I, responder := R}} = D) ->
     case FromPub =/= ToPub andalso ([] == [FromPub, ToPub] -- [I, R]) of
         true ->
-            handle_upd_transfer(FromPub, ToPub, Amount, From, set_ongoing(D));
+            handle_upd_transfer(FromPub, ToPub, Amount, From, Opts, set_ongoing(D));
         false ->
             keep_state(set_ongoing(D), [{reply, From, {error, invalid_pubkeys}}])
     end;

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -1,6 +1,7 @@
 -module(aesc_offchain_update).
 
 -define(UPDATE_VSN, 2).
+-define(UPDATE_VSN_1_OR_2(V), V =:= 1; V =:= 2).
 
 -record(transfer, {
           from_id      :: aeser_id:id(),
@@ -367,23 +368,23 @@ type2swagger_name(call_contract)   -> <<"OffChainCallContract">>;
 type2swagger_name(meta)            -> <<"OffChainMeta">>.
 
 -spec update_serialization_template(non_neg_integer(), update_type()) -> list().
-update_serialization_template(?UPDATE_VSN, transfer) ->
+update_serialization_template(V, transfer) when ?UPDATE_VSN_1_OR_2(V) ->
     [ {from,    id},
       {to,      id},
       {amount,  int}];
-update_serialization_template(?UPDATE_VSN, deposit) ->
+update_serialization_template(V, deposit) when ?UPDATE_VSN_1_OR_2(V) ->
     [ {from,    id},
       {amount,  int}];
-update_serialization_template(?UPDATE_VSN, withdraw) ->
+update_serialization_template(V, withdraw) when ?UPDATE_VSN_1_OR_2(V) ->
     [ {to,      id},
       {amount,  int}];
-update_serialization_template(?UPDATE_VSN, create_contract) ->
+update_serialization_template(V, create_contract) when ?UPDATE_VSN_1_OR_2(V) ->
     [ {owner,       id},
       {ct_version,  int},
       {code,        binary},
       {deposit,     int},
       {call_data,   binary}];
-update_serialization_template(?UPDATE_VSN, call_contract) ->
+update_serialization_template(V, call_contract) when ?UPDATE_VSN_1_OR_2(V) ->
     [ {caller,      id},
       {contract,    id},
       {abi_version, int},

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -1,6 +1,6 @@
 -module(aesc_offchain_update).
 
--define(UPDATE_VSN, 1).
+-define(UPDATE_VSN, 2).
 
 -record(transfer, {
           from_id      :: aeser_id:id(),
@@ -38,14 +38,17 @@
           gas          :: non_neg_integer()
          }).
 
+-record(meta, { data :: binary() }).
+
 -opaque update() :: #transfer{}
                   | #withdraw{}
                   | #deposit{}
                   | #create_contract{}
-                  | #call_contract{}.
+                  | #call_contract{}
+                  | #meta{}.
 
 -type update_type() :: transfer | withdraw | deposit | create_contract |
-                       call_contract.
+                       call_contract | meta.
 
 -export_type([update/0]).
 
@@ -55,6 +58,7 @@
         , op_new_contract/6
         , op_call_contract/6
         , op_call_contract/8
+        , op_meta/1
         ]).
 
 -export([serialize/1,
@@ -88,6 +92,8 @@ from_db_format(#create_contract{} = U) ->
     U;
 from_db_format(#call_contract{} = U) ->
     U;
+from_db_format(#meta{} = U) ->
+    U;
 from_db_format(Tuple) ->
     OldType = element(1, Tuple),
     NewType = maps:get(OldType, #{0 => transfer,
@@ -102,6 +108,7 @@ from_db_format(Tuple) ->
         #deposit{} -> Updated;
         #create_contract{} -> Updated;
         #call_contract{} -> Updated;
+        #meta{} -> Updated;
         _ ->
             error(illegal_db_format)
     end.
@@ -159,6 +166,9 @@ op_call_contract(CallerId, ContractId, ABIVersion, Amount, CallData, CallStack,
                    gas_price = GasPrice,
                    gas = Gas}.
 
+op_meta(Data) ->
+    #meta{ data = Data }.
+
 -spec apply_on_trees(aesc_offchain_update:update(), aec_trees:trees(),
                      aec_trees:trees(), aetx_env:env(),
                      non_neg_integer(), non_neg_integer()) -> aec_trees:trees().
@@ -201,7 +211,9 @@ apply_on_trees(Update, Trees0, OnChainTrees, OnChainEnv, Round, Reserve) ->
             _Trees = aect_channel_contract:run(ContractPubKey, ABIVersion, Call,
                                                CallData, CallStack,
                                                Trees2, Amount, GasPrice, Gas,
-                                               OnChainTrees, OnChainEnv)
+                                               OnChainTrees, OnChainEnv);
+        #meta{} ->
+            Trees0
     end.
 
 -spec for_client(update()) -> map().
@@ -240,7 +252,11 @@ for_client(#call_contract{caller_id = CallerId, contract_id = ContractId,
       <<"gas">>         => Gas,
       <<"gas_price">>   => GasPrice,
       <<"call_data">>   => aeser_api_encoder:encode(contract_bytearray, CallData),
-      <<"call_stack">>  => CallStack}.
+      <<"call_stack">>  => CallStack};
+for_client(#meta{data = Data}) ->
+    #{<<"op">>   => type2swagger_name(meta),
+      <<"data">> => Data}.
+
 
 -spec serialize(update()) -> binary().
 serialize(Update) ->
@@ -291,7 +307,9 @@ update2fields(#call_contract{caller_id = CallerId, contract_id = ContractId,
       {gas, Gas},
       {gas_price, GasPrice},
       {call_data, CallData},
-      {call_stack, CallStack}].
+      {call_stack, CallStack}];
+update2fields(#meta{data = Data}) ->
+    [ {data, Data} ].
 
 -spec fields2update(update_type(), list()) -> update().
 fields2update(transfer, [{from,   From},
@@ -320,28 +338,33 @@ fields2update(call_contract, [ {caller, CallerId},
                                {call_data, CallData},
                                {call_stack, CallStack}]) ->
     op_call_contract(CallerId, ContractId, ABIVersion, Amount, CallData,
-                     CallStack, GasPrice, Gas).
+                     CallStack, GasPrice, Gas);
+fields2update(meta, [{data, Data}]) ->
+    op_meta(Data).
 
 -spec ut2type(update_type())  -> atom().
 ut2type(transfer)             -> channel_offchain_update_transfer;
 ut2type(deposit)              -> channel_offchain_update_deposit;
 ut2type(withdraw)             -> channel_offchain_update_withdraw;
 ut2type(create_contract)      -> channel_offchain_update_create_contract;
-ut2type(call_contract)        -> channel_offchain_update_call_contract.
+ut2type(call_contract)        -> channel_offchain_update_call_contract;
+ut2type(meta)                 -> channel_offchain_update_meta.
 
 -spec type2ut(atom()) -> update_type().
 type2ut(channel_offchain_update_transfer)         -> transfer;
 type2ut(channel_offchain_update_deposit)          -> deposit;
 type2ut(channel_offchain_update_withdraw)         -> withdraw;
 type2ut(channel_offchain_update_create_contract)  -> create_contract;
-type2ut(channel_offchain_update_call_contract)    -> call_contract.
+type2ut(channel_offchain_update_call_contract)    -> call_contract;
+type2ut(channel_offchain_update_meta)             -> meta.
 
 -spec type2swagger_name(update_type()) -> binary().
 type2swagger_name(transfer)        -> <<"OffChainTransfer">>;
 type2swagger_name(deposit)         -> <<"OffChainDeposit">>;
 type2swagger_name(withdraw)        -> <<"OffChainWithdrawal">>;
 type2swagger_name(create_contract) -> <<"OffChainNewContract">>;
-type2swagger_name(call_contract)   -> <<"OffChainCallContract">>.
+type2swagger_name(call_contract)   -> <<"OffChainCallContract">>;
+type2swagger_name(meta)            -> <<"OffChainMeta">>.
 
 -spec update_serialization_template(non_neg_integer(), update_type()) -> list().
 update_serialization_template(?UPDATE_VSN, transfer) ->
@@ -368,14 +391,17 @@ update_serialization_template(?UPDATE_VSN, call_contract) ->
       {gas,         int},
       {gas_price,   int},
       {call_data,   binary},
-      {call_stack,  [int]}].
+      {call_stack,  [int]}];
+update_serialization_template(?UPDATE_VSN, meta) ->
+    [ {data, binary} ].
 
 -spec record_to_update_type(update()) -> update_type().
 record_to_update_type(#transfer{})        -> transfer;
 record_to_update_type(#deposit{})         -> deposit;
 record_to_update_type(#withdraw{})        -> withdraw;
 record_to_update_type(#create_contract{}) -> create_contract;
-record_to_update_type(#call_contract{})   -> call_contract.
+record_to_update_type(#call_contract{})   -> call_contract;
+record_to_update_type(#meta{})            -> meta.
 
 check_min_amt(Amt, Reserve) ->
     if Amt < Reserve ->

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -171,6 +171,7 @@ op_call_contract(CallerId, ContractId, ABIVersion, Amount, CallData, CallStack,
                    gas = Gas}.
 
 op_meta(Data) ->
+    true = can_serialize(meta),
     #meta{ data = Data }.
 
 -spec apply_on_trees(aesc_offchain_update:update(), aec_trees:trees(),
@@ -507,3 +508,9 @@ extract_abi_version(#call_contract{abi_version = ABIVersion}) ->
 
 update_error(Err) ->
     error({off_chain_update_error, Err}).
+
+can_serialize(Op) ->
+    can_serialize(Op, get_update_vsn()).
+
+can_serialize(meta, ?UPDATE_VSN_1) -> error(meta_not_allowed);
+can_serialize(_   ,             _) -> true.

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -740,7 +740,8 @@ update_volley(#{pub := PubI} = I, #{pub := PubR} = R, Cfg) ->
     do_update(PubI, PubR, 1, I1, R1, false, Cfg).
 
 do_update(From, To, Amount, #{fsm := FsmI} = I, R, Debug, Cfg) ->
-    rpc(dev1, aesc_fsm, upd_transfer, [FsmI, From, To, Amount], Debug),
+    Opts = #{meta => [<<"meta1">>, <<"meta2">>]},
+    rpc(dev1, aesc_fsm, upd_transfer, [FsmI, From, To, Amount, Opts], Debug),
     {I1, _} = await_signing_request(update, I, Debug, Cfg),
     {R1, _} = await_signing_request(update_ack, R, Debug, Cfg),
     check_info(if_debug(Debug, 20, 0), Debug),
@@ -2365,6 +2366,8 @@ if_debug(_, _, Y) -> Y.
 
 apply_updates([], R) ->
     R;
+apply_updates([{meta, _} | T], R) ->
+    apply_updates(T, R);
 apply_updates([{transfer, FromId, ToId, Amount} | T], R) -> %TODO:FIX THIS
     From = aeser_id:specialize(FromId, account),
     To = aeser_id:specialize(ToId, account),

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -26,6 +26,7 @@
         , channel_insufficent_tokens/1
         , inband_msgs/1
         , upd_transfer/1
+        , upd_transfer_meta_fails_on_old_vsn/1
         , update_with_conflict/1
         , update_with_soft_reject/1
         , deposit_with_conflict/1
@@ -130,6 +131,7 @@ groups() ->
       , channel_insufficent_tokens
       , inband_msgs
       , upd_transfer
+      , upd_transfer_meta_fails_on_old_vsn
       , update_with_conflict
       , update_with_soft_reject
       , deposit_with_conflict
@@ -493,6 +495,36 @@ upd_transfer(Cfg) ->
     check_info(20),
     ok.
 
+upd_transfer_meta_fails_on_old_vsn(Cfg) ->
+    Debug = get_debug(Cfg),
+    XOpts = #{versions => #{offchain_update => 1}},
+    #{ i := #{fsm := FsmI, channel_id := ChannelId} = I
+     , r := #{} = R
+     , spec := #{ initiator := PubI
+                , responder := PubR }} = create_channel_(
+                                           [?SLOGAN|Cfg], XOpts, Debug),
+    {BalI, BalR} = get_both_balances(FsmI, PubI, PubR),
+    try  do_update(PubI, PubR, 2, I, R, true, Cfg),
+         error(expected_to_fail)
+    catch
+        throw:{error, _} = Error->
+            log(Debug, "Got expected error: ~p", [Error]),
+            ok
+    end,
+    {I1, R1} = do_update(PubI, PubR, 2, I, R, true, [{use_meta,false}|Cfg]),
+    {BalI1, BalR1} = get_both_balances(FsmI, PubI, PubR),
+    BalI1 = BalI - 2,
+    BalR1 = BalR + 2,
+    ok = rpc(dev1, aesc_fsm, shutdown, [FsmI]),
+    {_I2, _} = await_signing_request(shutdown, I1, Cfg),
+    {_R2, _} = await_signing_request(shutdown_ack, R1, Cfg),
+    SignedTx = await_on_chain_report(I, ?TIMEOUT),
+    SignedTx = await_on_chain_report(R, ?TIMEOUT), % same tx
+    wait_for_signed_transaction_in_block(dev1, SignedTx, Debug),
+    verify_close_mutual_tx(SignedTx, ChannelId),
+    check_info(20),
+    ok.
+
 update_with_conflict(Cfg) ->
     Debug = true,
     #{ i := #{fsm := FsmI} = I
@@ -740,12 +772,19 @@ update_volley(#{pub := PubI} = I, #{pub := PubR} = R, Cfg) ->
     do_update(PubI, PubR, 1, I1, R1, false, Cfg).
 
 do_update(From, To, Amount, #{fsm := FsmI} = I, R, Debug, Cfg) ->
-    Opts = #{meta => [<<"meta1">>, <<"meta2">>]},
-    rpc(dev1, aesc_fsm, upd_transfer, [FsmI, From, To, Amount, Opts], Debug),
-    {I1, _} = await_signing_request(update, I, Debug, Cfg),
-    {R1, _} = await_signing_request(update_ack, R, Debug, Cfg),
-    check_info(if_debug(Debug, 20, 0), Debug),
-    {I1, R1}.
+    Opts = case proplists:get_value(use_meta, Cfg, true) of
+               true  -> #{meta => [<<"meta1">>, <<"meta2">>]};
+               false -> #{}
+           end,
+    case rpc(dev1, aesc_fsm, upd_transfer, [FsmI, From, To, Amount, Opts], Debug) of
+        {error, _} = Error ->
+            throw(Error);
+        ok ->
+            {I1, _} = await_signing_request(update, I, Debug, Cfg),
+            {R1, _} = await_signing_request(update_ack, R, Debug, Cfg),
+            check_info(if_debug(Debug, 20, 0), Debug),
+            {I1, R1}
+    end.
 
 msg_volley(#{fsm := FsmI, pub := PubI} = I, #{fsm := FsmR, pub := PubR} = R, _) ->
     rpc(dev1, aesc_fsm, inband_msg, [FsmI, PubR, <<"ping">>], false),
@@ -1763,18 +1802,27 @@ create_channel_(Cfg) ->
     create_channel_(Cfg, get_debug(Cfg)).
 
 create_channel_(Cfg, Debug) ->
-    {I, R, Spec} = channel_spec(Cfg),
+    create_channel_(Cfg, #{}, Debug).
+
+create_channel_(Cfg, XOpts, Debug) ->
+    {I, R, Spec} = channel_spec(Cfg, XOpts),
     log(Debug, "channel_spec: ~p", [{I, R, Spec}]),
     Port = proplists:get_value(port, Cfg, 9325),
     create_channel_from_spec(I, R, Spec, Port, proplists:get_bool(use_any, Cfg),
                              Debug, Cfg).
 
 channel_spec(Cfg) ->
+    channel_spec(Cfg, #{}).
+
+channel_spec(Cfg, XOpts) ->
     PushAmount = proplists:get_value(push_amount, Cfg, 200000),
     ChannelReserve = proplists:get_value(channel_reserve, Cfg, 300000),
-    channel_spec(Cfg, ChannelReserve, PushAmount).
+    channel_spec(Cfg, ChannelReserve, PushAmount, XOpts).
 
 channel_spec(Cfg, ChannelReserve, PushAmount) ->
+    channel_spec(Cfg, ChannelReserve, PushAmount, #{}).
+
+channel_spec(Cfg, ChannelReserve, PushAmount, XOpts) ->
     I = ?config(initiator, Cfg),
     R = ?config(responder, Cfg),
 
@@ -1783,19 +1831,19 @@ channel_spec(Cfg, ChannelReserve, PushAmount) ->
 
     IAmt = ?config(initiator_amount, Cfg),
     RAmt = ?config(responder_amount, Cfg),
-    Spec = #{initiator        => maps:get(pub, I),
-             responder        => maps:get(pub, R),
-             initiator_amount => IAmt,
-             responder_amount => RAmt,
-             push_amount      => PushAmount,
-             lock_period      => 10,
-             channel_reserve  => ChannelReserve,
-             minimum_depth    => config(minimum_depth, Cfg, ?MINIMUM_DEPTH),
-             client           => self(),
-             noise            => [{noise, Proto}],
-             timeouts         => #{idle => 20000},
-             slogan           => slogan(Cfg),
-             report           => #{debug => true} },
+    Spec = maps:merge(#{initiator        => maps:get(pub, I),
+                        responder        => maps:get(pub, R),
+                        initiator_amount => IAmt,
+                        responder_amount => RAmt,
+                        push_amount      => PushAmount,
+                        lock_period      => 10,
+                        channel_reserve  => ChannelReserve,
+                        minimum_depth    => config(minimum_depth, Cfg, ?MINIMUM_DEPTH),
+                        client           => self(),
+                        noise            => [{noise, Proto}],
+                        timeouts         => #{idle => 20000},
+                        slogan           => slogan(Cfg),
+                        report           => #{debug => true} }, XOpts),
     Spec1 = case ?config(nonce, Cfg) of
                 undefined -> Spec;
                 Nonce     -> Spec#{nonce => Nonce}

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -49,6 +49,7 @@ websocket_init(Params) ->
             {stop, undefined};
         {Handler, ChannelOpts} ->
             lager:debug("Starting Channel WS with params ~p", [Params]),
+            lager:debug("ChannelOpts = ~p", [ChannelOpts]),
             case start_link_fsm(Handler, ChannelOpts) of
                 {ok, FsmPid} ->
                     MRef = erlang:monitor(process, FsmPid),
@@ -304,6 +305,8 @@ read_channel_options(Params) ->
                                                      mandatory => false}),
     ReadReport = ReadMap(report, <<"report">>, #{type => boolean,
                                                      mandatory => false}),
+    ReadVsns = ReadMap(versions, <<"version">>, #{type => integer,
+                                                  mandatory => false}),
     OnChainOpts =
         case (sc_ws_utils:read_param(
                 <<"existing_channel_id">>, existing_channel_id,
@@ -347,6 +350,7 @@ read_channel_options(Params) ->
       ++ lists:map(ReadTimeout, aesc_fsm:timeouts() ++ [awaiting_open,
                                                         initialized])
       ++ lists:map(ReadReport, aesc_fsm:report_tags())
+      ++ lists:map(ReadVsns, aesc_fsm:version_tags())
      ).
 
 jobs_ask() ->

--- a/apps/aehttp/src/sc_ws_utils.erl
+++ b/apps/aehttp/src/sc_ws_utils.erl
@@ -1,0 +1,145 @@
+-module(sc_ws_utils).
+
+-export([ check_params/1
+        , check_params/2
+        , read_f/1
+        , readmap_f/1
+        , put_f/0
+        , read_param/3
+        , check_type/3 ]).
+
+check_params(Checks) ->
+    check_params(Checks, #{}).
+
+check_params(Checks, Acc) ->
+    lists:foldl(
+      fun(_, {error, _} = Err) -> Err;
+         (Fun, Acc1) ->
+              Fun(Acc1)
+      end, Acc, Checks).
+
+read_f(Params) ->
+    fun(KeyBin, Key, Opts) ->
+            fun(M) ->
+                    case (read_param(KeyBin, Key, Opts))(Params) of
+                        not_set -> M;
+                        {ok, Val} -> maps:put(Key, Val, M);
+                        {error, _} = Err -> Err
+                    end
+            end
+    end.
+
+readmap_f(Params) ->
+    fun(MapName, Prefix, Opts) ->
+            fun(Name) ->
+                    NameBin = atom_to_binary(Name, utf8),
+                    Key = <<Prefix/binary, "_", NameBin/binary>>,
+                    fun(M) ->
+                            OldVal = maps:get(MapName, M, #{}),
+                            case (read_param(Key, Name, Opts))(Params) of
+                                not_set -> M;
+                                {ok, Val} -> maps:put(MapName, maps:put(Name, Val, OldVal), M);
+                                {error, _} = Err -> Err
+                            end
+                    end
+            end
+    end.
+
+put_f() ->
+    fun(K, V) ->
+            fun(M) -> maps:put(K, V, M) end
+    end.
+
+-spec read_param(binary(), atom(), map()) -> fun((map()) -> {ok, term()} |
+                                                            not_set |
+                                                            {error, {atom(), atom()}}).
+read_param(ParamName, RecordField, Options) ->
+    fun(Params) ->
+        Mandatory = maps:get(mandatory, Options, true),
+        case maps:get(ParamName, Params, undefined) of
+            undefined when Mandatory ->
+                {error, {RecordField, missing}};
+            undefined when not Mandatory ->
+                not_set;
+            Val ->
+                check_type(Options, Val, RecordField)
+        end
+    end.
+
+check_type(Options, Val0, RecordField) ->
+    Type = maps:get(type, Options, binary),
+    try parse_by_type(Type, Val0, RecordField) of
+        {error, _} = Err -> Err;
+        {ok, Val} ->
+            case maps:get(enum, Options, undefined) of
+                undefined ->  {ok, Val};
+                AllowedVals when is_list(AllowedVals) ->
+                    case lists:member(Val, AllowedVals) of
+                        true -> {ok, Val};
+                        false ->
+                            {error, {RecordField, invalid}}
+                    end
+            end
+    catch
+        error:_ -> {error, {RecordField, invalid}}
+    end.
+
+parse_by_type(binary, V, _) when is_binary(V) ->
+    {ok, V};
+parse_by_type(boolean, V, _) when is_binary(V) ->
+    case V of
+        <<"true">>  -> {ok, true};
+        <<"false">> -> {ok, false};
+        _           -> {error, not_bool}
+    end;
+parse_by_type(string, V, _) when is_binary(V) ->
+    {ok, binary_to_list(V)};
+parse_by_type(atom, V, _) when is_binary(V) ->
+    {ok, binary_to_existing_atom(V, utf8)};
+parse_by_type(integer, V, _) when is_binary(V) ->
+    {ok, list_to_integer(binary_to_list(V))};
+parse_by_type(integer, V, _) when is_integer(V) ->
+    {ok, V};
+parse_by_type({hash, Type}, V, RecordField) when is_binary(V) ->
+    case aeser_api_encoder:safe_decode(Type, V) of
+        {error, _} ->
+            {error, {RecordField, broken_encoding}};
+        {ok, _} = OK -> OK
+    end;
+parse_by_type({alt, L}, V, RecordField) when is_list(L) ->
+    lists:foldl(
+      fun(_, {ok,_} = Ok) -> Ok;
+         (Alt, Acc) when is_map(Alt) ->
+              case check_type(Alt, V, RecordField) of
+                  {ok, _} = Ok -> Ok;
+                  {error,_} -> Acc
+              end
+      end, {error, {RecordField, invalid}}, L);
+parse_by_type(serialized_tx, V, RecordField) when is_binary(V) ->
+    case aeser_api_encoder:safe_decode(transaction, V) of
+        {ok, TxBin} ->
+            try {ok, aetx_sign:deserialize_from_binary(TxBin)}
+            catch
+                error:_ ->
+                    {error, {RecordField, invalid_tx_serialization}}
+            end;
+        {error, _} ->
+            {error, {RecordField, broken_encoding}}
+    end;
+parse_by_type({list, Opts}, V, RecordField) when is_list(V) ->
+    ThrowTag = {?MODULE, ?LINE},
+    try V1 = lists:map(
+               fun(X) ->
+                       case check_type(Opts, X, RecordField) of
+                           {ok, X1} ->
+                               X1;
+                           {error, _} = Err ->
+                               throw({ThrowTag, Err})
+                       end
+               end, V),
+         {ok, V1}
+    catch
+        throw:{ThrowTag, Err} ->
+            Err
+    end.
+                                               

--- a/apps/aehttp/src/sc_ws_utils.erl
+++ b/apps/aehttp/src/sc_ws_utils.erl
@@ -142,4 +142,3 @@ parse_by_type({list, Opts}, V, RecordField) when is_list(V) ->
         throw:{ThrowTag, Err} ->
             Err
     end.
-                                               

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -22,6 +22,7 @@
     sc_ws_basic_open_close_server/1,
     sc_ws_failed_update/1,
     sc_ws_generic_messages/1,
+    sc_ws_update_with_meta/1,
     sc_ws_update_conflict/1,
     sc_ws_snapshot_solo/1,
     sc_ws_close_mutual/1,
@@ -99,6 +100,7 @@ groups() ->
         sc_ws_basic_open_close,
         sc_ws_basic_open_close_server,
         sc_ws_snapshot_solo,
+        sc_ws_update_with_meta,
         %% both can start close mutual
         sc_ws_close_mutual,
         %% both can solo-close
@@ -684,6 +686,7 @@ channel_update(#{initiator := IConnPid, responder :=RConnPid},
                 {RConnPid, IConnPid, RPubkey, RPrivkey,
                                     IPubkey, IPrivkey}
         end,
+    IncludeMeta = proplists:get_bool(include_meta, Config),
     ok = ?WS:register_test_for_channel_events(IConnPid, [sign, info, update,
                                                          get, error]),
     ok = ?WS:register_test_for_channel_events(RConnPid, [sign, info, update,
@@ -696,9 +699,15 @@ channel_update(#{initiator := IConnPid, responder :=RConnPid},
                       end,
     {ok, {Ba0, Bb0} = Bal0} = GetBothBalances(IConnPid),
     ct:log("Balances before: ~p", [Bal0]),
-    UpdateOpts = #{from => aeser_api_encoder:encode(account_pubkey, StarterPubkey),
+    UpdateOpts0 = #{from => aeser_api_encoder:encode(account_pubkey, StarterPubkey),
                    to => aeser_api_encoder:encode(account_pubkey, AcknowledgerPubkey),
                    amount => Amount},
+    MetaStr = <<"meta 1">>,
+    UpdateOpts = if IncludeMeta ->
+                         UpdateOpts0#{ meta => [MetaStr] };
+                    true ->
+                         UpdateOpts0
+                 end,
     if TestErrors ->
             ws_send_tagged(StarterPid, <<"channels.update.new">>,
                            UpdateOpts#{amount => <<"1">>}, Config),
@@ -711,6 +720,10 @@ channel_update(#{initiator := IConnPid, responder :=RConnPid},
             ws_send_tagged(StarterPid, <<"channels.update.new">>,
                            UpdateOpts#{to => <<"ABCDEF">>}, Config),
             {ok, #{<<"reason">> := <<"broken_encoding: accounts">>}} =
+                wait_for_channel_event(StarterPid, error, Config),
+            ws_send_tagged(StarterPid, <<"channels.update.new">>,
+                           UpdateOpts#{meta => 17}, Config),
+            {ok, #{<<"reason">> := <<"Invalid meta object">>}} =
                 wait_for_channel_event(StarterPid, error, Config);
        true -> ok
     end,
@@ -719,21 +732,17 @@ channel_update(#{initiator := IConnPid, responder :=RConnPid},
 
     %% starter signs the new state
     #{tx := UnsignedStateTx,
-      updates := Updates} = channel_sign_tx(StarterPubkey, StarterPid, StarterPrivkey, <<"channels.update">>, Config),
+      updates := UpdatesS} = channel_sign_tx(StarterPubkey, StarterPid, StarterPrivkey, <<"channels.update">>, Config),
     ct:log("Unsigned state tx ~p", [UnsignedStateTx]),
     %% verify contents
     {channel_offchain_tx, _OffchainTx} = aetx:specialize_type(UnsignedStateTx),
-    [Update] = Updates,
-    Expected = aesc_offchain_update:op_transfer(aeser_id:create(account, StarterPubkey),
-                                                aeser_id:create(account, AcknowledgerPubkey), Amount),
-    ExpectedForClient = aesc_offchain_update:for_client(Expected),
-    {ExpectedForClient, _} = {Update, ExpectedForClient},
-
+    ok = verify_updates(UpdatesS, StarterPubkey, AcknowledgerPubkey, Amount, IncludeMeta, MetaStr),
 
     %% acknowledger signs the new state
     {ok, #{<<"event">> := <<"update">>}} = wait_for_channel_event(AcknowledgerPid, info, Config),
     #{tx := UnsignedStateTx,
-      updates := Updates} = channel_sign_tx(AcknowledgerPubkey, AcknowledgerPid, AcknowledgerPrivkey, <<"channels.update_ack">>, Config),
+      updates := UpdatesR} = channel_sign_tx(AcknowledgerPubkey, AcknowledgerPid, AcknowledgerPrivkey, <<"channels.update_ack">>, Config),
+    {UpdatesR, UpdatesS} = {UpdatesS, UpdatesR},   % verify that they are identical
 
     {ok, #{<<"state">> := NewState}} = wait_for_channel_event(IConnPid, update, Config),
     {ok, #{<<"state">> := NewState}} = wait_for_channel_event(RConnPid, update, Config),
@@ -764,6 +773,25 @@ channel_update(#{initiator := IConnPid, responder :=RConnPid},
 
     ok.
 
+verify_updates(Updates, StarterPubkey, AcknowledgerPubkey, Amount, false, _) ->
+    [Update] = Updates,
+    Expected = aesc_offchain_update:op_transfer(
+                 aeser_id:create(account, StarterPubkey),
+                 aeser_id:create(account, AcknowledgerPubkey), Amount),
+    ExpectedForClient = aesc_offchain_update:for_client(Expected),
+    {ExpectedForClient, _} = {Update, ExpectedForClient},
+    ok;
+verify_updates(Updates, StarterPubkey, AcknowledgerPubkey, Amount, true, MetaStr) ->
+    [Update, Meta] = Updates,
+    ExpUpd = aesc_offchain_update:op_transfer(
+               aeser_id:create(account, StarterPubkey),
+               aeser_id:create(account, AcknowledgerPubkey), Amount),
+    ExpMeta = aesc_offchain_update:op_meta(MetaStr),
+    ExpUpdForClient = aesc_offchain_update:for_client(ExpUpd),
+    ExpMetaForClient = aesc_offchain_update:for_client(ExpMeta),
+    {ExpUpdForClient, _} = {Update, ExpUpdForClient},
+    {ExpMetaForClient, _} = {Meta, ExpMetaForClient},
+    ok.
 
 channel_update_fail(#{initiator := IConnPid, responder :=RConnPid},
                StarterRole,
@@ -2583,6 +2611,11 @@ wait_for_info_msgs(Pids, Pat, F, Config) when is_list(Pids)
                     end, Pids),
               {ok, Msgs}
       end).
+
+sc_ws_update_with_meta(Config0) ->
+    Config = sc_ws_open_(Config0),
+    ok = sc_ws_update_([include_meta|Config]),
+    ok = sc_ws_close_(Config).
 
 sc_ws_basic_client_reconnect_i(Config) ->
     sc_ws_basic_client_reconnect_(initiator, Config).

--- a/docs/release-notes/next/PT-167808073-offchain-tx-metadata.md
+++ b/docs/release-notes/next/PT-167808073-offchain-tx-metadata.md
@@ -1,0 +1,4 @@
+* Metadata objects (of type binary) can now be added to an offchain update transfer request.
+  These objects serve as comments and are not part of the signed transaction, nor do they
+  affect the offchain state trees. This is an incompatible change in the serialization of offchain
+  updates, but old offchain updates can still be deserialized.

--- a/docs/release-notes/next/PT-167808073-offchain-tx-metadata.md
+++ b/docs/release-notes/next/PT-167808073-offchain-tx-metadata.md
@@ -1,4 +1,5 @@
 * Metadata objects (of type binary) can now be added to an offchain update transfer request.
   These objects serve as comments and are not part of the signed transaction, nor do they
   affect the offchain state trees. This is an incompatible change in the serialization of offchain
-  updates, but old offchain updates can still be deserialized.
+  updates, but old offchain updates can still be deserialized. When creating a channel with a party
+  running an older node version, add `version_offchain_update=1` to the channel params.

--- a/rebar.config
+++ b/rebar.config
@@ -68,7 +68,7 @@
         {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "10cc127"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                          {ref,"d87adfd"}}},
+                          {ref,"e24650d"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
                          {ref, "96ffd9a"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -68,7 +68,7 @@
         {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "10cc127"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                          {ref,"4a07297"}}},
+                          {ref,"d87adfd"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
                          {ref, "96ffd9a"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"4a072977745571ceb6cf34e6387a96b808ae20b3"}},
+      {ref,"d87adfd58333b70a725e707a2caf8a4604e6a126"}},
   0},
  {<<"aestratum_lib">>,
   {git,"https://github.com/aeternity/aestratum_lib.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"d87adfd58333b70a725e707a2caf8a4604e6a126"}},
+      {ref,"e24650d52adc71452be5ab003d74a943f16aaf0d"}},
   0},
  {<<"aestratum_lib">>,
   {git,"https://github.com/aeternity/aestratum_lib.git",

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -157,7 +157,8 @@ test_different_nodes_channel_(InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg)
         responder_node => node2,
         responder_id => ?ALICE,
         responder_amount => 50000 * aest_nodes:gas_price(),
-        push_amount => 2
+        push_amount => 2,
+        version_offchain_update => 1
     },
     simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg).
 

--- a/system_test/common/helpers/aest_api.erl
+++ b/system_test/common/helpers/aest_api.erl
@@ -51,18 +51,20 @@ sc_open(Params, Cfg) ->
     #{ pubkey := RPubKey, privkey := RPrivKey } = RAccount,
 
     {Host, _Port} = node_ws_int_addr(RNodeName, Cfg),
-    Opts = #{
-        protocol => <<"json-rpc">>,
-        host => Host,
-        port => maps:get(responder_port, Params, 9000),
-        initiator_id => aeser_api_encoder:encode(account_pubkey, IPubKey),
-        responder_id => aeser_api_encoder:encode(account_pubkey, RPubKey),
-        lock_period => maps:get(lock_period, Params, 10),
-        push_amount => maps:get(push_amount, Params, 10),
-        initiator_amount => IAmt,
-        responder_amount => RAmt,
-        channel_reserve => maps:get(channel_reserve, Params, 2)
-    },
+    Opts = maps:merge(
+             #{
+               protocol => <<"json-rpc">>,
+               host => Host,
+               port => maps:get(responder_port, Params, 9000),
+               initiator_id => aeser_api_encoder:encode(account_pubkey, IPubKey),
+               responder_id => aeser_api_encoder:encode(account_pubkey, RPubKey),
+               lock_period => maps:get(lock_period, Params, 10),
+               push_amount => maps:get(push_amount, Params, 10),
+               initiator_amount => IAmt,
+               responder_amount => RAmt,
+               channel_reserve => maps:get(channel_reserve, Params, 2)
+              },
+             maps:with([version_offchain_update], Params)),
 
     {ok, IConn} = sc_start_ws(INodeName, initiator, Opts, Cfg),
     ok = ?WS:register_test_for_channel_events(IConn, [info, sign, on_chain_tx]),


### PR DESCRIPTION
See [PT #167808073](https://www.pivotaltracker.com/story/show/167808073)

This PR adds a `{meta, binary()}` update op to the channel_offchain_updates. This could be added to any update request, but is currently only supported by the fsm for `upd_transfer`. The `fsm_SUITE` has been slightly extended to verify that meta objects can be added, but the WS API has not yet been changed to support them.

This PR depends on a PR to aeserialization.