### PR TITLE
Wrap network and timing sensitive CI operations in a retry loop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,8 @@ references:
   install_os_deps: &install_os_deps
     run:
       name: Install OS dependancies
+      environment:
+        MAX_RETRIES: 5
       command: |
         ./ci/try sudo apt-get -qq -y install git curl \
           autoconf build-essential ncurses-dev libssl-dev
@@ -83,6 +85,7 @@ references:
       environment:
         # See minimum_otp_vsn in rebar.config
         OTP_VERSION: "20.1"
+        MAX_RETRIES: 5
       command: |
         # Install OTP package deps
         ./ci/try sudo apt-get -qq -y update
@@ -100,6 +103,7 @@ references:
       name: Install libsodium
       environment:
         LIBSODIUM_VERSION: "1.0.16"
+        MAX_RETRIES: 5
       # source: https://github.com/aeternity/docker-builder/blob/master/Dockerfile#L23
       command: |
         LIBSODIUM_DOWNLOAD_URL="https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}/libsodium-${LIBSODIUM_VERSION}.tar.gz"
@@ -216,9 +220,9 @@ references:
         PACKAGE_TESTS_DIR: *package_tests_workspace
       command: |
         epmd -daemon
-        ./ci/try make python-env
+        MAX_RETRIES=5 ./ci/try make python-env
         mkdir ${PACKAGE_TESTS_DIR:?}
-        MAX_RETRIES=2 ./ci/try make python-package-win32-test python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} PACKAGE=${PACKAGE_TARBALL:?}
+        ./ci/try make python-package-win32-test python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} PACKAGE=${PACKAGE_TARBALL:?}
 
   test_arch_os_dependencies: &test_arch_os_dependencies
     run:
@@ -318,12 +322,16 @@ references:
   install_system_test_deps: &install_system_test_deps
     run:
       name: Install deps for system tests
+      environment:
+        MAX_RETRIES: 5
       command: |
         ./ci/try make system-test-deps
 
   install_system_smoke_test_deps: &install_system_smoke_test_deps
     run:
       name: Install deps for system smoke tests
+      environment:
+        MAX_RETRIES: 5
       command: |
         ./ci/try make system-smoke-test-deps
 
@@ -355,7 +363,7 @@ references:
         name: Test
         command: |
           epmd -daemon
-          MAX_RETRIES=2 ./ci/try make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
+          ./ci/try make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
     # Isolates the junit.xml report because additional files in _build/test/logs
     # are somehow causing issue with xunit report upload, parsing and merging
     - run:
@@ -378,7 +386,7 @@ references:
         name: Test
         command: |
           epmd -daemon
-          MAX_RETRIES=2 ./ci/try make ${MAKE_TARGET:?}
+          ./ci/try make ${MAKE_TARGET:?}
     - *store_rebar3_crashdump
     - *fail_notification
 
@@ -745,9 +753,9 @@ jobs:
           name: UAT Tests
           command: |
             epmd -daemon
-            ./ci/try make python-env
+            MAX_RETRIES=5 ./ci/try make python-env
             make multi-build
-            MAX_RETRIES=2 ./ci/try make python-uats
+            ./ci/try make python-uats
       - run:
           name: Prepare JUnit Report
           command: mv py/tests/nosetests.xml py/tests/junit.xml
@@ -826,7 +834,7 @@ jobs:
           name: System Tests
           no_output_timeout: 2h
           command: |
-            MAX_RETRIES=2 ./ci/try sudo -u ubuntu -E -H make system-test
+            ./ci/try sudo -u ubuntu -E -H make system-test
       - *collect_system_test_host_logs
       - *fail_notification_system_test
       - *save_machine_build_cache
@@ -853,7 +861,7 @@ jobs:
           name: System Smoke Tests
           no_output_timeout: 1h
           command: |
-            MAX_RETRIES=2 ./ci/try sudo -u ubuntu -E -H make smoke-test-run
+            ./ci/try sudo -u ubuntu -E -H make smoke-test-run
       - *collect_system_test_host_logs
       - *fail_notification_system_test
       - *save_machine_build_cache
