### PR TITLE
SC user abort & recoverable errors

### DIFF
--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -64,3 +64,6 @@
 %% Error codes
 -define(ERR_VALIDATION, 1).
 -define(ERR_CONFLICT  , 2).
+-define(ERR_TIMEOUT   , 3).
+-define(ERR_ABORT     , 4).
+-define(ERR_USER      , 128).  % anything >= 128 is a user error

--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -145,6 +145,7 @@
               %% checks
               , op = ?NO_OP                   :: latest_op()
               , ongoing_update = false        :: boolean()
+              , error_msg_type = undefined    :: undefined | error_msg_type()
               , last_reported_update          :: undefined | non_neg_integer()
               , log                           :: log()
               , strict_checks = true          :: boolean()
@@ -190,6 +191,10 @@
                   | ?UPDATE_ACK
                   | ?SHUTDOWN
                   | ?SHUTDOWN_ACK.
+
+-type error_msg_type() :: ?UPDATE_ERR
+                        | ?DEP_ERR
+                        | ?WDRAW_ERR.
 
 -opaque opts() :: #{ minimum_depth => non_neg_integer() %% Defaulted for responder, not for initiator.
                    , timeouts := #{state_name() := pos_integer()

--- a/apps/aehttp/src/sc_ws_api_jsonrpc.erl
+++ b/apps/aehttp/src/sc_ws_api_jsonrpc.erl
@@ -172,6 +172,7 @@ json_rpc_error_object({broken_encoding,What}, R) ->
     error_obj(3, [broken_encoding_code(W) || W <- What], R);
 json_rpc_error_object({meta, invalid}     , R) -> error_obj(3     , [1014], R);
 json_rpc_error_object(not_found           , R) -> error_obj(3     , [100] , R);
+json_rpc_error_object(error_code          , R) -> error_obj(3     , [1015], R);
 json_rpc_error_object(Other               , R) ->
     lager:debug("Unrecognized error reason: ~p", [Other]),
     error_obj(-32603        , R).
@@ -243,6 +244,7 @@ error_data_msgs() ->
      , 1012 => <<"Offchain tx expected">>
      , 1013 => <<"Tx already on-chain">>
      , 1014 => <<"Invalid meta object">>
+     , 1015 => <<"Invalid error code (expect 1...65535)">>
      }.
 
 broken_encoding_code(account    ) -> 1005;
@@ -537,6 +539,16 @@ process_request(#{<<"method">> := <<"channels.withdraw">>,
         {error, _Reason} = Err -> Err
     end;
 process_request(#{<<"method">> := Method,
+                  <<"params">> := #{<<"error">> := ErrorCode}}, FsmPid)
+  when ?METHOD_SIGNED(Method) ->
+    Tag = ?METHOD_TAG(Method),
+    case valid_error_code(ErrorCode) of
+        true ->
+            aesc_fsm:signing_response(FsmPid, Tag, {error, ErrorCode});
+        false ->
+            {error, error_code}
+    end;
+process_request(#{<<"method">> := Method,
                   <<"params">> := #{<<"signed_tx">> := EncodedTx}}, FsmPid)
     when ?METHOD_SIGNED(Method) ->
     Tag = ?METHOD_TAG(Method),
@@ -629,3 +641,14 @@ check_params(<<"channels.update.new">>, Params) when is_map(Params) ->
                                , mandatory => false})]);
 check_params(Method, Params) ->
     {error, {unknown, Method, Params}}.
+
+valid_error_code(ErrorCode) when is_integer(ErrorCode) ->
+    ErrorCode >= 1 andalso ErrorCode =< 16#ffFF;
+valid_error_code(ErrorCode) when is_binary(ErrorCode) ->
+    try valid_error_code(binary_to_integer(ErrorCode))
+    catch
+        error:_ ->
+            false
+    end;
+valid_error_code(_) ->
+    false.


### PR DESCRIPTION
See [#168160333](https://www.pivotaltracker.com/story/show/168160333)

First commit (WIP). Old test suites seem to pass, but no new tests added yet.

Approach:
* Allow client to answer a signing request with an `{error: ErrorCode}` parameter
* Timeouts during ongoing updates/deposits/... lead to an appropriate error message (`error_code: ?ERR_TIMEOUT`), reverting to stable offchain state and moving to the `open` FSM state
* Reserve error codes >= 128 to users. The `error_code` field is two bytes.
