### PR TITLE
Fate map fixes

### DIFF
--- a/apps/aevm/src/aevm_eeevm_store.erl
+++ b/apps/aevm/src/aevm_eeevm_store.erl
@@ -103,7 +103,7 @@ store(Address, Value, State) when is_integer(Value) ->
             {ok, aect_contracts:store()} | {error, term()}.
 from_sophia_state(Version = #{vm := VM}, Data) when VM =< ?VM_AEVM_SOPHIA_3 ->
     aevm_eeevm_store_vm3:from_sophia_state(Version, Data);
-from_sophia_state(Version, Data) ->
+from_sophia_state(_Version, Data) ->
     %% TODO: less encoding/decoding
     case aeb_heap:from_binary({tuple, [typerep]}, Data) of
         {ok, {Type}} ->
@@ -116,7 +116,7 @@ from_sophia_state(Version, Data) ->
                     Ptr       = aeb_heap:heap_value_pointer(StateValue),
                     StateData = <<Ptr:256, Mem/binary>>,
                     Maps      = aeb_heap:heap_value_maps(StateValue),
-                    Store     = store_maps(Version, Maps,
+                    Store     = store_maps(Maps,
                                     store_put(?SOPHIA_STATE_KEY,      StateData,
                                     store_put(?SOPHIA_STATE_TYPE_KEY, TypeData,
                                     store_empty()))),
@@ -138,11 +138,11 @@ second_component(<<Ptr:256, Heap/binary>> = Data) ->
 -spec set_sophia_state(aect_contracts:version(), aeb_heap:heap_value(), aect_contracts:store()) -> aect_contracts:store().
 set_sophia_state(Version = #{vm := VM}, Value, Store) when VM =< ?VM_AEVM_SOPHIA_3 ->
     aevm_eeevm_store_vm3:set_sophia_state(Version, Value, Store);
-set_sophia_state(Version, Value, Store) ->
+set_sophia_state(_Version, Value, Store) ->
     Ptr = aeb_heap:heap_value_pointer(Value),
     Mem = aeb_heap:heap_value_heap(Value),
     Maps = aeb_heap:heap_value_maps(Value),
-    store_maps(Version, Maps, store_put(?SOPHIA_STATE_KEY, <<Ptr:256, Mem/binary>>, Store)).
+    store_maps(Maps, store_put(?SOPHIA_STATE_KEY, <<Ptr:256, Mem/binary>>, Store)).
 
 -spec get_sophia_state(aect_contracts:store()) -> aeb_heap:heap_value().
 get_sophia_state(Store) ->
@@ -208,41 +208,33 @@ show_store(Store0) ->
 
 %% -- Updating Sophia maps --
 
-store_maps(Version, Maps0, Store) ->
+store_maps(Maps0, Store) ->
     Maps       = maps:to_list(Maps0#maps.maps),
 
     RefCounts  = get_ref_counts(Store),
     OldMapKeys = maps:keys(RefCounts),
     NewMapKeys = [ Id || {Id, _} <- Maps ],
 
-    NewRefCounts = update_ref_counts(OldMapKeys, NewMapKeys, Maps, RefCounts, Store),
+    DeltaRefCounts = update_ref_counts(OldMapKeys, NewMapKeys, Maps, RefCounts, Store),
 
-    Garbage    = [ G || G <- OldMapKeys -- NewMapKeys, 0 == maps:get(G, NewRefCounts, 0) ],
+    Garbage    = [ G || G <- OldMapKeys -- NewMapKeys, 0 == maps:get(G, RefCounts, 0) + maps:get(G, DeltaRefCounts, 0) ],
     AllMapKeys = lists:usort(NewMapKeys ++ OldMapKeys) -- Garbage,
 
     Updates = compute_map_updates(Garbage, Maps),
     ?DEBUG_PRINT("Updates: ~p\n", [Updates]),
 
     Store1 = store_put(?SOPHIA_STATE_MAPS_KEY, << <<Id:256>> || Id <- AllMapKeys >>, Store),
-    NewRefCounts1 = maps:filter(fun(Id, _) -> lists:member(Id, AllMapKeys) end, NewRefCounts),
-    PerformUpdate = fun(Upd, S) -> perform_update(Version, Upd, S) end,
-    NewStore = set_ref_counts(NewRefCounts1, lists:foldl(PerformUpdate, Store1, Updates)),
+    DeltaRefCounts1 = maps:filter(fun(Id, _) -> lists:member(Id, AllMapKeys) end, DeltaRefCounts),
+    PerformUpdate = fun(Upd, S) -> perform_update(Upd, S) end,
+    NewStore = add_ref_counts(DeltaRefCounts1, lists:foldl(PerformUpdate, Store1, Updates)),
     ?DEBUG_PRINT("NewStore:\n~s\n", [show_store(NewStore)]),
     NewStore.
 
-perform_update(#{ vm := Version }, {new_inplace, NewId, OldId, Size}, Store) ->
+perform_update({new_inplace, NewId, OldId, Size}, Store) ->
     OldKey   = <<OldId:256>>,
     NewKey   = <<NewId:256>>,
-    Entry =
-        case Version >= ?VM_AEVM_SOPHIA_2 of
-            true ->
-                %% Don't forget to update the size
-                ?MapInfo(RId, RefCount, _,    Bin) = store_get(OldKey, Store),
-                ?MapInfo(RId, RefCount, Size, Bin);
-            false ->
-                %% Buggy before AEVM_SOPHIA_2.
-                store_get(OldKey, Store)
-        end,
+    ?MapInfo(RId, RefCount, _, Bin) = store_get(OldKey, Store),
+    Entry = ?MapInfo(RId, RefCount, Size, Bin),
     %% Subtle: Don't remove the RealId entry because the mp trees requires
     %% there to be a value at any node that we want to get a subtree for. We
     %% need this for store_subtree.
@@ -251,21 +243,32 @@ perform_update(#{ vm := Version }, {new_inplace, NewId, OldId, Size}, Store) ->
                   true            -> Store
                end,
     store_put(NewKey, Entry, Store1);
-perform_update(_Version, {insert, Id, Key, Val}, Store) ->
-    RealId = real_id(Id, Store),
-    store_put(<<RealId:256, Key/binary>>, Val, Store);
-perform_update(_Version, {delete, Id, Key}, Store) ->
-    RealId = real_id(Id, Store),
-    store_remove(<<RealId:256, Key/binary>>, Store);
-perform_update(_Version, {new, Id, Map0}, Store) ->
-    Map = aevm_eeevm_maps:flatten_map(Store, Id, Map0),
+perform_update({insert, Id, ValType, Key, Val}, Store) ->
+    RealId  = real_id(Id, Store),
+    RealKey = <<RealId:256, Key/binary>>,
+    Store1  = store_put(RealKey, Val, Store),
+    %% We also need to subtract reference counts for the value that got
+    %% overwritten (broken pre-lima).
+    subtract_removed_ref_counts(store_get(RealKey, Store), ValType, Store1);
+perform_update({delete, Id, ValType, Key}, Store) ->
+    RealId  = real_id(Id, Store),
+    RealKey = <<RealId:256, Key/binary>>,
+    Store1  = store_remove(RealKey, Store),
+    %% We also need to subtract reference counts for the value that got
+    %% deleted (broken pre-lima).
+    subtract_removed_ref_counts(store_get(RealKey, Store), ValType, Store1);
+perform_update({new, Id, Map0}, Store0) ->
+    %% Here we need to add reference counts for the copied entries (broken
+    %% pre-lima).
+    Map      = aevm_eeevm_maps:flatten_map(Store0, Id, Map0),
+    Store    = add_copied_ref_counts(Map0, Map, Store0),
     RefCount = 0,   %% Set later
     Size     = Map0#pmap.size,
     Bin      = aeb_heap:to_binary({Map#pmap.key_t, Map#pmap.val_t}),
     Info = [{<<Id:256>>, ?MapInfo(Id, RefCount, Size, Bin)}],
     Data = [ {<<Id:256, Key/binary>>, Val} || {Key, Val} <- maps:to_list(Map#pmap.data) ],
     lists:foldl(fun({K, V}, S) -> store_put(K, V, S) end, Store, Info ++ Data);
-perform_update(_Version, {gc, Id}, Store) ->
+perform_update({gc, Id}, Store) ->
     RealId = real_id(Id, Store),
     %% Remove map info entry. Also remove RealId which we kept around for mp
     %% tree reasons (see note at `new_inplace` case above), and all the data.
@@ -274,19 +277,36 @@ perform_update(_Version, {gc, Id}, Store) ->
     lists:foldl(fun store_remove/2, Store, ToRemove).
 
 update_ref_counts(OldMapKeys, NewMapKeys, Maps, RefCounts, Store) ->
-    RefCounts1       = update_ref_counts1(Maps, RefCounts, Store),
+    DeltaCounts      = update_ref_counts1(Maps, #{}, Store),
     PotentialGarbage = OldMapKeys -- NewMapKeys,
-    ref_count_garbage(PotentialGarbage, [], Maps, RefCounts1, Store).
+    ref_count_garbage(PotentialGarbage, [], Maps, RefCounts, DeltaCounts, Store).
 
-ref_count_garbage(PotentialGarbage, ActualGarbage, Maps, RefCounts, Store) ->
-    Garbage = [ G || G <- PotentialGarbage, 0 == maps:get(G, RefCounts, 0) ],
+subtract_removed_ref_counts(<<>>, _, Store) -> Store;
+subtract_removed_ref_counts(Val, ValType, Store) ->
+    Used = aevm_data:used_maps(ValType, Val),
+    lists:foldl(fun(Id, S) -> add_ref_count(Id, -1, S) end, Store, Used).
+
+add_copied_ref_counts(#pmap{data = Updates}, #pmap{val_t = ValType, data = Data}, Store) ->
+    %% Increase ref counts for all entries not overwritten by Updates
+    Overwritten =
+        case Updates of
+            stored -> [];
+            _      -> maps:keys(Updates)
+        end,
+    Used = [ Id || Val <- maps:values(maps:without(Overwritten, Data)),
+                   Id  <- aevm_data:used_maps(ValType, Val) ],
+    lists:foldl(fun(Id, S) -> add_ref_count(Id, 1, S) end,
+                Store, Used).
+
+ref_count_garbage(PotentialGarbage, ActualGarbage, Maps, RefCounts, DeltaCounts, Store) ->
+    Garbage = [ G || G <- PotentialGarbage, 0 == maps:get(G, RefCounts, 0) + maps:get(G, DeltaCounts, 0) ],
     {ActualGarbage1, _} = do_inplace_assignment(Garbage, Maps),
     case ActualGarbage1 -- ActualGarbage of
-        []         ->  RefCounts;    %% No new garbage
+        []         ->  DeltaCounts;    %% No new garbage
         NewGarbage ->
-            RefCounts1 = lists:foldl(fun(Id, RfC) -> gc_ref_count(Id, RfC, Store) end,
-                                     RefCounts, NewGarbage),
-            ref_count_garbage(PotentialGarbage, ActualGarbage1, Maps, RefCounts1, Store)
+            DeltaCounts1 = lists:foldl(fun(Id, RfC) -> gc_ref_count(Id, RfC, Store) end,
+                                       DeltaCounts, NewGarbage),
+            ref_count_garbage(PotentialGarbage, ActualGarbage1, Maps, RefCounts, DeltaCounts1, Store)
     end.
 
 gc_ref_count(Id, RefCounts, Store) ->
@@ -298,7 +318,7 @@ gc_ref_count(Id, RefCounts, Store) ->
                 lists:append([ aevm_data:used_maps(ValType, Val)
                                 || {_Key, Val} <- store_to_list(Id, Store) ]),
             lists:foldl(fun(Used, RfC) ->
-                            maps:update_with(Used, fun(N) -> N - 1 end, RfC)
+                            maps:update_with(Used, fun(N) -> N - 1 end, -1, RfC)
                         end, RefCounts, UsedMaps)
     end.
 
@@ -312,23 +332,16 @@ update_ref_counts1([{_Id, Map} | Maps], RefCounts, Store) ->
         Data ->
             ValType = Map#pmap.val_t,
             DeltaCount =
-                fun({Key, Val}, Counts) ->
+                fun({_Key, Val}, Counts) ->
                         New =
                             case Val of
                                 tombstone -> [];
                                 _         -> aevm_data:used_maps(ValType, Val)
                             end,
-                        Old =
-                            case Map#pmap.parent of
-                                none -> [];
-                                PId  ->
-                                    case get_value(PId, Key, Store) of
-                                        false  -> [];
-                                        OldVal -> aevm_data:used_maps(ValType, OldVal)
-                                    end
-                            end,
-                        %% Subtract old from new
-                        Updates = [ {I, 1} || I <- New ] ++ [ {I, -1} || I <- Old ],
+                        %% We don't know if this map will be copied or
+                        %% updated in-place so don't subtract the old
+                        %% value yet (broken pre-lima).
+                        Updates = [ {I, 1} || I <- New ],
                         lists:foldl(fun({I, Count}, RfC) ->
                                         maps:update_with(I, fun(N) -> N + Count end, Count, RfC)
                                     end, Counts, Updates)
@@ -370,10 +383,10 @@ compute_map_updates(Garbage, Maps0) ->
         [ [{new, Id, Map} || {Id, Map} <- Copy]
         , [ [{new_inplace, Id, Parent, Size},
             [ case Val of
-                tombstone -> {delete, Id, Key};
-                _         -> {insert, Id, Key, Val}
+                tombstone -> {delete, Id, ValType, Key};
+                _         -> {insert, Id, ValType, Key, Val}
               end || {Key, Val} <- maps:to_list(Data) ]]
-           || {Id, #pmap{ parent = Parent, data = Data, size = Size }} <- Inplace ]
+           || {Id, #pmap{ parent = Parent, val_t = ValType, data = Data, size = Size }} <- Inplace ]
         , [{gc, Id} || Id <- ActualGarbage ]
         ]).
 
@@ -399,14 +412,14 @@ ref_count(Id, Store) ->
     ?MapInfo(_, RefCount, _, _) = store_get(<<Id:256>>, Store),
     RefCount.
 
-set_ref_count(Id, RefCount, Store) ->
-    ?MapInfo(RealId, _, Size, Bin) = store_get(<<Id:256>>, Store),
-    store_put(<<Id:256>>, ?MapInfo(RealId, RefCount, Size, Bin), Store).
+add_ref_count(Id, Delta, Store) ->
+    ?MapInfo(RealId, RefCount, Size, Bin) = store_get(<<Id:256>>, Store),
+    store_put(<<Id:256>>, ?MapInfo(RealId, RefCount + Delta, Size, Bin), Store).
 
-set_ref_counts(RefCounts, Store) ->
-    lists:foldl(fun({Id, RefCount}, St) ->
-                    set_ref_count(Id, RefCount, St)
-                end, Store, maps:to_list(RefCounts)).
+add_ref_counts(RefCounts, Store) ->
+    maps:fold(fun(Id, Delta, St) ->
+                    add_ref_count(Id, Delta, St)
+                end, Store, RefCounts).
 
 get_ref_counts(Store) ->
     maps:from_list([ {Id, ref_count(Id, Store)} || Id <- all_map_ids(Store) ]).

--- a/apps/aevm/src/aevm_eeevm_store_vm3.erl
+++ b/apps/aevm/src/aevm_eeevm_store_vm3.erl
@@ -1,12 +1,13 @@
 %%%-------------------------------------------------------------------
 %%% @copyright (C) 2017, Aeternity Anstalt
 %%% @doc
-%%%     Handle store
+%%%     Handle store.
+%%%     Legacy code for VM_AEVM_SOPHIA_3 and earlier. DO NOT CHANGE!
 %%% @end
 %%% Created : 9 Oct 2017
 %%%-------------------------------------------------------------------
 
--module(aevm_eeevm_store).
+-module(aevm_eeevm_store_vm3).
 
 -export([ load/2
         , store/3
@@ -101,8 +102,6 @@ store(Address, Value, State) when is_integer(Value) ->
 %% The argument should be a binary encoding a pair of a typerep and a value of that type.
 -spec from_sophia_state(aect_contracts:version(), aeb_heap:binary_value()) ->
             {ok, aect_contracts:store()} | {error, term()}.
-from_sophia_state(Version = #{vm := VM}, Data) when VM =< ?VM_AEVM_SOPHIA_3 ->
-    aevm_eeevm_store_vm3:from_sophia_state(Version, Data);
 from_sophia_state(Version, Data) ->
     %% TODO: less encoding/decoding
     case aeb_heap:from_binary({tuple, [typerep]}, Data) of
@@ -136,8 +135,6 @@ second_component(<<Ptr:256, Heap/binary>> = Data) ->
     <<Snd:256, Heap/binary>>.
 
 -spec set_sophia_state(aect_contracts:version(), aeb_heap:heap_value(), aect_contracts:store()) -> aect_contracts:store().
-set_sophia_state(Version = #{vm := VM}, Value, Store) when VM =< ?VM_AEVM_SOPHIA_3 ->
-    aevm_eeevm_store_vm3:set_sophia_state(Version, Value, Store);
 set_sophia_state(Version, Value, Store) ->
     Ptr = aeb_heap:heap_value_pointer(Value),
     Mem = aeb_heap:heap_value_heap(Value),

--- a/rebar.config
+++ b/rebar.config
@@ -65,7 +65,7 @@
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                    {ref, "0a82f0f"}}},
 
-        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "10cc127"}}},
+        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "c6475fe"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"e24650d"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"10cc1278831ad7e90138533466ceef4bcafd74a9"}},
+      {ref,"c6475fe1c2bbc2acaf973f207f99f2dd472d534d"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",


### PR DESCRIPTION
The map reference counting was wrong in both FATE and AEVM. The problem was that reference counts were not updated properly in case a map was copied instead of updated in-place. h/t QuickCheck.

See also https://github.com/aeternity/aebytecode/pull/74