### PR TITLE
Pass protocol version instead of height to aetx_sign

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1851,6 +1851,10 @@ curr_height() ->
     {_, Height} = curr_hash_and_height(),
     Height.
 
+curr_protocol() ->
+    TopHeader = aec_chain:top_header(),
+    aec_headers:version(TopHeader).
+
 -spec protocol_at_height(aec_blocks:height()) -> aec_hard_forks:protocol_vsn().
 protocol_at_height(Height) ->
     {ok, Header} = aec_chain:get_key_header_by_height(Height),
@@ -2870,8 +2874,8 @@ has_my_signature(Me, SignedTx) ->
                 _Other -> has_my_signature(Me, aega_meta_tx:tx(Tx)) %% go deeper
             end;
         {_NotGA, _} -> %% innermost transaction
-            CurrHeight = curr_height(),
-            ok =:= aetx_sign:verify_one_pubkey(Me, SignedTx, CurrHeight)
+            Protocol = curr_protocol(),
+            ok =:= aetx_sign:verify_one_pubkey(Me, SignedTx, Protocol)
     end.
 
 

--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -623,8 +623,8 @@ verify_signatures(SignedTx, Trees, Env, CheckedSigners,
         {_, _} -> % most inner tx
             {ok, Signers} = aetx:signers(Tx, Trees),
             BasicSigners  = Signers -- CheckedSigners,
-            Height        = aetx_env:height(Env),
-            aetx_sign:verify_half_signed(BasicSigners, SignedTx, Height)
+            Protocol      = aetx_env:consensus_version(Env),
+            aetx_sign:verify_half_signed(BasicSigners, SignedTx, Protocol)
     end.
 
 -spec is_delegate(aesc_channels:id(), aec_keys:pubkey(),

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -583,8 +583,8 @@ apply_txs_on_state_trees([], ValidTxs, InvalidTxs, Trees,Env,Opts) ->
 apply_txs_on_state_trees([SignedTx | Rest], ValidTxs, InvalidTxs, Trees, Env, Opts) ->
     Strict     = proplists:get_value(strict, Opts, false),
     DontVerify = proplists:get_value(dont_verify_signature, Opts, false),
-    Height     = aetx_env:height(Env),
-    case verify_signature(SignedTx, Trees, Height, DontVerify) of
+    Protocol   = aetx_env:consensus_version(Env),
+    case verify_signature(SignedTx, Trees, Protocol, DontVerify) of
         ok ->
             Env1 = aetx_env:set_signed_tx(Env, {value, SignedTx}),
             Tx = aetx_sign:tx(SignedTx),
@@ -620,8 +620,8 @@ apply_txs_on_state_trees([SignedTx | Rest], ValidTxs, InvalidTxs, Trees, Env, Op
             apply_txs_on_state_trees(Rest, ValidTxs, Invalid1, Trees, Env, Opts)
     end.
 
-verify_signature(_, _, _, true)             -> ok;
-verify_signature(STx, Trees, Height, false) -> aetx_sign:verify(STx, Trees, Height).
+verify_signature(_, _, _, true)               -> ok;
+verify_signature(STx, Trees, Protocol, false) -> aetx_sign:verify(STx, Trees, Protocol).
 
 -spec grant_fee(aec_keys:pubkey(), trees(), non_neg_integer()) -> trees().
 grant_fee(BeneficiaryPubKey, Trees0, Fee) ->

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -795,8 +795,8 @@ check_valid_at_protocol(Tx, _TxHash, Block, _BlockHash, _Trees, _Event) ->
     aetx:check_protocol(aetx_sign:tx(Tx), Protocol).
 
 check_signature(Tx, TxHash, Block, _BlockHash, Trees, _Event) ->
-    Height = aec_blocks:height(Block),
-    case aetx_sign:verify(Tx, Trees, Height) of
+    Protocol = aec_blocks:version(Block),
+    case aetx_sign:verify(Tx, Trees, Protocol) of
         {error, _} = E ->
             lager:info("Failed signature check on tx: ~p, ~p\n", [E, TxHash]),
             E;

--- a/apps/aetx/test/aetx_sign_tests.erl
+++ b/apps/aetx/test/aetx_sign_tests.erl
@@ -70,10 +70,10 @@ sign_txs_test_() ->
                case lists:last(aec_hard_forks:sorted_protocol_versions()) of
                    Vsn when Vsn < ?LIMA_PROTOCOL_VSN ->
                        ?assertEqual({error, signature_check_failed},
-                                    ?TEST_MODULE:verify(SignedTx, aec_trees:new(), ?TEST_HEIGHT));
-                   _Vsn ->
+                                    ?TEST_MODULE:verify(SignedTx, aec_trees:new(), Vsn));
+                   Vsn ->
                        ?assertEqual(ok,
-                                    ?TEST_MODULE:verify(SignedTx, aec_trees:new(), ?TEST_HEIGHT))
+                                    ?TEST_MODULE:verify(SignedTx, aec_trees:new(), Vsn))
                end
        end}
      ]}.


### PR DESCRIPTION
[PT-168428278](https://www.pivotaltracker.com/n/projects/2124891/stories/168428278)

Preparatory PR for fork signalling.

The protocol version is known in all places where the functions from `aetx_sign` are called. `aec_hard_forks:protocol_effective_at_height` can be therefore removed from `aetx_sign` module, and the protocol version can be passed directly instead of block height.