### PR TITLE
reinit_chain_state waits for tx_pool

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -228,6 +228,7 @@ reinit_chain_state() ->
                                init_chain_state()
                        end),
     exit(whereis(aec_tx_pool), kill),
+    aec_tx_pool:await_tx_pool(),
     ok.
 
 handle_call({add_synced_block, Block},_From, State) ->

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -62,6 +62,8 @@
         , raw_delete/2
         ]).
 
+-export([await_tx_pool/0]).
+
 -include("aec_tx_pool.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
 
@@ -225,6 +227,12 @@ peek_nonces() ->
     [N || {N} <- ets:tab2list(NDb)].
 -endif.
 
+await_tx_pool() ->
+    gproc:await({n,l,?MODULE}, 5000).
+
+gproc_reg() ->
+    gproc:reg({n,l,?MODULE}).
+
 %% The specified maximum number of transactions avoids requiring
 %% building in memory the complete list of all transactions in the
 %% pool.
@@ -308,6 +316,7 @@ init([]) ->
     ok = aec_db:ensure_transaction(fun() -> aec_db:fold_mempool(InitF, ok) end),
     ets:delete(Handled),
     lager:debug("init: GCHeight = ~p", [GCHeight]),
+    gproc_reg(),
     {ok, #state{gc_height = GCHeight}}.
 
 handle_call(Req, From, St) ->


### PR DESCRIPTION
See [PT #167941408](https://www.pivotaltracker.com/story/show/167941408)

Errors seen in CI, where a test fails when calling on the `tx_pool` immediately after a `reinit_chain_state`. In the proposed fix, the function `aec_conductor:reinit_chain_state()` waits for the tx_pool to be initialized before returning. Note: this is only used for testing. However, the gproc registration is done in normal code. Therefore, the function to wait for the gproc name to be registered is also unconditionally exported.