### PR TITLE
PT-167221635 remote type check

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -4496,9 +4496,9 @@ sophia_safe_math() ->
           end,
 
     %% Test vectors
-    Values = [ Z || X <- [1, 2, 5, 173, 255, 256, 1 bsl 128 - 1, 1 bsl 128, Medium, 1 bsl 255 - 2,
-                          1 bsl 255 - 1, 1 bsl 255, Large],
-                    Z <- [X, -X], Z < 1 bsl 255 ],
+    Values = [ Z || Z <- [1, -1, 2, -2, 255, 256, -256, 1 bsl 128 - 1, 1 bsl 128, - (1 bsl 128),
+                          Medium, -Medium, 1 bsl 255 - 1, 1 bsl 255, Large, -Large],
+                    Z < 1 bsl 255 ],
     Ops    = [{add, fun erlang:'+'/2}, {sub,   fun erlang:'-'/2},
               {mul, fun erlang:'*'/2}, {'div', fun erlang:'div'/2},
               {pow, fun(X, Y) -> Pow(X, Y, 1) end}],

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -19,6 +19,13 @@
 %% for testing from a shell
 -export([ init_tests/2 ]).
 
+%% Running contracts
+-export([ state/0, state/1
+        , new_account/2
+        , create_contract/5
+        , call_contract/7
+        ]).
+
 %% test case exports
 -export([ call_contract/1
         , call_contract_error_value/1

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -22,6 +22,7 @@
 -export([ check_remote/2
         , check_return_type/1
         , check_signature_and_bind_args/3
+        , bind_args_from_signature/2
         , unfold_store_maps/2
         , unfold_store_maps_in_args/2
         , check_type/2

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -119,6 +119,7 @@
         , aens_revoke/4
         , ecverify/5
         , ecverify_secp256k1/5
+        , ecrecover_secp256k1/4
         , contract_to_address/3
         , sha3/3
         , sha256/3
@@ -1305,6 +1306,9 @@ ecverify(Arg0, Arg1, Arg2, Arg3, ES) ->
 ecverify_secp256k1(Arg0, Arg1, Arg2, Arg3, ES) ->
     ter_op(ecverify_secp256k1, {Arg0, Arg1, Arg2, Arg3}, ES).
 
+ecrecover_secp256k1(Arg0, Arg1, Arg2, ES) ->
+    bin_op(ecrecover_secp256k1, {Arg0, Arg1, Arg2}, ES).
+
 contract_to_address(Arg0, Arg1, ES) ->
     un_op(contract_to_address, {Arg0, Arg1}, ES).
 
@@ -1602,7 +1606,9 @@ op(bits_difference, A, B)
   when ?IS_FATE_BITS(A), ?IS_FATE_BITS(B) ->
     ?FATE_BITS(BitsA) = A,
     ?FATE_BITS(BitsB) = B,
-    ?FATE_BITS((BitsA band BitsB) bxor BitsA).
+    ?FATE_BITS((BitsA band BitsB) bxor BitsA);
+op(ecrecover_secp256k1, _Hash, _Sig) ->
+    aefa_fate:abort(bad_bytecode).
 
 %% Terinay operations
 op(map_update, Map, Key, Value) when ?IS_FATE_MAP(Map),

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -5,9 +5,9 @@
 -export([ return/1
         , returnr/2
         , call/2
-        , call_r/5
+        , call_r/6
         , call_t/2
-        , call_gr/6
+        , call_gr/7
         , call_value/2
         , jump/2
         , jumpif/3
@@ -154,55 +154,49 @@ unused_2(ES) ->
 %% Call/return instructions
 %% ------------------------------------------------------
 return(EngineState) ->
-    ES = aefa_fate:check_return_type(EngineState),
-    aefa_fate:pop_call_stack(ES).
+    aefa_fate:pop_call_stack(EngineState).
 
 returnr(Arg0, EngineState) ->
     ES1 = un_op(get, {{stack, 0}, Arg0}, EngineState),
-    ES2 = aefa_fate:check_return_type(ES1),
-    aefa_fate:pop_call_stack(ES2).
+    aefa_fate:pop_call_stack(ES1).
 
 call(Arg0, EngineState) ->
     ES1 = aefa_fate:push_return_address(EngineState),
     {Fun, ES2} = get_op_arg(Arg0, ES1),
     Signature = aefa_fate:get_function_signature(Fun, ES2),
-    ES3 = aefa_fate:check_signature_and_bind_args(any, Signature, ES2),
+    ES3 = aefa_fate:bind_args_from_signature(Signature, ES2),
     {jump, 0, aefa_fate:set_local_function(Fun, ES3)}.
 
 call_t(Arg0, EngineState) ->
     {Fun, ES1} = get_op_arg(Arg0, EngineState),
     Signature = aefa_fate:get_function_signature(Fun, ES1),
-    ES2 = aefa_fate:check_signature_and_bind_args(any, Signature, ES1),
-    Caller = aefa_engine_state:current_function(EngineState),
-    CallerSignature = aefa_fate:get_function_signature(Caller, EngineState),
-    CallerTvars = aefa_engine_state:current_tvars(EngineState),
-    ES3 = aefa_fate:push_return_type_check(Signature, CallerSignature, CallerTvars, ES2),
-    {jump, 0, aefa_fate:set_local_function(Fun, ES3)}.
+    ES2 = aefa_fate:bind_args_from_signature(Signature, ES1),
+    {jump, 0, aefa_fate:set_local_function(Fun, ES2)}.
 
-call_r(Arg0, Arg1, Arg2, Arg3, EngineState) when ?IS_FATE_INTEGER(Arg2) ->
+call_r(Arg0, Arg1, Arg2, Arg3, Arg4, EngineState) ->
     ES1 = aefa_fate:push_return_address(EngineState),
-    {Contract, ES2} = get_op_arg(Arg0, ES1),
-    {Value, ES3} = get_op_arg(Arg3, ES2),
-    {_Signature, ES4} = remote_call_common(Contract, Arg1, Arg2, Value, ES3),
+    {[Contract, ArgType, RetType, Value], ES2} = get_op_args([Arg0, Arg2, Arg3, Arg4], ES1),
+    ES3 = remote_call_common(Contract, Arg1, ArgType, RetType, Value, ES2),
+    {jump, 0, ES3}.
+
+call_gr(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, EngineState) ->
+    ES1 = aefa_fate:push_return_address(EngineState),
+    {[Contract, ArgType, RetType, Value, GasCap], ES2} = get_op_args([Arg0, Arg2, Arg3, Arg4, Arg5], ES1),
+    ES3 = aefa_fate:push_gas_cap(GasCap, ES2),
+    ES4 = remote_call_common(Contract, Arg1, ArgType, RetType, Value, ES3),
     {jump, 0, ES4}.
 
-call_gr(Arg0, Arg1, Arg2, Arg3, Arg4, EngineState) when ?IS_FATE_INTEGER(Arg2) ->
-    ES1 = aefa_fate:push_return_address(EngineState),
-    {Contract, ES2} = get_op_arg(Arg0, ES1),
-    {Value, ES3}   = get_op_arg(Arg3, ES2),
-    {GasCap, ES4}  = get_op_arg(Arg4, ES3),
-    {_Signature, ES5} = remote_call_common(Contract, Arg1, Arg2, Value, ES4),
-    ES6 = aefa_fate:push_gas_cap(GasCap, ES5),
-    {jump, 0, ES6}.
-
-remote_call_common(Contract, Function, Arity, Value, EngineState) ->
+remote_call_common(Contract, Function, ?FATE_TYPEREP({tuple, ArgTypes}), ?FATE_TYPEREP(RetType), Value, EngineState) ->
     Current   = aefa_engine_state:current_contract(EngineState),
+    Arity     = length(ArgTypes),
     ES1       = aefa_fate:unfold_store_maps_in_args(Arity, EngineState),
     ES2       = aefa_fate:check_remote(Contract, ES1),
     ES3       = aefa_fate:set_remote_function(Contract, Function, ES2),
     Signature = aefa_fate:get_function_signature(Function, ES3),
     ES4       = aefa_fate:check_signature_and_bind_args(Arity, Signature, ES3),
-    {Signature, transfer_value(Current, Contract, Value, ES4)}.
+    TVars     = aefa_engine_state:current_tvars(ES4),
+    ES5       = aefa_fate:push_return_type_check(Signature, {ArgTypes, RetType}, TVars, ES4),
+    transfer_value(Current, Contract, Value, ES5).
 
 transfer_value(_From, ?FATE_CONTRACT(_To), Value, ES) when not ?IS_FATE_INTEGER(Value) ->
     aefa_fate:abort({value_does_not_match_type, Value, integer}, ES);

--- a/apps/aefate/test/aefate_engine_test.erl
+++ b/apps/aefate/test/aefate_engine_test.erl
@@ -50,9 +50,6 @@ variant_test_() ->
 bits_test_() ->
     make_calls(bits()).
 
-fail_test_() ->
-    make_calls(fail()).
-
 make_calls(ListOfCalls) ->
     Cache = setup_contracts(),
     %% Dummy values since they should not come into play in this test
@@ -267,15 +264,6 @@ bits() ->
             ]
     ].
 
-fail() ->
-    [ {<<"fail">>, F, A, R}
-      || {F, A, R} <-
-            [ {<<"bad_poly_return">>,       [1, <<"string">>], {error, <<"Type error on return: <<\"string\">> is not of type integer">>}}
-            , {<<"bad_return_after_call">>, [false], {error, <<"Type error on return: 3 is not of type boolean">>}}
-            , {<<"bad_tail_call_return">>,  [false], {error, <<"Type error on return: 1 is not of type boolean">>}}
-            ]
-    ].
-
 make_call(Contract, Function0, Arguments) ->
     Function = aeb_fate_code:symbol_identifier(Function0),
     #{ contract  => pad_contract_name(Contract)
@@ -349,7 +337,8 @@ contracts() ->
                        {'CALL_R',
                         {immediate, aeb_fate_data:make_contract(pad_contract_name(<<"remote">>))},
                         {immediate, aeb_fate_code:symbol_identifier(<<"add_five">>)},
-                        {immediate, 1},
+                        {immediate, {typerep, {tuple, [integer]}}},
+                        {immediate, {typerep, integer}},
                         {immediate, 0}
                        } ]}
                , {1, [ {'INC', {stack, 0}},
@@ -742,30 +731,4 @@ contracts() ->
                       , 'RETURN']}]}
 
            ]
