### PR TITLE
SC Call.origin and Call.caller cleanup and tests

### DIFF
--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -201,7 +201,8 @@ apply_on_trees(Update, Trees0, OnChainTrees, OnChainEnv, Round, Reserve) ->
             _Trees = aect_channel_contract:run(ContractPubKey, ABIVersion, Call,
                                                CallData, CallStack,
                                                Trees2, Amount, GasPrice, Gas,
-                                               OnChainTrees, OnChainEnv)
+                                               OnChainTrees, OnChainEnv,
+                                               Caller)
     end.
 
 -spec for_client(update()) -> map().

--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -2708,8 +2708,11 @@ fp_use_onchain_enviroment(Cfg) ->
     Timestamp1 = 654321,
     BeneficiaryInt = 42,
     Beneficiary = <<BeneficiaryInt:?BENEFICIARY_PUB_BYTES/unit:8>>,
-    ExpBeneficiary = ?IF_AEVM(BeneficiaryInt,
-                              aeb_fate_data:make_address(Beneficiary)),
+    EncAddress =
+        fun(<<AddressInt:32/unit:8>> = Address) ->
+            ?IF_AEVM(AddressInt, aeb_fate_data:make_address(Address))
+        end,
+    ExpBeneficiary = EncAddress(Beneficiary), 
 
     Height2 = Height1 + LockPeriod + 1,
     Height3 = Height2 + LockPeriod + 1,
@@ -2744,7 +2747,26 @@ fp_use_onchain_enviroment(Cfg) ->
                 set_tx_env(Height3, Timestamp1, Beneficiary),
                 ForceCall(Forcer, <<"coinbase">>, word, ExpBeneficiary),
                 set_tx_env(Height4, Timestamp1, Beneficiary),
