### PR TITLE
also pass version opts at reestablish

### DIFF
--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -201,7 +201,8 @@ simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, C
     test_offchain_operations(Chan, Cfg),
 
     {ok, LatestState} = sc_leave(Chan),
-    {ok, Chan1} = sc_reestablish(Chan, INodeName, RNodeName, LatestState, Cfg),
+    {ok, Chan1} = sc_reestablish(Chan, INodeName, RNodeName, LatestState,
+                                 [{channel_opts, ChannelOpts}|Cfg]),
 
     test_offchain_operations(Chan1, Cfg),
 

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -23,7 +23,9 @@
 %% Helpers
 -export([
     create_state_channel_perform_operations_leave/2,
-    reestablish_state_channel_perform_operations/3
+    reestablish_state_channel_perform_operations/3,
+    set_old_update_vsn/1,
+    simulate_fsm_vsn_env/1
 ]).
 
 -import(aest_nodes, [
@@ -149,19 +151,35 @@ test_simple_different_nodes_channel(Cfg) ->
 
 test_compat_with_initiator_node_using_fortuna_major_channel_version(Cfg) ->
     test_different_nodes_channel_(set_genesis_accounts(node_base_spec_with_fortuna_major_channel_version()),
-                                  set_genesis_accounts(#{}), Cfg).
+                                  set_genesis_accounts(#{}),
+                                  set_old_update_vsn(Cfg)).
 
 test_compat_with_responder_node_using_fortuna_major_channel_version(Cfg) ->
     test_different_nodes_channel_(set_genesis_accounts(#{}),
-                                  set_genesis_accounts(node_base_spec_with_fortuna_major_channel_version()), Cfg).
+                                  set_genesis_accounts(node_base_spec_with_fortuna_major_channel_version()),
+                                  set_old_update_vsn(Cfg)).
 
 test_compat_with_initiator_node_using_latest_stable_version(Cfg) ->
     test_different_nodes_channel_(set_genesis_accounts(node_base_spec_with_latest_stable_version()),
-                                  set_genesis_accounts(#{}), Cfg).
+                                  set_genesis_accounts(#{}),
+                                  set_old_update_vsn(Cfg)).
 
 test_compat_with_responder_node_using_latest_stable_version(Cfg) ->
     test_different_nodes_channel_(set_genesis_accounts(#{}),
-                                  set_genesis_accounts(node_base_spec_with_latest_stable_version()), Cfg).
+                                  set_genesis_accounts(node_base_spec_with_latest_stable_version()),
+                                  set_old_update_vsn(Cfg)).
+
+set_old_update_vsn(Cfg) ->
+    [{channel_opts, #{version_offchain_update => 1}}|Cfg].
+
+simulate_fsm_vsn_env(Cfg) ->
+    case lists:keyfind(channel_opts, 1, Cfg) of
+        {_, #{version_offchain_update := V}} ->
+            aesc_offchain_update:set_vsn(V),
+            ok;
+        false ->
+            ok
+    end.
 
 test_different_nodes_channel_(InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg) ->
     ChannelOpts = #{
@@ -171,8 +189,7 @@ test_different_nodes_channel_(InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg)
         responder_node => node2,
         responder_id => ?ALICE,
         responder_amount => 50000 * aest_nodes:gas_price(),
-        push_amount => 2,
-        version_offchain_update => 1
+        push_amount => 2
     },
     simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg).
 
@@ -201,8 +218,7 @@ simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, C
     test_offchain_operations(Chan, Cfg),
 
     {ok, LatestState} = sc_leave(Chan),
-    {ok, Chan1} = sc_reestablish(Chan, INodeName, RNodeName, LatestState,
-                                 [{channel_opts, ChannelOpts}|Cfg]),
+    {ok, Chan1} = sc_reestablish(Chan, INodeName, RNodeName, LatestState, Cfg),
 
     test_offchain_operations(Chan1, Cfg),
 

--- a/system_test/common/helpers/aest_api.erl
+++ b/system_test/common/helpers/aest_api.erl
@@ -69,7 +69,7 @@ sc_open(Params, Cfg) ->
                responder_amount => RAmt,
                channel_reserve => maps:get(channel_reserve, Params, 2)
               },
-             maps:with([version_offchain_update], Params)),
+             version_opts(Params)),
 
     {IConn, RConn} = sc_start_ws_peers(INodeName, RNodeName, Opts, Cfg),
     ok = sc_wait_channel_open(IConn, RConn),
@@ -116,13 +116,14 @@ sc_reestablish(#{ channel_id := ChannelId
                 , responder := {RAccount, _}} = Chan
               , INodeName, RNodeName, LatestState, Cfg) ->
     {Host, _Port} = node_ws_int_addr(RNodeName, Cfg),
-    Opts = #{
-        existing_channel_id => aeser_api_encoder:encode(channel, ChannelId),
-        host => Host,
-        offchain_tx => LatestState,
-        port => 9000,
-        protocol => <<"json-rpc">>
-        },
+    Opts = maps:merge(
+             #{
+               existing_channel_id => aeser_api_encoder:encode(channel, ChannelId),
+               host => Host,
+               offchain_tx => LatestState,
+               port => 9000,
+               protocol => <<"json-rpc">>
+              }, maybe_version_opts(Cfg)),
 
     {IConn, RConn} = sc_start_ws_peers(INodeName, RNodeName, Opts, Cfg),
     {ok, #{ <<"event">> := <<"channel_reestablished">> }} = sc_wait_for_channel_event(IConn, info),
@@ -408,3 +409,16 @@ ws_send(ConnPid, Tag, Data) ->
     ?WS:json_rpc_notify(ConnPid,
         #{ <<"method">> => Method
          , <<"params">> => Data}).
+
+%--- HELPER TO MANAGE ENCODING OPTIONS -----------------------------------------
+
+maybe_version_opts(Cfg) ->
+    case lists:keyfind(channel_opts, 1, Cfg) of
+        {_, Opts} ->
+            version_opts(Opts);
+        false ->
+            #{}
+    end.
+
+version_opts(Params) ->
+    maps:with([version_offchain_update], Params).

--- a/system_test/common/helpers/aest_api.erl
+++ b/system_test/common/helpers/aest_api.erl
@@ -69,7 +69,7 @@ sc_open(Params, Cfg) ->
                responder_amount => RAmt,
                channel_reserve => maps:get(channel_reserve, Params, 2)
               },
-             version_opts(Params)),
+             maybe_version_opts(Cfg)),
 
     {IConn, RConn} = sc_start_ws_peers(INodeName, RNodeName, Opts, Cfg),
     ok = sc_wait_channel_open(IConn, RConn),


### PR DESCRIPTION
See [PT #168074662](https://www.pivotaltracker.com/story/show/168074662)

System tests fail since proper encoding versions are not passed along in `reestablish`, causing the newer node to use the wrong encoding version for `offchain_update`.