### PR TITLE
Refactor aesc_offchain_update versioning

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -65,7 +65,6 @@
         , record_fields/1
         , report_tags/0
         , timeouts/0
-        , version_tags/0
         , bh_deltas/0
         ]).
 
@@ -305,8 +304,6 @@ record_fields(Other) -> aesc_offchain_state:record_fields(Other).
 report_tags() ->
     maps:keys(?DEFAULT_REPORT_FLAGS).
 
-version_tags() ->
-    [offchain_update].
 
 bh_deltas() ->
     record_info(fields, bh_delta).
@@ -2771,12 +2768,12 @@ send_recoverable_error_msg(?WDRAW_ERR, Sn, Msg) ->
     lager:debug("send withdraw_error: ~p", [Msg]),
     aesc_session_noise:wdraw_error(Sn,Msg);
 send_recoverable_error_msg(?SHUTDOWN_ERR, Sn, Msg) ->
-    case aesc_offchain_update:get_vsn() of
-        V when V > 1 ->
+    case was_fork_activated(?LIMA_PROTOCOL_VSN) of
+        true ->
             lager:debug("send shutdown_error: ~p", [Msg]),
             aesc_session_noise:shutdown_error(Sn,Msg);
         _ ->
-            %% This message won't be defined in earlier FSMs
+            %% This message won't be defined pre Lima
             ok
     end.
 
@@ -3415,7 +3412,6 @@ init(#{opts := Opts0} = Arg) ->
               fun check_timeout_opt/1,
               fun check_rpt_opt/1,
               fun check_log_opt/1,
-              fun check_version_opts/1,
               fun check_block_hash_deltas/1
              ], Opts2),
     #{initiator := Initiator} = Opts,
