### PR TITLE
PT-168025582 Relax protocol version checks in block serialization

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -333,6 +333,9 @@ update_micro_candidate(#mic_block{} = Block, TxsRootHash, RootHash, Txs) ->
 %%% Serialization
 %%%===================================================================
 
+%% Serialization assumes the protocol version in the header to be valid for the
+%% provided height. This should have been validated before calling this
+%% function.
 -spec serialize_to_binary(block()) -> binary().
 serialize_to_binary(#key_block{} = Block) ->
     aec_headers:serialize_to_binary(to_key_header(Block));

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -337,24 +337,14 @@ update_micro_candidate(#mic_block{} = Block, TxsRootHash, RootHash, Txs) ->
 serialize_to_binary(#key_block{} = Block) ->
     aec_headers:serialize_to_binary(to_key_header(Block));
 serialize_to_binary(#mic_block{} = Block) ->
-    Hdr    = to_micro_header(Block),
+    Hdr = to_micro_header(Block),
     HdrBin = aec_headers:serialize_to_binary(Hdr),
-    Height = aec_headers:height(Hdr),
-    Vsn    = version(Block),
-    case serialization_template(micro, Height, Vsn) of
-        {error, What} ->
-            error({serialization_error, What});
-        {ok, Template} ->
-            Txs = [ aetx_sign:serialize_to_binary(Tx) || Tx <- txs(Block)],
-            Rest = aeser_chain_objects:serialize(
-                     micro_block,
-                     Vsn,
-                     Template,
-                     [ {txs, Txs}
-                     , {pof, aec_pof:serialize(pof(Block))}
-                     ]),
-            <<HdrBin/binary, Rest/binary>>
-    end.
+    Version = aec_headers:version(Hdr),
+    Template = serialization_template(micro),
+    Txs = [aetx_sign:serialize_to_binary(Tx) || Tx <- txs(Block)],
+    Fields = [{txs, Txs}, {pof, aec_pof:serialize(pof(Block))}],
+    Rest = aeser_chain_objects:serialize(micro_block, Version, Template, Fields),
+    <<HdrBin/binary, Rest/binary>>.
 
 -spec deserialize_from_binary(binary()) -> {'error', term()} | {'ok', block()}.
 deserialize_from_binary(Bin) ->
@@ -368,27 +358,16 @@ deserialize_from_binary(Bin) ->
     end.
 
 deserialize_micro_block_from_binary(Bin, Header) ->
-    Vsn = aec_headers:version(Header),
-    case serialization_template(micro, aec_headers:height(Header), Vsn) of
-        {ok, Template} ->
-            [{txs, Txs0}, {pof, PoF0}] =
-                aeser_chain_objects:deserialize(micro_block, Vsn, Template, Bin),
-            Txs = [aetx_sign:deserialize_from_binary(Tx)
-                   || Tx <- Txs0],
-            PoF = aec_pof:deserialize(PoF0),
-            {ok, #mic_block{header = Header, txs = Txs, pof = PoF}};
-        Err = {error, _} ->
-            Err
-    end.
+    Version = aec_headers:version(Header),
+    Template =  serialization_template(micro),
+    [{txs, Txs0}, {pof, PoF0}] =
+        aeser_chain_objects:deserialize(micro_block, Version, Template, Bin),
+    Txs = [aetx_sign:deserialize_from_binary(Tx) || Tx <- Txs0],
+    PoF = aec_pof:deserialize(PoF0),
+    {ok, #mic_block{header = Header, txs = Txs, pof = PoF}}.
 
-serialization_template(micro, Height, Vsn) ->
-    case aec_hard_forks:protocol_effective_at_height(Height) of
-        Vsn ->
-            {ok, [ {txs, [binary]}
-                 , {pof, [binary]}]};
-        Other ->
-            {error, {bad_block_vsn, Other}}
-    end.
+serialization_template(micro) ->
+    [{txs, [binary]}, {pof, [binary]}].
 
 %%%===================================================================
 %%% Validation
@@ -455,4 +434,3 @@ validate_pof(#mic_block{pof = PoF} = Block) ->
         true ->
             aec_pof:validate(PoF)
     end.
-

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -562,6 +562,10 @@ deserialize_from_binary_partial(<<_Version:32,
             {error, malformed_header}
     end.
 
+%% The function does not check the validity of the protocol version based on
+%% height. It gets the protocol version from the block header. The protocol
+%% version check based on height is performed before inserting it into the
+%% database (aec_conductor).
 -spec deserialize_key_from_binary(deterministic_header_binary()) ->
                                          {'ok', key_header()}
                                        | {'error', term()}.
@@ -600,6 +604,10 @@ deserialize_key_from_binary(_Other) ->
     {error, malformed_header}.
 
 
+%% The function does not check the validity of the protocol version based on
+%% height. It gets the protocol version from the block header. The protocol
+%% version check based on height is performed before inserting it into the
+%% database (aec_conductor).
 -spec deserialize_micro_from_binary(deterministic_header_binary()) ->
                                            {'ok', micro_header()}
                                          | {'error', term()}.

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -581,26 +581,21 @@ deserialize_key_from_binary(<<Version:32,
                               Time:64,
                               Info/binary
                             >>) ->
-    case aec_hard_forks:protocol_effective_at_height(Height) =:= Version of
-        false ->
-            {error, illegal_version};
-        true ->
-            PowEvidence = deserialize_pow_evidence_from_binary(PowEvidenceBin),
-            H = #key_header{height = Height,
-                            prev_hash = PrevHash,
-                            prev_key = PrevKeyHash,
-                            root_hash = RootHash,
-                            miner = Miner,
-                            beneficiary = Beneficiary,
-                            target = Target,
-                            pow_evidence = PowEvidence,
-                            nonce = Nonce,
-                            time = Time,
-                            version = Version,
-                            info = Info
-                           },
-            {ok, H}
-    end;
+    PowEvidence = deserialize_pow_evidence_from_binary(PowEvidenceBin),
+    H = #key_header{height = Height,
+                    prev_hash = PrevHash,
+                    prev_key = PrevKeyHash,
+                    root_hash = RootHash,
+                    miner = Miner,
+                    beneficiary = Beneficiary,
+                    target = Target,
+                    pow_evidence = PowEvidence,
+                    nonce = Nonce,
+                    time = Time,
+                    version = Version,
+                    info = Info
+                   },
+    {ok, H};
 deserialize_key_from_binary(_Other) ->
     {error, malformed_header}.
 
@@ -624,22 +619,16 @@ deserialize_micro_from_binary(<<Version:32,
     case Rest of
         <<PoFHash:PoFHashSize/binary,
           Signature:?BLOCK_SIGNATURE_BYTES/binary>> ->
-            ExpectedVsn = aec_hard_forks:protocol_effective_at_height(Height),
-            case  ExpectedVsn =:= Version of
-                false ->
-                    {error, illegal_version};
-                true ->
-                    H = #mic_header{height = Height,
-                                    pof_hash = PoFHash,
-                                    prev_hash = PrevHash,
-                                    prev_key = PrevKeyHash,
-                                    root_hash = RootHash,
-                                    signature = Signature,
-                                    txs_hash = TxsHash,
-                                    time = Time,
-                                    version = Version},
-                    {ok, H}
-            end;
+            H = #mic_header{height = Height,
+                            pof_hash = PoFHash,
+                            prev_hash = PrevHash,
+                            prev_key = PrevKeyHash,
+                            root_hash = RootHash,
+                            signature = Signature,
+                            txs_hash = TxsHash,
+                            time = Time,
+                            version = Version},
+            {ok, H};
         _ ->
             {error, malformed_header}
     end;


### PR DESCRIPTION
[PT-168025582](https://www.pivotaltracker.com/n/projects/2124891/stories/168025582)

Preparatory PR for fork signalling.

`deserialize_[key|micro]_from_binary` is called in `aec_blocks:deserialize_from_binary` which is used in:
* ~`aeu_import:disklog_fold/3` - not used anywhere?!~ - module was deleted
* `aec_peer_connection:deserialize_block/2` - when `aec_peer_connection` wants to insert a new block to the db, it calls `aec_conductor:post_block/1` where the block is validated (including the version check).

`serialization_template` called in `aec_blocks:serialize_to_binary` used `aec_hard_forks:protocol_effective_at_height` which is not needed because `aec_blocks:serialize_to_binary` is called for blocks read from the db, so they were validated for the right protocol version when inserted into the db. 