@@ -960,6 +968,8 @@ jobs:
       - checkout
       - run:
           name: Install PlantUML dependencies
+          environment:
+            MAX_RETRIES: 5
           command: |
             ./ci/try sudo apt-get -qq -y update
             ./ci/try sudo apt-get -qq -y install graphviz librsvg2-bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ references:
     run:
       name: Install OS dependancies
       command: |
-        sudo apt-get -qq -y install git curl \
+        ./ci/try sudo apt-get -qq -y install git curl \
           autoconf build-essential ncurses-dev libssl-dev
 
   install_otp: &install_otp
@@ -85,14 +85,15 @@ references:
         OTP_VERSION: "20.1"
       command: |
         # Install OTP package deps
-        sudo apt-get update && sudo apt-get install libwxbase3.0-dev libwxgtk3.0-dev libsctp1
+        ./ci/try sudo apt-get -qq -y update
+        ./ci/try sudo apt-get -qq -y install libwxbase3.0-dev libwxgtk3.0-dev libsctp1
         # Install OTP binary package
         PACKAGE_NAME=esl-erlang_${OTP_VERSION}-1~ubuntu~xenial_amd64.deb
         OTP_DOWNLOAD_URL=https://packages.erlang-solutions.com/erlang/debian/pool/${PACKAGE_NAME}
         # TODO temporary disable SSL checks on erlang-solutions.com until they fix their certificate
         # FIXME ^^ (multi-editor support :))
-        curl -fsSL --insecure -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"
-        sudo dpkg -i ${PACKAGE_NAME}
+        ./ci/try curl -fsSL --insecure -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"
+        ./ci/try sudo dpkg -i ${PACKAGE_NAME}
 
   install_libsodium: &install_libsodium
     run:
@@ -101,12 +102,15 @@ references:
         LIBSODIUM_VERSION: "1.0.16"
       # source: https://github.com/aeternity/docker-builder/blob/master/Dockerfile#L23
       command: |
-        LIBSODIUM_DOWNLOAD_URL="https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}/libsodium-${LIBSODIUM_VERSION}.tar.gz" \
-          && curl -fsSL -o libsodium-src.tar.gz "$LIBSODIUM_DOWNLOAD_URL" \
-          && mkdir libsodium-src \
-          && tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1 \
-          && cd libsodium-src \
-          && ./configure && make -j$(nproc) && sudo make install && sudo ldconfig
+        LIBSODIUM_DOWNLOAD_URL="https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}/libsodium-${LIBSODIUM_VERSION}.tar.gz"
+          ./ci/try curl -fsSL -o libsodium-src.tar.gz "$LIBSODIUM_DOWNLOAD_URL"
+          mkdir libsodium-src
+          tar -zxf libsodium-src.tar.gz -C libsodium-src --strip-components=1
+          cd libsodium-src
+          ./configure
+          make -j$(nproc)
+          sudo make install
+          sudo ldconfig
 
   tag_regex: &tag_regex /^v.*$/
   master_branch: &master_branch master
@@ -212,9 +216,9 @@ references:
         PACKAGE_TESTS_DIR: *package_tests_workspace
       command: |
         epmd -daemon
-        make python-env
+        ./ci/try make python-env
         mkdir ${PACKAGE_TESTS_DIR:?}
-        make python-package-win32-test python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} PACKAGE=${PACKAGE_TARBALL:?}
+        MAX_RETRIES=2 ./ci/try make python-package-win32-test python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} PACKAGE=${PACKAGE_TARBALL:?}
 
   test_arch_os_dependencies: &test_arch_os_dependencies
     run:
@@ -315,13 +319,13 @@ references:
     run:
       name: Install deps for system tests
       command: |
-        make system-test-deps
+        ./ci/try make system-test-deps
 
   install_system_smoke_test_deps: &install_system_smoke_test_deps
     run:
       name: Install deps for system smoke tests
       command: |
-        make system-smoke-test-deps
+        ./ci/try make system-smoke-test-deps
 
   system_test_logs: &system_test_logs system_test/logs
 
