### PR TITLE
Replace confusing account_nonce_too_high/low errors

### DIFF
--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -587,9 +587,9 @@ create_wrong_nonce(_Cfg) ->
             Env = aetx_env:set_signed_tx(Env0, {value, SignedTx}),
             {error, Err} = aetx:process(Tx, Trees, Env)
         end,
-    Test(Nonce - 1, account_nonce_too_high),
-    Test(Nonce, account_nonce_too_high),
-    Test(Nonce + 2, account_nonce_too_low),
+    Test(Nonce - 1, tx_nonce_already_used_for_account),
+    Test(Nonce, tx_nonce_already_used_for_account),
+    Test(Nonce + 2, tx_nonce_too_high_for_account),
     ok.
 
 create_exsisting(Cfg) ->
@@ -880,9 +880,9 @@ close_mutual_wrong_nonce(Cfg) ->
                  prepare_balances_for_mutual_close(),
                  negative(fun close_mutual_/2, {error, Error})])
         end,
-    Test(InitiatorNonce - 1,  account_nonce_too_high),
-    Test(InitiatorNonce,      account_nonce_too_high),
-    Test(InitiatorNonce + 2,  account_nonce_too_low),
+    Test(InitiatorNonce - 1,  tx_nonce_already_used_for_account),
+    Test(InitiatorNonce,      tx_nonce_already_used_for_account),
+    Test(InitiatorNonce + 2,  tx_nonce_too_high_for_account),
     ok.
 
 
@@ -957,7 +957,7 @@ reject_old_offchain_tx_vsn(Cfg) ->
                 set_prop(height, RomaHeight),
                 create_payload(),
                 set_prop(height, LimaHeight),
-                %% it fails after Lima 
+                %% it fails after Lima
                 negative(fun close_solo_/2, {error, invalid_at_height})
                 ])
         end,
@@ -1608,9 +1608,9 @@ settle_wrong_nonce(Cfg) ->
     % settle tx amounts must be equal to the last on-chain tx
     ActualTest =
         fun(Closer, Setler) ->
-            Test(Closer, Setler, Nonce - 1,  account_nonce_too_high),
-            Test(Closer, Setler, Nonce    ,  account_nonce_too_high),
-            Test(Closer, Setler, Nonce + 2,  account_nonce_too_low)
+            Test(Closer, Setler, Nonce - 1,  tx_nonce_already_used_for_account),
+            Test(Closer, Setler, Nonce    ,  tx_nonce_already_used_for_account),
+            Test(Closer, Setler, Nonce + 2,  tx_nonce_too_high_for_account)
         end,
     [ActualTest(Closer, Setler) ||  Closer <- ?ROLES,
                                     Setler <- RolesWithKeys],
@@ -4441,7 +4441,7 @@ create_payload() ->
 
 reuse_or_create_payload(Key, Props) ->
     case maps:get(Key, Props, not_specified) of
-        not_specified -> 
+        not_specified ->
             CreateFun = create_payload(Key),
             Props1 = CreateFun(Props),
             maps:get(Key, Props1);
@@ -4959,9 +4959,9 @@ test_both_wrong_nonce(Cfg, Fun, InitProps) ->
         end,
     lists:foreach(
         fun(Poster) ->
-            Test(Poster, AccountNonce - 1,  account_nonce_too_high),
-            Test(Poster, AccountNonce,      account_nonce_too_high),
-            Test(Poster, AccountNonce + 2,  account_nonce_too_low)
+            Test(Poster, AccountNonce - 1,  tx_nonce_already_used_for_account),
+            Test(Poster, AccountNonce,      tx_nonce_already_used_for_account),
+            Test(Poster, AccountNonce + 2,  tx_nonce_too_high_for_account)
         end,
         ?ROLES),
     ok.
@@ -5492,7 +5492,7 @@ fp_sophia_versions(Cfg) ->
             OK          %% Lima
          },
          %% AEVM 2
