### PR TITLE
PT-168051213 Refactor block validation

### DIFF
--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -50,8 +50,8 @@
          txs_hash/1,
          type/1,
          update_micro_candidate/4,
-         validate_key_block/1,
-         validate_micro_block/1,
+         validate_key_block/2,
+         validate_micro_block/2,
          version/1
         ]).
 
@@ -376,21 +376,23 @@ serialization_template(micro) ->
 %%% Validation
 %%%===================================================================
 
--spec validate_key_block(key_block()) -> 'ok' | {'error', {'header', term()}}.
-validate_key_block(#key_block{} = Block) ->
-    case aec_headers:validate_key_block_header(to_key_header(Block)) of
+-spec validate_key_block(key_block(), aec_hard_forks:protocol_vsn()) ->
+                                'ok' | {'error', {'header', term()}}.
+validate_key_block(#key_block{} = Block, Protocol) ->
+    case aec_headers:validate_key_block_header(to_key_header(Block), Protocol) of
         ok -> ok;
         {error, Reason} -> {error, {header, Reason}}
     end.
 
--spec validate_micro_block(micro_block()) -> 'ok' | {'error', {'header' | 'block', term()}}.
-validate_micro_block(#mic_block{} = Block) ->
+-spec validate_micro_block(micro_block(), aec_hard_forks:protocol_vsn()) ->
+                                  'ok' | {'error', {'header' | 'block', term()}}.
+validate_micro_block(#mic_block{} = Block, Protocol) ->
     Validators = [fun validate_txs_hash/1,
                   fun validate_gas_limit/1,
                   fun validate_txs_fee/1,
                   fun validate_pof/1
                  ],
-    case aec_headers:validate_micro_block_header(to_micro_header(Block)) of
+    case aec_headers:validate_micro_block_header(to_micro_header(Block), Protocol) of
         ok ->
             case aeu_validation:run(Validators, [Block]) of
                 ok              -> ok;

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -143,7 +143,9 @@ is_leader() ->
 
 -spec post_block(aec_blocks:block()) -> 'ok' | {'error', any()}.
 post_block(Block) ->
-    case aec_validation:validate_block(Block) of
+    Height = aec_blocks:height(Block),
+    Protocol = aec_hard_forks:protocol_effective_at_height(Height),
+    case aec_validation:validate_block(Block, Protocol) of
         ok ->
             gen_server:call(?SERVER, {post_block, Block}, 30000);
         {error, {header, Reason}} ->
@@ -156,7 +158,9 @@ post_block(Block) ->
 
 -spec add_synced_block(aec_blocks:block()) -> 'ok' | {'error', any()}.
 add_synced_block(Block) ->
-    case aec_validation:validate_block(Block) of
+    Height = aec_blocks:height(Block),
+    Protocol = aec_hard_forks:protocol_effective_at_height(Height),
+    case aec_validation:validate_block(Block, Protocol) of
         ok ->
             gen_server:call(?SERVER, {add_synced_block, Block}, 30000);
         {error, {header, Reason}} ->

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -2,14 +2,11 @@
 
 -export([check_env/0]).
 -export([protocols/0,
-         check_protocol_version_validity/2,
          protocol_effective_at_height/1
         ]).
 
 -ifdef(TEST).
--export([check_protocol_version_validity/3,
-         sorted_protocol_versions/0
-        ]).
+-export([sorted_protocol_versions/0]).
 -endif.
 
 -include("blocks.hrl").
@@ -45,13 +42,6 @@ protocols() ->
 -spec check_env() -> ok.
 check_env() ->
     assert_protocols(protocols()).
-
--spec check_protocol_version_validity(version(), aec_blocks:height()) ->
-                                         ok | {error, Reason} when
-    Reason :: unknown_protocol_version
-            | {protocol_version_mismatch, ExpectedVersion::non_neg_integer()}.
-check_protocol_version_validity(Version, Height) ->
-    check_protocol_version_validity(Version, Height, protocols()).
 
 -spec protocol_effective_at_height(aec_blocks:height()) -> version().
 protocol_effective_at_height(H) ->
@@ -101,19 +91,6 @@ protocols_from_network_id(_ID) ->
             maps:fold(fun(K, V, Acc) ->
                               Acc#{binary_to_integer(K) => V}
                       end, #{}, M)
-    end.
-
-
-%% Exported for tests
-check_protocol_version_validity(Version, Height, Protocols) ->
-    case maps:is_key(Version, Protocols) of
-        false ->
-            {error, unknown_protocol_version};
-        true ->
-            case protocol_effective_at_height(Height, Protocols) of
-                Version -> ok;
-                Other   -> {error, {protocol_version_mismatch, Other}}
-            end
     end.
 
 %% Exported for tests

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -699,12 +699,11 @@ validate_micro_block_header(Header, Version) ->
     end.
 
 -spec validate_version(header(), aec_hard_forks:protocol_vsn()) ->
-                              ok | {error, Reason} when
-      Reason :: {protocol_version_mismatch, ExpectedVersion::non_neg_integer()}.
+                              ok | {error, protocol_version_mismatch}.
 validate_version(Header, Version) ->
     case version(Header) =:= Version of
         true  -> ok;
-        false -> {error, {protocol_version_mismatch, Version}}
+        false -> {error, protocol_version_mismatch}
     end.
 
 -spec validate_pow(header()) ->

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -1277,31 +1277,48 @@ pre_assembly_check(MicroHeader) ->
     case aec_db:has_block(Hash) of
         true -> known;
         false ->
-            Validators = [fun validate_micro/1,
-                          fun validate_connected_to_chain/1,
-                          fun validate_delta_height/1,
-                          fun validate_prev_key_block/1,
-                          fun validate_micro_signature/1],
-            aeu_validation:run(Validators, [MicroHeader])
+            {PrevHeader, PrevKeyHeader} = get_onchain_env(MicroHeader),
+            Validators = [fun validate_micro_block_header/3,
+                          fun validate_connected_to_chain/3,
+                          fun validate_delta_height/3,
+                          fun validate_prev_key_block/3,
+                          fun validate_micro_signature/3],
+            aeu_validation:run(Validators, [MicroHeader, PrevHeader, PrevKeyHeader])
     end.
 
-validate_micro(MicroHeader) ->
-    case aec_db:find_header(aec_headers:prev_key_hash(MicroHeader)) of
-        none ->
-            {error, prev_key_block_not_found}; %% This is virtually impossible!
-        {value, KeyHeader} ->
-            ExpectedVersion = aec_headers:version(KeyHeader),
-            aec_headers:validate_micro_block_header(MicroHeader, ExpectedVersion)
+get_onchain_env(MicroHeader) ->
+    PrevHeaderHash = aec_headers:prev_hash(MicroHeader),
+    PrevKeyHash = aec_headers:prev_key_hash(MicroHeader),
+    case aec_chain:get_header(PrevHeaderHash) of
+        {ok, PrevHeader} ->
+            case aec_headers:type(PrevHeader) of
+                key ->
+                    {PrevHeader, PrevHeader};
+                micro ->
+                    case aec_chain:get_header(PrevKeyHash) of
+                        {ok, PrevKeyHeader} -> {PrevHeader, PrevKeyHeader};
+                        error               -> {PrevHeader, not_found}
+                    end
+            end;
+        error ->
+            {not_found, not_found}
     end.
 
-validate_connected_to_chain(MicroHeader) ->
-    case aec_chain_state:hash_is_connected_to_genesis(
-            aec_headers:prev_hash(MicroHeader)) of
-        true -> ok;
+validate_micro_block_header(MicroHeader, _PrevHeader, PrevKeyHeader)
+  when PrevKeyHeader =/= not_found ->
+    Protocol = aec_headers:version(PrevKeyHeader),
+    aec_headers:validate_micro_block_header(MicroHeader, Protocol);
+validate_micro_block_header(_MicroHeader, _PrevHeader, not_found) ->
+    {error, prev_key_block_not_found}. %% This is virtually impossible!
+
+validate_connected_to_chain(MicroHeader, _PrevHeader, _PrevKeyHeader) ->
+    PrevHeaderHash = aec_headers:prev_hash(MicroHeader),
+    case aec_chain_state:hash_is_connected_to_genesis(PrevHeaderHash) of
+        true  -> ok;
         false -> {error, orphan_blocks_not_allowed}
     end.
 
-validate_delta_height(MicroHeader) ->
+validate_delta_height(MicroHeader, _PrevHeader, _PrevKeyHeader) ->
     Height = aec_headers:height(MicroHeader),
     case aec_chain:top_header() of
         undefined -> ok;
@@ -1313,40 +1330,37 @@ validate_delta_height(MicroHeader) ->
             end
     end.
 
-validate_prev_key_block(MicroHeader) ->
-    case aec_db:find_header(aec_headers:prev_hash(MicroHeader)) of
-        {value, PrevHeader} ->
-            case aec_headers:height(PrevHeader) == aec_headers:height(MicroHeader) of
-                false -> {error, wrong_prev_key_block_height};
-                true ->
-                    case aec_headers:type(PrevHeader) of
-                        key ->
-                            case aec_headers:prev_key_hash(MicroHeader) ==
-                                    aec_headers:prev_hash(MicroHeader) of
-                                true -> ok;
-                                false -> {error, wrong_prev_key_hash}
-                            end;
-                        micro ->
-                            case aec_headers:prev_key_hash(MicroHeader) ==
-                                    aec_headers:prev_key_hash(PrevHeader) of
-                                true -> ok;
-                                false -> {error, wrong_prev_key_hash}
-                            end
+validate_prev_key_block(MicroHeader, PrevHeader, _PrevKeyHeader)
+  when PrevHeader =/= not_found ->
+    case aec_headers:height(PrevHeader) =:= aec_headers:height(MicroHeader) of
+        false -> {error, wrong_prev_key_block_height};
+        true ->
+            case aec_headers:type(PrevHeader) of
+                key ->
+                    case aec_headers:prev_key_hash(MicroHeader) =:=
+                        aec_headers:prev_hash(MicroHeader) of
+                        true -> ok;
+                        false -> {error, wrong_prev_key_hash}
+                    end;
+                micro ->
+                    case aec_headers:prev_key_hash(MicroHeader) =:=
+                        aec_headers:prev_key_hash(PrevHeader) of
+                        true -> ok;
+                        false -> {error, wrong_prev_key_hash}
                     end
-            end;
-        none ->
-            {error, orphan_blocks_not_allowed}
-    end.
-
-validate_micro_signature(MicroHeader) ->
-    case aec_db:find_header(aec_headers:prev_key_hash(MicroHeader)) of
-        none -> {error, signer_not_found}; %% This is virtually impossible!
-        {value, KeyHeader} ->
-            Bin = aec_headers:serialize_to_signature_binary(MicroHeader),
-            Sig = aec_headers:signature(MicroHeader),
-            Signer = aec_headers:miner(KeyHeader),
-            case enacl:sign_verify_detached(Sig, Bin, Signer) of
-                {ok, _}    -> ok;
-                {error, _} -> {error, signature_verification_failed}
             end
-    end.
+    end;
+validate_prev_key_block(_MicroHeader, not_found, _PrevKeyHeader) ->
+    {error, orphan_blocks_not_allowed}.
+
+validate_micro_signature(MicroHeader, _PrevHeader, PrevKeyHeader)
+  when PrevKeyHeader =/= not_found ->
+    Bin = aec_headers:serialize_to_signature_binary(MicroHeader),
+    Sig = aec_headers:signature(MicroHeader),
+    Signer = aec_headers:miner(PrevKeyHeader),
+    case enacl:sign_verify_detached(Sig, Bin, Signer) of
+        {ok, _}    -> ok;
+        {error, _} -> {error, signature_verification_failed}
+    end;
+validate_micro_signature(_MicroHeader, _PrevHeader, not_found) ->
+    {error, signer_not_found}. %% This is virtually impossible!

--- a/apps/aecore/src/aec_validation.erl
+++ b/apps/aecore/src/aec_validation.erl
@@ -8,17 +8,17 @@
 -module(aec_validation).
 
 %% API
--export([validate_block/1
+-export([validate_block/2
         ]).
 
 %%%===================================================================
 %%% API
 %%%===================================================================
 
-validate_block(Block) ->
+validate_block(Block, Version) ->
     case aec_blocks:is_key_block(Block) of
         true ->
-            aec_blocks:validate_key_block(Block);
+            aec_blocks:validate_key_block(Block, Version);
         false ->
-            aec_blocks:validate_micro_block(Block)
+            aec_blocks:validate_micro_block(Block, Version)
     end.

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -66,7 +66,7 @@ validate_test_malformed_txs_root_hash() ->
               aec_blocks:root_hash(RawBlock),
               [SignedSpend]),
     ?assertEqual({error, {block, malformed_txs_hash}},
-                 ?TEST_MODULE:validate_micro_block(Block)).
+                 ?TEST_MODULE:validate_micro_block(Block, aec_blocks:version(Block))).
 
 validate_test_pass_validation_no_txs() ->
     Txs = [],
@@ -77,7 +77,7 @@ validate_test_pass_validation_no_txs() ->
               RawBlock, TxsRootHash,
               aec_blocks:root_hash(RawBlock),
               []),
-    ?assertEqual(ok, ?TEST_MODULE:validate_micro_block(Block)).
+    ?assertEqual(ok, ?TEST_MODULE:validate_micro_block(Block, aec_blocks:version(Block))).
 
 validate_test_pass_validation() ->
     SignedSpend =
@@ -96,6 +96,6 @@ validate_test_pass_validation() ->
               aec_blocks:root_hash(RawBlock),
               Txs),
 
-    ?assertEqual(ok, ?TEST_MODULE:validate_micro_block(Block)).
+    ?assertEqual(ok, ?TEST_MODULE:validate_micro_block(Block, aec_blocks:version(Block))).
 
 -endif.

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -215,10 +215,10 @@ chain_test_() ->
              {ok, _} = ?TEST_MODULE:start_link([{autostart, false}]),
              meck:new(aec_headers, [passthrough]),
              meck:new(aec_blocks, [passthrough]),
-             meck:expect(aec_headers, validate_key_block_header, fun(_) -> ok end),
-             meck:expect(aec_headers, validate_micro_block_header, fun(_) -> ok end),
-             meck:expect(aec_blocks, validate_key_block, fun(_) -> ok end),
-             meck:expect(aec_blocks, validate_micro_block, fun(_) -> ok end),
+             meck:expect(aec_headers, validate_key_block_header, fun(_, _) -> ok end),
+             meck:expect(aec_headers, validate_micro_block_header, fun(_, _) -> ok end),
+             meck:expect(aec_blocks, validate_key_block, fun(_, _) -> ok end),
+             meck:expect(aec_blocks, validate_micro_block, fun(_, _) -> ok end),
              TmpKeysDir
      end,
      fun(TmpKeysDir) ->
@@ -413,10 +413,10 @@ generation_test_() ->
              meck:new(aec_headers, [passthrough]),
              meck:new(aec_blocks, [passthrough]),
              meck:new(aec_mining, [passthrough]),
-             meck:expect(aec_headers, validate_key_block_header, fun(_) -> ok end),
-             meck:expect(aec_headers, validate_micro_block_header, fun(_) -> ok end),
-             meck:expect(aec_blocks, validate_key_block, fun(_) -> ok end),
-             meck:expect(aec_blocks, validate_micro_block, fun(_) -> ok end),
+             meck:expect(aec_headers, validate_key_block_header, fun(_, _) -> ok end),
+             meck:expect(aec_headers, validate_micro_block_header, fun(_, _) -> ok end),
+             meck:expect(aec_blocks, validate_key_block, fun(_, _) -> ok end),
+             meck:expect(aec_blocks, validate_micro_block, fun(_, _) -> ok end),
              TmpKeysDir
      end,
      fun(TmpKeysDir) ->

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -247,48 +247,45 @@ validate_test_() ->
      end,
      [fun() ->
               Header = ?TEST_MODULE:set_version(raw_key_header(), 736),
-              ?assertEqual({error, {protocol_version_mismatch, 1}},
+              ?assertEqual({error, protocol_version_mismatch},
                            ?TEST_MODULE:validate_key_block_header(Header, 1))
       end,
       fun() ->
               GV = ?GENESIS_VERSION,
-              Protocols = #{GV   =>       ?GENESIS_HEIGHT,
-                            1+GV => 100 + ?GENESIS_HEIGHT,
-                            3+GV => 150 + ?GENESIS_HEIGHT},
 
               %% Check for any off-by-one errors around first switch.
-              ?assertEqual({error, {protocol_version_mismatch, GV}},
+              ?assertEqual({error, protocol_version_mismatch},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  1+GV,
                                  99 + ?GENESIS_HEIGHT), GV)),
-              ?assertEqual({error, {protocol_version_mismatch, 1+GV}},
+              ?assertEqual({error, protocol_version_mismatch},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  GV,
                                  100 + ?GENESIS_HEIGHT), 1+GV)),
-              ?assertEqual({error, {protocol_version_mismatch, 1+GV}},
+              ?assertEqual({error, protocol_version_mismatch},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  3+GV,
                                  101 + ?GENESIS_HEIGHT), 1+GV)),
               %% Check for any off-by-one errors around second switch.
-              ?assertEqual({error, {protocol_version_mismatch, 1+GV}},
+              ?assertEqual({error, protocol_version_mismatch},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  3+GV,
                                  149 + ?GENESIS_HEIGHT), 1+GV)),