@@ -351,7 +355,7 @@ references:
         name: Test
         command: |
           epmd -daemon
-          make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
+          MAX_RETRIES=2 ./ci/try make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
     # Isolates the junit.xml report because additional files in _build/test/logs
     # are somehow causing issue with xunit report upload, parsing and merging
     - run:
@@ -374,7 +378,7 @@ references:
         name: Test
         command: |
           epmd -daemon
-          make ${MAKE_TARGET:?}
+          MAX_RETRIES=2 ./ci/try make ${MAKE_TARGET:?}
     - *store_rebar3_crashdump
     - *fail_notification
 
@@ -405,7 +409,9 @@ commands:
     steps:
       - run:
           name: Setup environment secrets
-          command: cd /infrastructure && make secrets SECRETS_OUTPUT_DIR=/secrets
+          command: |
+            cd /infrastructure
+            make secrets SECRETS_OUTPUT_DIR=/secrets
 
   docker_login:
     steps:
@@ -739,8 +745,9 @@ jobs:
           name: UAT Tests
           command: |
             epmd -daemon
-            make python-env && make multi-build
-            make python-uats
+            ./ci/try make python-env
+            make multi-build
+            MAX_RETRIES=2 ./ci/try make python-uats
       - run:
           name: Prepare JUnit Report
           command: mv py/tests/nosetests.xml py/tests/junit.xml
@@ -819,7 +826,7 @@ jobs:
           name: System Tests
           no_output_timeout: 2h
           command: |
-            sudo -u ubuntu -E -H make system-test
+            MAX_RETRIES=2 ./ci/try sudo -u ubuntu -E -H make system-test
       - *collect_system_test_host_logs
       - *fail_notification_system_test
       - *save_machine_build_cache
@@ -846,7 +853,7 @@ jobs:
           name: System Smoke Tests
           no_output_timeout: 1h
           command: |
-            sudo -u ubuntu -E -H make smoke-test-run
+            MAX_RETRIES=2 ./ci/try sudo -u ubuntu -E -H make smoke-test-run
       - *collect_system_test_host_logs
       - *fail_notification_system_test
       - *save_machine_build_cache
@@ -954,7 +961,8 @@ jobs:
       - run:
           name: Install PlantUML dependencies
           command: |
-            sudo apt-get -qq -y update && sudo apt-get -qq -y install graphviz librsvg2-bin
+            ./ci/try sudo apt-get -qq -y update
+            ./ci/try sudo apt-get -qq -y install graphviz librsvg2-bin
       - run: make build-uml
       - store_artifacts:
           path: docs/state-channels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,6 @@ references:
   install_os_deps: &install_os_deps
     run:
       name: Install OS dependancies
-      environment:
-        MAX_RETRIES: 5
       command: |
         ./ci/try sudo apt-get -qq -y install git curl \
           autoconf build-essential ncurses-dev libssl-dev
@@ -85,7 +83,6 @@ references:
       environment:
         # See minimum_otp_vsn in rebar.config
         OTP_VERSION: "20.1"
-        MAX_RETRIES: 5
       command: |
         # Install OTP package deps
         ./ci/try sudo apt-get -qq -y update
@@ -103,7 +100,6 @@ references:
       name: Install libsodium
       environment:
         LIBSODIUM_VERSION: "1.0.16"
-        MAX_RETRIES: 5
       # source: https://github.com/aeternity/docker-builder/blob/master/Dockerfile#L23
       command: |
         LIBSODIUM_DOWNLOAD_URL="https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}/libsodium-${LIBSODIUM_VERSION}.tar.gz"
@@ -220,7 +216,7 @@ references:
         PACKAGE_TESTS_DIR: *package_tests_workspace
       command: |
         epmd -daemon
-        MAX_RETRIES=5 ./ci/try make python-env
+        ./ci/try make python-env
         mkdir ${PACKAGE_TESTS_DIR:?}
         ./ci/try make python-package-win32-test python-release-test WORKDIR=${PACKAGE_TESTS_DIR:?} PACKAGE=${PACKAGE_TARBALL:?}
 