-     , <<"fail">> =>
-           [ {<<"bad_poly_return">>
-             , {[{tvar, 0}, {tvar, 1}], {tvar, 0}}
-             , [ {0, [ {'RETURNR', {arg, 1}} ]} ]
-             }
-           , {<<"id">>
-             , {[{tvar, 0}], {tvar, 0}}
-             , [ {0, [{'RETURNR', {arg, 0}}] } ]
-             }
-           , {<<"bad_return_after_call">>
-             , {[{tvar, 0}], {tvar, 0}}
-             , [ {0, [ {'PUSH', {immediate, 1}}
-                     , {'CALL', {immediate, aeb_fate_code:symbol_identifier(<<"id">>)}}
-                     ]}
-               , {1, [ {'PUSH', {immediate, 2}}
-                     , {'ADD', {stack, 0}, {stack, 0}, {stack, 0}}
-                     , 'RETURN' ]}
-               ]
-             }
-           , {<<"bad_tail_call_return">>
-             , {[{tvar, 0}], {tvar, 0}}
-             , [ {0, [ {'PUSH', {immediate, 1}}
-                     , {'CALL_T', {immediate, aeb_fate_code:symbol_identifier(<<"id">>)}}
-                     ]}
-               ]
-             } ]
      }.

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1172,7 +1172,7 @@ remote_gas_test_contract(Config) ->
     [] = call_func(APub, APriv, EncC1Pub, Contract, "call", [ZeroContract, "2", "1"], error),
     force_fun_calls(Node),
     Balance5 = get_balance(APub),
