### PR TITLE
Pt 168245174 memory gas

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -5602,6 +5602,7 @@ sophia_state_gas_store_size(_Cfg) ->
 
 
 sophia_use_memory_gas(_Cfg) ->
+    ?skipRest(sophia_version() =< ?SOPHIA_FORTUNA, fate_gas_only_post_fortuna),
     state(aect_test_utils:new_state()),
     Acc      = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     ContractName = use_memory,

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -365,20 +365,18 @@ spend_gas(X, #es{gas = Gas} = ES) ->
         false -> ES#es{gas = NewGas}
     end.
 
--define(CHEAP_CELLS, 10000). %% TODO: move to governance.
--define(CELL_COST_GROWTH, 0.6).
-
+%% The gas price per cell increases by 1 for each kibiword (each 1024 64-bit word) used.
 -spec spend_gas_for_new_cells(non_neg_integer(), state()) -> state().
-spend_gas_for_new_cells(NewCells, #es{ created_cells = Cells } = ES) when NewCells + Cells =< ?CHEAP_CELLS ->
+spend_gas_for_new_cells(NewCells, #es{ created_cells = Cells } = ES) when NewCells + Cells =< 1024 ->
     TotalCells = Cells + NewCells,
     spend_gas(NewCells, ES#es{ created_cells = TotalCells });
-spend_gas_for_new_cells(1, #es{ created_cells = Cells } = ES) when Cells >= ?CHEAP_CELLS ->
+spend_gas_for_new_cells(1, #es{ created_cells = Cells } = ES) ->
     TotalCells = Cells + 1,
-    CellCost = round(math:pow(TotalCells - ?CHEAP_CELLS, ?CELL_COST_GROWTH)),
+    CellCost = 1 + (TotalCells bsr 10),
     spend_gas(CellCost, ES#es{ created_cells = TotalCells });
-spend_gas_for_new_cells(NewCells, #es{ created_cells = Cells } = ES) when NewCells + Cells > ?CHEAP_CELLS ->
+spend_gas_for_new_cells(NewCells, #es{ created_cells = Cells } = ES) ->
     TotalCells = Cells + NewCells,
-    CellCost = round(math:pow(TotalCells - ?CHEAP_CELLS, ?CELL_COST_GROWTH)),
+    CellCost = 1 + (TotalCells bsr 10),
     spend_gas(NewCells * CellCost, ES#es{ created_cells = TotalCells }).
 
 %%%------------------

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -71,6 +71,7 @@
         , push_gas_cap/2
         , push_return_type_check/3
         , spend_gas/2
+        , spend_gas_for_new_cells/2
         , update_for_remote_call/3
         ]).
 
@@ -93,6 +94,7 @@
             , call_value        :: non_neg_integer()
             , chain_api         :: aefa_chain_api:state()
             , code_cache        :: map() %% Cache for loaded contracts.
+            , created_cells     :: integer() %% Heap memory used
             , current_bb        :: non_neg_integer()
             , current_contract  :: ?FATE_VOID | pubkey()
             , current_function  :: ?FATE_VOID | binary()
@@ -123,6 +125,7 @@ new(Gas, Value, Spec, Stores, APIState, CodeCache) ->
        , call_value        = Value
        , chain_api         = APIState
        , code_cache        = CodeCache
+       , created_cells     = 0
        , current_bb        = 0
        , current_contract  = ?FATE_VOID
        , current_function  = ?FATE_VOID
@@ -287,31 +290,39 @@ push_return_type_check(RetType, TVars, #es{ call_stack = Stack} = ES) ->
 -spec push_accumulator(aeb_fate_data:fate_type(), state()) -> state().
 push_accumulator(V, #es{ accumulator = ?FATE_VOID
                        , accumulator_stack = [] } = ES) ->
-    ES#es{ accumulator = V
-         , accumulator_stack = []};
+    ES1 = ES#es{ accumulator = V
+               , accumulator_stack = []},
+    spend_gas_for_new_cells(1, ES1);
 push_accumulator(V, #es{ accumulator = X
                        , accumulator_stack = Stack } = ES) ->
-    ES#es{ accumulator = V
-         , accumulator_stack = [X|Stack]}.
+    ES1 = ES#es{ accumulator = V
+               , accumulator_stack = [X|Stack]},
+    spend_gas_for_new_cells(1, ES1).
 
 -spec pop_accumulator(state()) -> {aeb_fate_data:fate_type(), state()}.
-pop_accumulator(#es{accumulator = X, accumulator_stack = []} = ES) ->
-    {X, ES#es{accumulator = ?FATE_VOID}};
-pop_accumulator(#es{accumulator = X, accumulator_stack = [V|Stack]} = ES) ->
+pop_accumulator(#es{accumulator = X, accumulator_stack = [], created_cells = C} = ES) ->
+    {X, ES#es{ accumulator = ?FATE_VOID
+             , created_cells = C - 1}};
+pop_accumulator(#es{accumulator = X,
+                    accumulator_stack = [V|Stack],
+                    created_cells = C} = ES) ->
     {X, ES#es{ accumulator = V
              , accumulator_stack = Stack
-           }}.
+             , created_cells = C - 1
+             }}.
 
 -spec dup_accumulator(state()) -> state().
 dup_accumulator(#es{accumulator = X, accumulator_stack = Stack} = ES) ->
-    ES#es{ accumulator = X
-         , accumulator_stack = [X|Stack]}.
+    ES1 = ES#es{ accumulator = X
+               , accumulator_stack = [X|Stack]},
+    spend_gas_for_new_cells(1, ES1).
 
 -spec dup_accumulator(pos_integer(), state()) -> state().
 dup_accumulator(N, #es{accumulator = X, accumulator_stack = Stack} = ES) ->
     {X1, Stack1} = get_n(N, [X|Stack]),
-    ES#es{ accumulator = X1
-         , accumulator_stack = [X|Stack1]}.
+    ES1 = ES#es{ accumulator = X1
+               , accumulator_stack = [X|Stack1]},
+    spend_gas_for_new_cells(1, ES1).
 
 get_n(0, [X|XS]) -> {X, [X|XS]};
 get_n(N, [X|XS]) ->
