### PR TITLE
Do not allow #meta{} before Lima hardfork

### DIFF
--- a/apps/aechannel/src/aesc_offchain_tx.erl
+++ b/apps/aechannel/src/aesc_offchain_tx.erl
@@ -242,7 +242,12 @@ version(#channel_offchain_tx{updates = Updates}) ->
 -spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
 valid_at_protocol(Protocol, Tx) ->
     case version(Tx) of
-        ?INITIAL_VSN -> true;
+        ?INITIAL_VSN ->
+            lists:all(
+                fun(Update) ->
+                    aesc_offchain_update:valid_at_protocol(Protocol, Update)
+                end,
+                Tx#channel_offchain_tx.updates);
         ?NO_UPDATES_VSN when Protocol >= ?FORTUNA_PROTOCOL_VSN -> true;
         _ -> false
     end.

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -65,7 +65,8 @@
 -export([serialize/1,
          deserialize/1,
          for_client/1,
-         apply_on_trees/6]).
+         apply_on_trees/6,
+         valid_at_protocol/2]).
 
 -export([is_call/1,
          is_contract_create/1,
@@ -81,6 +82,8 @@
 -ifdef(TEST).
 -export([type2swagger_name/1]).
 -endif.
+
+-include_lib("aecontract/include/hard_forks.hrl").
 
 -spec from_db_format(update() | tuple()) -> update().
 from_db_format(#transfer{} = U) ->
@@ -216,6 +219,14 @@ apply_on_trees(Update, Trees0, OnChainTrees, OnChainEnv, Round, Reserve) ->
         #meta{} ->
             Trees0
     end.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), update()) -> boolean().
+valid_at_protocol(Protocol, #meta{}) when Protocol >= ?LIMA_PROTOCOL_VSN ->
+    true;
+valid_at_protocol(_PreLimaProtocol, #meta{}) ->
+    false;
+valid_at_protocol(_Protocol, _) ->
+    true.
 
 -spec for_client(update()) -> map().
 for_client(#transfer{from_id = FromId, to_id = ToId, amount = Amount}) ->


### PR DESCRIPTION
Current implementation allows both versions of off-chain updates with and without a list of off-chain updates. Adding a new update type allows for it to be smuggled on-chain in a off-chain transaction that is provided for a payload for force progress, solo close or slash transactions.

This PR makes it protocol aware so a `#meta{}` doesn't make it on-chain before Lima.