### PR TITLE
Improve System Tests stability

### DIFF
--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -186,7 +186,9 @@ simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, C
 
     MikePubkey = aeser_api_encoder:encode(account_pubkey, maps:get(pubkey, ?MIKE)),
     NodeConfig = #{ beneficiary => MikePubkey },
-    setup([spec(node1, [], InitiatorNodeBaseSpec), spec(node2, [node1], ResponderNodeBaseSpec)], NodeConfig, Cfg),
+    setup([spec(node1, [], InitiatorNodeBaseSpec),
+           spec(node2, [node1], ResponderNodeBaseSpec#{mining => #{autostart => false}})],
+          NodeConfig, Cfg),
     NodeNames = [INodeName, RNodeName],
     start_node(node1, Cfg),
     start_node(node2, Cfg),

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -141,7 +141,7 @@ test_simple_same_node_channel(Cfg) ->
         push_amount => 2 * aest_nodes:gas_price(),
         bh_delta_not_newer_than => 0,
         bh_delta_not_older_than => 100,
-        bh_delta_pick           => 1
+        bh_delta_pick           => 10
     },
     simple_channel_test(ChannelOpts, #{}, #{}, Cfg).
 
@@ -169,7 +169,7 @@ test_different_nodes_channel_(InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg)
         push_amount => 2,
         bh_delta_not_newer_than => 0,
         bh_delta_not_older_than => 100,
-        bh_delta_pick           => 1
+        bh_delta_pick           => 10
     },
     simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, Cfg).
 
@@ -257,7 +257,7 @@ create_state_channel_perform_operations_leave({INodeName, RNodeName}, Config) ->
         push_amount => 2,
         bh_delta_not_newer_than => 0,
         bh_delta_not_older_than => 100,
-        bh_delta_pick           => 1
+        bh_delta_pick           => 10
     },
     IAccount = maps:get(initiator_id, ChannelOpts),
     RAccount = maps:get(responder_id, ChannelOpts),

--- a/system_test/common/aest_db_SUITE.erl
+++ b/system_test/common/aest_db_SUITE.erl
@@ -193,7 +193,9 @@ sc_leave_upgrade_reestablish( {{BeforeNodeNameI, BeforeNodeTypeI}, {BeforeNodeNa
     %% Try reestablishing
     start_and_wait_nodes(AfterNames, ?STARTUP_TIMEOUT, Cfg),
     timer:sleep(1000),
-    ok = aest_channels_SUITE:reestablish_state_channel_perform_operations({AfterNodeNameI, AfterNodeNameR}, ReestablishOpts, Cfg).
+    ok = aest_channels_SUITE:reestablish_state_channel_perform_operations_close({AfterNodeNameI, AfterNodeNameR}, ReestablishOpts, Cfg),
+    timer:sleep(1000),
+    ok.
 
 populate_db(NodeName, Cfg) ->
     TargetHeight = 3,

--- a/system_test/common/helpers/aest_api.erl
+++ b/system_test/common/helpers/aest_api.erl
@@ -217,6 +217,7 @@ sc_leave(Channel) ->
     {ok, #{ <<"event">> := <<"died">> }} = sc_wait_for_channel_event(IConn, info),
     {ok, #{ <<"state">> := LatestState }} = sc_wait_for_channel_event(RConn, leave),
     {ok, #{ <<"event">> := <<"died">> }} = sc_wait_for_channel_event(RConn, info),
+    timer:sleep(300),
 
     {ok, LatestState}.
 


### PR DESCRIPTION
PT [SC ST failure:  {{timeout,{messages, ...](https://www.pivotaltracker.com/story/show/168423650)

Symptoms: in system tests [run](https://circleci.com/gh/aeternity/aeternity/78808#artifacts/containers/0) there is a crash with:
```


%%% aest_channels_SUITE ==> test_simple_same_node_channel: FAILED
%%% aest_channels_SUITE ==> {{timeout,{messages,[]}},
 [{aehttp_ws_test_utils,wait_for_msg,5,
                        [{file,"/home/circleci/aeternity/_build/system_test+test/extras/apps/aehttp/test/aehttp_ws_test_utils.erl"},
                         {line,313}]},
  {aest_api,sc_wait_for_channel_event,2,
            [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/helpers/aest_api.erl"},
             {line,249}]},
  {aest_api,sc_process_offchain_tx,4,
            [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/helpers/aest_api.erl"},
             {line,297}]},
  {aest_api,sc_deploy_contract,7,
            [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/helpers/aest_api.erl"},
             {line,263}]},
  {aest_channels_SUITE,'-test_offchain_operations/2-fun-2-',3,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,384}]},
  {aest_channels_SUITE,'-test_offchain_operations/2-lc$^3/1-1-',2,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,390}]},
  {aest_channels_SUITE,'-test_offchain_operations/2-lc$^3/1-1-',2,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,390}]},
  {aest_channels_SUITE,simple_channel_test,4,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,198}]}]}

%%% aest_channels_SUITE ==> test_simple_different_nodes_channel: FAILED
%%% aest_channels_SUITE ==> {{timeout,{messages,[]}},
 [{aehttp_ws_test_utils,wait_for_msg,5,
                        [{file,"/home/circleci/aeternity/_build/system_test+test/extras/apps/aehttp/test/aehttp_ws_test_utils.erl"},
                         {line,313}]},
  {aest_api,sc_wait_for_channel_event,2,
            [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/helpers/aest_api.erl"},
             {line,249}]},
  {aest_api,sc_process_offchain_tx,4,
            [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/helpers/aest_api.erl"},
             {line,297}]},
  {aest_api,sc_transfer,7,
            [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/helpers/aest_api.erl"},
             {line,292}]},
  {aest_channels_SUITE,'-test_offchain_operations/2-fun-0-',1,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,375}]},
  {aest_channels_SUITE,'-test_offchain_operations/2-lc$^1/1-0-',2,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,378}]},
  {aest_channels_SUITE,test_offchain_operations,2,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,378}]},
  {aest_channels_SUITE,simple_channel_test,4,
                       [{file,"/home/circleci/aeternity/_build/system_test+test/extras/system_test/common/aest_channels_SUITE.erl"},
                        {line,198}]}]}
```

[log](https://78808-99802036-gh.circle-artifacts.com/0/home/circleci/aeternity/system_test/logs/ct_run.aeternity_ct@localhost.2019-09-11_00.05.34/system_test.common.logs/run.2019-09-11_00.05.35/aest_channels_suite.test_simple_same_node_channel.html)

This improves the test for not picking the previous keyblock hash but the one 10 generations ago. This will fix possible forks due to fast mining setup