-         {?VM_AEVM_SOPHIA_2, SophiaVsn1, 
+         {?VM_AEVM_SOPHIA_2, SophiaVsn1,
             ErrUnknown, %% Roma
             OK,         %% Minerva
             OK,         %% Fortuna

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -585,7 +585,7 @@ create_contract_negative(_Cfg) ->
     %% Test too high account nonce
     RTx3 = create_tx(PubKey, #{nonce => 0}, S1),
     {error, _, S1} = sign_and_apply_transaction(RTx3, PrivKey, S1),
-    {error, account_nonce_too_high} = aetx:process(RTx3, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(RTx3, Trees, Env),
 
     ok.
 

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -82,7 +82,7 @@ check_test_() ->
               SenderAccount = new_account(#{pubkey => ?SENDER_PUBKEY, balance => 1000000, nonce => AccountNonce}),
               StateTree = aec_test_utils:create_state_tree_with_account(SenderAccount),
               Env = aetx_env:tx_env(20),
-              ?assertEqual({error, account_nonce_too_high},
+              ?assertEqual({error, tx_nonce_already_used_for_account},
                            aetx:process(SpendTx, StateTree, Env))
       end},
       {"TX TTL is too small",

--- a/apps/aens/test/aens_SUITE.erl
+++ b/apps/aens/test/aens_SUITE.erl
@@ -122,7 +122,7 @@ preclaim_negative(Cfg) ->
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:preclaim_tx_spec(PubKey, CHash, #{nonce => 0}, S1),
     {ok, Tx3} = aens_preclaim_tx:new(TxSpec3),
-    {error, account_nonce_too_high} = aetx:process(Tx3, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(Tx3, Trees, Env),
 
     %% Test commitment already present
     {PubKey2, Name, NameSalt, S3} = preclaim(Cfg),
@@ -234,7 +234,7 @@ claim_negative(Cfg) ->
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:claim_tx_spec(PubKey, Name, NameSalt, #{nonce => 0}, S1),
     {ok, Tx3} = aens_claim_tx:new(TxSpec3),
-    {error, account_nonce_too_high} = aetx:process(Tx3, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(Tx3, Trees, Env),
 
     %% Test commitment not found
     TxSpec4 = aens_test_utils:claim_tx_spec(PubKey, Name, NameSalt + 1, S1),
@@ -335,7 +335,7 @@ update_negative(Cfg) ->
     %% Test too high account nonce
     TxSpec4 = aens_test_utils:update_tx_spec(PubKey, NHash, #{nonce => 0}, S1),
     {ok, Tx4} = aens_update_tx:new(TxSpec4),
-    {error, account_nonce_too_high} = aetx:process(Tx4, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(Tx4, Trees, Env),
 
     %% Test name not present
     {ok, NHash2} = aens:get_name_hash(<<"othername.test">>),
@@ -412,7 +412,7 @@ transfer_negative(Cfg) ->
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:transfer_tx_spec(PubKey, NHash, PubKey, #{nonce => 0}, S1),
     {ok, Tx3} = aens_transfer_tx:new(TxSpec3),
-    {error, account_nonce_too_high} = aetx:process(Tx3, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(Tx3, Trees, Env),
 
     %% Test name not present
     {ok, NHash2} = aens:get_name_hash(<<"othername.test">>),
@@ -486,7 +486,7 @@ revoke_negative(Cfg) ->
     %% Test too high account nonce
     TxSpec3 = aens_test_utils:revoke_tx_spec(PubKey, NHash, #{nonce => 0}, S1),
     {ok, Tx3} = aens_revoke_tx:new(TxSpec3),
-    {error, account_nonce_too_high} = aetx:process(Tx3, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(Tx3, Trees, Env),
 
     %% Test name not present
     {ok, NHash2} = aens:get_name_hash(<<"othername.test">>),

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -145,7 +145,7 @@ register_oracle_negative(_Cfg) ->
 
     %% Test too high account nonce
     RTx3 = aeo_test_utils:register_tx(PubKey, #{nonce => 0}, S1),
-    {error, account_nonce_too_high} = aetx:process(RTx3, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(RTx3, Trees, Env),
 
     %% Test too low fee
     RTx4 = aeo_test_utils:register_tx(PubKey, #{fee => 0}, S1),
@@ -293,7 +293,7 @@ extend_oracle_negative(Cfg) ->
 
     %% Test too high account nonce
     RTx4 = aeo_test_utils:extend_tx(OracleKey, #{nonce => 0}, S2),
-    {error, account_nonce_too_high} = aetx:process(RTx4, Trees2, Env2),
+    {error, tx_nonce_already_used_for_account} = aetx:process(RTx4, Trees2, Env2),
 
     %% Test too low fee
     RTx5 = aeo_test_utils:extend_tx(OracleKey, #{fee => 0}, S2),
@@ -390,7 +390,7 @@ query_oracle_negative(Cfg) ->
 
     %% Test too high nonce in account
     Q3 = aeo_test_utils:query_tx(SenderKey, OracleId, #{nonce => 0}, S2),
-    {error, account_nonce_too_high} = aetx:process(Q3, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(Q3, Trees, Env),
 
     %% Test too low fee
     Q4 = aeo_test_utils:query_tx(SenderKey, OracleId, #{fee => 0}, S2),
@@ -528,7 +528,7 @@ query_response_negative(Cfg) ->
 
     %% Test too high nonce for account
     RTx2 = aeo_test_utils:response_tx(OracleKey, ID, <<"42">>, #{nonce => 0}, S1),
-    {error, account_nonce_too_high} = aetx:process(RTx2, Trees, Env),
+    {error, tx_nonce_already_used_for_account} = aetx:process(RTx2, Trees, Env),
 
     %% Test fee too low
     RTx3 = aeo_test_utils:response_tx(OracleKey, ID, <<"42">>, #{fee => 0}, S1),

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -1443,8 +1443,8 @@ assert_ga_env(Pubkey, Nonce, #state{tx_env = Env}) ->
 assert_account_nonce(Account, Nonce) ->
     case aec_accounts:nonce(Account) of
         N when N + 1 =:= Nonce -> ok;
-        N when N >= Nonce -> runtime_error(account_nonce_too_high);
-        N when N < Nonce  -> runtime_error(account_nonce_too_low)
+        N when N >= Nonce -> runtime_error(tx_nonce_already_used_for_account);
+        N when N < Nonce  -> runtime_error(tx_nonce_too_high_for_account)
     end.
 
 assert_account_balance(Account, Balance) ->

--- a/apps/aetx/src/aetx_utils.erl
+++ b/apps/aetx/src/aetx_utils.erl
@@ -73,15 +73,15 @@ check_balance(Account, Amount) ->
     end.
 
 -spec check_nonce(aec_accounts:account(), non_neg_integer(), aetx_env:env()) ->
-        ok | {error, account_nonce_too_high | account_nonce_too_low}.
+        ok | {error, atom()}.
 check_nonce(Account, Nonce, Env) ->
     case aec_accounts:type(Account) of
         basic ->
-            AccountNonce = aec_accounts:nonce(Account),
+            ANonce = aec_accounts:nonce(Account),
             if
-                Nonce =:= (AccountNonce + 1) -> ok;
-                Nonce =< AccountNonce -> {error, account_nonce_too_high};
-                Nonce > AccountNonce -> {error, account_nonce_too_low}
+                Nonce == (ANonce + 1) -> ok;
+                Nonce =< ANonce       -> {error, tx_nonce_already_used_for_account};
+                Nonce >  ANonce       -> {error, tx_nonce_too_high_for_account}
             end;
         generalized ->
             GANonce = aetx_env:ga_nonce(Env, aec_accounts:pubkey(Account)),


### PR DESCRIPTION
These errors are only reported for `basic` accounts - i.e. they can't get into error messages for meta-transactions.