### PR TITLE
Allow writing to FATE function argument

### DIFF
--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -42,7 +42,7 @@
 
 %% Memory handling.
 -export([ lookup_var/2
-        , store_var/3]).
+        , store_var/3 ]).
 
 %% Stack handling.
 -export([ dup/1
@@ -203,8 +203,6 @@ abort(bad_store_map_id, ES) ->
     ?t("Maps: Map does not exist", [], ES);
 abort({type_error, cons}, ES) ->
     ?t("Type error in cons: creating polymorphic list", [], ES);
-abort({cannot_write_to_arg, N}, ES) ->
-    ?t("Arguments are read only: ~p", [N], ES);
 abort({undefined_var, Var}, ES) ->
     ?t("Undefined var: ~p", [Var], ES);
 abort({bad_return_type, Val, Type}, ES) ->

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -1405,8 +1405,8 @@ write({stack, 0}, Val, ES) ->
     aefa_engine_state:push_accumulator(Val, ES);
 write({var, _} = Name,  Val, ES) ->
     aefa_fate:store_var(Name, Val, ES);
-write({arg, N}, _, ES) ->
-    aefa_fate:abort({cannot_write_to_arg, N}, ES).
+write({arg, _} = Arg, Val, ES) ->
+    aefa_fate:store_var(Arg, Val, ES).
 
 
 %% ------------------------------------------------------

--- a/apps/aevm/src/aevm_ae_primops.erl
+++ b/apps/aevm/src/aevm_ae_primops.erl
@@ -136,7 +136,7 @@ types(?PRIM_CALL_AENS_CLAIM,_HeapValue,_Store,_State) ->
     {[word, string, word, sign_t()], tuple0_t()};
 types(?PRIM_CALL_AENS_PRECLAIM,_HeapValue,_Store,_State) ->
     {[word, word, sign_t()], tuple0_t()};
-types(?PRIM_CALL_AENS_RESOLVE, HeapValue, Store, State) ->
+types(?PRIM_CALL_AENS_RESOLVE, HeapValue, _Store, State) ->
     %% The out type is given in the third argument
     T = {tuple, [word, word, word, typerep]},
     {ok, Bin} = aevm_eeevm_state:heap_value_to_binary(T, HeapValue, State),


### PR DESCRIPTION
We need to do this in order to compile tail calls to the current function to a jump instead of a function call.