@@ -322,16 +318,12 @@ references:
   install_system_test_deps: &install_system_test_deps
     run:
       name: Install deps for system tests
-      environment:
-        MAX_RETRIES: 5
       command: |
         ./ci/try make system-test-deps
 
   install_system_smoke_test_deps: &install_system_smoke_test_deps
     run:
       name: Install deps for system smoke tests
-      environment:
-        MAX_RETRIES: 5
       command: |
         ./ci/try make system-smoke-test-deps
 
@@ -363,7 +355,11 @@ references:
         name: Test
         command: |
           epmd -daemon
-          ./ci/try make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
+          make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
+          if [ $? != 0 ]; then
+            find _build/test/logs _build/test/extras -name "dev*" -type d -exec rm -rf \;
+            make ${MARKET_TARGET:?} CT_TEST_FLAGS="--retry"
+          fi
     # Isolates the junit.xml report because additional files in _build/test/logs
     # are somehow causing issue with xunit report upload, parsing and merging
     - run:
@@ -386,7 +382,7 @@ references:
         name: Test
         command: |
           epmd -daemon
-          ./ci/try make ${MAKE_TARGET:?}
+          make ${MAKE_TARGET:?}
     - *store_rebar3_crashdump
     - *fail_notification
 
@@ -753,7 +749,7 @@ jobs:
           name: UAT Tests
           command: |
             epmd -daemon
-            MAX_RETRIES=5 ./ci/try make python-env
+            ./ci/try make python-env
             make multi-build
             ./ci/try make python-uats
       - run:
@@ -834,7 +830,11 @@ jobs:
           name: System Tests
           no_output_timeout: 2h
           command: |
-            ./ci/try sudo -u ubuntu -E -H make system-test
+            sudo -u ubuntu -E -H make system-test
+            if [ $? != 0 ]; then
+              find _build/test/logs _build/test/extras -name "dev*" -type d -exec rm -rf \;
+              sudo -u ubuntu -E -H make system-test CT_TEST_FLAGS="--retry"
+            fi
       - *collect_system_test_host_logs
       - *fail_notification_system_test
       - *save_machine_build_cache
@@ -861,7 +861,11 @@ jobs:
           name: System Smoke Tests
           no_output_timeout: 1h
           command: |
-            ./ci/try sudo -u ubuntu -E -H make smoke-test-run
+            sudo -u ubuntu -E -H make smoke-test-run
+            if [ $? != 0 ]; then
+              find _build/test/logs _build/test/extras -name "dev*" -type d -exec rm -rf \;
+              sudo -u ubuntu -E -H make smoke-test-run CT_TEST_FLAGS="--retry"
+            fi
       - *collect_system_test_host_logs
       - *fail_notification_system_test
       - *save_machine_build_cache
@@ -968,8 +972,6 @@ jobs:
       - checkout
       - run:
           name: Install PlantUML dependencies
-          environment:
-            MAX_RETRIES: 5
           command: |
             ./ci/try sudo apt-get -qq -y update
             ./ci/try sudo apt-get -qq -y install graphviz librsvg2-bin

--- a/Makefile
+++ b/Makefile
@@ -294,16 +294,14 @@ smoke-test-run: KIND=system_test
 smoke-test-run: internal-build
 	@$(REBAR) as $(KIND),test do upgrade, ct $(ST_CT_DIR) $(ST_CT_FLAGS) --suite=aest_sync_SUITE,aest_commands_SUITE,aest_peers_SUITE
 
-system-smoke-test-deps:
-	$(MAKE) docker
+system-smoke-test-deps: docker
 	docker pull "aeternity/aeternity:v1.4.0"
 
 local-system-test: KIND=system_test
 local-system-test: internal-build
 	@$(REBAR) as $(KIND) do ct $(ST_CT_LOCALDIR) $(ST_CT_FLAGS) $(CT_TEST_FLAGS)
 
-system-test-deps:
-	$(MAKE) system-smoke-test-deps
+system-test-deps: system-smoke-test-deps
 	docker pull "aeternity/aeternity:v2.3.0"
 	docker pull "aeternity/aeternity:v4.0.0"
 	docker pull "aeternity/aeternity:v4.2.0"

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ smoke-test: docker smoke-test-run
 
 smoke-test-run: KIND=system_test
 smoke-test-run: internal-build