-              ?assertEqual({error, {protocol_version_mismatch, 3+GV}},
+              ?assertEqual({error, protocol_version_mismatch},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  1+GV,
                                  150 + ?GENESIS_HEIGHT), 3+GV)),
-              ?assertEqual({error, {protocol_version_mismatch, 3+GV}},
+              ?assertEqual({error, protocol_version_mismatch},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -255,12 +255,7 @@ validate_test_() ->
               Protocols = #{GV   =>       ?GENESIS_HEIGHT,
                             1+GV => 100 + ?GENESIS_HEIGHT,
                             3+GV => 150 + ?GENESIS_HEIGHT},
-              MockFun =
-                  fun(V, H) ->
-                          aec_hard_forks:check_protocol_version_validity(V, H, Protocols)
-                  end,
-              meck:expect(aec_hard_forks, check_protocol_version_validity,
-                          MockFun),
+
               %% Check for any off-by-one errors around first switch.
               ?assertEqual({error, {protocol_version_mismatch, GV}},
                            ?TEST_MODULE:validate_key_block_header(

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -247,7 +247,8 @@ validate_test_() ->
      end,
      [fun() ->
               Header = ?TEST_MODULE:set_version(raw_key_header(), 736),
-              ?assertEqual({error, unknown_protocol_version}, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertEqual({error, {protocol_version_mismatch, 1}},
+                           ?TEST_MODULE:validate_key_block_header(Header, 1))
       end,
       fun() ->
               GV = ?GENESIS_VERSION,
@@ -266,45 +267,46 @@ validate_test_() ->
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  1+GV,
-                                 99 + ?GENESIS_HEIGHT))),
+                                 99 + ?GENESIS_HEIGHT), GV)),
               ?assertEqual({error, {protocol_version_mismatch, 1+GV}},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  GV,
-                                 100 + ?GENESIS_HEIGHT))),
+                                 100 + ?GENESIS_HEIGHT), 1+GV)),
               ?assertEqual({error, {protocol_version_mismatch, 1+GV}},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  3+GV,
-                                 101 + ?GENESIS_HEIGHT))),
+                                 101 + ?GENESIS_HEIGHT), 1+GV)),
               %% Check for any off-by-one errors around second switch.
               ?assertEqual({error, {protocol_version_mismatch, 1+GV}},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  3+GV,
-                                 149 + ?GENESIS_HEIGHT))),
+                                 149 + ?GENESIS_HEIGHT), 1+GV)),
               ?assertEqual({error, {protocol_version_mismatch, 3+GV}},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  1+GV,
-                                 150 + ?GENESIS_HEIGHT))),
+                                 150 + ?GENESIS_HEIGHT), 3+GV)),
               ?assertEqual({error, {protocol_version_mismatch, 3+GV}},
                            ?TEST_MODULE:validate_key_block_header(
                               ?TEST_MODULE:set_version_and_height(
                                  raw_key_header(),
                                  1+GV,
-                                 151 + ?GENESIS_HEIGHT))),
+                                 151 + ?GENESIS_HEIGHT), 3+GV)),
               ok
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, false),
               Header = ?TEST_MODULE:set_version_and_height(
                           raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
-              ?assertEqual({error, incorrect_pow}, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertEqual({error, incorrect_pow},
+                           ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, true),
@@ -313,21 +315,22 @@ validate_test_() ->
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_time_in_msecs(Header0, 2 * NowTime),
-              ?assertEqual({error, block_from_the_future}, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertEqual({error, block_from_the_future},
+                           ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, true),
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_time_in_msecs(Header0, ?GENESIS_TIME + 1),
-              ?assertEqual(ok, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertEqual(ok, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, false),
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_time_in_msecs(Header0, ?GENESIS_TIME + 1),
-              ?assertEqual({error, incorrect_pow}, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertEqual({error, incorrect_pow}, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, true),
@@ -335,31 +338,31 @@ validate_test_() ->
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_time_in_msecs(Header0,
                                                       aeu_time:now_in_msecs() + aec_governance:accepted_future_block_time_shift() + 100),
-              ?assertEqual({error, block_from_the_future}, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertEqual({error, block_from_the_future}, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, true),
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_nonce(Header0, -1),
-              ?assertError(function_clause, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertError(function_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, true),
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_nonce(Header0, 16#1ffffffffffffffff),
-              ?assertError(function_clause, ?TEST_MODULE:validate_key_block_header(Header))
+              ?assertError(function_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               Header = ?TEST_MODULE:set_version_and_height(
                            raw_micro_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
-              ?assertEqual(ok, ?TEST_MODULE:validate_micro_block_header(Header))
+              ?assertEqual(ok, ?TEST_MODULE:validate_micro_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_micro_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_time_in_msecs(Header0,
                                                       aeu_time:now_in_msecs() + aec_governance:accepted_future_block_time_shift() + 100),
-              ?assertEqual({error, block_from_the_future}, ?TEST_MODULE:validate_micro_block_header(Header))
+              ?assertEqual({error, block_from_the_future}, ?TEST_MODULE:validate_micro_block_header(Header, ?GENESIS_VERSION))
       end]}.

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -57,7 +57,7 @@ mine_block_test_() ->
 
                  ?assertEqual(1, aec_blocks:height(Block)),
                  ?assertEqual(ok, aec_headers:validate_key_block_header(
-                                    aec_blocks:to_header(Block)))
+                                    aec_blocks:to_header(Block), aec_blocks:version(Block)))
          end}},
        {timeout, 60,
         {"Proof of work fails with no_solution",
@@ -121,4 +121,3 @@ generate_valid_test_data(TopBlock, Tries) ->
         {error, no_solution} ->
             generate_valid_test_data(TopBlock, Tries -1)
     end.
-


### PR DESCRIPTION
[PT-168051213](https://www.pivotaltracker.com/n/projects/2124891/stories/168051213)

Preparatory PR for fork signalling.

`aec_hard_forks:check_protocol_validity` is not needed in the block validation functions. The protocol version can be passed to the validation functions as it is known in the conductor process. 

Micro block validation in `aec_peer_connection` also uses less db reads after refactoring.