@@ -3532,28 +3528,6 @@ check_timeout_opt(#{timeouts := TOs} = Opts) ->
     Opts1;
 check_timeout_opt(Opts) ->
     check_timeout_opt(Opts#{timeouts => #{}}).
-
-check_version_opts(#{versions := S} = Opts) ->
-    case maps:fold(
-           fun(_, _, {error,_} = E) ->
-                   E;
-              (offchain_update = Cat, V, ok) ->
-                  try aesc_offchain_update:set_vsn(V)
-                  ?CATCH_LOG(_E)
-                      {error, {invalid_vsn, Cat}}
-                  end;
-              (Cat, _V, ok) ->
-                   lager:debug("Unsupported version option ~p - ignoring", [Cat]),
-                   ok
-           end, ok, S) of
-        ok ->
-            Opts;
-        {error, _} = Error ->
-            lager:error("Invalid serialization: ~p", [Error]),
-            maps:remove(versions, Opts)
-    end;
-check_version_opts(Opts) ->
-    Opts.
 
 check_rpt_opt(#{report := R} = Opts) when is_map(R) ->
     L = [{K,V} || {K,V} <- maps:to_list(R),

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -2768,14 +2768,8 @@ send_recoverable_error_msg(?WDRAW_ERR, Sn, Msg) ->
     lager:debug("send withdraw_error: ~p", [Msg]),
     aesc_session_noise:wdraw_error(Sn,Msg);
 send_recoverable_error_msg(?SHUTDOWN_ERR, Sn, Msg) ->
-    case was_fork_activated(?LIMA_PROTOCOL_VSN) of
-        true ->
-            lager:debug("send shutdown_error: ~p", [Msg]),
-            aesc_session_noise:shutdown_error(Sn,Msg);
-        _ ->
-            %% This message won't be defined pre Lima
-            ok
-    end.
+    lager:debug("send shutdown_error: ~p", [Msg]),
+    aesc_session_noise:shutdown_error(Sn, Msg).
 
 request_signing(Tag, Aetx, Updates, BlockHash, #data{} = D) ->
     request_signing(Tag, Aetx, Updates, BlockHash, D, send).

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -2,7 +2,6 @@
 
 -define(UPDATE_VSN_1, 1).
 -define(UPDATE_VSN_2, 2).
--define(UPDATE_VSN_1_OR_2(V), V =:= ?UPDATE_VSN_1; V =:= ?UPDATE_VSN_2).
 
 -record(transfer, {
           from_id      :: aeser_id:id(),
@@ -371,23 +370,23 @@ type2swagger_name(call_contract)   -> <<"OffChainCallContract">>;
 type2swagger_name(meta)            -> <<"OffChainMeta">>.
 
 -spec update_serialization_template(non_neg_integer(), update_type()) -> list().
-update_serialization_template(V, transfer) when ?UPDATE_VSN_1_OR_2(V) ->
+update_serialization_template(V, transfer) when V =:= ?UPDATE_VSN_1 ->
     [ {from,    id},
       {to,      id},
       {amount,  int}];
-update_serialization_template(V, deposit) when ?UPDATE_VSN_1_OR_2(V) ->
+update_serialization_template(V, deposit) when V =:= ?UPDATE_VSN_1 ->
     [ {from,    id},
       {amount,  int}];
-update_serialization_template(V, withdraw) when ?UPDATE_VSN_1_OR_2(V) ->
+update_serialization_template(V, withdraw) when V =:= ?UPDATE_VSN_1 ->
     [ {to,      id},
       {amount,  int}];
-update_serialization_template(V, create_contract) when ?UPDATE_VSN_1_OR_2(V) ->
+update_serialization_template(V, create_contract) when V =:= ?UPDATE_VSN_1 ->
     [ {owner,       id},
       {ct_version,  int},
       {code,        binary},
       {deposit,     int},
       {call_data,   binary}];
-update_serialization_template(V, call_contract) when ?UPDATE_VSN_1_OR_2(V) ->
+update_serialization_template(V, call_contract) when V =:= ?UPDATE_VSN_1 ->
     [ {caller,      id},
       {contract,    id},
       {abi_version, int},

--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -1,8 +1,8 @@
 -module(aesc_offchain_update).
 
--define(UPDATE_VSN, 2).
 -define(UPDATE_VSN_1, 1).
--define(UPDATE_VSN_1_OR_2(V), V =:= ?UPDATE_VSN_1; V =:= ?UPDATE_VSN).
+-define(UPDATE_VSN_2, 2).
+-define(UPDATE_VSN_1_OR_2(V), V =:= ?UPDATE_VSN_1; V =:= ?UPDATE_VSN_2).
 
 -record(transfer, {
           from_id      :: aeser_id:id(),
@@ -68,9 +68,6 @@
          for_client/1,
          apply_on_trees/6]).
 
--export([set_vsn/1,
-         get_vsn/0]).
-
 -export([is_call/1,
          is_contract_create/1,
          extract_call/1,
@@ -113,7 +110,6 @@ from_db_format(Tuple) ->
         #deposit{} -> Updated;
         #create_contract{} -> Updated;
         #call_contract{} -> Updated;
-        #meta{} -> Updated;
         _ ->
             error(illegal_db_format)
     end.
@@ -172,7 +168,6 @@ op_call_contract(CallerId, ContractId, ABIVersion, Amount, CallData, CallStack,
                    gas = Gas}.
 
 op_meta(Data) ->
-    true = can_serialize(meta),
     #meta{ data = Data }.
 
 -spec apply_on_trees(aesc_offchain_update:update(), aec_trees:trees(),
@@ -264,26 +259,13 @@ for_client(#meta{data = Data}) ->
     #{<<"op">>   => type2swagger_name(meta),
       <<"data">> => Data}.
 
-update_vsn_key() ->
-    {?MODULE, update_vsn}.
-
-get_vsn() ->
-    case get(update_vsn_key()) of
-        undefined ->
-            ?UPDATE_VSN;
-        V ->
-            V
-    end.
-
-set_vsn(V) when ?UPDATE_VSN_1_OR_2(V) ->
-    lager:debug("set serialization vsn to ~p", [V]),
-    put(update_vsn_key(), V),
-    ok.
+vsn(#meta{}) -> ?UPDATE_VSN_2;
+vsn(_) -> ?UPDATE_VSN_1.
 
 -spec serialize(update()) -> binary().
 serialize(Update) ->
     Fields = update2fields(Update),
-    Vsn = get_vsn(),
+    Vsn = vsn(Update),
     UpdateType = record_to_update_type(Update),
     aeser_chain_objects:serialize(
       ut2type(UpdateType),
@@ -414,7 +396,7 @@ update_serialization_template(V, call_contract) when ?UPDATE_VSN_1_OR_2(V) ->
       {gas_price,   int},
       {call_data,   binary},
       {call_stack,  [int]}];
-update_serialization_template(?UPDATE_VSN, meta) ->
+update_serialization_template(?UPDATE_VSN_2, meta) ->
     [ {data, binary} ].
 
 -spec record_to_update_type(update()) -> update_type().
@@ -511,8 +493,3 @@ extract_abi_version(#call_contract{abi_version = ABIVersion}) ->
 update_error(Err) ->
     error({off_chain_update_error, Err}).
 
-can_serialize(Op) ->
-    can_serialize(Op, get_vsn()).
-
-can_serialize(meta, ?UPDATE_VSN_1) -> error(meta_not_allowed);
-can_serialize(_   ,             _) -> true.

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -948,9 +948,9 @@ update_volley(#{pub := PubI} = I, #{pub := PubR} = R, Cfg) ->
     do_update(PubI, PubR, 1, I1, R1, false, Cfg).
 
 do_update(From, To, Amount, #{fsm := FsmI} = I, R, Debug, Cfg) ->
-    Opts = case proplists:get_value(use_meta, Cfg, true) of
-               true  -> #{meta => [<<"meta1">>, <<"meta2">>]};
-               false -> #{}
+    Opts = case aect_test_utils:latest_protocol_version() < ?LIMA_PROTOCOL_VSN of
+               false -> #{meta => [<<"meta1">>, <<"meta2">>]};
+               true  -> #{}
            end,
     case rpc(dev1, aesc_fsm, upd_transfer, [FsmI, From, To, Amount, Opts], Debug) of
         {error, _} = Error ->

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -26,7 +26,6 @@
         , channel_insufficent_tokens/1
         , inband_msgs/1
         , upd_transfer/1
-        , upd_transfer_meta_fails_on_old_vsn/1
         , update_with_conflict/1
         , update_with_soft_reject/1
         , deposit_with_conflict/1
@@ -146,7 +145,6 @@ groups() ->
       , channel_insufficent_tokens
       , inband_msgs
       , upd_transfer
-      , upd_transfer_meta_fails_on_old_vsn
       , update_with_conflict
       , update_with_soft_reject
       , deposit_with_conflict
@@ -629,36 +627,6 @@ upd_transfer(Cfg) ->
     BalI1 = BalI - 2,
     BalR1 = BalR + 2,
     {I1, R1} = update_bench(I0, R0, Cfg),
-    ok = rpc(dev1, aesc_fsm, shutdown, [FsmI]),
-    {_I2, _} = await_signing_request(shutdown, I1, Cfg),
-    {_R2, _} = await_signing_request(shutdown_ack, R1, Cfg),
-    SignedTx = await_on_chain_report(I, ?TIMEOUT),
-    SignedTx = await_on_chain_report(R, ?TIMEOUT), % same tx
-    wait_for_signed_transaction_in_block(dev1, SignedTx, Debug),
-    verify_close_mutual_tx(SignedTx, ChannelId),
-    check_info(20),
-    ok.
-
-upd_transfer_meta_fails_on_old_vsn(Cfg) ->
-    Debug = get_debug(Cfg),
-    XOpts = #{versions => #{offchain_update => 1}},
-    #{ i := #{fsm := FsmI, channel_id := ChannelId} = I
-     , r := #{} = R
-     , spec := #{ initiator := PubI
-                , responder := PubR }} = create_channel_(
-                                           [?SLOGAN|Cfg], XOpts, Debug),
-    {BalI, BalR} = get_both_balances(FsmI, PubI, PubR),
-    try  do_update(PubI, PubR, 2, I, R, true, Cfg),
-         error(expected_to_fail)
-    catch
-        throw:{error, _} = Error->
-            log(Debug, "Got expected error: ~p", [Error]),
-            ok
-    end,
-    {I1, R1} = do_update(PubI, PubR, 2, I, R, true, [{use_meta,false}|Cfg]),
-    {BalI1, BalR1} = get_both_balances(FsmI, PubI, PubR),
-    BalI1 = BalI - 2,
-    BalR1 = BalR + 2,
     ok = rpc(dev1, aesc_fsm, shutdown, [FsmI]),
     {_I2, _} = await_signing_request(shutdown, I1, Cfg),
     {_R2, _} = await_signing_request(shutdown_ack, R1, Cfg),

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -305,8 +305,6 @@ read_channel_options(Params) ->
                                                      mandatory => false}),
     ReadReport = ReadMap(report, <<"report">>, #{type => boolean,
                                                      mandatory => false}),
-    ReadVsns = ReadMap(versions, <<"version">>, #{type => integer,
-                                                  mandatory => false}),
     ReadBHDelta = ReadMap(block_hash_delta, <<"bh_delta">>, #{ type => integer
                                                             , mandatory => false }),
     OnChainOpts =
@@ -352,7 +350,6 @@ read_channel_options(Params) ->
       ++ lists:map(ReadTimeout, aesc_fsm:timeouts() ++ [awaiting_open,
                                                         initialized])
       ++ lists:map(ReadReport, aesc_fsm:report_tags())
-      ++ lists:map(ReadVsns, aesc_fsm:version_tags())
       ++ lists:map(ReadBHDelta, aesc_fsm:bh_deltas())
      ).
 

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -21,9 +21,7 @@
 %% Helpers
 -export([
     create_state_channel_perform_operations_leave/2,
-    reestablish_state_channel_perform_operations/3,
-    set_old_update_vsn/1,
-    simulate_fsm_vsn_env/1
+    reestablish_state_channel_perform_operations/3
 ]).
 
 -import(aest_nodes, [
@@ -153,24 +151,12 @@ test_simple_different_nodes_channel(Cfg) ->
 test_compat_with_initiator_node_using_latest_stable_version(Cfg) ->
     test_different_nodes_channel_(set_genesis_accounts(node_base_spec_with_latest_stable_version()),
                                   set_genesis_accounts(#{}),
-                                  set_old_update_vsn(Cfg)).
+                                  Cfg).
 
 test_compat_with_responder_node_using_latest_stable_version(Cfg) ->
     test_different_nodes_channel_(set_genesis_accounts(#{}),
                                   set_genesis_accounts(node_base_spec_with_latest_stable_version()),
-                                  set_old_update_vsn(Cfg)).
-
-set_old_update_vsn(Cfg) ->
-    [{channel_opts, #{version_offchain_update => 1}}|Cfg].
-
-simulate_fsm_vsn_env(Cfg) ->
-    case lists:keyfind(channel_opts, 1, Cfg) of
-        {_, #{version_offchain_update := V}} ->
-            aesc_offchain_update:set_vsn(V),
-            ok;
-        false ->
-            ok
-    end.
+                                  Cfg).
 
 test_different_nodes_channel_(InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg) ->
     ChannelOpts = #{

--- a/system_test/common/aest_db_SUITE.erl
+++ b/system_test/common/aest_db_SUITE.erl
@@ -126,12 +126,11 @@ tx_mempool_compatibility(PopulateF, Cfg) ->
     },
     node_can_reuse_db_of_other_node_(Test, Cfg).
 
-node_can_reuse_db_of_other_node_(T = #db_reuse_test_spec{}, Cfg0)
+node_can_reuse_db_of_other_node_(T = #db_reuse_test_spec{}, Cfg)
   when is_function(T#db_reuse_test_spec.create, 2),
        is_function(T#db_reuse_test_spec.populate, 2),
        is_function(T#db_reuse_test_spec.reuse, 2),
        is_function(T#db_reuse_test_spec.assert, 3) ->
-    Cfg = aest_channels_SUITE:set_old_update_vsn(Cfg0),
     DbHostPath = node_db_host_path(node1, Cfg),
     N1 = (T#db_reuse_test_spec.create)(node1, DbHostPath),
     aest_nodes:setup_nodes([N1], Cfg),
@@ -147,8 +146,7 @@ node_can_reuse_db_of_other_node_(T = #db_reuse_test_spec{}, Cfg0)
 
 sc_leave_upgrade_reestablish( {{BeforeNodeNameI, BeforeNodeTypeI}, {BeforeNodeNameR, BeforeNodeTypeR}}
                             , {{AfterNodeNameI, AfterNodeTypeI}, {AfterNodeNameR, AfterNodeTypeR}}
-                            , Cfg0) ->
-    Cfg = aest_channels_SUITE:set_old_update_vsn(Cfg0),
+                            , Cfg) ->
     HostPathI = node_db_host_path(BeforeNodeNameI, Cfg),
     HostPathR = node_db_host_path(BeforeNodeNameR, Cfg),
 

--- a/system_test/common/aest_db_SUITE.erl
+++ b/system_test/common/aest_db_SUITE.erl
@@ -254,7 +254,6 @@ populate_db_with_channels_force_progress_tx(NodeName, Cfg) ->
     %% The state channel fsm sets its environment to be able to encode data using old
     %% protocols, but in this case, we're not producing the tx inside the fsm, so we
     %% must simulate the relevant part of the environment.
-    aest_channels_SUITE:simulate_fsm_vsn_env(Cfg),
     #{tx_hash := TxHash} =
         aest_nodes:post_force_progress_state_channel_tx(
           NodeName,


### PR DESCRIPTION
PT [Improve off-chain update versioning](https://www.pivotaltracker.com/story/show/168370492)

This PR keeps the canonical serialization of Force Progress transactions:
```
(aeternity@localhost)3> aeser_api_encoder:encode(tx_hash, aetx_sign:hash(FP)).
<<"th_tDn4WaKAqweS2m7WbG3X2hBWfe4U1CmuFUVtk19uvdHJYAsNv">>
```

It takes heavy advantange of `aesc_offchain_update:update()` not being part of [what is accepted Lima hard fork on](https://github.com/aeternity/aeternity/blob/master/apps/aechannel/src/aesc_offchain_tx.erl#L242-L249) so if participants send each other `#meta{}` off-chain updates, those will not impact the off-chain transaction being produced and thus - pre-Lima meta updates will not impact the ability of users to use co-authenticated transactions in a Force Progress.