### PR TITLE
Fix the (invalid) swagger schema

### DIFF
--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -2889,11 +2889,16 @@ definitions:
         type: array
         description: Txs
         items:
-          oneOf:
-            - $ref: '#/definitions/EncodedByteArray'
-            - $ref: '#/definitions/DryRunCallReq'
+          $ref: '#/definitions/DryRunInputItem'
     required:
       - txs
+  DryRunInputItem:
+    type: object
+    properties:
+      tx:
+        $ref: '#/definitions/EncodedByteArray'
+      call_req:
+        $ref: '#/definitions/DryRunCallReq'
   DryRunCallReq:
     type: object
     properties:

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -565,7 +565,7 @@ dry_run_accounts_([Account | Accounts], Acc) ->
 
 dry_run_txs_([], Txs) ->
     {ok, lists:reverse(Txs)};
-dry_run_txs_([ETx | Txs], Acc) when is_binary(ETx) ->
+dry_run_txs_([#{ <<"tx">> := ETx } | Txs], Acc) ->
     case aeser_api_encoder:safe_decode(transaction, ETx) of
         {ok, DTx} ->
             Tx = aetx:deserialize_from_binary(DTx),
@@ -578,7 +578,7 @@ dry_run_txs_([ETx | Txs], Acc) when is_binary(ETx) ->
         Err = {error, _Reason} ->
             Err
     end;
-dry_run_txs_([CallReq | Txs], Acc) when is_map(CallReq) ->
+dry_run_txs_([#{ <<"call_req">> := CallReq } | Txs], Acc) ->
     dry_run_txs_(Txs, [{call_req, CallReq} | Acc]).
 
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1304,7 +1304,7 @@ force_fun_calls(Node, MaxMinedBlocks) ->
     check_calls(Calls).
 
 dry_run_txs(Calls) ->
-    Txs = [ Tx || {#{tx_encoded := Tx}, _} <- Calls ],
+    Txs = [ #{tx => Tx} || {#{tx_encoded := Tx}, _} <- Calls ],
     {ok, 200, #{ <<"results">> := Results }} = dry_run(Txs),
     check_dry_calls(Calls, Results).
 

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -664,9 +664,9 @@ abi_version() ->
 do_dry_run(STx, ExpRes) ->
     Tx = try aetx_sign:tx(STx)
          catch _:_ -> STx end,
+    EncTx = aeser_api_encoder:encode(transaction, aetx:serialize_to_binary(Tx)),
     Host = aecore_suite_utils:internal_address(),
-    case http_request(Host, post, "debug/transactions/dry-run",
-                      #{ txs => [aeser_api_encoder:encode(transaction, aetx:serialize_to_binary(Tx))] }) of
+    case http_request(Host, post, "debug/transactions/dry-run", #{ txs => [#{tx => EncTx}] }) of
         {ok, 200, #{ <<"results">> := [#{ <<"result">> := Res } = ResObj] }} ->
             ct:pal("ResObj: ~p", [ResObj]),
             ?assertMatch(ExpRes, binary_to_atom(Res, utf8));

--- a/py/tests/integration/common.py
+++ b/py/tests/integration/common.py
@@ -31,7 +31,7 @@ INT_API = {}
 def create_client(node_name, port):
     node_config = config['nodes'][node_name]
     url = 'http://' + node_config['host'] + ':' + str(node_config['ports'][port]) + '/api'
-    client_config = {'validate_responses': False, 'validate_swagger_spec': False}
+    client_config = {'validate_responses': False}
     return SwaggerClient.from_url(url, config=client_config)
 
 def external_api(name):

--- a/py/tests/release.py
+++ b/py/tests/release.py
@@ -170,7 +170,7 @@ EXT_API = {}
 def external_api(name):
     if not name in EXT_API:
         url = SETUP[name]['api_url']
-        client_config = {'validate_responses': False, 'validate_swagger_spec': False}
+        client_config = {'validate_responses': False}
         EXT_API[name] = SwaggerClient.from_url(url, config=client_config).external
     return EXT_API[name]
 


### PR DESCRIPTION
In https://github.com/aeternity/aeternity/pull/2716 Swagger schema introduced [`oneOf`](https://github.com/aeternity/aeternity/pull/2716/files#diff-89b8ec7c2f28f3e3c7d21ca9bf070bb7R2890) which is [invalid](http://online.swagger.io/validator/debug?url=https://raw.githubusercontent.com/aeternity/aeternity/master/config/swagger.yaml) swagger v2 key

e.g.:
```
Swagger schema validation failed. 
  Data does not match any schemas from 'anyOf' at #/definitions/DryRunInput/properties/txs/items
    Additional properties not allowed: oneOf at #/definitions/DryRunInput/properties/txs/items
    Expected type array but found type object at #/definitions/DryRunInput/properties/txs/items
 
JSON_OBJECT_VALIDATION_FAILED

```

This PR introduce workaround (suggested by @hanssv) that would get us back the valid schema.