-	@$(REBAR) as $(KIND),test do upgrade, ct $(ST_CT_DIR) $(ST_CT_FLAGS) --suite=aest_sync_SUITE,aest_commands_SUITE,aest_peers_SUITE
+	@$(REBAR) as $(KIND),test do upgrade, ct $(ST_CT_DIR) $(ST_CT_FLAGS) --suite=aest_sync_SUITE,aest_commands_SUITE,aest_peers_SUITE $(CT_TEST_FLAGS)
 
 system-smoke-test-deps: docker
 	docker pull "aeternity/aeternity:v1.4.0"

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -57,6 +57,7 @@
         , responder_spend/1
         , client_reconnect_initiator/1
         , client_reconnect_responder/1
+        , fail_fast/1
         ]).
 
 %% exports for aehttp_integration_SUITE
@@ -127,6 +128,7 @@ groups() ->
      {transactions, [sequence],
       [
         create_channel
+      , fail_fast
       , multiple_responder_keys_per_port
       , channel_insufficent_tokens
       , inband_msgs
@@ -1613,6 +1615,9 @@ client_reconnect_initiator(Cfg) ->
 
 client_reconnect_responder(Cfg) ->
     client_reconnect_(responder, Cfg).
+
+fail_fast(Cfg) ->
+    ct:fail("Forced fail").
 
 client_reconnect_(Role, Cfg) ->
     Debug = get_debug(Cfg),

--- a/ci/try
+++ b/ci/try
@@ -4,7 +4,7 @@
 # been reached. In between retries the script waits for
 # (INITIAL_TIMEOUT)^RETRIES , such that the time between retries increases.
 
-MAX_RETRIES=${MAX_RETRIES:-2}
+MAX_RETRIES=${MAX_RETRIES:-3}
 COMMAND="$*"
 
 timeout=${INITIAL_TIMEOUT:-2}

--- a/ci/try
+++ b/ci/try
@@ -4,11 +4,12 @@
 # been reached. In between retries the script waits for
 # (INITIAL_TIMEOUT)^RETRIES , such that the time between retries increases.
 
-MAX_RETRIES=${MAX_RETRIES:-5}
+MAX_RETRIES=${MAX_RETRIES:-2}
 COMMAND="$*"
 
 timeout=${INITIAL_TIMEOUT:-2}
 retry=0
+exit_code=0
 
 if [ "${COMMAND}" = "" ]; then
   echo "ERROR: no command to execute given"
@@ -16,8 +17,11 @@ if [ "${COMMAND}" = "" ]; then
 fi
 
 until [ ${retry} -ge ${MAX_RETRIES} ]; do
-  ${COMMAND} && break
+  ${COMMAND} && exit 0
+  exit_code=$?
   retry=$[${retry}+1]
   sleep ${timeout}
   timeout=$[${timeout}*2]
 done
+
+exit ${exit_code}

--- a/ci/try
+++ b/ci/try
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+#
+# This script executes a given COMMAND until it succeeds or MAX_RETRIES have
+# been reached. In between retries the script waits for
+# (INITIAL_TIMEOUT)^RETRIES , such that the time between retries increases.
+
+MAX_RETRIES=${MAX_RETRIES:-5}
+COMMAND="$*"
+
+timeout=${INITIAL_TIMEOUT:-2}
+retry=0
+
+if [ "${COMMAND}" = "" ]; then
+  echo "ERROR: no command to execute given"
+  exit 1
+fi
+
+until [ ${retry} -ge ${MAX_RETRIES} ]; do
+  ${COMMAND} && break
+  retry=$[${retry}+1]
+  sleep ${timeout}
+  timeout=$[${timeout}*2]
+done


### PR DESCRIPTION
Often CI jobs fail due to small random network errors or host CPU
stalls. This change introduces a simple retry loop around operations
which are prone to such issues. If a job still fails after a retry the
author of a change can at least be confident that the issue wasn't a
one-off problem.