### PR TITLE
[PT-168283496] Change configuration option name `ws_handlers` to `sc_ws_handlers`

### DIFF
--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -354,4 +354,4 @@ read_channel_options(Params) ->
      ).
 
 jobs_ask() ->
-    jobs:ask(ws_handlers).
+    jobs:ask(sc_ws_handlers).

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -845,29 +845,6 @@
                         }
                     }
                 },
-                "ws_handlers" : {
-                    "description" : "websocket handlers.",
-                    "type" : "object",
-                    "additionalProperties" : false,
-                    "properties" : {
-                        "counter" : {
-                            "type" : "integer",
-                            "default" : 10
-                        },
-                        "rate" : {
-                            "type" : "integer",
-                            "default" : 0
-                        },
-                        "max_size" : {
-                            "type" : "integer",
-                            "default" : 5
-                        },
-                        "max_time" : {
-                            "type" : "integer",
-                            "default" : 0
-                        }
-                    }
-                },
                 "sc_ws_handlers" : {
                     "description" : "State channel websocket handlers.",
                     "type" : "object",

--- a/docs/release-notes/next-lima/PT-168283496-change-configuration-ws-handlers.md
+++ b/docs/release-notes/next-lima/PT-168283496-change-configuration-ws-handlers.md
@@ -1,0 +1,2 @@
+* State Channels: Changed configuration option name `ws_handlers` to `sc_ws_handlers` which
+  correctly implies that the limit applies to SC websocket connections.


### PR DESCRIPTION
The new name already existed, but wasn't used. Instead the
previous name was used, which is misleading to the user as it
implied a general limit.

Fixes [PT-168283496](https://www.pivotaltracker.com/story/show/168283496)