### PR TITLE
Cache tx env for better SC FSM performance

### DIFF
--- a/apps/aechannel/src/aechannel.app.src
+++ b/apps/aechannel/src/aechannel.app.src
@@ -7,6 +7,7 @@
    [kernel,
     stdlib,
     lager,
+    gproc,
     aetx,
     sext
    ]},

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -3827,4 +3827,4 @@ block_hash_from_op(?NO_OP) -> %% in case of unexpected close
     ?NOT_SET_BLOCK_HASH.
 
 tx_env_and_trees_from_top(Type) ->
-    aesc_state_cache:tx_env_and_trees_from_top(Type).
+    aesc_tx_env_cache:tx_env_and_trees_from_top(Type).

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -716,7 +716,7 @@ awaiting_signature(cast, {?SIGNED, ?UPDATE_ACK, SignedTx} = Msg,
         fun() ->
             D1 = send_update_ack_msg(SignedTx, D),
             {OnChainEnv, OnChainTrees} =
-                aetx_env:tx_env_and_trees_from_top(aetx_contract),
+                tx_env_and_trees_from_top(aetx_contract),
             State = aesc_offchain_state:set_signed_tx(SignedTx, Updates, D1#data.state,
                                                       OnChainTrees, OnChainEnv, Opts),
             D2 = D1#data{ log   = log_msg(rcv, ?SIGNED, Msg, D1#data.log)
@@ -1441,7 +1441,7 @@ new_onchain_tx(channel_deposit_tx, #{acct := FromId,
                #data{on_chain_id = ChanId, state=State}, CurrHeight) ->
     Updates = [aesc_offchain_update:op_deposit(aeser_id:create(account, FromId), Amount)],
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     ActiveProtocol = aec_hard_forks:protocol_effective_at_height(Height),
     UpdatedStateTx = aesc_offchain_state:make_update_tx(Updates, State,
@@ -1466,7 +1466,7 @@ new_onchain_tx(channel_withdraw_tx, #{acct := ToId,
                #data{on_chain_id = ChanId, state=State}, CurrHeight) ->
     Updates = [aesc_offchain_update:op_withdraw(aeser_id:create(account, ToId), Amount)],
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     ActiveProtocol = aec_hard_forks:protocol_effective_at_height(Height),
     UpdatedStateTx = aesc_offchain_state:make_update_tx(Updates, State,
@@ -1736,7 +1736,7 @@ new_contract_tx_for_signing(Opts, From, #data{ state = State
     Id = aeser_id:create(account, Owner),
     Updates = [aesc_offchain_update:op_new_contract(Id, VmVersion, ABIVersion, Code,
                                                     Deposit, CallData)],
-    {OnChainEnv, OnChainTrees} = aetx_env:tx_env_and_trees_from_top(aetx_contract),
+    {OnChainEnv, OnChainTrees} = tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     %% TODO PT-165214367: maybe set block_hash
     BlockHash = ?NOT_SET_BLOCK_HASH,
@@ -2111,14 +2111,14 @@ check_signed_update_tx(Type, SignedTx, Updates,
 
 check_update_tx_initial(SignedTx, Updates, State, Opts) ->
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     aesc_offchain_state:check_initial_update_tx(SignedTx, Updates, State,
                                                 OnChainTrees, OnChainEnv,
                                                 Opts).
 
 check_update_tx(SignedTx, Updates, State, Opts, ChannelPubkey) ->
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     ActiveProtocol = aec_hard_forks:protocol_effective_at_height(Height),
     aesc_offchain_state:check_update_tx(SignedTx, Updates, State,
@@ -2160,7 +2160,7 @@ check_signed_update_ack_tx(SignedTx, Msg,
                                              not_offchain_tx) of
               ok ->
                   {OnChainEnv, OnChainTrees} =
-                      aetx_env:tx_env_and_trees_from_top(aetx_contract),
+                      tx_env_and_trees_from_top(aetx_contract),
                   {ok, D#data{state = aesc_offchain_state:set_signed_tx(
                                         SignedTx, Updates, State, OnChainTrees, OnChainEnv, Opts),
                               log = log_msg(rcv, ?UPDATE_ACK, Msg, D#data.log)}};
@@ -2190,7 +2190,7 @@ handle_upd_transfer(FromPub, ToPub, Amount, From, #data{ state = State
                                                        } = D) ->
     Updates = [aesc_offchain_update:op_transfer(aeser_id:create(account, FromPub),
                                                 aeser_id:create(account, ToPub), Amount)],
-    {OnChainEnv, OnChainTrees} = aetx_env:tx_env_and_trees_from_top(aetx_contract),
+    {OnChainEnv, OnChainTrees} = tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     %% TODO PT-165214367: maybe set block_hash
     BlockHash = ?NOT_SET_BLOCK_HASH,
@@ -2754,7 +2754,7 @@ verify_signatures_channel_create(SignedTx, Who) ->
 verify_signatures_onchain_check(Pubkeys, SignedTx) ->
     {Mod, Tx} = aetx:specialize_callback(aetx_sign:innermost_tx(SignedTx)),
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     {ok, Participants} = Mod:signers(Tx, OnChainTrees),
     SkipKeys = Participants -- Pubkeys,
     case aesc_utils:verify_signatures_onchain(SignedTx, OnChainTrees, OnChainEnv,
@@ -2765,7 +2765,7 @@ verify_signatures_onchain_check(Pubkeys, SignedTx) ->
 
 verify_signatures_onchain_skip(SkipKeys, SignedTx) ->
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     case aesc_utils:verify_signatures_onchain(SignedTx, OnChainTrees, OnChainEnv,
                                               SkipKeys) of
         ok -> ok;
@@ -2774,7 +2774,7 @@ verify_signatures_onchain_skip(SkipKeys, SignedTx) ->
 
 verify_signatures_offchain(ChannelPubkey, Pubkeys, SignedTx) ->
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     {ok, Channel} = aec_chain:get_channel(ChannelPubkey),
     InitiatorPubkey = aesc_channels:initiator_pubkey(Channel),
     ResponderPubkey = aesc_channels:responder_pubkey(Channel),
@@ -3240,14 +3240,14 @@ is_channel_locked(LockedUntil) ->
     LockedUntil >= curr_height().
 
 withdraw_locked_complete(SignedTx, Updates, #data{state = State, opts = Opts} = D) ->
-    {OnChainEnv, OnChainTrees} = aetx_env:tx_env_and_trees_from_top(aetx_contract),
+    {OnChainEnv, OnChainTrees} = tx_env_and_trees_from_top(aetx_contract),
     State1 = aesc_offchain_state:set_signed_tx(SignedTx, Updates, State,
                                                OnChainTrees, OnChainEnv, Opts),
     D1 = D#data{state = State1},
     next_state(open, D1).
 
 deposit_locked_complete(SignedTx, Updates, #data{state = State , opts = Opts} = D) ->
-    {OnChainEnv, OnChainTrees} = aetx_env:tx_env_and_trees_from_top(aetx_contract),
+    {OnChainEnv, OnChainTrees} = tx_env_and_trees_from_top(aetx_contract),
     lager:debug("Applying updates: ~p", [Updates]),
     State1 = aesc_offchain_state:set_signed_tx(SignedTx, Updates, State,
                                                OnChainTrees, OnChainEnv, Opts),
@@ -3304,7 +3304,7 @@ funding_locked_complete(#data{ op = #op_lock{ tag = create
                              , create_tx = CreateTx
                              , state = State
                              , opts = Opts} = D) ->
-    {OnChainEnv, OnChainTrees} = aetx_env:tx_env_and_trees_from_top(aetx_contract),
+    {OnChainEnv, OnChainTrees} = tx_env_and_trees_from_top(aetx_contract),
     State1 = aesc_offchain_state:set_signed_tx(CreateTx, Updates, State, OnChainTrees,
                                                OnChainEnv, Opts),
     D1 = D#data{state = State1},
@@ -3458,7 +3458,7 @@ handle_call_(open, {upd_call_contract, Opts, ExecType}, From,
                                                    CallData, CallStack),
     Updates = [Update],
     {OnChainEnv, OnChainTrees} =
-        aetx_env:tx_env_and_trees_from_top(aetx_contract),
+        tx_env_and_trees_from_top(aetx_contract),
     Height = aetx_env:height(OnChainEnv),
     ActiveProtocol = aec_hard_forks:protocol_effective_at_height(Height),
     try  Tx1 = aesc_offchain_state:make_update_tx(Updates, State,
@@ -3826,3 +3826,5 @@ block_hash_from_op(#op_watch{data = #op_data{block_hash = BlockHash}}) ->
 block_hash_from_op(?NO_OP) -> %% in case of unexpected close
     ?NOT_SET_BLOCK_HASH.
 
+tx_env_and_trees_from_top(Type) ->
+    aesc_state_cache:tx_env_and_trees_from_top(Type).

--- a/apps/aechannel/src/aesc_state_cache.erl
+++ b/apps/aechannel/src/aesc_state_cache.erl
@@ -21,8 +21,6 @@
         , code_change/3
         ]).
 
--export([tx_env_and_trees_from_top/1]).
-
 -export([
           table_specs/1
         , check_tables/1
@@ -43,7 +41,6 @@
 
 -define(SERVER, ?MODULE).
 -define(TAB, aesc_state_cache_ch).
--define(ETAB, aesc_env_cache).
 -define(PTAB, aesc_state_cache).
 
 new(ChId, PubKey, State) ->
@@ -90,15 +87,13 @@ start_link() ->
     case ets:info(?TAB, name) of
         undefined ->
             ets:new(?TAB, [ordered_set, public, named_table,
-                              {keypos, #ch.id}]),
-            ets:new(?ETAB, [set, public, named_table]);
+                              {keypos, #ch.id}]);
         _ ->
             ok
     end,
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 init([]) ->
-    true = aec_events:subscribe(top_changed),
     {ok, #st{}}.
 
 handle_call({new, ChId, PubKey, Pid, State}, _From, St) ->
@@ -141,9 +136,6 @@ handle_cast({delete, ChId}, St) ->
 handle_cast(_Msg, St) ->
     {noreply, St}.
 
-handle_info({gproc_ps_event, top_changed, #{info := Info}}, St) ->
-    St1 = refresh_env_cache(Info, St),
-    {noreply, St1};
 handle_info({'DOWN', MRef, process, _Pid, _}, St) ->
     case lookup_by_mref(MRef, St) of
         {ChId, PubKey} ->
@@ -318,32 +310,3 @@ delete_state(ChId, St) ->
     ets:select_delete(
       ?TAB, [{ #ch{id = key(ChId, '_'), _ = '_'}, [], [true] }]),
     St.
-
-refresh_env_cache(#{ block_hash := TopBlockHash }, St) ->
-    case ets:info(?TAB, size) of
-        0 ->
-            %% No running fsms - don't bother updating the cache
-            St;
-        _ ->
-            %% Fetching the tx_env from top takes roughly 5 ms, but is immutable, so
-            %% caching it in ets makes a lot of sense.
-            CEnv = aetx_env:tx_env_and_trees_from_hash(aetx_contract, TopBlockHash),
-            ets:insert(?ETAB, {top_env_ckey(), CEnv}),
-            St
-    end.
-
-top_env_ckey() ->
-    {top_env_and_trees, aetx_contract}.
-
-tx_env_and_trees_from_top(aetx_contract) ->
-    Key = top_env_ckey(),
-    case ets:lookup(?ETAB, Key) of
-        [] ->
-            Res = aetx_env:tx_env_and_trees_from_top(aetx_contract),
-            ets:insert(?ETAB, {Key, Res}),
-            Res;
-        [{_, Res}] ->
-            Res
-    end;
-tx_env_and_trees_from_top(Type) ->
-    aetx_env:tx_env_and_trees_from_top(Type).

--- a/apps/aechannel/src/aesc_sup.erl
+++ b/apps/aechannel/src/aesc_sup.erl
@@ -15,6 +15,7 @@ start_link() ->
 
 init([]) ->
     {ok, {{one_for_one, 5, 10}, [ ?CHILD(aesc_state_cache, 5000, worker)
+                                , ?CHILD(aesc_tx_env_cache, 5000, worker)
                                 , ?CHILD(aesc_fsm_sup, 5000, supervisor)
                                 , ?CHILD(aesc_sessions_sup, 5000, supervisor)
                                 , ?CHILD(aesc_listeners, 5000, worker)

--- a/apps/aechannel/src/aesc_tx_env_cache.erl
+++ b/apps/aechannel/src/aesc_tx_env_cache.erl
@@ -1,0 +1,63 @@
+-module(aesc_tx_env_cache).
+-behavior(gen_server).
+
+-export([tx_env_and_trees_from_top/1]).
+
+-export([start_link/0]).
+
+%% Behavior exports
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3 ]).
+
+-define(SERVER, ?MODULE).
+-record(st, {top_env = #{}}).
+
+tx_env_and_trees_from_top(Type) ->
+    gen_server:call(?SERVER, {tx_env_and_trees_from_top, Type}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    true = aec_events:subscribe(top_changed),
+    {ok, #st{}}.
+
+handle_call({tx_env_and_trees_from_top, Type}, _From, St) ->
+    {Res, St1} = tx_env_and_trees_from_top_(Type, St),
+    {reply, Res, St1};
+handle_call(_, _From, St) ->
+    {reply, {error, unknown_call}, St}.
+
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+handle_info({gproc_ps_event, top_changed, _}, #st{top_env = C} = St) when map_size(C) == 0 ->
+    {noreply, St};
+handle_info({gproc_ps_event, top_changed, _}, St) ->
+    %% Evict the old top env from the cache
+    {noreply, St#st{top_env = #{}}};
+handle_info(_Msg, St) ->
+    {noreply, St}.
+
+terminate(_Reason, _St) ->
+    ok.
+
+code_change(_FromVsn, State, _Extra) ->
+    {ok, State}.
+
+tx_env_and_trees_from_top_(Type, #st{top_env = Cache} = St) ->
+    Key = top_env_ckey(Type),
+    case maps:find(Key, Cache) of
+        error ->
+            Res = aetx_env:tx_env_and_trees_from_top(Type),
+            {Res, St#st{top_env = Cache#{Key => Res}}};
+        {ok, Res} ->
+            {Res, St}
+    end.
+
+top_env_ckey(Type) ->
+    {top_env_and_trees, Type}.


### PR DESCRIPTION
See [PT #167938013](https://www.pivotaltracker.com/story/show/167938013). Caching the tx_env data turns out to have a significant impact on SC FSM performance.

(This PR was based on PR #2659, for better precision evaluating benchmark results.)

The aetx_env data is cached in an env cache ets table introduced in the `aesc_state_cache` process. The state cache subscribes to `top_changed` events and refreshes the top block tx_env, but only if it has cached offchain states, indicating that there are actually running FSMs.

The cost of an individual tx_env lookup went down from `4-6 ms` to `5 us`, and performance in the `multiple_channels` benchmark test increased from ca `77 tps` to `105 tps`.