@@ -320,10 +331,20 @@ get_n(N, [X|XS]) ->
 
 -spec drop_accumulator(non_neg_integer(), state()) -> state().
 drop_accumulator(0, ES) -> ES;
-drop_accumulator(N, #es{accumulator_stack = [V|Stack]} = ES) ->
-    drop_accumulator(N-1, ES#es{accumulator = V, accumulator_stack = Stack});
-drop_accumulator(N, #es{accumulator_stack = []} = ES) ->
-    drop_accumulator(N-1, ES#es{accumulator = ?FATE_VOID, accumulator_stack = []}).
+drop_accumulator(N, #es{accumulator_stack = [V|Stack],
+                        created_cells = C
+                       } = ES) ->
+    drop_accumulator(N-1, ES#es{ accumulator = V
+                               , accumulator_stack = Stack
+                               , created_cells = C - 1
+                               });
+drop_accumulator(N, #es{accumulator_stack = [],
+                        created_cells = C
+                       } = ES) ->
+    drop_accumulator(N-1, ES#es{accumulator = ?FATE_VOID
+                               , accumulator_stack = []
+                               , created_cells = C - 1
+                               }).
 
 %%%------------------
 
@@ -343,6 +364,22 @@ spend_gas(X, #es{gas = Gas} = ES) ->
         true  -> aefa_fate:abort(out_of_gas, ES);
         false -> ES#es{gas = NewGas}
     end.
+
+-define(CHEAP_CELLS, 10000). %% TODO: move to governance.
+-define(CELL_COST_GROWTH, 0.6).
+
+-spec spend_gas_for_new_cells(non_neg_integer(), state()) -> state().
+spend_gas_for_new_cells(NewCells, #es{ created_cells = Cells } = ES) when NewCells + Cells =< ?CHEAP_CELLS ->
+    TotalCells = Cells + NewCells,
+    spend_gas(NewCells, ES#es{ created_cells = TotalCells });
+spend_gas_for_new_cells(1, #es{ created_cells = Cells } = ES) when Cells >= ?CHEAP_CELLS ->
+    TotalCells = Cells + 1,
+    CellCost = round(math:pow(TotalCells - ?CHEAP_CELLS, ?CELL_COST_GROWTH)),
+    spend_gas(CellCost, ES#es{ created_cells = TotalCells });
+spend_gas_for_new_cells(NewCells, #es{ created_cells = Cells } = ES) when NewCells + Cells > ?CHEAP_CELLS ->
+    TotalCells = Cells + NewCells,
+    CellCost = round(math:pow(TotalCells - ?CHEAP_CELLS, ?CELL_COST_GROWTH)),
+    spend_gas(NewCells * CellCost, ES#es{ created_cells = TotalCells }).
 
 %%%------------------
 

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -619,11 +619,12 @@ int_to_addr(Arg0, Arg1, EngineState) ->
     ES2 = aefa_engine_state:spend_gas_for_new_cells(Cells + 1, ES1),
     write(Arg0, Result, ES2).
 
+%% One Cell per 64 bit word
 string_cells(String) when ?IS_FATE_STRING(String) ->
-    byte_size(?FATE_STRING_VALUE(String)) div 64.
+    byte_size(?FATE_STRING_VALUE(String)) div 8.
 
 address_cells(A) when ?IS_FATE_ADDRESS(A) ->
-    byte_size(?FATE_ADDRESS_VALUE(A)) div 64.
+    byte_size(?FATE_ADDRESS_VALUE(A)) div 8.
 
 %% ------------------------------------------------------
 %% Variant instructions

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -621,12 +621,15 @@ str_reverse(Arg0, Arg1, EngineState) ->
 int_to_addr(Arg0, Arg1, EngineState) ->
     {LeftValue, ES1} = get_op_arg(Arg1, EngineState),
     Result = gop(int_to_addr, LeftValue, ES1),
-    Cells = string_cells(Result),
+    Cells = address_cells(Result),
     ES2 = aefa_engine_state:spend_gas_for_new_cells(Cells + 1, ES1),
     write(Arg0, Result, ES2).
 
 string_cells(String) when ?IS_FATE_STRING(String) ->
     byte_size(?FATE_STRING_VALUE(String)) div 64.
+
+address_cells(A) when ?IS_FATE_ADDRESS(A) ->
+    byte_size(?FATE_ADDRESS_VALUE(A)) div 64.
 
 %% ------------------------------------------------------
 %% Variant instructions

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -527,7 +527,8 @@ is_nil(Arg0, Arg1, EngineState) ->
     un_op(is_nil, {Arg0, Arg1}, EngineState).
 
 cons(Arg0, Arg1, Arg2, EngineState) ->
-    bin_op(cons, {Arg0, Arg1, Arg2}, EngineState).
+    ES1 = bin_op(cons, {Arg0, Arg1, Arg2}, EngineState),
+    aefa_engine_state:spend_gas_for_new_cells(2, ES1).
 
 hd(Arg0, Arg1, EngineState) ->
     un_op(hd, {Arg0, Arg1}, EngineState).
@@ -539,7 +540,11 @@ length(Arg0, Arg1, EngineState) ->
     un_op(length, {Arg0, Arg1}, EngineState).
 
 append(Arg0, Arg1, Arg2, EngineState) ->
-    bin_op(append, {Arg0, Arg1, Arg2}, EngineState).
+    ES1 = bin_op(append, {Arg0, Arg1, Arg2}, EngineState),
+    %% We will create a new copy of the first list.
+    {List, _} = get_op_arg(Arg1, EngineState),
+    Size = length(?FATE_LIST_VALUE(List)),
+    aefa_engine_state:spend_gas_for_new_cells(Size * 2, ES1).
 
 %% ------------------------------------------------------
 %% String instructions

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -318,19 +318,39 @@ dec(Arg0, EngineState) ->
     un_op(dec, {Arg0, Arg0}, EngineState).
 
 add(Arg0, Arg1, Arg2, EngineState) ->
-    bin_op(add, {Arg0, Arg1, Arg2}, EngineState).
+    {A, ES1} = get_op_arg(Arg1, EngineState),
+    {B, ES2} = get_op_arg(Arg2, ES1),
+    Res = gop(add, A, B, ES2),
+    ES3 = aefa_engine_state:spend_gas_for_new_cells(words_used(Res), ES2),
+    write(Arg0, Res, ES3).
 
 sub(Arg0, Arg1, Arg2, EngineState) ->
-    bin_op(sub, {Arg0, Arg1, Arg2}, EngineState).
+    {A, ES1} = get_op_arg(Arg1, EngineState),
+    {B, ES2} = get_op_arg(Arg2, ES1),
+    Res = gop(sub, A, B, ES2),
+    ES3 = aefa_engine_state:spend_gas_for_new_cells(words_used(Res), ES2),
+    write(Arg0, Res, ES3).
 
 mul(Arg0, Arg1, Arg2, EngineState) ->
-    bin_op(mul, {Arg0, Arg1, Arg2}, EngineState).
+    {A, ES1} = get_op_arg(Arg1, EngineState),
+    {B, ES2} = get_op_arg(Arg2, ES1),
+    Res = gop(mul, A, B, ES2),
+    ES3 = aefa_engine_state:spend_gas_for_new_cells(words_used(Res), ES2),
+    write(Arg0, Res, ES3).
 
 divide(Arg0, Arg1, Arg2, EngineState) ->
-    bin_op('div', {Arg0, Arg1, Arg2}, EngineState).
+    {A, ES1} = get_op_arg(Arg1, EngineState),
+    {B, ES2} = get_op_arg(Arg2, ES1),
+    Res = gop('div', A, B, ES2),
+    ES3 = aefa_engine_state:spend_gas_for_new_cells(words_used(Res), ES2),
+    write(Arg0, Res, ES3).
 
 modulo(Arg0, Arg1, Arg2, EngineState) ->
-    bin_op(mod, {Arg0, Arg1, Arg2}, EngineState).
+    {A, ES1} = get_op_arg(Arg1, EngineState),
+    {B, ES2} = get_op_arg(Arg2, ES1),
+    Res = gop(mod, A, B, ES2),
+    ES3 = aefa_engine_state:spend_gas_for_new_cells(words_used(Res), ES2),
+    write(Arg0, Res, ES3).
 
 pow(Arg0, Arg1, Arg2, EngineState) ->
     {Base, ES1} = get_op_arg(Arg1, EngineState),

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -359,12 +359,8 @@ pow(Arg0, Arg1, Arg2, EngineState) ->
             if Exponent < 0 ->
                     aefa_fate:abort({arithmetic_error, negative_exponent}, ES2);
                true ->
-                    case pow(Base, Exponent, ES2) of
-                        {Res, ES3} ->
-                            write(Arg0, Res, ES3);
-                        out_of_gas ->
-                            aefa_fate:abort(out_of_gas, ES2)
-                    end
+                    {Res, ES3} = pow(Base, Exponent, ES2),
+                    write(Arg0, Res, ES3)
             end
     end.
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1155,7 +1155,7 @@ remote_gas_test_contract(Config) ->
     call_get(APub, APriv, EncC2Pub, Contract, 100),
     force_fun_calls(Node),
     Balance1 = get_balance(APub),
-    ?assertMatchVM(1600596, 1600040, (Balance0 - Balance1) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(1600596, 1600042, (Balance0 - Balance1) div ?DEFAULT_GAS_PRICE),
 
     %% Test remote call with limited gas
     %% Call contract remote set function with limited gas
@@ -1163,13 +1163,13 @@ remote_gas_test_contract(Config) ->
     call_get(APub, APriv, EncC2Pub, Contract, 1),
     force_fun_calls(Node),
     Balance2 = get_balance(APub),
-    ?assertMatchVM(1610855, 1600380, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(1610855, 1600391, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
 
     %% Test remote call with limited gas (3) that fails (out of gas).
     [] = call_func(APub, APriv, EncC1Pub, Contract, "call", [EncC2Pub, "2", "3"], error),
     force_fun_calls(Node),
     Balance3 = get_balance(APub),
-    ?assertMatchVM(809981, 800143, (Balance2 - Balance3) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(809981, 800147, (Balance2 - Balance3) div ?DEFAULT_GAS_PRICE),
 
     %% Check that store/state not changed (we tried to write 2).
     call_get(APub, APriv, EncC2Pub, Contract, 1),
@@ -1181,7 +1181,7 @@ remote_gas_test_contract(Config) ->
     [] = call_func(APub, APriv, EncC1Pub, Contract, "call", [ZeroContract, "2", "1"], error),
     force_fun_calls(Node),
     Balance5 = get_balance(APub),
-    ?assertMatchVM(900000, 800141, (Balance4 - Balance5) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(900000, 800145, (Balance4 - Balance5) div ?DEFAULT_GAS_PRICE),
 
     ok.
 

--- a/rebar.config
+++ b/rebar.config
@@ -265,7 +265,7 @@
              {compile, "erlc test/ct_eunit_xform.erl"} %% {ct_first_files, _} does not work
             ]}.
 
-{post_hooks, [{compile, "rm ct_eunit_xform.beam"},
+{post_hooks, [{compile, "rm -f ct_eunit_xform.beam"},
               {clean, "make -C ./otp_patches clean"}
              ]}.
 

--- a/test/contracts/use_memory.aes
+++ b/test/contracts/use_memory.aes
@@ -1,0 +1,7 @@
+contract UseMemory =
+
+  entrypoint str_concat(s1, s2) = String.concat(s1, s2)
+
+  entrypoint dup_str(s, n) =
+    if (n > 0) dup_str(String.concat(s, s), n - 1)
+    else s


### PR DESCRIPTION
Spend gas for memory usage (stack, tuples, strings and large integers).
Each used underlying machine word (64-bits), called a cell, cost 1 unit.
For each 1024 used cells (8 KiB) the price per unit increases by 1.
When the stack shrinks the number of used cells decreases, this does not give you back gas spent for using the stack cell but the price of new cells might go down.
Not all integer operations uses new cells and only operations that can use many cells counts towards the gas cost.

TODO: describe this model in the protocol documentation. 