-    ?assertEqual(900000 * ?DEFAULT_GAS_PRICE, Balance4 - Balance5),
+    ?assertMatchVM(900000, 800017, (Balance4 - Balance5) div ?DEFAULT_GAS_PRICE),
 
     ok.
 

--- a/rebar.config
+++ b/rebar.config
@@ -65,7 +65,7 @@
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                    {ref, "0a82f0f"}}},
 
-        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "af6224c"}}},
+        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "fdd660a"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"4a07297"}}},
@@ -196,7 +196,7 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"b669d2d"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"e566186"}}},
                             {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {tag, "v3.2.0"}}}
                            ]}
                    ]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"af6224cb3b3732562df58485b2bd2a0534d74f2a"}},
+      {ref,"fdd660a2191f19e1bd77cafe0d39c826539c1b6c"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",

--- a/test/contracts/remote_type_check.aes
+++ b/test/contracts/remote_type_check.aes
@@ -7,6 +7,12 @@ contract Remote =
 
 contract Main =
 
+  type state = int
+
+  entrypoint init() = 0
+
+  entrypoint next_state() = state + 1
+
   entrypoint id(x : int) =
     x
 
@@ -36,3 +42,12 @@ contract Main =
 
   entrypoint remote_wrong_ret_tailcall_type_vars(r : Remote, x) =
     r.bogus_id(x)
+
+  stateful entrypoint remote_wrong_put(r : Remote, x) =
+    put(r.bogus_id(x))
+
+  function call_bogus_id(r : Remote, x : 'a) : 'a = r.bogus_id(x)
+
+  stateful entrypoint remote_wrong_put_polymorphic(r : Remote, x) =
+    put(call_bogus_id(r, x))
+

--- a/test/contracts/sophia_2/remote_type_check.aes
+++ b/test/contracts/sophia_2/remote_type_check.aes
@@ -7,6 +7,12 @@ contract Remote =
 
 contract Main =
 
+  type state = int
+
+  function init() = 0
+
+  function next_state() = state + 1
+
   function id(x : int) =
     x
 
@@ -36,3 +42,12 @@ contract Main =
 
   function remote_wrong_ret_tailcall_type_vars(r : Remote, x) =
     r.bogus_id(x)
+
+  function remote_wrong_put(r : Remote, x) =
+    put(r.bogus_id(x))
+
+  function call_bogus_id(r : Remote, x : 'a) : 'a = r.bogus_id(x)
+
+  function remote_wrong_put_polymorphic(r : Remote, x) =
+    put(call_bogus_id(r, x))
+


### PR DESCRIPTION
**Sits on top of #2644.**

- [PT-167221671](https://www.pivotaltracker.com/story/show/167221671)
- [PT-167221635](https://www.pivotaltracker.com/story/show/167221635)
- aeternity/aebytecode#67
- aeternity/aesophia#123

Removes the type checking of local calls and fixes checking of remote calls. On a remote call we check that
- the given arguments have the types that the *callee* expects
- the result has the type the *caller* expects