-                ForceCall(Forcer, <<"timestamp">>, word, Timestamp1)
+                ForceCall(Forcer, <<"timestamp">>, word, Timestamp1),
+                set_from(Forcer),
+                fun(#{ owner       := OwnerPubkey
+                     , from_pubkey := ForcerPubkey} = Props) ->
+                    ExpectedCaller  = EncAddress(ForcerPubkey),
+                    ExpectedCreator = EncAddress(OwnerPubkey),
+                    run(Props,
+                        [ ForceCall(Forcer, <<"caller">>, word, ExpectedCaller)
+                        , ForceCall(Forcer, <<"origin">>, word, ExpectedCaller)
+                        , fun(#{height := H} = Props1) ->
+                              case aec_hard_forks:protocol_effective_at_height(H) of
+                                  PreF when PreF < ?FORTUNA_PROTOCOL_VSN -> %% no creator
+                                      Props1;
+                                  _PostFortuna ->
+                                      (ForceCall(Forcer, <<"creator">>, word,
+                                                 ExpectedCreator))(Props1)
+                              end
+                          end
+                        ])
+                end
                ])
         end,
     [CallOnChain(Owner, Forcer) || Owner  <- ?ROLES,

--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -2712,7 +2712,7 @@ fp_use_onchain_enviroment(Cfg) ->
         fun(<<AddressInt:32/unit:8>> = Address) ->
             ?IF_AEVM(AddressInt, aeb_fate_data:make_address(Address))
         end,
-    ExpBeneficiary = EncAddress(Beneficiary), 
+    ExpBeneficiary = EncAddress(Beneficiary),
 
     Height2 = Height1 + LockPeriod + 1,
     Height3 = Height2 + LockPeriod + 1,

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -4,7 +4,7 @@
 
 -export([new/6,
          run_new/6,
-         run/11,
+         run/12,
          get_call/4,
          insert_failed_call/6
         ]).
@@ -38,7 +38,7 @@ run_new(ContractPubKey, Call, CallData0, Trees0, OnChainTrees,
     CallData = assert_init_function(CallData0, VmVersion, Code),
     {Contract, Trees1} = prepare_init_call(VmVersion, Contract0, Trees0),
     Store = aect_contracts:state(Contract),
-    CallDef = make_call_def(OwnerPubKey, ContractPubKey,
+    CallDef = make_call_def(OwnerPubKey, OwnerPubKey, ContractPubKey,
                             _Gas = 1000000, _GasPrice = 1,
                             _Amount = 0, %TODO: make this configurable
                             CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees1),
@@ -105,12 +105,12 @@ assert_init_function(CallData, VMVersion, SerializedCode) when ?IS_AEVM_SOPHIA(V
 -spec run(aect_contracts:pubkey(), aect_contracts:abi_version(), aect_call:call(),
           binary(), [non_neg_integer()], aec_trees:trees(),
           non_neg_integer(), non_neg_integer(), non_neg_integer(),
-          aec_trees:trees(), aetx_env:env()) -> aec_trees:trees().
+          aec_trees:trees(), aetx_env:env(), aec_keys:pubkey()) -> aec_trees:trees().
 run(ContractPubKey, ABIVersion, Call, CallData, CallStack, Trees0,
-    Amount, GasPrice, Gas, OnChainTrees, OnChainEnv) ->
+    Amount, GasPrice, Gas, OnChainTrees, OnChainEnv, CallerPubkey) ->
     ContractsTree  = aec_trees:contracts(Trees0),
     Contract = aect_state_tree:get_contract(ContractPubKey, ContractsTree),
-    OwnerPubKey = aect_contracts:owner_pubkey(Contract),
+    OwnerPubkey = aect_contracts:owner_pubkey(Contract),
     Code = aect_contracts:code(Contract),
     Store = aect_contracts:state(Contract),
     VmVersion = aect_contracts:vm_version(Contract),
@@ -120,7 +120,7 @@ run(ContractPubKey, ABIVersion, Call, CallData, CallStack, Trees0,
         true                                 -> erlang:error(wrong_vm_version);
         false                                -> erlang:error(wrong_abi_version)
     end,
-    CallDef = make_call_def(OwnerPubKey, ContractPubKey, Gas, GasPrice, Amount,
+    CallDef = make_call_def(CallerPubkey, OwnerPubkey, ContractPubKey, Gas, GasPrice, Amount,
               CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees0),
     {CallRes, Trees, _} = aect_dispatch:run(#{vm => VmVersion, abi => ABIVersion}, CallDef),
     UpdatedTrees = aect_utils:insert_call_in_trees(CallRes, Trees),
@@ -128,10 +128,10 @@ run(ContractPubKey, ABIVersion, Call, CallData, CallStack, Trees0,
 
 
 
-make_call_def(OwnerPubKey, ContractPubKey, GasLimit, GasPrice, Amount,
+make_call_def(CallerPubkey, OwnerPubKey, ContractPubKey, GasLimit, GasPrice, Amount,
               CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv,
               OffChainTrees) ->
-    #{caller          => OwnerPubKey
+    #{caller          => CallerPubkey
     , contract        => ContractPubKey
     , gas             => GasLimit
     , gas_price       => GasPrice
@@ -145,7 +145,7 @@ make_call_def(OwnerPubKey, ContractPubKey, GasLimit, GasPrice, Amount,
     , tx_env          => OnChainEnv
     , off_chain       => true
     , on_chain_trees  => OnChainTrees
-    , origin          => OwnerPubKey
+    , origin          => CallerPubkey
     , creator         => OwnerPubKey
     }.
 

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -1660,7 +1660,7 @@ sc_ws_enviroment_contract_(Owner, GetVolley, CreateContract, ConnPid1, ConnPid2,
                                       Fun, Updates, Tx, Config),
             {R, R} = {R0, R},
             case is_function(Result) of
-                true -> true = Result(R);
+                true -> true = Result(Who, R);
                 false ->
                     {R, R} = {Result, R}
             end
@@ -1678,7 +1678,22 @@ sc_ws_enviroment_contract_(Owner, GetVolley, CreateContract, ConnPid1, ConnPid2,
 
     Test(<<"block_height">>, BlockHeight),
     Test(<<"coinbase">>, EncBeneficiary),
-    Test(<<"timestamp">>, fun(T) -> T > Time end),
+    Test(<<"timestamp">>, fun(_, T) -> T > Time end),
+    CheckCaller =
+        fun(Who, Result) ->
+            Participants = proplists:get_value(participants, Config),
+            #{pub_key := Pubkey} = maps:get(Who, Participants),
+            EncPubkey = aeser_api_encoder:encode(account_pubkey, Pubkey),
+            {Result, Result, Who} = {Result, EncPubkey, Who},
+            true
+        end,
+    Test(<<"caller">>, CheckCaller), 
+    Test(<<"origin">>, CheckCaller),
+    case aect_test_utils:latest_protocol_version() of
+        PostFortuna when PostFortuna >= ?FORTUNA_PROTOCOL_VSN ->
+            Test(<<"creator">>, fun(_, Res) -> CheckCaller(Owner, Res) end);
+        _PreFortuna -> pass
+    end,
     ok.
 
 sc_ws_remote_call_contract_(Owner, GetVolley, CreateContract, ConnPid1, ConnPid2,

--- a/docs/release-notes/RELEASE-NOTES-4.2.1.md
+++ b/docs/release-notes/RELEASE-NOTES-4.2.1.md
@@ -4,6 +4,7 @@
 It includes the following changes:
 * Change to a generic error message for the inner transaction of a GAMetaTX.
 * Long overdue bump of info-field in key block header from pre-fortuna value.
+* Improves State Channels tests to cover `Call.origin` and `Call.caller`
 
 [this-release]: https://github.com/aeternity/aeternity/releases/tag/v4.2.1
 

--- a/docs/release-notes/RELEASE-NOTES-4.2.1.md
+++ b/docs/release-notes/RELEASE-NOTES-4.2.1.md
@@ -4,7 +4,7 @@
 It includes the following changes:
 * Change to a generic error message for the inner transaction of a GAMetaTX.
 * Long overdue bump of info-field in key block header from pre-fortuna value.
-* Improves State Channels tests to cover `Call.origin` and `Call.caller`
+* Fix incorrect values of Call.origin and Call.caller in state channels off-chain contract calls.
 
 [this-release]: https://github.com/aeternity/aeternity/releases/tag/v4.2.1
 

--- a/test/contracts/channel_env.aes
+++ b/test/contracts/channel_env.aes
@@ -6,3 +6,9 @@ contract ChannelEnv =
   entrypoint block_height() : int = Chain.block_height
 
   entrypoint difficulty() : int = Chain.difficulty
+
+  entrypoint caller() : address = Call.caller
+
+  entrypoint origin() : address = Call.origin
+
+  entrypoint creator() : address = Contract.creator

--- a/test/contracts/sophia_2/channel_env.aes
+++ b/test/contracts/sophia_2/channel_env.aes
@@ -6,3 +6,7 @@ contract ChannelEnv =
   public function block_height() : int = Chain.block_height
 
   public function difficulty() : int = Chain.difficulty
+
+  public function caller() : address = Call.caller
+
+  public function origin() : address = Call.origin


### PR DESCRIPTION
[PT-166477826](https://www.pivotaltracker.com/story/show/166477826)

Off-chain transactions calls and Force progress transactions have a bug: the result of a `Call.origin` or `Call.caller` calls is not the caller of the contract but rather the owner of the contract.