### PR TITLE
[PT-168073522] [aepp-demo] SC reconnect more flexible

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -3091,7 +3091,7 @@ report_update(#data{state = State, last_reported_update = Last} = D) ->
 
 report_leave(#data{role = Role, opts = Opts, state = State} = D) ->
     {_, SignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
-    case {Role, maps:find(keep_running, Opts)} of
+    case {Role, maps:get(keep_running, Opts, false)} of
         {responder, {ok, true}} ->
             report_with_notice(leave, SignedTx, keep_running, D);
         _ ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -919,7 +919,7 @@ mutual_closed(cast, {?SHUTDOWN_ERR, Msg}, D) ->
             report(conflict, Msg, D1),
             next_state(open, D1);
         {error, Error} ->
-            report_with_notice(conflict, Msg, _Notice = Error, D),
+            report_with_notice(conflict, Msg, Error, D),
             keep_state(log(rcv, ?SHUTDOWN_ERR, Msg, D))
     end;
 mutual_closed(timeout, _Msg, D) ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -75,7 +75,8 @@
 %% Used by client
 -export([ signing_response/3          %% (Fsm, Tag, Obj)
         , check_state_password/1      %% (Map)
-        , error_code_to_msg/1]).      %% (Code)
+        , error_code_to_msg/1         %% (Code)
+        , stop/1 ]).                  %% (Fsm)
 
 %% Used by min-depth watcher
 -export([ minimum_depth_achieved/4      %% (Fsm, OnChainId, Type, TxHash)
@@ -130,7 +131,6 @@
 
 -ifdef(TEST).
 -export([ strict_checks/2
-        , stop/1
         ]).
 -endif.
 
@@ -207,12 +207,14 @@ initiate(Host, Port, #{} = Opts0) ->
     lager:debug("initiate(~p, ~p, ~p)", [Host, Port, aesc_utils:censor_init_opts(Opts0)]),
     Opts = maps:merge(#{client => self(),
                         role   => initiator}, Opts0),
-    case init_checks(Opts) of
+    try init_checks(Opts) of
         ok ->
             aesc_fsm_sup:start_child([#{ host => Host
                                        , port => Port
                                        , opts => Opts }]);
         {error, _Reason} = Err -> Err
+    ?CATCH_LOG(_E)
+        {error, _E}
     end.
 
 leave(Fsm) ->
@@ -297,7 +299,7 @@ change_state_password(Fsm, StatePassword) ->
 %% Inspection and configuration functions
 
 patterns() ->
-    [{?MODULE, F, A, []} || {F,A} <- gen_tcp:module_info(exports),
+    [{gen_tcp, F, A, []} || {F,A} <- gen_tcp:module_info(exports),
                             F =/= module_info] ++
     [{?MODULE, F, A, []} || {F,A} <- ?MODULE:module_info(exports),
                             not lists:member(F, [module_info, patterns])].
@@ -382,6 +384,44 @@ error_code_to_msg(Code) when Code >= ?ERR_USER ->
 error_code_to_msg(_) ->
     <<"unknown">>.
 
+-spec stop(pid()) -> ok.
+stop(Fsm) ->
+    lager:debug("Ungracefully stopping the FSM ~p", [Fsm]),
+    MRef = erlang:monitor(process, Fsm),
+    try_stop(Fsm, 3, MRef).
+
+try_stop(Fsm, Retries, MRef) ->
+    BT = process_info(Fsm, backtrace),
+    stop_ok(catch gen_statem:stop(Fsm, shutdown, 5000), Fsm, Retries, MRef, BT).
+
+%% TODO
+%% This function is currently exported in the WS API, and used by the aehtt_sc_SUITE.
+%% This should be addressed. We really don't want this kind of stop method exported.
+stop_ok(ok, _, _, MRef, _) ->
+    erlang:demonitor(MRef),
+    ok;
+stop_ok({'EXIT', noproc}, _, _, MRef, _) ->
+    erlang:demonitor(MRef),
+    ok;
+stop_ok({'EXIT', {normal,{sys,terminate,_}}}, _, _, MRef, _) ->
+    erlang:demonitor(MRef),
+    ok;
+stop_ok({'EXIT', timeout}, Fsm, Retries, MRef, BT) when Retries > 0 ->
+    BT1 = process_info(Fsm, backtrace),
+    lager:debug("Timed out stopping fsm (~p): ~p", [Fsm, process_info(Fsm)]),
+    lager:debug("Trace0 = ~s", [element(2, BT)]),
+    lager:debug("Trace1 = ~s", [element(2, BT1)]),
+    timer:sleep(100),
+    try_stop(Fsm, Retries-1, MRef);
+stop_ok({'EXIT', timeout}, Fsm, _, MRef, BT) ->
+    lager:debug("Killing fsm (~p) ...", [Fsm]),
+    lager:debug("Trace = ~s", [element(2, BT)]),
+    exit(Fsm, kill),
+    receive
+       {'DOWN', MRef, _, _, _} ->
+            ok
+    end.
+
 %% ==================================================================
 %% Used by min-depth watcher
 
@@ -415,11 +455,6 @@ channel_unlocked(Fsm, Info) ->
 -spec strict_checks(pid(), boolean()) -> ok.
 strict_checks(Fsm, Strict) when is_boolean(Strict) ->
     gen_statem:call(Fsm, {strict_checks, Strict}).
-
--spec stop(pid()) -> ok.
-stop(Fsm) ->
-    lager:debug("Gracefully stopping the FSM ~p", [Fsm]),
-    stop_ok(catch gen_statem:stop(Fsm)).
 -endif.
 
 %% ======================================================================
@@ -443,7 +478,7 @@ initialized(cast, {?CH_ACCEPT, Msg}, #data{role = initiator} = D) ->
             close(Error, D)
     end;
 initialized(Type, Msg, D) ->
-    handle_common_event(Type, Msg, error_all, D).
+    handle_common_event(Type, Msg, postpone, D).
 
 accepted(enter, _OldSt, _D) -> keep_state_and_data;
 accepted(cast, {?FND_CREATED, Msg}, #data{role = responder} = D) ->
@@ -461,7 +496,7 @@ accepted(cast, {?FND_CREATED, Msg}, #data{role = responder} = D) ->
              close(Error, D)
     end;
 accepted(Type, Msg, D) ->
-    handle_common_event(Type, Msg, error_all, D).
+    handle_common_event(Type, Msg, postpone, D).
 
 awaiting_leave_ack(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_leave_ack(cast, {?LEAVE_ACK, Msg}, D) ->
@@ -544,7 +579,7 @@ awaiting_open({call, From}, {attach_responder, _Info}, #data{channel_status = at
 awaiting_open({call, From}, {attach_responder, Info}, #data{opts = Opts} = D) ->
     lager:debug("Attach request: ~p", [Info]),
     #{initiator := I, responder := R} = Opts,
-    case check_attach_info(Info, I, R) of
+    case check_attach_info(Info, I, R, D) of
         ok ->
             #{ initiator := I1
              , port      := _Port
@@ -553,44 +588,49 @@ awaiting_open({call, From}, {attach_responder, Info}, #data{opts = Opts} = D) ->
             Opts1 = Opts#{initiator => I1},
             {Pid, _} = From,
             keep_state(maybe_initialize_offchain_state(
-                         I, I1, D#data{session = Pid, opts = Opts1, channel_status = attached}),
+                         I, I1, D#data{ session = Pid
+                                      , opts = Opts1, channel_status = attached}),
                        [{reply, From, ok}]);
         {error, Err} ->
             lager:debug("Bad attach info: ~p", [Err]),
-            gen:reply(From, {error, invalid_attach}),
+            lager:debug("My regs: ~p", [gproc:info(self(), gproc)]),
             keep_state(D, [{reply, From, {error, invalid_attach}}])
     end;
 awaiting_open(Type, Msg, D) ->
     handle_common_event(Type, Msg, error_all, D).
 
 awaiting_reestablish(enter, _OldSt, _D) -> keep_state_and_data;
-awaiting_reestablish(cast, {?CH_REESTABL, Msg}, #data{role = responder} = D) ->
+awaiting_reestablish(cast, {?CH_REESTABL, Msg}, #data{ role = responder
+                                                     , op = Op} = D) ->
     case check_reestablish_msg(Msg, D) of
         {ok, D1} ->
             report(info, channel_reestablished, D1),
-            D2 = restart_watcher(D1),
-            gproc_register(D2),
+            lager:debug("Op = ~p", [Op]),
+            D2 = case Op#op_reestablish.mode of
+                     restart ->
+                         lager:debug("re-register and restart watcher", []),
+                         gproc_register(D1),
+                         restart_watcher(D1);
+                     remain ->
+                         lager:debug("Already running - don't re-register", []),
+                         D1
+                 end,
             next_state(open, send_reestablish_ack_msg(D2));
         {error, _} = Error ->
             close(Error, D)
     end;
-awaiting_reestablish({call, From}, {attach_responder, Info},
-                     #data{ opts        = #{responder := R}
-                          , on_chain_id = ChannelId
-                          , role        = responder } = D) ->
+awaiting_reestablish({call, From},
+                     {attach_responder, #{ reestablish := true
+                                         , gproc_key   := K } = Info},
+                     #data{ role        = responder } = D) ->
     lager:debug("Attach request: ~p", [Info]),
-    ChainHash = aec_chain:genesis_hash(),
-    case Info of
-        #{ chain_hash := ChainHash
-         , channel_id := ChannelId
-         , responder  := R
-         , port       := _Port
-         , gproc_key  := K } ->
+    case check_attach_info(Info, D) of
+        ok ->
             gproc:unreg(K),
             gen:reply(From, ok),
             {Pid, _} = From,
-            keep_state(D#data{session = Pid}, [{reply, From, ok}]);
-        _ ->
+            keep_state(D#data{ session = Pid }, [{reply, From, ok}]);
+        {error,_} ->
             keep_state(D, [{reply, From, {error, invalid_attach}}])
     end;
 awaiting_reestablish(Type, Msg, D) ->
@@ -742,7 +782,7 @@ awaiting_signature(cast, {?SIGNED, ?UPDATE_ACK, SignedTx} = Msg,
 awaiting_signature(cast, {?SIGNED, ?SHUTDOWN, SignedTx} = Msg,
                    #data{op = #op_sign{ tag = ?SHUTDOWN
                                       , data = OpData0}} = D) ->
-    #op_data{updates = Updates} = OpData0,
+    #op_data{} = OpData0,
     lager:debug("SHUTDOWN signed", []),
     maybe_check_auth(SignedTx, OpData0, not_close_mutual_tx, me,
         fun() ->
@@ -877,7 +917,7 @@ mutual_closed(cast, {?SHUTDOWN_ERR, Msg}, D) ->
             report(conflict, Msg, D1),
             next_state(open, D1);
         {error, Error} ->
-            report(conflict, Msg#{notice => Error}, D),
+            report_with_notice(conflict, Msg, _Notice = Error, D),
             keep_state(log(rcv, ?SHUTDOWN_ERR, Msg, D))
     end;
 mutual_closed(timeout, _Msg, D) ->
@@ -1004,7 +1044,7 @@ half_signed(cast, {?FND_SIGNED, Msg},
             close(Error, D)
     end;
 half_signed(Type, Msg, D) ->
-    handle_common_event(Type, Msg, error_all, D).
+    handle_common_event(Type, Msg, postpone, D).
 
 mutual_closing(enter, _OldSt, _D) -> keep_state_and_data;
 mutual_closing(cast, {?SHUTDOWN_ERR, Msg}, D) ->
@@ -1112,17 +1152,44 @@ open(cast, {?WDRAW_CREATED, Msg}, D) ->
 open(cast, {?SIGNED, _, _} = Msg, D) ->
     lager:debug("Received signing reply in 'open' - ignore: ~p", [Msg]),
     keep_state(log(ignore, ?SIGNED, Msg, D));
+open({call, From}, {attach_responder, #{reestablish := true} = Info} = _Req,
+     #data{ peer_connected = false, opts = Opts } = D) ->
+    lager:debug("call: ~p; D = ~p", [_Req, pr_data(D)]),
+    #{ initiator := I, responder := R } = Opts,
+    case check_attach_info(Info, I, R, D) of
+        ok ->
+            gproc:unreg(maps:get(gproc_key, Info)),
+            {Pid, _} = From,
+            next_state(awaiting_reestablish,
+                       D#data{ session = Pid
+                             , op = #op_reestablish{mode = remain}
+                             , peer_connected = true
+                             , channel_status = attached },
+                       [{reply, From, ok}]);
+        {error, Err} ->
+            lager:debug("Bad attach info: ~p", [Err]),
+            keep_state(D, [{reply, From, {error, invalid_attach}}])
+    end;
 open({call, From}, Request, D) ->
     handle_call(open, Request, From, D);
-open(cast, {?LEAVE, Msg}, D) ->
+open(cast, {?LEAVE, Msg}, #data{ role = Role
+                               , opts = Opts } = D) ->
     case check_leave_msg(Msg, D) of
         {ok, D1} ->
             lager:debug("received leave msg", []),
             send_leave_ack_msg(D1),
             report_leave(D1),
-            close(leave, D1);
-        {error, _} = Err ->
-            close(Err, D)
+            case {Role, maps:get(keep_running, Opts, false)} of
+                {responder, true} ->
+                    lager:debug("Keep running after peer leave", []),
+                    keep_state(D1);
+                _ ->
+                    lager:debug("Closing due to peer leave", []),
+                    close(leave, D1)
+            end;
+        {error, E} ->
+            lager:debug("leave msg error: ~p", [E]),
+            keep_state(D)
     end;
 open(cast, {?SHUTDOWN, Msg}, D) ->
     shutdown_msg_received(Msg, D);
@@ -1140,7 +1207,7 @@ reestablish_init(cast, {?CH_REEST_ACK, Msg}, D) ->
             close(Err, D)
     end;
 reestablish_init(Type, Msg, D) ->
-    handle_common_event(Type, Msg, error_all, D).
+    handle_common_event(Type, Msg, postpone, D).
 
 signed(enter, _OldSt, _D) -> keep_state_and_data;
 signed(cast, {?FND_LOCKED, Msg}, D) ->
@@ -1154,7 +1221,7 @@ signed(cast, {?FND_LOCKED, Msg}, D) ->
 signed(cast, {?SHUTDOWN, Msg}, D) ->
     shutdown_msg_received(Msg, D);
 signed(Type, Msg, D) ->
-    handle_common_event(Type, Msg, error_all, D).
+    handle_common_event(Type, Msg, postpone, D).
 
 wdraw_half_signed(enter, _OldSt, _D) -> keep_state_and_data;
 wdraw_half_signed(cast, {Req,_} = Msg, D) when ?UPDATE_CAST(Req) ->
@@ -1263,9 +1330,10 @@ check_open_msg(#{ chain_hash           := ChainHash
                      , initiator_amount   => InitiatorAmt
                      , responder_amount   => ResponderAmt
                      , channel_reserve    => ChanReserve},
-            {ok, Data#data{ channel_id = ChanId
-                          , opts       = Opts1
-                          , log        = log_msg(rcv, ?CH_OPEN, Msg, Log) }};
+            {ok, Data#data{ channel_id     = ChanId
+                          , opts           = Opts1
+                          , peer_connected = true
+                          , log            = log_msg(rcv, ?CH_OPEN, Msg, Log) }};
         _ ->
             {error, chain_hash_mismatch}
     end.
@@ -1281,7 +1349,7 @@ send_reestablish_msg(#{ existing_channel_id := ChId
     aesc_session_noise:channel_reestablish(Sn, Msg),
     Data#data{ channel_id  = ChId
              , on_chain_id = ChId
-             , op          = #op_reestablish{offchain_tx = OffChainTx}
+             , op          = #op_reestablish{mode = restart, offchain_tx = OffChainTx}
              , log         = log_msg(snd, ?CH_REESTABL, Msg, Log)}.
 
 check_reestablish_msg(#{ chain_hash := ChainHash
@@ -1292,17 +1360,18 @@ check_reestablish_msg(#{ chain_hash := ChainHash
     case ChannelRes of
         {ok, _Channel} ->
             try SignedTx = aetx_sign:deserialize_from_binary(TxBin),
-                Check = aesc_offchain_state:check_reestablish_tx(SignedTx, State),
-                case Check of
-                    {ok, NewState} ->
-                        Log1 = log_msg(rcv, ?CH_REESTABL, Msg, Log),
-                        {ok, Data#data{ channel_id  = ChId
-                                      , on_chain_id = ChId
-                                      , state       = NewState
-                                      , log         = Log1 }};
-                    {error, _} = TxErr ->
-                        TxErr
-                end
+                 Check = aesc_offchain_state:check_reestablish_tx(SignedTx, State),
+                 case Check of
+                     {ok, NewState} ->
+                         Log1 = log_msg(rcv, ?CH_REESTABL, Msg, Log),
+                         {ok, Data#data{ channel_id     = ChId
+                                       , on_chain_id    = ChId
+                                       , peer_connected = true
+                                       , state          = NewState
+                                       , log            = Log1 }};
+                     {error, _} = TxErr ->
+                         TxErr
+                 end
             ?CATCH_LOG(_E)
                 {error, invalid_reestablish}
             end;
@@ -1331,7 +1400,12 @@ check_reestablish_ack_msg(#{data := #{tx := TxBin}} = Msg, Data) ->
            , fun chk_same_tx/3
            , fun log_reestabl_ack_msg/3
            ],
-    run_checks(Funs, Msg, SignedTx, Data).
+    case run_checks(Funs, Msg, SignedTx, Data) of
+        {ok, D1} ->
+            {ok, D1#data{peer_connected = true}};
+        Other ->
+            Other
+    end.
 
 run_checks([], _, _, Data) ->
     {ok, Data};
@@ -1435,6 +1509,7 @@ check_accept_msg(#{ chain_hash           := ChainHash
             {ok, Data#data{ opts = Opts#{ minimum_depth => MinDepth
                                         , initiator     => Initiator
                                         , responder     => Responder }
+                          , peer_connected = true
                           , log = Log1 }};
         _ ->
             {error, chain_hash_mismatch}
@@ -2198,7 +2273,8 @@ fall_back_to_stable_state(#data{ state = State } = D) ->
     {LastRound, _} = aesc_offchain_state:get_latest_signed_tx(State),
     case aesc_offchain_state:get_fallback_state(State) of
         {LastRound, State1} -> %% same round
-            {ok, D#data{state = State1, op = ?NO_OP}};
+            {ok, clear_ongoing(D#data{ state = State1
+                                     , op    = ?NO_OP })};
         _Other ->
             lager:debug("Fallback state mismatch: ~p/~p",
                         [LastRound, _Other]),
@@ -2499,7 +2575,7 @@ check_leave_msg(#{ channel_id := ChId } = Msg,
 send_leave_ack_msg(#data{ on_chain_id = ChId
                         , session     = Session} = Data) ->
     Msg = #{ channel_id => ChId },
-    aesc_session_noise:leave(Session, Msg),
+    aesc_session_noise:leave_ack(Session, Msg),
     log(snd, ?LEAVE_ACK, Msg, Data).
 
 check_leave_ack_msg(#{channel_id := ChId} = Msg,
@@ -2652,6 +2728,22 @@ check_inband_msg(#{ channel_id := ChanId
 check_inband_msg(_, _) ->
     {error, chain_id_mismatch}.
 
+check_client_reconnect_tx(SignedTx, #data{ opts = #{ reconnect_security := none } } = D) ->
+    case aetx:specialize_callback(aetx_sign:innermost_tx(SignedTx)) of
+        {aesc_client_reconnect_tx = Mod, Tx} ->
+            MyPubKey = my_account(D),
+            #data{role = MyRole, on_chain_id = ChId} = D,
+            try {Mod:channel_pubkey(Tx), Mod:role(Tx), Mod:origin(Tx), Mod:round(Tx)} of
+                {ChId, MyRole, MyPubKey, Round} ->
+                    {ok, D#data{client_reconnect_nonce = Round}};
+                _ ->
+                    {error, invalid}
+            ?CATCH_LOG(_E)
+                    {error, invalid}
+            end;
+        _ ->
+            {error, invalid}
+    end;
 check_client_reconnect_tx(SignedTx, #data{ strict_checks = true } = D) ->
     lager:debug("Check reconnect tx", []),
     Checks =
@@ -2675,7 +2767,8 @@ check_client_reconnect_tx(Tx, D) ->
     {ok, D#data{ client_reconnect_nonce = Round }}.
 
 fallback_to_stable_state(#data{state = State} = D) ->
-    D#data{state = aesc_offchain_state:fallback_to_stable_state(State)}.
+    clear_ongoing(D#data{ state = aesc_offchain_state:fallback_to_stable_state(State)
+                        , op    = ?NO_OP }).
 
 tx_round(Tx) -> call_cb(Tx, round, []).
 
@@ -2737,13 +2830,7 @@ maybe_send_error_msg(#{ code := Code, msg_type := MsgType }, Sn, Msg, _) ->
             send_recoverable_error_msg(error_msg_type(MsgType), Sn, Msg)
     end;
 maybe_send_error_msg(_, Sn, Msg, #data{error_msg_type = Type}) ->
-    case Type of
-        undefined ->
-            lager:debug("no msg_type given - not sending error msg", []),
-            ok;
-        _ ->
-            send_recoverable_error_msg(Type, Sn, Msg)
-    end.
+    send_recoverable_error_msg(Type, Sn, Msg).
 
 error_msg_type(#{msg_type := Type}, _)          -> error_msg_type(Type);
 error_msg_type(_, #data{error_msg_type = Type}) -> Type.
@@ -2770,6 +2857,9 @@ starting_msg(withdraw_tx) -> true;
 starting_msg(?SHUTDOWN  ) -> true;
 starting_msg(_) -> false.
 
+send_recoverable_error_msg(undefined, _, _) ->
+    lager:debug("no msg_type given - not sending error msg", []),
+    ok;
 send_recoverable_error_msg(?UPDATE_ERR, Sn, Msg) ->
     lager:debug("send update_error: ~p", [Msg]),
     aesc_session_noise:update_error(Sn, Msg);
@@ -2949,14 +3039,28 @@ on_chain_id(D, SignedTx) ->
 
 initialize_cache(#data{ on_chain_id = ChId
                       , state       = State
+                      , opts        = Opts0
                       , state_password_wrapper = StatePasswordWrapper} = D) ->
+    Opts = maps:with(opts_to_cache(), Opts0),
     case aesc_state_password_wrapper:get(StatePasswordWrapper) of
         {ok, StatePassword} ->
-            aesc_state_cache:new(ChId, my_account(D), State, StatePassword);
+            aesc_state_cache:new(ChId, my_account(D), State, Opts, StatePassword);
         error ->
-            aesc_state_cache:new(ChId, my_account(D), State)
+            aesc_state_cache:new(ChId, my_account(D), State, Opts)
     end,
     D#data{state_password_wrapper = undefined}.
+
+opts_to_cache() ->
+    [ role
+    , initiator
+    , responder
+    , connection
+    , minimum_depth
+    , lock_period
+    , timeouts
+    , report
+    , log_keep
+    , keep_running ].
 
 cache_state(#data{ on_chain_id = ChId
                  , state       = State } = D) ->
@@ -2983,9 +3087,14 @@ report_update(#data{state = State, last_reported_update = Last} = D) ->
             D#data{last_reported_update = New}
     end.
 
-report_leave(#data{state = State} = D) ->
+report_leave(#data{role = Role, opts = Opts, state = State} = D) ->
     {_, SignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
-    report(leave, SignedTx, D),
+    case {Role, maps:find(keep_running, Opts)} of
+        {responder, {ok, true}} ->
+            report_with_notice(leave, SignedTx, keep_running, D);
+        _ ->
+            report(leave, SignedTx, D)
+    end,
     cache_state(D).
 
 report_on_chain_tx(Info, SignedTx, D) ->
@@ -3015,6 +3124,19 @@ maybe_act_on_tx(_, _, D) ->
 signed_tx_type(SignedTx) ->
     {Type, _} = aetx:specialize_type(aetx_sign:innermost_tx(SignedTx)),
     Type.
+
+report_with_notice(Tag, Info, Notice, D) ->
+    report_info(do_rpt(Tag, D), #{ type   => report
+                                 , tag    => Tag
+                                 , notice => Notice
+                                 , info   => Info }, D).
+
+%% report_with_notice(Tag, St, Msg, Notice, D) ->
+%%     report_info(do_rpt(Tag, D), #{ type   => report
+%%                                  , tag    => Tag
+%%                                  , notice => Notice
+%%                                  , info   => St
+%%                                  , data   => Msg }, D).
 
 report(Tag, Info, D) ->
     report_info(do_rpt(Tag, D), #{ type => report
@@ -3378,10 +3500,34 @@ check_account(A) ->
         _                 -> {error, not_found}
     end.
 
+
+check_attach_info(Info, #data{opts = Opts} = D) ->
+    #{initiator := I, responder := R} = Opts,
+    check_attach_info(Info, I, R, D).
+
+check_attach_info(#{reestablish := true} = Info, _I, R, #data{on_chain_id = ChannelId}) ->
+    ChainHash = aec_chain:genesis_hash(),
+    lager:debug("Info = ~p, ChainHash = ~p, ChannelId = ~p", [Info, ChainHash, ChannelId]),
+    case Info of
+        #{ chain_hash := ChainHash
+         , channel_id := ChannelId
+         , responder  := R
+         , port       := _Port
+         , gproc_key  := _K } ->
+            ok;
+        _ ->
+            case maps:find(responder, Info) of
+                {ok, R1} when R1 =/= R ->
+                    {error, responder_key_mismatch};
+                _Other ->
+                    {error, unrecognized_attach_info}
+            end
+    end;
 check_attach_info(#{ initiator := I1
                    , responder := R1
                    , port      := _P
-                   , gproc_key := _K}, I, R) ->
+                   , gproc_key := _K} = Info, I, R, _D) ->
+    lager:debug("Info = ~p, I = ~p, R = ~p", [Info, I, R]),
     if I =:= any, R1 =:= R ->
             check_account(I1);
        I1 =:= I, R1 =:= R ->
@@ -3393,7 +3539,8 @@ check_attach_info(#{ initiator := I1
        true ->
             {error, unrecognized_attach_info}
     end;
-check_attach_info(_, _I, _R) ->
+check_attach_info(_Info, _I, _R, _D) ->
+    lager:debug("Unrecognized: Info = ~p, I = ~p, R = ~p", [_Info, _I, _R]),
     {error, unrecognized_attach_info}.
 
 %% ==================================================================
@@ -3416,22 +3563,25 @@ init(#{opts := Opts0} = Arg) ->
     Opts1 = maps:remove(state_password, Opts0),
     {Role, Opts2} = maps:take(role, Opts1),
     Client = maps:get(client, Opts2),
-    {Reestablish, ReestablishOpts, Opts3} =
+    {Reestablish, ReestablishOpts, ConnectOpts, Opts3} =
         { maps:is_key(existing_channel_id, Opts2)
         , maps:with(?REESTABLISH_OPTS_KEYS, Opts2)
-        , maps:without(?REESTABLISH_OPTS_KEYS, Opts2)
+        , connection_opts(Arg)
+        , maps:without(?REESTABLISH_OPTS_KEYS ++ ?CONNECT_OPTS_KEYS, Opts1)
         },
     DefMinDepth = default_minimum_depth(Role),
-    Opts = check_opts(
+    Opts4 = check_opts(
              [
               fun(O) -> check_minimum_depth_opt(DefMinDepth, Role, O) end,
               fun check_timeout_opt/1,
               fun check_rpt_opt/1,
               fun check_log_opt/1,
-              fun check_block_hash_deltas/1
+              fun check_block_hash_deltas/1,
+              fun(O) -> check_keep_running_opt(Role, O) end
              ], Opts3),
+    Opts = Opts4#{connection => ConnectOpts},
     #{initiator := Initiator} = Opts,
-    Session = start_session(Arg, Reestablish, Opts#{role => Role}),
+    Session = start_session(ReestablishOpts, Opts#{role => Role}),
     StateInitF = fun(NewI) ->
                           CheckedOpts = maps:merge(Opts#{ role => Role
                                                         , state_password_wrapper => StatePasswordWrapper
@@ -3464,13 +3614,13 @@ init(#{opts := Opts0} = Arg) ->
                     , client           = Client
                     , client_mref      = ClientMRef
                     , client_connected = true
-	                , block_hash_delta = BlockHashDelta
+                    , block_hash_delta = BlockHashDelta
                     , state_password_wrapper = MaybeStatePasswordWrapper
-                    , session = Session
+                    , session = maybe_save_session(Role, Session)
                     , opts    = Opts
                     , state   = State
                     , log     = aesc_window:new(maps:get(log_keep, Opts)) },
-        lager:debug("Session started, Data = ~p", [Data]),
+        lager:debug("Session started, Data = ~p", [pr_data(Data)]),
         %% TODO: Amend the fsm above to include this step. We have transport-level
         %% connectivity, but not yet agreement on the channel parameters. We will next send
         %% a channel_open() message and await a channel_accept().
@@ -3483,7 +3633,8 @@ init(#{opts := Opts0} = Arg) ->
                 ChanId = maps:get(existing_channel_id, ReestablishOpts),
                 ok_next(awaiting_reestablish,
                         Data#data{ channel_id  = ChanId
-                                 , on_chain_id = ChanId });
+                                 , on_chain_id = ChanId
+                                 , op = #op_reestablish{mode = restart} });
             {responder, false} ->
                 ok_next(awaiting_open, Data)
         end
@@ -3503,6 +3654,15 @@ init(#{opts := Opts0} = Arg) ->
     %% Always force garbage collection here, when reestablishing the password will be removed here
     garbage_collect(),
     InitRes.
+
+maybe_save_session(initiator, Session) ->
+    Session;
+maybe_save_session(_, _) ->
+    undefined.
+
+connection_opts(#{opts := Opts} = Arg) ->
+    maps:merge(maps:with([host,port], Arg),
+               maps:with(?CONNECT_OPTS_KEYS, Opts)).
 
 terminate(Reason, _State, #data{session = Sn} = Data) ->
     lager:debug("terminate(~p, ~p, _)", [Reason, _State]),
@@ -3602,32 +3762,61 @@ check_block_hash_deltas(#{block_hash_delta := InvalidBHDelta} = Opts) ->
 check_block_hash_deltas(Opts) ->
     Opts.
 
+check_keep_running_opt(Role, Opts) ->
+    case {maps:find(keep_running, Opts), Role} of
+        {{ok, Bool}, responder} when is_boolean(Bool) ->
+            Opts;
+        {{ok, _}, initiator} ->
+            lager:debug("The 'keep_running' option not valid for initiator - ignoring", []),
+            maps:remove(keep_running, Opts);
+        {{ok, Other}, _} ->
+            lager:debug("Invalid 'keep_running' option (~p) - ignoring", [Other]),
+            maps:remove(keep_running, Opts);
+        {error, _} ->
+            Opts
+    end.
+
 check_opts([], Opts) ->
     Opts;
 check_opts([H|T], Opts) ->
     check_opts(T, H(Opts)).
 
+prepare_for_reestablish(#data{ opts = Opts
+                             , on_chain_id = ChanId } = D) ->
+    try
+        _Session = start_session(#{ existing_channel_id => ChanId },
+                                 Opts#{role => responder}),
+        %% We don't save the session pid here
+        D
+    ?CATCH_LOG(_E)
+            D
+    end.
+
 %% @doc As per CHANNELS.md, the responder is regarded as the one typically
 %% providing the service, and the initiator connects.
-start_session(#{ port := Port
-               , opts := Opts0 }, Reestablish, #{ role      := responder
-                                                , responder := Responder
-                                                , initiator := Initiator } = Opts) ->
-    NoiseOpts = maps:get(noise, Opts, []),
-    SessionOpts = if Reestablish ->
+start_session(ReestablishOpts, #{ role       := responder
+                                , responder  := Responder
+                                , initiator  := Initiator
+                                , connection := #{ port := Port } = COpts }) ->
+    NoiseOpts = maps:get(noise, COpts, []),
+    lager:debug("NoiseOpts = ~p", [NoiseOpts]),
+    SessionOpts = case maps:find(existing_channel_id, ReestablishOpts) of
+                      {ok, ChId} ->
                           #{ reestablish => true
                            , port        => Port
                            , chain_hash  => aec_chain:genesis_hash()
-                           , channel_id  => maps:get(existing_channel_id, Opts0)
+                           , channel_id  => ChId
                            , responder   => Responder };
-                     true ->
+                      error ->
                           #{ initiator => Initiator
                            , responder => Responder
                            , port      => Port }
                   end,
     ok(aesc_session_noise:accept(SessionOpts, NoiseOpts));
-start_session(#{host := Host, port := Port}, _, #{role := initiator} = Opts) ->
-    NoiseOpts = maps:get(noise, Opts, []),
+start_session(_, #{ role       := initiator
+                  , connection := #{ host := Host, port := Port } = COpts}) ->
+    NoiseOpts = maps:get(noise, COpts, []),
+    lager:debug("COpts = ~p", [COpts]),
     ok(aesc_session_noise:connect(Host, Port, NoiseOpts)).
 
 ok({ok, X}) -> X.
@@ -3640,15 +3829,6 @@ maybe_initialize_offchain_state(_, _, D) ->
 
 ok_next(Next, Data) ->
     {ok, Next, cur_st(Next, Data), [timer_for_state(Next, Data)]}.
-
--ifdef(TEST).
-stop_ok(ok) ->
-    ok;
-stop_ok({'EXIT', noproc}) ->
-    ok;
-stop_ok({'EXIT', {normal,{sys,terminate,_}}}) ->
-    ok.
--endif.
 
 timer(Name, Msg, #data{opts = #{timeouts := TOs}}) ->
     timeout_(maps:get(Name, TOs), Msg).
@@ -3911,6 +4091,8 @@ handle_call(_, {?RECONNECT_CLIENT, Pid, Tx} = Msg, From,
     ?CATCH_LOG(E)
         keep_state(D, [{reply, From, E}])
     end;
+handle_call(_, {?RECONNECT_CLIENT, _, _}, From, #data{ client = Client } = D) when is_pid(Client) ->
+    keep_state(D, [{reply, From, {error, {existing_client, Client}}}]);
 handle_call(_, {change_state_password, StatePassword}, From, #data{channel_status = open, on_chain_id = ChId} = D) ->
     case is_password_valid(StatePassword) of
         ok ->
@@ -3924,7 +4106,7 @@ handle_call(_, {change_state_password, StatePassword}, From, #data{channel_statu
             keep_state(D, [{reply, From, Err}])
        end;
 handle_call(St, Req, From, #data{} = D) ->
-    lager:debug("handle_call(~p, ~p, ~p, ~p)", [St, Req, From, D]),
+    lager:debug("handle_call(~p, ~p, ~p, ~p)", [St, Req, From, pr_data(D)]),
     try handle_call_(St, Req, From, D)
     ?CATCH_LOG(E, "maybe_block_hash_error")
         keep_state(D, [{reply, From, {error, E}}])
@@ -4283,14 +4465,26 @@ handle_common_event_(timeout, Info, _St, _M, D) when D#data.ongoing_update == tr
     handle_recoverable_error(#{code => ?ERR_TIMEOUT}, D);
 handle_common_event_(timeout, St = T, St, _, D) ->
     close({timeout, T}, D);
-handle_common_event_(cast, ?DISCONNECT = Msg, _St, _, D) ->
+handle_common_event_(cast, ?DISCONNECT = Msg, _St, _, #data{ channel_status = Status
+                                                           , client_may_disconnect = MayDisconnect
+                                                           , role = Role
+                                                           , opts = Opts } = D) ->
     D1 = log(rcv, ?DISCONNECT, Msg, D),
-    case D1#data.channel_status of
+    case Status of
         closing ->
             keep_state(D1);
         _ ->
-            report(info, peer_disconnected, D1),
-            next_state(open, fallback_to_stable_state(D1))
+            case {Role, maps:get(keep_running, Opts, false), MayDisconnect} of
+                {responder, true, true} ->
+                    report(info, peer_disconnected, D1),
+                    next_state(
+                      open,
+                      prepare_for_reestablish(
+                        fallback_to_stable_state(D1#data{ session = undefined
+                                                        , peer_connected = false })));
+                _ ->
+                    close(disconnect, D1)
+            end
     end;
 handle_common_event_(cast, {?INBAND_MSG, Msg}, _St, _, D) ->
     NewD = case check_inband_msg(Msg, D) of
@@ -4378,6 +4572,16 @@ get_channel(ChainHash, ChId) ->
             {error, chain_hash_mismatch}
     end.
 
+init_checks(#{existing_channel_id := _} = Opts) ->
+    #{ role := _Role
+     ,  offchain_tx := _ } = Opts,
+    Checks = [fun() -> check_state_password(Opts) end],
+    case aeu_validation:run(Checks) of
+        {error, _Reason} = Err ->
+            Err;
+        ok ->
+            ok
+    end;
 init_checks(Opts) ->
     #{ initiator   := Initiator
      , responder   := Responder
@@ -4451,11 +4655,13 @@ abbrev_args(L) when is_list(L) ->
          (X) -> X
       end, L).
 
+-endif.
+
+%% This is also used in some debug log entries
 pr_data(D) ->
     lager:pr(setelement(
                #data.state,
                setelement(#data.log, D, {snip}), {snip}), ?MODULE).
--endif.
 
 -spec check_block_hash(aec_keys:pubkey(), #data{}) -> ok.
 check_block_hash(?NOT_SET_BLOCK_HASH, _) -> ok;

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -3092,7 +3092,7 @@ report_update(#data{state = State, last_reported_update = Last} = D) ->
 report_leave(#data{role = Role, opts = Opts, state = State} = D) ->
     {_, SignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
     case {Role, maps:get(keep_running, Opts, false)} of
-        {responder, {ok, true}} ->
+        {responder, true} ->
             report_with_notice(leave, SignedTx, keep_running, D);
         _ ->
             report(leave, SignedTx, D)

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -785,7 +785,6 @@ awaiting_signature(cast, {?SIGNED, ?UPDATE_ACK, SignedTx} = Msg,
 awaiting_signature(cast, {?SIGNED, ?SHUTDOWN, SignedTx} = Msg,
                    #data{op = #op_sign{ tag = ?SHUTDOWN
                                       , data = OpData0}} = D) ->
-    #op_data{} = OpData0,
     lager:debug("SHUTDOWN signed", []),
     maybe_check_auth(SignedTx, OpData0, not_close_mutual_tx, me,
         fun() ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -632,7 +632,8 @@ awaiting_reestablish({call, From},
             gen:reply(From, ok),
             {Pid, _} = From,
             keep_state(D#data{ session = Pid }, [{reply, From, ok}]);
-        {error,_} ->
+        {error, Error} ->
+                lager:debug("Attach failed with ~p", [Error]),
             keep_state(D, [{reply, From, {error, invalid_attach}}])
     end;
 awaiting_reestablish(Type, Msg, D) ->

--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -10,6 +10,12 @@
     , offchain_tx
     ]).
 
+-define(CONNECT_OPTS_KEYS,
+    [ host
+    , port
+    , noise
+    ]).
+
 -define(DEFAULT_TIMEOUTS,
     #{ accept         => 120000
      , funding_create => 120000
@@ -150,12 +156,13 @@
               , channel_status                  :: undefined | attached | open | closing
               , cur_statem_state                :: undefined | atom()
               , state                           :: aesc_offchain_state:state() | function()
-              , session                         :: pid()
+              , session                         :: pid() | undefined
               , client                          :: pid() | undefined
               , client_mref                     :: reference() | undefined
               , client_connected = true         :: boolean()
               , client_may_disconnect = false   :: boolean()
               , client_reconnect_nonce = 0      :: non_neg_integer()
+              , peer_connected = false          :: boolean()
               , opts                            :: map()
               , state_password_wrapper          :: undefined | aesc_state_password_wrapper:wrapper()
               , channel_id                      :: undefined | binary()
@@ -256,7 +263,8 @@
                   , data    :: #op_data{}
                   }).
 
--record(op_reestablish, {offchain_tx :: aetx_sign:signed_tx()
+-record(op_reestablish, { offchain_tx :: aetx_sign:signed_tx() | undefined
+                        , mode = restart :: restart | remain
                         }).
 
 -record(op_close, { data :: #op_data{}

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -94,7 +94,7 @@ recover_from_offchain_tx(#{ existing_channel_id    := ChId
                 aesc_state_cache:reestablish(ChId, MyPubkey)
         end,
     case ReestablishResult of
-        {ok, #state{} = State} ->
+        {ok, #state{} = State, _CachedOpts} ->
             case is_latest_signed_tx(SignedTx, State) of
                 true ->
                     {ok, State};
@@ -164,7 +164,6 @@ check_update_tx(SignedTx, Updates, #state{signed_tx = OldSignedTx}=State,
                 ChannelPubkey,
                 Protocol, OnChainTrees,
                 OnChainEnv, Opts) when OldSignedTx =/= ?NO_TX ->
-    lager:debug("check_update_tx(State = ~p)", [State]),
     {Mod, TxI} = aetx:specialize_callback(aetx_sign:innermost_tx(SignedTx)),
     lager:debug("Tx = ~p", [TxI]),
     case Mod:valid_at_protocol(Protocol, TxI) of

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -347,10 +347,7 @@ locate_fsm(Type, MInfo, #st{ init_op = {accept, SnInfo, _Opts} } = St) ->
     Info0 = maps:merge(maps:with([ initiator
                                  , responder
                                  , port ], SnInfo), MInfo),
-    Info = case Type of
-               ?CH_OPEN     -> Info0;
-               ?CH_REESTABL -> Info0#{reestablish => true}
-           end,
+    Info = Info0#{reestablish => (Type =:= ?CH_REESTABL)},
     Cands = get_cands(Type, Info),
     lager:debug("Cands = ~p", [Cands]),
     try_cands(Cands, 3, 0, Type, Info, St).

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -105,7 +105,7 @@ shutdown_error     (Session, Msg) -> cast(Session, {msg, ?SHUTDOWN_ERR , Msg}).
 close(Session) ->
     try call(Session, close)
     ?_catch_(E, R, StackTrace)
-        case {R, E} of
+        case {E, R} of
             {error, _} ->
                 ok;
             {exit, {noproc, _}} ->
@@ -142,7 +142,7 @@ connect(Host, Port, Opts) ->
 
 accept(#{ port := Port, responder := R } = Opts0, NoiseOpts) ->
     TcpOpts = tcp_opts(listen, NoiseOpts),
-    lager:debug("listen: TcpOpts = ~p", [TcpOpts]),
+    lager:debug("listen: Opts0 = ~p; TcpOpts = ~p", [Opts0, TcpOpts]),
     {ok, LSock} = aesc_listeners:listen(Port, R, TcpOpts),
     Opts = Opts0#{lsock => LSock},
     accept_(Opts, NoiseOpts).
@@ -152,11 +152,15 @@ accept_(#{ reestablish := true
          , channel_id  := ChId
          , responder   := R
          , port        := Port } = Opts, NoiseOpts) ->
-    gproc:reg(responder_reestabl_regkey(ChainH, ChId, R, Port)),
+    Regkey = responder_reestabl_regkey(ChainH, ChId, R, Port),
+    lager:debug("Regkey = ~p", [Regkey]),
+    gproc:reg(Regkey),
     {ok, _Pid} = aesc_sessions_sup:start_child(
                    [#{fsm => self(), op => {accept, Opts, NoiseOpts}}]);
 accept_(#{ initiator := I, responder := R, port := Port } = Opts, NoiseOpts) ->
-    gproc:reg(responder_regkey(R, I, Port)),
+    Regkey = responder_regkey(R, I, Port),
+    lager:debug("Regkey = ~p", [Regkey]),
+    gproc:reg(Regkey),
     aesc_sessions_sup:start_child([#{fsm => self(), op => {accept, Opts, NoiseOpts}}]).
 
 start_link(Arg) when is_map(Arg) ->
@@ -311,6 +315,7 @@ handle_info(Msg, St) ->
 
 handle_info_({noise, EConn, Data}, #st{econn = EConn, fsm = Fsm} = St) ->
     {Type, Info} = Msg = aesc_codec:dec(Data),
+    lager:debug("Msg = ~p", [Msg]),
     St1 = case {Type, Fsm} of
               {?CH_OPEN, undefined} ->
                   locate_fsm(Type, Info, St);
@@ -337,7 +342,15 @@ code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
 
 locate_fsm(Type, MInfo, #st{ init_op = {accept, SnInfo, _Opts} } = St) ->
-    Info = maps:merge(SnInfo, MInfo),  % any duplicates overridden by what was received
+    lager:debug("Type = ~p, MInfo = ~p, SnInfo = ~p", [Type, MInfo, SnInfo]),
+    %% any duplicates overridden by what was received
+    Info0 = maps:merge(maps:with([ initiator
+                                 , responder
+                                 , port ], SnInfo), MInfo),
+    Info = case Type of
+               ?CH_OPEN     -> Info0;
+               ?CH_REESTABL -> Info0#{reestablish => true}
+           end,
     Cands = get_cands(Type, Info),
     lager:debug("Cands = ~p", [Cands]),
     try_cands(Cands, 3, 0, Type, Info, St).

--- a/apps/aechannel/src/aesc_state_cache.erl
+++ b/apps/aechannel/src/aesc_state_cache.erl
@@ -31,8 +31,8 @@
 
 -export([
           start_link/0
-        , new/3
         , new/4
+        , new/5
         , reestablish/2
         , reestablish/3
         , change_state_password/3
@@ -78,8 +78,10 @@
              min_depth = ?MIN_DEPTH}).
 -type ch_cache_id() :: { aeser_id:val()
                        , aeser_id:val() | atom()}.
+-type opts() :: map().
 -record(ch_cache, { cache_id    :: ch_cache_id() | undefined
                   , state       :: aesc_offchain_state:state() | atom() | undefined
+                  , opts = #{}  :: map() | '_'
                   , salt        :: binary() | atom()
                   , session_key :: binary() | atom()
                   }).
@@ -91,6 +93,7 @@
                              , salt            :: binary() | atom()
                              , nonce           :: binary() | atom()
                              , encrypted_state :: binary() | atom()
+                             , opts = #{}      :: opts() | '_'         % unencrypted
                              }).
 
 -define(SERVER, ?MODULE).
@@ -98,19 +101,19 @@
 -define(PTAB, aesc_state_cache).
 -define(CACHE_DEFAULT_PASSWORD, "correct horse battery staple").
 
--spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state()) -> ok | {error, any()}.
-new(ChId, Pubkey, State) ->
-    new(ChId, Pubkey, State, ?CACHE_DEFAULT_PASSWORD).
+-spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state(), map()) -> ok | {error, any()}.
+new(ChId, Pubkey, State, Opts) ->
+    new(ChId, Pubkey, State, Opts, ?CACHE_DEFAULT_PASSWORD).
 
--spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state(), string()) -> ok | {error, any()}.
-new(ChId, PubKey, State, Password) ->
-    gen_server:call(?SERVER, {new, ChId, PubKey, self(), State, unicode:characters_to_binary(Password)}).
+-spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state(), map(), string()) -> ok | {error, any()}.
+new(ChId, PubKey, State, Opts, Password) ->
+    gen_server:call(?SERVER, {new, ChId, PubKey, self(), State, Opts, unicode:characters_to_binary(Password)}).
 
--spec reestablish(aeser_id:val(), aeser_id:val()) -> {ok, aesc_offchain_state:state()} | {error, atom()}.
+-spec reestablish(aeser_id:val(), aeser_id:val()) -> {ok, aesc_offchain_state:state(), opts()} | {error, atom()}.
 reestablish(ChId, Pubkey) ->
     reestablish(ChId, Pubkey, ?CACHE_DEFAULT_PASSWORD).
 
--spec reestablish(aeser_id:val(), aeser_id:val(), string()) -> {ok, aesc_offchain_state:state()} | {error, atom()}.
+-spec reestablish(aeser_id:val(), aeser_id:val(), string()) -> {ok, aesc_offchain_state:state(), opts()} | {error, atom()}.
 reestablish(ChId, PubKey, Password) ->
     gen_server:call(?SERVER, {reestablish, ChId, PubKey, self(), unicode:characters_to_binary(Password)}).
 
@@ -197,7 +200,7 @@ transform_record_to_encrypted_form_with_default_password(#pch{id = ChId, pubkeys
     [encrypt_cache(Cache1)];
 transform_record_to_encrypted_form_with_default_password(#pch{pubkeys = [Pub1, Pub2]} = Record) ->
     Records = [Record#pch{pubkeys = [Pub1]}, Record#pch{pubkeys = [Pub2]}],
-    lists:flatten([transform_record_to_encrypted_form_with_default_password(Record) || Record <- Records]).
+    lists:flatten([transform_record_to_encrypted_form_with_default_password(R) || R <- Records]).
 
 start_link() ->
     case ets:info(?TAB, name) of
@@ -225,10 +228,10 @@ setup_keys_in_cache(Password) ->
             Err
     end.
 
-handle_call({new, ChId, PubKey, Pid, State, Password}, _From, St) ->
+handle_call({new, ChId, PubKey, Pid, State, Opts, Password}, _From, St) ->
     Resp = case setup_keys_in_cache(Password) of
         {ok, Result} ->
-            case ets:insert_new(?TAB, Result#ch_cache{cache_id = key(ChId, PubKey), state = State}) of
+            case ets:insert_new(?TAB, Result#ch_cache{cache_id = key(ChId, PubKey), state = State, opts = Opts}) of
                 true ->
                     St1 = monitor_fsm(Pid, ChId, PubKey, St),
                     {reply, ok, St1};
@@ -242,10 +245,10 @@ handle_call({new, ChId, PubKey, Pid, State, Password}, _From, St) ->
     Resp;
 handle_call({reestablish, ChId, PubKey, Pid, Password}, _From, St) ->
     Resp = case try_reestablish_cached(ChId, PubKey, Password) of
-        {ok, Result} ->
+        {ok, State, Opts} ->
             St1 = monitor_fsm(Pid, ChId, PubKey,
                               remove_watcher(ChId, St)),
-            {reply, {ok, Result}, St1};
+            {reply, {ok, State, Opts}, St1};
         {error, _} = Error ->
             {reply, Error, St}
     end,
@@ -253,8 +256,8 @@ handle_call({reestablish, ChId, PubKey, Pid, Password}, _From, St) ->
     Resp;
 handle_call({fetch, ChId, PubKey}, _From, St) ->
     case ets:lookup(?TAB, key(ChId, PubKey)) of
-        [#ch_cache{state = State}] ->
-            {reply, {ok, State}, St};
+        [#ch_cache{state = State, opts = Opts}] ->
+            {reply, {ok, State, Opts}, St};
         [] ->
             {reply, error, St}
     end;
@@ -332,8 +335,8 @@ cache_status_(ChId) ->
 try_reestablish_cached(ChId, PubKey, Password) ->
     CacheId = key(ChId, PubKey),
     case ets:lookup(?TAB, CacheId) of
-        [#ch_cache{state = State}] ->
-            {ok, State};
+        [#ch_cache{state = State, opts = Opts}] ->
+            {ok, State, Opts};
         [] ->
             case read_persistent(CacheId) of
                 {ok, Encrypted} ->
@@ -346,15 +349,17 @@ try_reestablish_cached(ChId, PubKey, Password) ->
 decrypt_with_key_and_move_to_ram(#pch_encrypted_cache{ cache_id = CacheId
                                                      , nonce = Nonce
                                                      , encrypted_state = EncryptedState
+                                                     , opts = Opts
                                                      }, Cache, SessionKey) ->
     case enacl:secretbox_open(EncryptedState, Nonce, SessionKey) of
         {ok, SerializedState} ->
             State = aesc_offchain_state:deserialize_from_binary(SerializedState),
             ets:insert(
-                    ?TAB, [Cache#ch_cache{cache_id = CacheId, state = State}]),
+                    ?TAB, [Cache#ch_cache{cache_id = CacheId, state = State, opts = Opts}]),
                     delete_persistent(CacheId),
-                    {ok, State};
+                    {ok, State, Opts};
         {error, _} ->
+            lager:debug("Invalid password (assumed) opening secretbox", []),
             {error, invalid_password}
     end.
 
@@ -387,6 +392,7 @@ encrypt_and_persist(Cache) ->
 encrypt_cache(#ch_cache{ cache_id = CacheId
                        , salt =  Salt
                        , state =  State
+                       , opts = Opts
                        , session_key = SessionKey}) ->
     Nonce = crypto:strong_rand_bytes(enacl:secretbox_nonce_size()),
     SerializedState = aesc_offchain_state:serialize_to_binary(State),
@@ -394,7 +400,8 @@ encrypt_cache(#ch_cache{ cache_id = CacheId
         cache_id = CacheId,
         salt = Salt,
         nonce = Nonce,
-        encrypted_state = enacl:secretbox(SerializedState, Nonce, SessionKey)
+        encrypted_state = enacl:secretbox(SerializedState, Nonce, SessionKey),
+        opts = Opts
     }.
 
 write_persistent(Pch) ->

--- a/apps/aechannel/src/aesc_state_cache.erl
+++ b/apps/aechannel/src/aesc_state_cache.erl
@@ -101,11 +101,11 @@
 -define(PTAB, aesc_state_cache).
 -define(CACHE_DEFAULT_PASSWORD, "correct horse battery staple").
 
--spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state(), map()) -> ok | {error, any()}.
+-spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state(), opts()) -> ok | {error, any()}.
 new(ChId, Pubkey, State, Opts) ->
     new(ChId, Pubkey, State, Opts, ?CACHE_DEFAULT_PASSWORD).
 
--spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state(), map(), string()) -> ok | {error, any()}.
+-spec new(aeser_id:val(), aeser_id:val(), aesc_offchain_state:state(), opts(), string()) -> ok | {error, any()}.
 new(ChId, PubKey, State, Opts, Password) ->
     gen_server:call(?SERVER, {new, ChId, PubKey, self(), State, Opts, unicode:characters_to_binary(Password)}).
 

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -2408,8 +2408,8 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
     %% round_too_high.check_incorrect_* and round_too_low.check_incorrect_* tests
     %% For now just wrap this operation in a retry loop and come back to it later
     ?LOG("=== Create channel~n"
-         "Spec = ~p"
-         "Msg Q: ~p", [Spec, element(2, process_info(self(), messages))]),
+    ?LOG("Spec = ~p", [Spec]),
+    ?PEEK_MSGQ,
     RSpec = customize_spec(responder, Spec, Cfg),
     ISpec = customize_spec(initiator, Spec, Cfg),
     {FsmI, FsmR, I1, R1} = retry(?CHANNEL_CREATION_RETRIES, 100,

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -2407,7 +2407,7 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
     %% TODO: Somehow there is a CI only race condition which rarely occurs in
     %% round_too_high.check_incorrect_* and round_too_low.check_incorrect_* tests
     %% For now just wrap this operation in a retry loop and come back to it later
-    ?LOG("=== Create channel~n"
+    ?LOG("=== Create channel~n", []),
     ?LOG("Spec = ~p", [Spec]),
     ?PEEK_MSGQ,
     RSpec = customize_spec(responder, Spec, Cfg),

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -425,7 +425,7 @@ stop_node(N, Config) ->
 
 create_channel(Cfg) ->
     %% with_trace(fun t_create_channel_/1, Cfg, "create_channel").
-    t_create_channel_(set_debug(true, Cfg)).
+    t_create_channel_(Cfg).
 
 multiple_responder_keys_per_port(Cfg) ->
     Slogan = ?SLOGAN,
@@ -1175,12 +1175,12 @@ close_solo_tx(#{ fsm        := Fsm
 
 leave_reestablish(Cfg) ->
     %% with_trace(fun t_leave_reestablish_/1, Cfg, "leave_reestablish").
-    t_leave_reestablish_([{debug,true}|Cfg]).
+    t_leave_reestablish_(Cfg).
 
 leave_reestablish_responder_stays(Cfg) ->
     with_trace(
       fun(Cfg1) ->
-              t_leave_reestablish_(cfg_responder_keeps_running(set_debug(true, Cfg1)))
+              t_leave_reestablish_(cfg_responder_keeps_running(Cfg1))
       end, [{activate_trace, ?TR_CHANNEL_CREATED}|Cfg], "leave_reest_responder_stays").
 
 t_leave_reestablish_(Cfg) ->
@@ -1278,7 +1278,8 @@ verify_channel(#{pub := PubI, fsm := FsmI} = I,
     ?PEEK_MSGQ,
     ?LOG(Debug, "verifying channel: deposit", []),
     {ok, I2, R2} = deposit_(I1, R1, 1, Debug, Cfg),
-    ?LOG("=== Channel verified~nMessage Q: ~p", [element(2,process_info(self(), messages))]),
+    ?LOG("=== Channel verified", []),
+    ?PEEK_MSGQ,
     {ok, I2, R2}.
 
 responder_stays(#{responder_opts := #{keep_running := Bool}}) ->
@@ -1802,7 +1803,7 @@ check_invalid_reestablish_password(Cfg) ->
 
 check_password_is_changeable(Cfg) ->
     %% Debug = get_debug(Cfg),
-    Debug = true,
+    Debug = get_debug(Cfg),
     {I0, R0, Spec0} = channel_spec(Cfg),
     #{ i := I
      , r := R } = CSpec = create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -2380,10 +2380,10 @@ prime_password(#{} = P, Key, Cfg) when Key =:= initiator_password; Key =:= respo
         undefined ->
             P#{state_password => generate_password()};
         ignore ->
-            ?LOG(Debug, "Ignoring password"),
+            ?LOG(Debug, "Ignoring password", []),
             maps:remove(state_password, P);
         Password ->
-            ?LOG(Debug, "Using predefined password"),
+            ?LOG(Debug, "Using predefined password", []),
             P#{state_password => Password}
      end.
 

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -43,6 +43,7 @@
         , withdraw/1
         , channel_detects_close_solo/1
         , leave_reestablish/1
+        , leave_reestablish_responder_stays/1
         , leave_reestablish_close/1
         , change_config_get_history/1
         , multiple_channels/1
@@ -91,6 +92,10 @@
 -define(BOGUS_PRIVKEY, <<12345:64/unit:8>>).
 -define(BOGUS_BLOCKHASH, <<42:32/unit:8>>).
 
+-define(LOG(E), ct:log("LINE ~p <== ~p", [?LINE, E])).
+-define(LOG(Fmt, Args), log(?LINE, Fmt, Args)).
+-define(LOG(Debug, Fmt, Args), log(Debug, ?LINE, Fmt, Args)).
+
 -define(PEEK_MSGQ, peek_message_queue(?LINE, Debug)).
 
 -define(MINIMUM_DEPTH, 3).
@@ -123,6 +128,21 @@
                             138,84,57,120,255>>).
 
 -define(R_OWNER, aega_test_utils:to_hex_lit(64, ?R_SECP256K1_PUB)).
+
+%% tracing checkpoints - to cut down on the amount of trace data collected
+%% When a given checkpoint is reached, there should be a call to
+%%
+%% trace_checkpoint(Checkpoint, Config).
+%%
+%% When tracing should be activated is controlled by adding the config option
+%% {activate_trace, Checkpoint}, for example:
+%%
+%% with_trace(fun my_test/1, [{activate_trace, ?TR_CHANNEL_CREATED}|Cfg], "my_test")
+%%
+%% If tracing is to be started from the beginning, no `activate_trace` option is needed,
+%% and {activate_trace, ?TR_START} is implied.
+-define(TR_START, start).
+-define(TR_CHANNEL_CREATED, channel_created).
 
 all() ->
     [{group, all_tests}].
@@ -161,6 +181,7 @@ groups() ->
       , withdraw
       , channel_detects_close_solo
       , leave_reestablish
+      , leave_reestablish_responder_stays
       , leave_reestablish_close
       , check_password_is_changeable
       , change_config_get_history
@@ -347,7 +368,7 @@ init_per_group_(Config) ->
         false ->
             aecore_suite_utils:start_node(dev1, Config),
             aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1), [block_pow, sc_cache_kdf]),
-            log("dev1 connected", []),
+            ?LOG("dev1 connected", []),
             try begin
                     Initiator = prep_initiator(dev1),
                     Responder = prep_responder(Initiator, dev1),
@@ -404,13 +425,13 @@ stop_node(N, Config) ->
 
 create_channel(Cfg) ->
     %% with_trace(fun t_create_channel_/1, Cfg, "create_channel").
-    t_create_channel_(Cfg).
+    t_create_channel_(set_debug(true, Cfg)).
 
 multiple_responder_keys_per_port(Cfg) ->
     Slogan = ?SLOGAN,
     Debug = get_debug(Cfg),
     {_, Responder2} = lists:keyfind(responder2, 1, Cfg),
-    log(Debug, "Responder2 = ~p", [Responder2]),
+    ?LOG(Debug, "Responder2 = ~p", [Responder2]),
     Cfg2 = lists:keyreplace(responder, 1, Cfg, {responder, Responder2}),
     Me = self(),
     Initiator = maps:get(pub, ?config(initiator, Cfg)),
@@ -448,15 +469,15 @@ multiple_responder_keys_per_port(Cfg) ->
     Cs = [C1, C2],
     %% mine_blocks(dev1, ?MINIMUM_DEPTH),
     %% Cs = collect_acks(Cs, channel_ack, 2),
-    log(Debug, "channel pids collected: ~p", [Cs]),
+    ?LOG(Debug, "channel pids collected: ~p", [Cs]),
     %% At this point, we know the pairing worked
     [begin
          MRef = erlang:monitor(process, P),
-         log(Debug, "P (~p) info: ~p", [P, process_info(P)]),
+         ?LOG(Debug, "P (~p) info: ~p", [P, process_info(P)]),
          P ! die,
          receive {'DOWN', MRef, _, _, _} -> ok
          after 5000 ->
-                 log(Debug, "timed out: ~p", [process_info(self(), messages)]),
+                 ?LOG(Debug, "timed out: ~p", [process_info(self(), messages)]),
                  erlang:error({channel_not_dying, P})
          end
      end || P <- Cs],
@@ -934,13 +955,13 @@ update_bench(I, R, C0) ->
     set_proxy_debug(false, R),
     C = set_debug(false, C0),
     Rounds = proplists:get_value(bench_rounds, C, 1000),
-    log("=== Starting benchmark ===", []),
+    ?LOG("=== Starting benchmark ===", []),
     {Time, I1, R1} = do_n(Rounds, fun update_volley/3,
                           cache_account_type(I),
                           cache_account_type(R), C),
     Fmt = "Time (1*2*" ++ integer_to_list(Rounds) ++ "): ~.1f s; ~.1f mspt; ~.1f tps",
     Args = [Time/1000, Time/(2*Rounds), 2000*Rounds/Time],
-    log(Fmt, Args),
+    ?LOG(Fmt, Args),
     ct:comment(Fmt, Args),
     {I1, R1}.
 
@@ -965,6 +986,7 @@ do_update(From, To, Amount, #{fsm := FsmI} = I, R, Debug, Cfg) ->
                false -> #{meta => [<<"meta1">>, <<"meta2">>]};
                true  -> #{}
            end,
+    ?PEEK_MSGQ,
     case rpc(dev1, aesc_fsm, upd_transfer, [FsmI, From, To, Amount, Opts], Debug) of
         {error, _} = Error ->
             throw(Error);
@@ -976,6 +998,8 @@ do_update(From, To, Amount, #{fsm := FsmI} = I, R, Debug, Cfg) ->
             await_update_incoming_report(R1, ?TIMEOUT, Debug),
             I2 = await_update_report(I1, ?TIMEOUT, Debug),
             R2 = await_update_report(R1, ?TIMEOUT, Debug),
+            ?LOG(Debug, "update successful", []),
+            ?PEEK_MSGQ,
             {I2, R2}
     end.
 
@@ -1000,7 +1024,7 @@ deposit(Cfg) ->
      , spec := #{ initiator := _PubI
                 , responder := _PubR }} = create_channel_(
                                             [?SLOGAN|Cfg]),
-    log(Debug, "I = ~p", [I]),
+    ?LOG(Debug, "I = ~p", [I]),
     #{initiator_amount := IAmt0, responder_amount := RAmt0} = I,
     {IAmt0, RAmt0, _, Round0 = 1} = check_fsm_state(FsmI),
     check_info(0),
@@ -1032,30 +1056,31 @@ deposit_(#{fsm := FsmI} = I, R, Deposit, Opts, Round1, Debug, Cfg) ->
     Round2 = Round1 + 1,
     ?PEEK_MSGQ,
     mine_blocks(dev1, ?MINIMUM_DEPTH),
-    await_own_deposit_locked(I, ?TIMEOUT, Debug),
-    await_own_deposit_locked(R, ?TIMEOUT, Debug),
-    await_deposit_locked(I, ?TIMEOUT, Debug),
-    await_deposit_locked(R, ?TIMEOUT, Debug),
+    await_own_deposit_locked(I1, ?TIMEOUT, Debug),
+    await_own_deposit_locked(R1, ?TIMEOUT, Debug),
+    await_deposit_locked(I1, ?TIMEOUT, Debug),
+    await_deposit_locked(R1, ?TIMEOUT, Debug),
+    
+    I2 = await_update_report(I1, ?TIMEOUT, Debug),
+    R2 = await_update_report(R1, ?TIMEOUT, Debug),
+    #{signed_tx := SignedTx} = I2, %% Same Tx
+    #{signed_tx := SignedTx} = R2, %% Same Tx
+
     {ok, Channel} = rpc(dev1, aec_chain, get_channel, [ChannelId]),
     {aesc_deposit_tx, DepositTx} =
         aetx:specialize_callback(aetx_sign:innermost_tx(SignedTx)),
     ChannelRound = aesc_channels:round(Channel),
     DepositRound = aesc_deposit_tx:round(DepositTx),
-    log(Debug, "Channel on-chain round ~p, expected round ~p", [ChannelRound,
+    ?LOG(Debug, "Channel on-chain round ~p, expected round ~p", [ChannelRound,
                                                             DepositRound]),
     {ChannelRound, ChannelRound} = {ChannelRound, DepositRound},
     {IAmt, RAmt0, StateHash, Round2} = check_fsm_state(FsmI),
     {IAmt, _} = {IAmt0 + Deposit, IAmt}, %% assert correct amounts
     Round2 = aesc_deposit_tx:round(DepositTx), %% assert correct round
     StateHash = aesc_deposit_tx:state_hash(DepositTx), %% assert correct state hash
-    log(Debug, "I1 = ~p", [I1]),
-    #{initiator_amount := IAmt2, responder_amount := RAmt2} = I1,
+    #{initiator_amount := IAmt2, responder_amount := RAmt2} = I2,
     Expected = {IAmt2, RAmt2},
     {Expected, Expected} = {{IAmt0 + Deposit, RAmt0}, Expected},
-    I2 = await_update_report(I1, ?TIMEOUT, Debug),
-    R2 = await_update_report(R1, ?TIMEOUT, Debug),
-    #{signed_tx := SignedTx} = I2, %% Same Tx
-    #{signed_tx := SignedTx} = R2, %% Same Tx
     {ok, I2, R2}.
 
 withdraw(Cfg) ->
@@ -1066,7 +1091,7 @@ withdraw(Cfg) ->
      , spec := #{ initiator := _PubI
                 , responder := _PubR }} = create_channel_(
                                             [?SLOGAN|Cfg]),
-    log(Debug, "I = ~p", [I]),
+    ?LOG(Debug, "I = ~p", [I]),
     {_IAmt0, _RAmt0, _, Round = 1} = check_fsm_state(FsmI),
     {ok, _I, _R} = withdraw_(I, R, Withdrawal, #{}, Round,
                              Debug, Cfg),
@@ -1111,7 +1136,7 @@ channel_detects_close_solo(Cfg) ->
     mine_blocks_until_txs_on_chain(dev1, [TxHash]),
     LockPeriod = maps:get(lock_period, Spec),
     TTL = current_height(dev1) + LockPeriod,
-    log(Debug, "Expected TTL = ~p", [TTL]),
+    ?LOG(Debug, "Expected TTL = ~p", [TTL]),
     SignedTx = await_on_chain_report(I1, #{info => solo_closing}, ?TIMEOUT),
     SignedTx = await_on_chain_report(R, #{info => solo_closing}, ?TIMEOUT),
     {ok,_} = receive_from_fsm(info, I1, fun closing/1, ?TIMEOUT, Debug),
@@ -1127,7 +1152,7 @@ close_solo_tx(#{ fsm        := Fsm
           , initiator  := IPubKey
           , responder  := RPubKey
           , round      := Round }} = St = rpc(dev1, aesc_fsm, get_state, [Fsm]),
-    log("St = ~p", [St]),
+    ?LOG("St = ~p", [St]),
     {ok, PoI} =  rpc(dev1, aesc_fsm, get_poi, [Fsm, [{account, IPubKey},
                                                      {account, RPubKey}]]),
     Nonce =
@@ -1150,7 +1175,13 @@ close_solo_tx(#{ fsm        := Fsm
 
 leave_reestablish(Cfg) ->
     %% with_trace(fun t_leave_reestablish_/1, Cfg, "leave_reestablish").
-    t_leave_reestablish_(Cfg).
+    t_leave_reestablish_([{debug,true}|Cfg]).
+
+leave_reestablish_responder_stays(Cfg) ->
+    with_trace(
+      fun(Cfg1) ->
+              t_leave_reestablish_(cfg_responder_keeps_running(set_debug(true, Cfg1)))
+      end, [{activate_trace, ?TR_CHANNEL_CREATED}|Cfg], "leave_reest_responder_stays").
 
 t_leave_reestablish_(Cfg) ->
     #{i := I, r := R} = leave_reestablish_([?SLOGAN|Cfg]),
@@ -1159,47 +1190,101 @@ t_leave_reestablish_(Cfg) ->
 
 leave_reestablish_(Cfg) ->
     Debug = get_debug(Cfg),
-    {I0, R0, Spec0} = channel_spec(Cfg),
-    #{ i := #{} = I
-     , r := #{} = R
+    {I0, R0, Spec0} = InitialSpec = channel_spec(Cfg),
+    ?LOG(Debug, "Initial spec = ~p", [InitialSpec]),
+    #{ i := #{} = I01
+     , r := #{} = R01
      , spec := #{ initiator := _PubI
-                , responder := _PubR }} =
+                , responder := _PubR }} = CSpec =
         create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),
-    log(Debug, "I = ~p", [I]),
+    {ok, I, R} = verify_channel(I01, R01, Cfg, Debug),
+    ResponderStays = responder_stays(CSpec),
+    ?LOG(Debug, "I = ~p", [I]),
     ChId = maps:get(channel_id, I),
     LeaveAndReestablish =
         fun(Idx, #{i := ILocal, r := RLocal}) ->
-            log(Debug, "starting attempt ~p", [Idx]),
+            ?LOG(Debug, "starting attempt ~p", [Idx]),
+            ?LOG(Debug,
+                 "ILocal = ~p~n"
+                 "RLocal = ~p", [ILocal, RLocal]),
             Cache1 = cache_status(ChId),
             [_, _] = in_ram(Cache1),
             [] = on_disk(Cache1),
             #{fsm := FsmI} = ILocal,
+            #{fsm := FsmR} = RLocal,
+            {IAmt, RAmt, _, _} = check_fsm_state(FsmI),
             ok = rpc(dev1, aesc_fsm, leave, [FsmI]),
             {ok,Li} = await_leave(ILocal, ?TIMEOUT, Debug),
             {ok,Lr} = await_leave(RLocal, ?TIMEOUT, Debug),
+            error = maps:find(notice, Li),
+            if ResponderStays ->
+                    keep_running = maps:get(notice, Lr);
+               true ->
+                    ok
+            end,
+            ?LOG(Debug, "Leave received; Lr = ~p", [Lr]),
             SignedTx = maps:get(info, Li),
             SignedTx = maps:get(info, Lr),
-            {ok,_} = receive_from_fsm(info, ILocal, fun died_normal/1, ?TIMEOUT, Debug),
-            {ok,_} = receive_from_fsm(info, RLocal, fun died_normal/1, ?TIMEOUT, Debug),
+            receive_dying_declarations(FsmI, FsmR, CSpec, Debug),
+            %% {ok,_} = receive_from_fsm(info, ILocal, fun died_normal/1, ?TIMEOUT, Debug),
+            %% if ResponderStays ->
+            %%         {ok,_} = receive_from_fsm(info, RLocal, peer_disconnected, ?TIMEOUT, Debug),
+            %%         ?LOG(Debug, "Initiator died, Responder remains", []);
+            %%    true ->
+            %%         {ok,_} = receive_from_fsm(info, RLocal, fun died_normal/1, ?TIMEOUT, Debug),
+            %%         consume_dying_log_report(RLocal),
+            %%         ?LOG(Debug, "both fsms died", [])
+            %% end,
             retry(3, 100,
                   fun() ->
                           Cache2 = cache_status(ChId),
-                          [] = in_ram(Cache2),
-                          [_, _] = on_disk(Cache2)
+                          ?LOG(Debug, "Cache2 = ~p", [Cache2]),
+                          if ResponderStays ->
+                                  [_] = in_ram(Cache2),
+                                  [_] = on_disk(Cache2);
+                             true ->
+                                  [] = in_ram(Cache2),
+                                  [_, _] = on_disk(Cache2)
+                          end
                   end),
             %%
             %% reestablish
             %%
             ChId = maps:get(channel_id, RLocal),
             mine_key_blocks(dev1, 6), % min depth at 4, so more than 4
-            log(Debug, "reestablishing ...", []),
-            Res = reestablish(ILocal, RLocal, SignedTx, Spec0, ?PORT, Debug),
-            log(Debug, "ending attempt ~p", [Idx]),
-            Res
+            ?LOG(Debug, "reestablishing ...", []),
+            #{i := ILocal1, r := RLocal1} = Res
+                    = reestablish(ILocal, RLocal, SignedTx,
+                                  Spec0#{ initiator_amount => IAmt
+                                        , responder_amount => RAmt },
+                                  CSpec, ?PORT, Debug),
+            {ok, ILocal2, RLocal2} = verify_channel(ILocal1, RLocal1, Cfg, Debug),
+            ?LOG(Debug, "ending attempt ~p", [Idx]),
+            Res#{i => ILocal2, r => RLocal2}
         end,
     lists:foldl(LeaveAndReestablish,
                 #{i => I, r => R},
                 lists:seq(1, 10)). % 10 iterations
+
+verify_channel(#{pub := PubI, fsm := FsmI} = I,
+               #{pub := PubR, fsm := FsmR} = R, Cfg, Debug) ->
+    ?LOG(Debug, "verifying channel: Fsm states", []),
+    ?PEEK_MSGQ,
+    FsmStateI = check_fsm_state(FsmI),
+    FsmStateR = check_fsm_state(FsmR),
+    {FsmStateI, FsmStateR} = {FsmStateR, FsmStateI},
+    ?LOG(Debug, "verifying channel: update", []),
+    {I1, R1} = do_update(PubI, PubR, 1, I, R, Debug, Cfg),
+    ?PEEK_MSGQ,
+    ?LOG(Debug, "verifying channel: deposit", []),
+    {ok, I2, R2} = deposit_(I1, R1, 1, Debug, Cfg),
+    ?LOG("=== Channel verified~nMessage Q: ~p", [element(2,process_info(self(), messages))]),
+    {ok, I2, R2}.
+
+responder_stays(#{responder_opts := #{keep_running := Bool}}) ->
+    Bool;
+responder_stays(_) ->
+    false.
 
 leave_reestablish_close(Cfg) ->
     Debug = get_debug(Cfg),
@@ -1280,7 +1365,7 @@ get_both_balances(Fsm, PubI, PubR) ->
 check_log([{Op, Type}|T], [{Op, Type, _, _}|T1]) ->
     check_log(T, T1);
 check_log([H|_], [H1|_]) ->
-    log("ERROR: Expected ~p in log; got ~p", [H, H1]),
+    ?LOG("ERROR: Expected ~p in log; got ~p", [H, H1]),
     error(log_inconsistent);
 check_log([_|_], []) ->
     %% the log is a sliding window; events may be flushed at the tail
@@ -1290,10 +1375,10 @@ check_log([], _) ->
 
 died_normal(#{info := {died,normal}}) -> ok.
 
-died_subverted(#{info := {died,_}}) -> ok.
+%% died_subverted(#{info := {died,_}}) -> ok.
 
 closing(#{info := closing} = Msg) ->
-    log("matches #{info := closing} - ~p", [Msg]),
+    ?LOG("matches #{info := closing} - ~p", [Msg]),
     ok.
 
 multiple_channels(Cfg) ->
@@ -1304,9 +1389,9 @@ many_chs_msg_loop(Cfg) ->
 
 multiple_channels_t(NumCs, FromPort, Msg, {slogan, Slogan}, Cfg) ->
     Debug = get_debug(Cfg),
-    log(Debug, "spawning ~p channels", [NumCs]),
+    ?LOG(Debug, "spawning ~p channels", [NumCs]),
     Initiator = maps:get(pub, ?config(initiator, Cfg)),
-    log(Debug, "Initiator: ~p", [Initiator]),
+    ?LOG(Debug, "Initiator: ~p", [Initiator]),
     Me = self(),
     Node = aecore_suite_utils:node_name(dev1),
     aecore_suite_utils:mock_mempool_nonce_offset(Node, NumCs),
@@ -1319,9 +1404,9 @@ multiple_channels_t(NumCs, FromPort, Msg, {slogan, Slogan}, Cfg) ->
                                 {slogan, {Slogan,N}} | Cfg], #{mine_blocks => {ask, MinerHelper},
                                                                debug => Debug})
           || N <- lists:seq(1, NumCs)],
-    log(Debug, "channels spawned", []),
+    ?LOG(Debug, "channels spawned", []),
     Cs = collect_acks(Cs, channel_ack, NumCs),
-    log(Debug, "channel pids collected: ~p", [Cs]),
+    ?LOG(Debug, "channel pids collected: ~p", [Cs]),
     [P ! Msg || P <- Cs],
     T0 = erlang:system_time(millisecond),
     Cs = collect_acks(Cs, loop_ack, NumCs),
@@ -1330,13 +1415,14 @@ multiple_channels_t(NumCs, FromPort, Msg, {slogan, Slogan}, Cfg) ->
     Transfers = NumCs*2*100,
     Fmt = "Time (~w*2*100) ~.1f s: ~.1f mspt; ~.1f tps",
     Args = [NumCs, Time/1000, Time/Transfers, (Transfers*1000)/Time],
-    log(Debug, Fmt, Args),
+    ?LOG(Debug, Fmt, Args),
     ct:comment(Fmt, Args),
     [P ! die || P <- Cs],
     ok = stop_miner_helper(MinerHelper),
     ok.
 
-check_incorrect_create(Cfg) ->
+check_incorrect_create(Cfg0) ->
+    Cfg = cfg_responder_keeps_running(Cfg0),
     {I, R, Spec} = channel_spec(Cfg),
     config(Cfg),
     Port = proplists:get_value(port, Cfg, ?PORT),
@@ -1433,7 +1519,7 @@ check_incorrect_update(Cfg) ->
             Debug = get_debug(Cfg),
             #{ i := #{pub := IPub, fsm := FsmI} = I
             , r := #{pub := RPub, fsm := FsmR} = R
-            , spec := Spec} = create_channel_([{port, CurPort}, ?SLOGAN|Cfg1]),
+            , spec := Spec} = CSpec = create_channel_([{port, CurPort}, ?SLOGAN|Cfg1]),
             Data = {I, R, Spec, CurPort, Debug},
             Deposit =
                 fun() ->
@@ -1447,7 +1533,7 @@ check_incorrect_update(Cfg) ->
                     responder -> {FsmR, FsmI}
                 end,
             ok = gen_statem:stop(AliveFsm),
-            receive_dying_declaration(AliveFsm, OtherFsm, Debug),
+            receive_dying_declarations(AliveFsm, OtherFsm, CSpec, Debug),
             bump_idx(),
             CurPort
           end,
@@ -1457,31 +1543,49 @@ check_incorrect_update(Cfg) ->
     lists:foldl(Test, InitialPort, Combinations),
     ok.
 
-receive_dying_declaration(Fsm, OtherFsm, Debug) ->
-    TRef = erlang:send_after(?TIMEOUT, self(), {dying_declaration, ?LINE}),
-    receive_dying_(Fsm, TRef, false, false, Debug),
-    receive
-        {aesc_fsm, OtherFsm, #{ tag := info
-                              , type := report
-                              , info := peer_disconnected }} ->
-            ok
-    after ?TIMEOUT ->
-            error(timeout)
+receive_dying_declarations(Fsm, OtherFsm, CSpec, Debug) ->
+    #{r := #{fsm := FsmR}} = CSpec,
+    TRefI = erlang:start_timer(?TIMEOUT, self(), {dying_declaration_i, ?LINE}),
+    TRefR = erlang:start_timer(?TIMEOUT, self(), {dying_declaration_r, ?LINE}),
+    receive_dying_(Fsm, TRefI, Debug),
+    case {OtherFsm =:= FsmR, responder_stays(CSpec)} of
+        {true, true} ->
+            ?LOG(Debug, "OtherFsm (~p) is responder, and is expected to remain", [OtherFsm]),
+            receive
+                {aesc_fsm, OtherFsm, #{ tag  := info
+                                      , type := report
+                                      , info := peer_disconnected }} ->
+                    erlang:cancel_timer(TRefR),
+                    ok;
+                {timeout, TRefR, Msg} ->
+                    error({timeout, Msg})
+            end;
+        _ ->
+            ?LOG(Debug, "OtherFsm (~p) is expected to die", [OtherFsm]),
+            receive_dying_(OtherFsm, TRefR, Debug)
     end.
+
+receive_dying_(Fsm, TRef, Debug) ->
+    receive_dying_(Fsm, TRef, false, false, Debug).
 
 receive_dying_(_, TRef, true, true, _) ->
     erlang:cancel_timer(TRef),
     ok;
 receive_dying_(Fsm, TRef, Died, Log, Debug) ->
+    ?LOG(Debug, "receive_dying_(~p, ~p, ~p, ~p, _)", [Fsm, TRef, Died, Log]),
     receive
         {aesc_fsm, Fsm, #{info := {died, _}} = Msg} ->
-            log(Debug, "from ~p: ~p", [Fsm, Msg]),
+            ?LOG(Debug, "from ~p: ~p", [Fsm, Msg]),
             receive_dying_(Fsm, TRef, true, Log, Debug);
         {aesc_fsm, Fsm, #{info := {log, _}} = Msg} ->
-            log(Debug, "from ~p: ~p", [Fsm, Msg]),
+            ?LOG(Debug, "from ~p: ~p", [Fsm, Msg]),
             receive_dying_(Fsm, TRef, Died, true, Debug);
-        {timeout, TRef, Msg} ->
-            error({timeout, Msg})
+        {timeout, TRef, TOMsg} ->
+            ?LOG(Debug, "timeout (~p). Q = ~p", [TOMsg, element(2,process_info(self(),messages))]),
+            error({timeout, TOMsg})
+    after ?TIMEOUT + 1000 ->
+            ?LOG(Debug, "OUTER timeout. Q = ~p", [element(2,process_info(self(),messages))]),
+            error(outer_timeout)
     end.
 
 check_incorrect_mutual_close(Cfg) ->
@@ -1501,7 +1605,7 @@ check_incorrect_mutual_close(Cfg) ->
                 {shutdown, [], shutdown,
                  shutdown_ack},
                 fun(#{fsm := FsmPid}, Debug1) ->
-                    log(Debug1, "checking state of ~p (Depositor=~p, Malicious=~p, FsmI = ~p, FsmR = ~p)",
+                    ?LOG(Debug1, "checking state of ~p (Depositor=~p, Malicious=~p, FsmI = ~p, FsmR = ~p)",
                         [FsmPid, Depositor, Malicious, maps:get(fsm,I), maps:get(fsm,R)]),
                         case Depositor =:= Malicious of
                             true ->
@@ -1604,9 +1708,9 @@ check_mutual_close_after_close_solo(Cfg) ->
 check_fsm_crash_reestablish(Cfg) ->
     Debug = get_debug(Cfg),
     {I0, R0, Spec0} = channel_spec(Cfg),
-    #{ i := I, r := R } = create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),
-    ct:log("I = ~p", [I]),
-    ct:log("R = ~p", [R]),
+    #{ i := I, r := R } = CSpec = create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),
+    ?LOG(Debug, "I = ~p", [I]),
+    ?LOG(Debug, "R = ~p", [R]),
     {_, I1, R1} = do_n(4, fun update_volley/3, I, R, Cfg),
     Actions = [
         fun fsm_crash_action_during_transfer/3,
@@ -1615,18 +1719,18 @@ check_fsm_crash_reestablish(Cfg) ->
         fun fsm_crash_action_during_shutdown/3
     ],
     lists:foldl(fun (Action, {IA, RA}) ->
-        {IA1, RA1} = fsm_crash_reestablish(IA, RA, Spec0, Cfg, Action),
+        {IA1, RA1} = fsm_crash_reestablish(IA, RA, Spec0, CSpec, Cfg, Action),
         {_, IA2, RA2} = do_n(4, fun update_volley/3, IA1, RA1, Cfg),
         {IA2, RA2}
     end, {I1, R1}, Actions).
 
-fsm_crash_reestablish(#{channel_id := ChId, fsm := FsmI} = I, #{fsm := FsmR} = R, Spec, Cfg, Action) ->
+fsm_crash_reestablish(#{channel_id := ChId, fsm := FsmI} = I, #{fsm := FsmR} = R, Spec, CSpec, Cfg, Action) ->
     Debug = get_debug(Cfg),
     {ok, State} = rpc(dev1, aesc_fsm, get_offchain_state, [FsmI]),
     {_, SignedTx} = aesc_offchain_state:get_latest_signed_tx(State),
-    ct:log("Performing action before crashing the FSM"),
+    ?LOG(Debug, "Performing action before crashing the FSM"),
     ok = Action(I, R, Cfg),
-    ct:log("Simulating random crash"),
+    ?LOG(Debug, "Simulating random crash"),
     erlang:exit(FsmI, test_fsm_random_crash),
     erlang:exit(FsmR, test_fsm_random_crash),
     timer:sleep(20), %% Give some time for the cache to persist the state
@@ -1635,8 +1739,8 @@ fsm_crash_reestablish(#{channel_id := ChId, fsm := FsmI} = I, #{fsm := FsmR} = R
     [] = in_ram(Cache),
     [_, _] = on_disk(Cache),
     check_info(20),
-    ct:log("reestablishing ...", []),
-    #{i := I1, r := R1} = reestablish(I, R, SignedTx, Spec, ?PORT, Debug),
+    ?LOG(Debug, "reestablishing ...", []),
+    #{i := I1, r := R1} = reestablish(I, R, SignedTx, Spec, CSpec, ?PORT, Debug),
     {I1, R1}.
 
 fsm_crash_action_during_transfer( #{fsm := FsmI, pub := PubI} = I
@@ -1679,11 +1783,11 @@ check_invalid_reestablish_password(Cfg) ->
     Debug = get_debug(Cfg),
     {I0, R0, Spec0} = channel_spec(Cfg),
     #{ i := I
-     , r := R } = create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),
-    ct:log("I = ~p", [I]),
-    ct:log("R = ~p", [R]),
+     , r := R } = CSpec = create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),
+    ?LOG(Debug, "I = ~p", [I]),
+    ?LOG(Debug, "R = ~p", [R]),
     {_, I1, R1} = do_n(4, fun update_volley/3, I, R, Cfg),
-    {ok, SignedTx} = leave_channel(I1, R1, Debug),
+    {ok, SignedTx} = leave_channel(I1, R1, CSpec, Debug),
 
     %% Reestablish with wrong passwords
     #{state_password := PwI} = I1,
@@ -1693,26 +1797,28 @@ check_invalid_reestablish_password(Cfg) ->
                               , SignedTx, Spec0, Debug),
 
     %% Check that after an invalid password has been provided we can still reestablish the channel
-    _ = reestablish(I1, R1, SignedTx, Spec0, ?PORT, Debug),
+    _ = reestablish(I1, R1, SignedTx, Spec0, CSpec, ?PORT, Debug),
     ok.
 
 check_password_is_changeable(Cfg) ->
-    Debug = get_debug(Cfg),
+    %% Debug = get_debug(Cfg),
+    Debug = true,
     {I0, R0, Spec0} = channel_spec(Cfg),
     #{ i := I
-     , r := R } = create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),
-    ct:log("I = ~p", [I]),
-    ct:log("R = ~p", [R]),
+     , r := R } = CSpec = create_channel_from_spec(I0, R0, Spec0, ?PORT, Debug, Cfg),
+    ?LOG(Debug, "I = ~p", [I]),
+    ?LOG(Debug, "R = ~p", [R]),
     {_, I1, R1} = do_n(4, fun update_volley/3, I, R, Cfg),
-
+    ?PEEK_MSGQ,
     I2 = change_password(I1),
     R2 = change_password(R1),
-    {ok, SignedTx} = leave_channel(I2, R2, Debug),
-
+    {ok, SignedTx} = leave_channel(I2, R2, CSpec, Debug),
+    ?PEEK_MSGQ,
     %% Reestablish with old password should fail
     reestablish_wrong_password(I1, R1, SignedTx, Spec0, Debug),
+    ?PEEK_MSGQ,
     %% Reestablish with new password should succeed
-    _ = reestablish(I2, R2, SignedTx, Spec0, ?PORT, Debug),
+    _ = reestablish(I2, R2, SignedTx, Spec0, CSpec, ?PORT, Debug),
 
     ok.
 
@@ -1721,19 +1827,18 @@ change_password(#{fsm := Fsm, state_password := StatePassword} = P) ->
     ok = rpc(dev1, aesc_fsm, change_state_password, [Fsm, StatePassword1]),
     P#{state_password => StatePassword1}.
 
-leave_channel(#{fsm := FsmI} = I, R, Debug) ->
+leave_channel(#{fsm := FsmI} = I, #{fsm := FsmR} = R, CSpec, Debug) ->
     ok = rpc(dev1, aesc_fsm, leave, [FsmI]),
     {ok,Li} = await_leave(I, ?TIMEOUT, Debug),
     {ok,Lr} = await_leave(R, ?TIMEOUT, Debug),
     SignedTx = maps:get(info, Li),
     SignedTx = maps:get(info, Lr),
-    {ok,_} = receive_from_fsm(info, I, fun died_normal/1, ?TIMEOUT, Debug),
-    {ok,_} = receive_from_fsm(info, R, fun died_normal/1, ?TIMEOUT, Debug),
+    ok = receive_dying_declarations(FsmI, FsmR, CSpec, Debug),
     {ok, SignedTx}.
 
 fsm_state(Pid, Debug) ->
     {State, _Data} = rpc(dev1, sys, get_state, [Pid, 1000], _RpcDebug = false),
-    log(Debug, "fsm_state(~p) -> ~p", [Pid, State]),
+    ?LOG(Debug, "fsm_state(~p) -> ~p", [Pid, State]),
     State.
 
 wrong_sig_action(ChannelStuff, Poster, Malicious,
@@ -1807,7 +1912,7 @@ wrong_create_({I, R, #{initiator_amount := IAmt0, responder_amount := RAmt0,
         fun(Tag, #{priv := Priv} = Signer, Debug1) ->
             receive {aesc_fsm, Fsm, #{type := sign, tag := Tag,
                                       info := #{signed_tx := SignedTx0, updates := Updates}} = Msg} ->
-                    log(Debug1, "await_signing(~p, ~p) <- ~p", [Tag, Fsm, Msg]),
+                    ?LOG(Debug1, "await_signing(~p, ~p) <- ~p", [Tag, Fsm, Msg]),
                     SignedTx = SignTxFun(SignedTx0, Priv),
                     Action(Tag, Signer, SignedTx, Updates)
             after ?TIMEOUT ->
@@ -1819,7 +1924,7 @@ wrong_create_({I, R, #{initiator_amount := IAmt0, responder_amount := RAmt0,
     {ok, FsmR} = rpc(dev1, aesc_fsm, respond, [Port, move_password_to_spec(R, Spec)], Debug),
     {ok, FsmI} = rpc(dev1, aesc_fsm, initiate, ["localhost", Port, move_password_to_spec(I, Spec)], Debug),
 
-    log(Debug, "FSMs, I = ~p, R = ~p", [FsmI, FsmR]),
+    ?LOG(Debug, "FSMs, I = ~p, R = ~p", [FsmI, FsmR]),
 
     I1 = I#{fsm => FsmI, initiator_amount => IAmt, responder_amount => RAmt},
     R1 = R#{fsm => FsmR, initiator_amount => IAmt, responder_amount => RAmt},
@@ -1843,9 +1948,8 @@ wrong_create_({I, R, #{initiator_amount := IAmt0, responder_amount := RAmt0,
             {ok,_} = receive_from_fsm(info, R1, ErrResponse, ?TIMEOUT, Debug),
             {ok,_} = receive_from_fsm(info, R1, fun(#{info := {died, normal}}) -> ok end,
                                       ?TIMEOUT, Debug),
-            {ok,_} = receive_from_fsm(info, I1, fun(#{info := peer_disconnected}) -> ok end,
-                                      ?TIMEOUT, Debug),
-            {ok,_} = receive_from_fsm(info, I1, fun died_subverted/1, ?TIMEOUT, Debug);
+            {ok,_} = receive_from_fsm(info, I1, fun(#{info := {died, disconnect}}) -> ok end,
+                                      ?TIMEOUT, Debug);
         responder ->
             {_I2, _} = await_signing_request(create_tx, I1, Debug, Cfg),
             receive_from_fsm(info, R1, funding_created, ?TIMEOUT, Debug),
@@ -1866,9 +1970,8 @@ wrong_create_({I, R, #{initiator_amount := IAmt0, responder_amount := RAmt0,
             {ok,_} = receive_from_fsm(info, I1, bad_signature, ?TIMEOUT, Debug),
             {ok,_} = receive_from_fsm(info, I1, fun(#{info := {died, normal}}) -> ok end,
                                       ?TIMEOUT, Debug),
-            {ok,_} = receive_from_fsm(info, R1, fun(#{info := peer_disconnected}) -> ok end,
-                                      ?TIMEOUT, Debug),
-            {ok,_} = receive_from_fsm(info, R1, fun died_subverted/1, ?TIMEOUT, Debug)
+            {ok,_} = receive_from_fsm(info, R1, fun(#{info := {died, disconnect}}) -> ok end,
+                                      ?TIMEOUT, Debug)
     end,
     ok.
 
@@ -1884,10 +1987,10 @@ wrong_action_modified_tx({I, R, _Spec, _Port, Debug}, Poster, Malicious,
                       receive {aesc_fsm, Fsm, #{type := sign, tag := Tag,
                                                 info := #{signed_tx := SignedTx0,
                                                           updates := Updates}} = Msg} ->
-                              log(Debug1, "await_signing(~p, ~p) <- ~p", [Tag, Fsm, Msg]),
+                              ?LOG(Debug1, "await_signing(~p, ~p) <- ~p", [Tag, Fsm, Msg]),
                               Tx0 = aetx_sign:innermost_tx(SignedTx0),
                               Tx = ModifyTxFun(Tx0, Fsm),
-                              log(Debug1, "modified ~p", [Tx]),
+                              ?LOG(Debug1, "modified ~p", [Tx]),
                               %% Note: this invalidates the authentication method of
                               %% the initial signer
                               SignedTx1 = aetx_sign:set_tx(SignedTx0, Tx),
@@ -1903,7 +2006,7 @@ wrong_action({I, R, _Spec, _Port, Debug}, Poster, Malicious,
               {FsmFun, FsmFunArg, FsmNewAction, FsmCreatedAction},
                DetectConflictFun, MaliciousSign, ErrMsg) ->
     Cfg = config(),
-    log(Debug, "Testing with Poster ~p, Malicious ~p",
+    ?LOG(Debug, "Testing with Poster ~p, Malicious ~p",
           [Poster, Malicious]),
     #{fsm := FsmI} = I,
     #{fsm := FsmR} = R,
@@ -1956,7 +2059,7 @@ wait_for_fsm_state(St, FsmPid, Retries, Debug) when Retries > 0 ->
         badrpc ->
             error(fsm_not_running);
         Other ->
-            log(Debug, "Fsm state (~p) is ~p - retrying for ~p", [FsmPid, Other, St]),
+            ?LOG(Debug, "Fsm state (~p) is ~p - retrying for ~p", [FsmPid, Other, St]),
             timer:sleep(50),
             wait_for_fsm_state(St, FsmPid, Retries-1, Debug)
     end.
@@ -1999,7 +2102,7 @@ settle_(TTL, MinDepth, #{fsm := FsmI, channel_id := ChannelId} = I, R, Debug,
        Cfg) ->
     ok = rpc(dev1, aesc_fsm, settle, [FsmI]),
     {_, SignedTx} = await_signing_request(settle_tx, I, Cfg),
-    log(Debug, "settle_tx signed", []),
+    ?LOG(Debug, "settle_tx signed", []),
     {ok, MinedKeyBlocks} = mine_blocks_until_txs_on_chain(
                              dev1,
                              [aeser_api_encoder:encode(tx_hash, aetx_sign:hash(SignedTx))]),
@@ -2013,11 +2116,11 @@ settle_(TTL, MinDepth, #{fsm := FsmI, channel_id := ChannelId} = I, R, Debug,
                 MinDepth + KeyBlocksMissingForTTL
         end,
     SignedTx = await_on_chain_report(I, #{info => channel_closed}, ?TIMEOUT), % same tx
-    log(Debug, "I received On-chain report: ~p", [SignedTx]),
+    ?LOG(Debug, "I received On-chain report: ~p", [SignedTx]),
     SignedTx = await_on_chain_report(R, #{info => channel_closed}, ?TIMEOUT), % same tx
-    log(Debug, "R received On-chain report: ~p", [SignedTx]),
+    ?LOG(Debug, "R received On-chain report: ~p", [SignedTx]),
     verify_settle_tx(SignedTx, ChannelId),
-    log(Debug, "settle_tx verified", []),
+    ?LOG(Debug, "settle_tx verified", []),
     if
         KeyBlocksMissingForMinDepth > 0 ->
             mine_key_blocks(dev1, KeyBlocksMissingForMinDepth);
@@ -2026,10 +2129,10 @@ settle_(TTL, MinDepth, #{fsm := FsmI, channel_id := ChannelId} = I, R, Debug,
     end,
     {ok, _} = receive_from_fsm(info, I, closed_confirmed, ?TIMEOUT, Debug),
     {ok, _} = receive_from_fsm(info, R, closed_confirmed, ?TIMEOUT, Debug),
-    log(Debug, "closed_confirmed received from both", []),
+    ?LOG(Debug, "closed_confirmed received from both", []),
     {ok,_} = receive_from_fsm(info, I, fun died_normal/1, ?TIMEOUT, Debug),
     {ok,_} = receive_from_fsm(info, R, fun died_normal/1, ?TIMEOUT, Debug),
-    log(Debug, "died_normal detected from both", []),
+    ?LOG(Debug, "died_normal detected from both", []),
     ok.
 
 client_reconnect_initiator(Cfg) ->
@@ -2048,15 +2151,15 @@ client_reconnect_(Role, Cfg) ->
                  responder -> r
              end,
     #{ fsm := Fsm, proxy := Proxy } = RoleI = maps:get(MapKey, Ch),
-    log(Debug, "Ch = ~p", [Ch]),
+    ?LOG(Debug, "Ch = ~p", [Ch]),
     {error, _} = Err = try_reconnect(Fsm, Role, RoleI, Debug),
-    log(Debug, "Reconnecting before disconnecting failed: ~p", [Err]),
+    ?LOG(Debug, "Reconnecting before disconnecting failed: ~p", [Err]),
     unlink(Proxy),
     exit(Proxy, kill),
     timer:sleep(50),  % give the above exit time to propagate
     ok = things_that_should_fail_if_no_client(Role, I, R, Debug, Cfg),
     Res = reconnect(Fsm, Role, RoleI, Debug),
-    log(Debug, "Reconnect req -> ~p", [Res]),
+    ?LOG(Debug, "Reconnect req -> ~p", [Res]),
     %% run tests here
     shutdown_(I, R, Cfg).
 
@@ -2092,7 +2195,7 @@ reconnect(Fsm, Role, #{} = R, Debug) ->
     NewProxy = spawn(fun() ->
                              erlang:monitor(process, Me),
                              ok = try_reconnect(Fsm, Role, R, Debug),
-                             log(Debug, "Reconnect successful; Fsm = ~p", [Fsm]),
+                             ?LOG(Debug, "Reconnect successful; Fsm = ~p", [Fsm]),
                              Me ! {self(), reconnected},
                              fsm_relay(R, Me, Debug)
                      end),
@@ -2116,7 +2219,7 @@ try_reconnect(Fsm, Round, Role, #{ channel_id := ChId
                                              , round      => Round
                                              , role       => Role
                                              , pub_key    => PubId }),
-    log(Debug, "Reconnect Tx = ~p", [Tx]),
+    ?LOG(Debug, "Reconnect Tx = ~p", [Tx]),
     SignedTx = aec_test_utils:sign_tx(Tx, Priv),
     rpc(dev1, aesc_fsm, reconnect_client, [Fsm, self(), SignedTx]).
 
@@ -2145,11 +2248,11 @@ on_disk(St) ->  proplists:get_value(on_disk, St).
 
 
 collect_acks([Pid | Pids], Tag, N) ->
-    log("collect_acks, Tag = ~p, N = ~p", [Tag, N]),
+    ?LOG("collect_acks, Tag = ~p, N = ~p", [Tag, N]),
     Timeout = 60000 + (N div 10)*5000,  % wild guess
     receive
         {Pid, Tag} ->
-            log("Ack from ~p (~p)", [Pid, Tag]),
+            ?LOG("Ack from ~p (~p)", [Pid, Tag]),
             [Pid | collect_acks(Pids, Tag, N)]
     after Timeout ->
             error(timeout)
@@ -2189,14 +2292,14 @@ ch_loop(I, R, Parent, Cfg) ->
             Parent ! {self(), loop_ack},
             ch_loop(I1, R1, Parent, Cfg);
         die ->
-            log("~p got die request", [self()]),
+            ?LOG("~p got die request", [self()]),
             #{ proxy := ProxyI } = I,
             #{ proxy := ProxyR } = R,
             ProxyI ! {self(), die},
             ProxyR ! {self(), die},
             exit(normal);
         Other ->
-            log(get_debug(Cfg), "Got Other = ~p, I = ~p~nR = ~p", [Other, I, R]),
+            ?LOG(get_debug(Cfg), "Got Other = ~p, I = ~p~nR = ~p", [Other, I, R]),
             ch_loop(I, R, Parent, Cfg)
     end.
 
@@ -2216,7 +2319,7 @@ create_channel_(Cfg, Debug) ->
 
 create_channel_(Cfg, XOpts, Debug) ->
     {I, R, Spec} = channel_spec(Cfg, XOpts),
-    log(Debug, "channel_spec: ~p", [{I, R, Spec}]),
+    ?LOG(Debug, "channel_spec: ~p", [{I, R, Spec}]),
     Port = proplists:get_value(port, Cfg, 9325),
     create_channel_from_spec(I, R, Spec, Port, proplists:get_bool(use_any, Cfg),
                              Debug, Cfg).
@@ -2271,14 +2374,15 @@ channel_spec(Cfg, ChannelReserve, PushAmount, XOpts) ->
     {I1, R1, Spec1}.
 
 prime_password(#{} = P, Key, Cfg) when Key =:= initiator_password; Key =:= responder_password ->
+    Debug = get_debug(Cfg),
     case ?config(Key, Cfg) of
         undefined ->
             P#{state_password => generate_password()};
         ignore ->
-            ct:log("Ignoring password"),
+            ?LOG(Debug, "Ignoring password"),
             maps:remove(state_password, P);
         Password ->
-            ct:log("Using predefined password"),
+            ?LOG(Debug, "Using predefined password"),
             P#{state_password => Password}
      end.
 
@@ -2302,32 +2406,37 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
     %% TODO: Somehow there is a CI only race condition which rarely occurs in
     %% round_too_high.check_incorrect_* and round_too_low.check_incorrect_* tests
     %% For now just wrap this operation in a retry loop and come back to it later
+    ?LOG("=== Create channel~n"
+         "Spec = ~p"
+         "Msg Q: ~p", [Spec, element(2, process_info(self(), messages))]),
+    RSpec = customize_spec(responder, Spec, Cfg),
+    ISpec = customize_spec(initiator, Spec, Cfg),
     {FsmI, FsmR, I1, R1} = retry(?CHANNEL_CREATION_RETRIES, 100,
         fun() ->
-            RProxy = spawn_responder(Port, Spec, R, UseAny, Debug),
-            IProxy = spawn_initiator(Port, Spec, I, Debug),
-            log("RProxy = ~p, IProxy = ~p", [RProxy, IProxy]),
+            RProxy = spawn_responder(Port, RSpec, R, UseAny, Debug),
+            IProxy = spawn_initiator(Port, ISpec, I, Debug),
+            ?LOG("RProxy = ~p, IProxy = ~p", [RProxy, IProxy]),
             #{ i := #{ fsm := WFsmI } = WI1
              , r := #{ fsm := WFsmR } = WR1 } = Info
                 = match_responder_and_initiator(RProxy, Debug),
-            log(Debug, "channel paired: ~p", [Info]),
+            ?LOG(Debug, "channel paired: ~p", [Info]),
             {WFsmI, WFsmR, WI1, WR1}
         end),
 
-    log(Debug, "FSMs, I = ~p, R = ~p", [FsmI, FsmR]),
+    ?LOG(Debug, "FSMs, I = ~p, R = ~p", [FsmI, FsmR]),
 
     {I2, R2} = try await_create_tx_i(I1, R1, Debug, Cfg)
                ?_catch_(error, Err, ST)
-                   log("Caught Err = ~p~nMessages = ~p",
+                   ?LOG("Caught Err = ~p~nMessages = ~p",
                        [Err, element(2, process_info(self(), messages))]),
                    error(Err, ST)
                end,
-    log(Debug, "mining blocks on dev1 for minimum depth", []),
+    ?LOG(Debug, "mining blocks on dev1 for minimum depth", []),
     SignedTx = await_on_chain_report(I2, ?TIMEOUT),
-    log(Debug, "=== SignedTx = ~p", [SignedTx]),
+    ?LOG(Debug, "=== SignedTx = ~p", [SignedTx]),
     SignedTx = await_on_chain_report(R2, ?TIMEOUT), % same tx
     ok = wait_for_signed_transaction_in_block(dev1, SignedTx, Debug),
-    log(Debug, "=== Signed tx in block: ~p", [SignedTx]),
+    ?LOG(Debug, "=== Signed tx in block: ~p", [SignedTx]),
     SignedTx = await_channel_changed_report(I2, ?TIMEOUT),
     SignedTx = await_channel_changed_report(R2, ?TIMEOUT),
     CurrentHeight = current_height(dev1),
@@ -2339,7 +2448,7 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
     %% height is reached
     aecore_suite_utils:wait_for_height(aecore_suite_utils:node_name(dev1),
                                        CurrentHeight + ?MINIMUM_DEPTH),
-    log(Debug, "=== Min-depth height achieved", []),
+    ?LOG(Debug, "=== Min-depth height achieved", []),
     %% we've seen 10-15 second block times in CI, so wait a while longer
 
     await_own_funding_locked(I2, ?TIMEOUT, Debug),
@@ -2351,22 +2460,34 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
 
     I3 = await_funding_locked(I2, ?TIMEOUT, Debug),
     R3 = await_funding_locked(R2, ?TIMEOUT, Debug),
-    log(Debug, "=== Funding locked ===", []),
+    ?LOG(Debug, "=== Funding locked ===", []),
     %%
     I4 = await_update_report(I3, ?TIMEOUT, Debug),
     R4 = await_update_report(R3, ?TIMEOUT, Debug),
-    log(Debug, "=== Update reports received ===", []),
+    ?LOG(Debug, "=== Update reports received ===", []),
     I5 = await_open_report(I4, ?TIMEOUT, Debug),
     R5 = await_open_report(R4, ?TIMEOUT, Debug),
-    log(Debug, "=== Open reports received ===", []),
-    log(Debug, "=== Message Q: ~p", [element(2,process_info(self(), messages))]),
+    ?LOG(Debug, "=== Open reports received ===", []),
+    ?PEEK_MSGQ,
     [] = check_info(0, Debug),
-    #{i => I5, r => R5, spec => Spec}.
+    trace_checkpoint(?TR_CHANNEL_CREATED, Cfg),
+    maps:merge(#{i => I5, r => R5, spec => Spec},
+               maps:from_list([{K,V} || {K,V} <- Cfg,
+                                        lists:member(K, [initiator_opts,
+                                                         responder_opts])])).
+
+customize_spec(Role, Spec, Cfg) ->
+    maps:merge(Spec, custom_spec_opts(Role, Cfg)).
+
+custom_spec_opts(responder, Cfg) ->
+    proplists:get_value(responder_opts, Cfg, #{});
+custom_spec_opts(initiator, Cfg) ->
+    proplists:get_value(initiator_opts, Cfg, #{}).
 
 spawn_responder(Port, Spec, R, UseAny, Debug) ->
     Me = self(),
-    spawn(fun() ->
-                       log("responder spawned: ~p", [Spec]),
+    spawn_link(fun() ->
+                       ?LOG("responder spawned: ~p", [Spec]),
                        Spec1 = maybe_use_any(UseAny, Spec#{ client => self() }),
                        Spec2 = move_password_to_spec(R, Spec1),
                        {ok, Fsm} = rpc(dev1, aesc_fsm, respond, [Port, Spec2], Debug),
@@ -2381,7 +2502,7 @@ maybe_use_any(false, Spec) ->
 spawn_initiator(Port, Spec, I, Debug) ->
     Me = self(),
     spawn(fun() ->
-                       log("initiator spawned: ~p", [Spec]),
+                       ?LOG(Debug, "initiator spawned: ~p", [Spec]),
                        Spec1 = Spec#{ client => self() },
                        Spec2 = move_password_to_spec(I, Spec1),
                        {ok, Fsm} = rpc(dev1, aesc_fsm, initiate,
@@ -2397,17 +2518,17 @@ move_password_to_spec(_, Spec) ->
 match_responder_and_initiator(RProxy, Debug) ->
     receive
         {channel_up, RProxy, Info} ->
-            log(Debug, "Matched initiator/responder pair: ~p", [Info]),
+            ?LOG(Debug, "Matched initiator/responder pair: ~p", [Info]),
             Info
     after ?TIMEOUT ->
-            log(Debug, "Timed out waiting for matched pair", []),
+            ?LOG(Debug, "Timed out waiting for matched pair", []),
             error(timeout)
     end.
 
 responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
     R = fsm_map(Fsm, Spec, R0),
     {ok, ChOpen} = receive_from_fsm(info, R, channel_open, ?TIMEOUT, Debug),
-    log(Debug, "Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
+    ?LOG(Debug, "Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
     #{data := #{temporary_channel_id := TmpChanId}} = ChOpen,
     R1 = R#{ proxy => self(), parent => Parent },
     gproc:reg({n,l,{?MODULE,TmpChanId,responder}}, #{ r => R1 }),
@@ -2423,7 +2544,7 @@ responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
 initiator_instance_(Fsm, Spec, I0, Parent, Debug) ->
     I = fsm_map(Fsm, Spec, I0),
     {ok, ChAccept} = receive_from_fsm(info, I, channel_accept, ?TIMEOUT, Debug),
-    log(Debug, "Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
+    ?LOG(Debug, "Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
     #{data := #{temporary_channel_id := TmpChanId}} = ChAccept,
     I1 = I#{ proxy => self() },
     gproc:reg({n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I1
@@ -2446,7 +2567,7 @@ set_proxy_debug(Bool, #{proxy := P}) when is_boolean(Bool) ->
 -record(relay_st, {parent, debug}).
 
 fsm_relay(Map, Parent, Debug) ->
-    log(Debug, "fsm_relay(~p, ~p, Debug)", [Map, Parent]),
+    ?LOG(Debug, "fsm_relay(~p, ~p, Debug)", [Map, Parent]),
     fsm_relay_(Map, #relay_st{ parent = Parent
                              , debug  = Debug }).
 
@@ -2454,20 +2575,20 @@ fsm_relay_(#{ fsm := Fsm } = Map, #relay_st{ parent = Parent
                                            , debug  = Debug } = St) ->
     St1 = receive
               {aesc_fsm, Fsm, _} = Msg ->
-                  log(Debug, "Relaying(~p) ~p", [Parent, Msg]),
+                  ?LOG(Debug, "Relaying(~p) ~p", [Parent, Msg]),
                   Parent ! Msg,
                   St;
               {Parent, debug, NewDebug} when is_boolean(NewDebug) ->
-                  log(NewDebug, "Applying new debug mode: ~p", [NewDebug]),
+                  ?LOG(NewDebug, "Applying new debug mode: ~p", [NewDebug]),
                   Parent ! {self(), debug_ack, Debug},
                   St#relay_st{ debug = NewDebug };
               {Parent, die} ->
-                  log(Debug, "Got 'die' from parent", []),
+                  ?LOG(Debug, "Got 'die' from parent", []),
                   aesc_fsm:stop(Fsm),
-                  log(Debug, "relay stopping (die)", []),
+                  ?LOG(Debug, "relay stopping (die)", []),
                   exit(normal);
               Other ->
-                  log(Debug, "Relay got Other: ~p", [Other]),
+                  ?LOG(Debug, "Relay got Other: ~p", [Other]),
                   St
           end,
     fsm_relay_(Map, St1).
@@ -2481,19 +2602,41 @@ fsm_map(Fsm, #{ initiator_amount := IAmt
         , initiator_amount => IAmt - PushAmt
         , responder_amount => RAmt + PushAmt }.
 
-reestablish( #{channel_id := ChId, initiator_amount := IAmt, responder_amount := RAmt} = I
-           , #{channel_id := ChId, initiator_amount := IAmt, responder_amount := RAmt} = R
-           , SignedTx, Spec0, Port, Debug) ->
-    Spec = Spec0#{existing_channel_id => ChId, offchain_tx => SignedTx,
-                  initiator_amount => IAmt, responder_amount => RAmt},
-    {ok, FsmR} = rpc(dev1, aesc_fsm, respond,
-                     [Port, move_password_to_spec(R, Spec)]),
+reestablish(I0, R0, SignedTx, Spec0, CSpec, Port, Debug) ->
+    ChId = maps:get(channel_id, I0),
+    ChId = maps:get(channel_id, R0),   % assertion
+    ResponderStays = responder_stays(CSpec),
+    #{initiator_amount := IAmt, responder_amount := RAmt} = Spec0,
+    I = set_amounts(IAmt, RAmt, I0),
+    R = set_amounts(IAmt, RAmt, R0),
+    Spec = Spec0#{existing_channel_id => ChId, offchain_tx => SignedTx},
+    ?LOG(Debug, "Reestablish Spec = ~p", [Spec]),
+    FsmR = if ResponderStays ->
+                   ?LOG(Debug, "Not trying to reestablish responder", []),
+                   maps:get(fsm, R);
+              true ->
+                   {ok, NewFsmR} = rpc(dev1, aesc_fsm, respond,
+                                       [Port, move_password_to_spec(R, Spec)]),
+                   NewFsmR
+           end,
     {ok, FsmI} = rpc(dev1, aesc_fsm, initiate,
                      ["localhost", Port, move_password_to_spec(I, Spec)], Debug),
+    ?PEEK_MSGQ,
     I1 = await_open_report(I#{fsm => FsmI}, ?TIMEOUT, Debug),
     R1 = await_open_report(R#{fsm => FsmR}, ?TIMEOUT, Debug),
-    check_info(20),
-    #{i => I1, r => R1, spec => Spec}.
+    ?PEEK_MSGQ,
+    receive_from_fsm(info, I1, channel_reestablished, ?TIMEOUT, Debug),
+    receive_from_fsm(info, R1, channel_reestablished, ?TIMEOUT, Debug),
+    ?PEEK_MSGQ,
+    {I2, R2} = if ResponderStays ->
+                       {await_update_report(I1, ?TIMEOUT, Debug), R1};
+                  true ->
+                       {await_update_report(I1, ?TIMEOUT, Debug),
+                        await_update_report(R1, ?TIMEOUT, Debug)}
+               end,
+    ?LOG(Debug, "Reestablish succeeded", []),
+    [] = element(2, process_info(self(), messages)),
+    #{i => I2, r => R2, spec => Spec}.
 
 reestablish_wrong_password( #{channel_id := ChId, initiator_amount := IAmt, responder_amount := RAmt} = I
                           , #{channel_id := ChId, initiator_amount := IAmt, responder_amount := RAmt} = R
@@ -2509,6 +2652,9 @@ update_tx(Tx0, F, Args) ->
     {Mod, TxI} = aetx:specialize_callback(Tx0),
     TxI1 = apply(Mod, F, [TxI|Args]),
     aetx:new(Mod, TxI1).
+
+set_amounts(IAmt, RAmt, Map) ->
+    Map#{initiator_amount => IAmt, responder_amount => RAmt}.
 
 verify_close_mutual_tx(SignedTx, ChannelId) ->
     {aesc_close_mutual_tx, Tx} =
@@ -2550,14 +2696,14 @@ await_locked_rpt(Type, #{role := Role} = R, Timeout, Debug) when Type==funding_l
                                                                  Type==deposit_locked;
                                                                  Type==withdraw_locked ->
     {ok, Msg} = receive_from_fsm(info, R, Type, Timeout, Debug),
-    log(Debug, "~p got ~p: ~p", [Role, Type, Msg]),
+    ?LOG(Debug, "~p got ~p: ~p", [Role, Type, Msg]),
     R#{channel_id => maps:get(channel_id, Msg)}.
 
 await_update_report(#{channel_id := ChId} = R, Timeout, Debug) ->
     {ok, Msg} = receive_from_fsm(
                   update, R,
                   fun(#{ channel_id := ChId1
-                         , info := SignedTx }) ->
+                       , info       := SignedTx }) ->
                           true =
                               ChId1 == ChId
                               andalso
@@ -2593,12 +2739,12 @@ await_signing_request(Tag, Signer, Action, Timeout, Debug, Cfg, SignatureType) -
 
 await_signing_request(Tag, #{fsm := Fsm, pub := Pub} = Signer, OtherSigs,
                       Action, Timeout, Debug, Cfg, SignatureType) ->
-    log(Debug, "await_signing_request, Fsm = ~p (Pub = ~p, Other = ~p)",
+    ?LOG(Debug, "await_signing_request, Fsm = ~p (Pub = ~p, Other = ~p)",
         [Fsm, Pub, [P || #{pub := P} <- OtherSigs]]),
     receive {aesc_fsm, Fsm, #{type := sign, tag := Tag,
                               info := #{signed_tx := SignedTx0,
                                         updates   := Updates}} = Msg} ->
-            log(Debug, "await_signing(~p, ~p, ~p, ~p) <- ~p",
+            ?LOG(Debug, "await_signing(~p, ~p, ~p, ~p) <- ~p",
                 [Tag, Pub, [P || #{pub := P} <- OtherSigs], Fsm, Msg]),
             {[Signer1|_], SignedTx} =
                 lists:mapfoldl(
@@ -2612,19 +2758,19 @@ await_signing_request(Tag, #{fsm := Fsm, pub := Pub} = Signer, OtherSigs,
                               end,
                           {S1, STx1}
                   end, SignedTx0, [Signer|OtherSigs]),
-            log(Debug,"SIGNED TX ~p", [SignedTx]),
+            ?LOG(Debug,"SIGNED TX ~p", [SignedTx]),
             Action(Tag, Signer1, SignedTx, Updates)
     after Timeout ->
             error(timeout)
     end.
 
 abort_signing_request(Tag, #{fsm := Fsm}, Code, Timeout, Debug) ->
-    log(Debug, "waiting to abort signing req, Fsm = ~p, (Code = ~p)",
+    ?LOG(Debug, "waiting to abort signing req, Fsm = ~p, (Code = ~p)",
         [Fsm, Code]),
     receive {aesc_fsm, Fsm, #{type := sign, tag := Tag,
                               info := #{signed_tx := SignedTx,
                                         updates   := _}} = Msg} ->
-            log(Debug, "abort_signing(~p, ~p, ~p) <- ~p", [Tag, Code, Fsm, Msg]),
+            ?LOG(Debug, "abort_signing(~p, ~p, ~p) <- ~p", [Tag, Code, Fsm, Msg]),
             aesc_fsm:signing_response(Fsm, Tag, {error, Code}),
             {ok, SignedTx}
     after Timeout ->
@@ -2655,15 +2801,15 @@ await_on_chain_report(R, Timeout) ->
     await_on_chain_report(R, #{}, Timeout).
 
 await_on_chain_report(#{fsm := Fsm}, Match, Timeout) ->
-    log("~p awaiting on-chain from ~p", [self(), Fsm]),
+    ?LOG("~p awaiting on-chain from ~p", [self(), Fsm]),
     receive
         {aesc_fsm, Fsm, #{info := {died, _}}} = Died ->
-            log("Fsm died while waiting for on-chain report:~n"
+            ?LOG("Fsm died while waiting for on-chain report:~n"
                    "~p", [Died]),
             error(fsm_died);
         {aesc_fsm, Fsm, #{type := report, tag := on_chain_tx,
                           info := #{tx := SignedTx} = I}} = M ->
-            log("OnChainRpt = ~p", [M]),
+            ?LOG("OnChainRpt = ~p", [M]),
             ok = match_info(I, Match),
             SignedTx
     after Timeout ->
@@ -2695,7 +2841,7 @@ await_own_locked_rpt(Type, #{role := Role, fsm := Fsm}, Timeout, Debug)
         {aesc_fsm, Fsm, #{ type := report
                          , tag  := info
                          , info := Type } = Msg} ->
-            log(Debug, "~p got ~p: ~p", [Role, Type, Msg]),
+            ?LOG(Debug, "~p got ~p: ~p", [Role, Type, Msg]),
             ok
     after Timeout ->
             error(timeout)
@@ -2749,11 +2895,11 @@ receive_from_fsm(Tag, R, Info, Timeout, Debug) ->
 
 receive_from_fsm(Tag, #{role := Role, fsm := Fsm} = R, Info, Timeout, Debug, _Cont)
   when is_atom(Info) ->
-    log(Debug, "receive_from_fsm_(~p, ~p, ~p, ~p, ~p, _Cont)",
+    ?LOG(Debug, "receive_from_fsm_(~p, ~p, ~p, ~p, ~p, _Cont)",
         [Tag, R, Info, Timeout, Debug]),
     receive
         {aesc_fsm, Fsm, #{type := _Type, tag := Tag, info := Info} = Msg} ->
-            log(Debug, "~p: received ~p:~p", [Role, Tag, Msg]),
+            ?LOG(Debug, "~p: received ~p:~p", [Role, Tag, Msg]),
             {ok, Msg}
     after Timeout ->
             flush(),
@@ -2764,15 +2910,15 @@ receive_from_fsm(Tag, R, Msg, Timeout, Debug, Cont) ->
     receive_from_fsm_(Tag, R, Msg, TRef, Debug, Cont).
 
 receive_from_fsm_(Tag, #{role := Role, fsm := Fsm} = R, Msg, TRef, Debug, Cont) ->
-    log(Debug, "receive_from_fsm_(~p, ~p, ~p, ~p, ~p, ~p)",
+    ?LOG(Debug, "receive_from_fsm_(~p, ~p, ~p, ~p, ~p, ~p)",
         [Tag, R, Msg, TRef, Debug, Cont]),
     receive
         {aesc_fsm, Fsm, #{type := Type, tag := Tag} = Msg1} ->
-            log(Debug, "~p: received ~p:~p/~p", [Role, Type, Tag, Msg1]),
+            ?LOG(Debug, "~p: received ~p:~p/~p", [Role, Type, Tag, Msg1]),
             try match_msgs(Msg, Msg1, Cont)
             catch
                 throw:continue ->
-                    log(Debug, "Failed match: ~p", [Msg1]),
+                    ?LOG(Debug, "Failed match: ~p", [Msg1]),
                     receive_from_fsm_(Tag, R, Msg, TRef, Debug, Cont)
             after
                 erlang:cancel_timer(TRef)
@@ -2780,11 +2926,14 @@ receive_from_fsm_(Tag, #{role := Role, fsm := Fsm} = R, Msg, TRef, Debug, Cont) 
         {timeout, TRef, receive_from_fsm} ->
             flush(),
             error(timeout)
+    after ?TIMEOUT ->
+            ?LOG(Debug, "Outer timeout. Q = ~p", [element(2,process_info(self(), messages))]),
+            error(outer_timeout)
     end.
 
 flush() ->
     receive M ->
-            log("<== ~p", [M]),
+            ?LOG("<== ~p", [M]),
             flush()
     after 0 ->
             ok
@@ -2799,8 +2948,8 @@ match_msgs(F, Msg, Cont) when is_function(F, 1) ->
                true ->
                     {module, Mod} = erlang:fun_info(F, module),
                     {name, Name} = erlang:fun_info(F, name),
-                    log("Message doesn't match fun: ~p / ~w:~w/1",
-                        [Msg, Mod, Name]),
+                    ?LOG("Message doesn't match fun: ~p / ~w:~w/1",
+                           [Msg, Mod, Name]),
                     error({message_mismatch, [Msg]})
             end
     end;
@@ -2818,7 +2967,7 @@ match_msgs(Pat, M, Cont) when is_map(M), is_map(Pat) ->
 match_msgs(_, _, true) ->
     throw(continue);
 match_msgs(A, B, false) ->
-    log("Messages don't match: ~p / ~p", [A, B]),
+    ?LOG("Messages don't match: ~p / ~p", [A, B]),
     erlang:error({message_mismatch, [A, B]}).
 
 check_info(Timeout) -> check_info(Timeout, false).
@@ -2826,10 +2975,10 @@ check_info(Timeout) -> check_info(Timeout, false).
 check_info(Timeout, Debug) ->
     receive
         Msg when element(1, Msg) == aesc_fsm ->
-            log(Debug, "UNEXPECTED: ~p", [Msg]),
+            ?LOG(Debug, "UNEXPECTED: ~p", [Msg]),
             [Msg|check_info(Timeout, Debug)]
     after Timeout ->
-            log(Debug, "unconsumed msgs: ~p",
+            ?LOG(Debug, "unconsumed msgs: ~p",
                 [element(2,process_info(self(),messages))]),
             []
     end.
@@ -2855,9 +3004,9 @@ opt_add_to_debug(_, Debug) ->
 
 prep_initiator(Node) ->
     {PrivKey, PubKey} = aecore_suite_utils:sign_keys(Node),
-    log("initiator Pubkey = ~p", [PubKey]),
+    ?LOG("initiator Pubkey = ~p", [PubKey]),
     mine_key_blocks(Node, 30),
-    log("initiator: 30 blocks mined on ~p", [Node]),
+    ?LOG("initiator: 30 blocks mined on ~p", [Node]),
     {ok, Balance} = rpc(Node, aehttp_logic, get_account_balance, [PubKey]),
     #{role => initiator,
       priv => PrivKey,
@@ -2883,7 +3032,7 @@ rpc(Node, Mod, Fun, Args) -> rpc(Node, Mod, Fun, Args, false).
 
 rpc(Node, Mod, Fun, Args, Debug) ->
     Res = rpc:call(aecore_suite_utils:node_name(Node), Mod, Fun, Args, 5000),
-    log(Debug, "rpc(~p,~p,~p,~p) -> ~p", [Node, Mod, Fun, Args, Res]),
+    ?LOG(Debug, "rpc(~p,~p,~p,~p) -> ~p", [Node, Mod, Fun, Args, Res]),
     Res.
 
 check_amounts(R, SignedTx, Updates) ->
@@ -2932,25 +3081,21 @@ current_height(Node) ->
         Header -> aec_headers:height(Header)
     end.
 
-log(Fmt, Args) ->
+log(L, Fmt, Args) ->
     Debug = case config() of
                 undefined ->
                     false;
                 Cfg ->
                     config(debug, Cfg, false)
             end,
-    log(Debug, Fmt, Args).
+    log(Debug, L, Fmt, Args).
 
-log(true, Fmt, Args) ->
-    ct:log("~p: " ++ Fmt, [self()|Args]);
-log(#{debug := true}, Fmt, Args) ->
-    ct:log("~p: " ++ Fmt, [self()|Args]);
-log(_, _, _) ->
+log(true, L, Fmt, Args) ->
+    ct:log("~p [~p]: " ++ Fmt, [self(), L|Args]);
+log(#{debug := true}, L, Fmt, Args) ->
+    ct:log("~p [~p]: " ++ Fmt, [self(), L|Args]);
+log(_, _, _, _) ->
     ok.
-
-if_debug(true, X, _) -> X;
-if_debug(#{debug := true}, X, _) -> X;
-if_debug(_, _, Y) -> Y.
 
 apply_updates([], R) ->
     R;
@@ -2993,21 +3138,21 @@ wait_for_signed_transaction_in_block(_, SignedTx, #{mine_blocks := {ask,Pid}}) -
             error(timeout)
     end;
 wait_for_signed_transaction_in_block(Node, SignedTx, Debug) ->
-    log(Debug, "waiting for tx ~p", [SignedTx]),
+    ?LOG(Debug, "waiting for tx ~p", [SignedTx]),
     TxHash = aetx_sign:hash(SignedTx),
     case rpc(dev1, aec_chain, find_tx_location, [TxHash], Debug) of
         BH when is_binary(BH) ->
-            log(Debug, "Found tx in block", []),
+            ?LOG(Debug, "Found tx in block", []),
             ok;
         NotConfirmed when NotConfirmed =:= mempool;
                           NotConfirmed =:= not_found ->
             EncTxHash = aeser_api_encoder:encode(tx_hash, TxHash),
             case mine_blocks_until_txs_on_chain(Node, [EncTxHash]) of
                 {ok, _Blocks} ->
-                    log(Debug, "Tx on-chain after mining ~p blocks", [length(_Blocks)]),
+                    ?LOG(Debug, "Tx on-chain after mining ~p blocks", [length(_Blocks)]),
                     ok;
                 {error, _Reason} ->
-                    log("Error: ~p - did not mine", [_Reason]),
+                    ?LOG(Debug, "Error: ~p - did not mine", [_Reason]),
                     did_not_mine
             end
     end.
@@ -3051,10 +3196,10 @@ mine_key_blocks(Node, KeyBlocks) ->
 with_trace(F, Config, File) ->
     with_trace(F, Config, File, on_error).
 
-with_trace(F, Config, File, When) ->
-    log("with_trace ...", []),
-    TTBRes = aesc_ttb:on_nodes([node()|get_nodes()], File),
-    log("Trace set up: ~p", [TTBRes]),
+with_trace(F, Config0, File, When) ->
+    ?LOG("with_trace ...", []),
+    Config = [{trace_destination, File}|Config0],
+    trace_checkpoint(?TR_START, Config),
     try F(Config)
     ?_catch_(Error, Reason, Stack)
         case {Error, Reason} of
@@ -3073,12 +3218,23 @@ with_trace(F, Config, File, When) ->
     end,
     case When of
         on_error ->
-            log("Discarding trace", []),
+            ?LOG("Discarding trace", []),
             aesc_ttb:stop_nofetch();
         always ->
             ttb_stop()
     end,
     ok.
+
+trace_checkpoint(CheckPoint, Config) ->
+    case ?config(activate_trace, Config) of
+        CheckPoint ->
+            {_, File} = lists:keyfind(trace_destination, 1, Config),
+            TTBRes = aesc_ttb:on_nodes([node()|get_nodes()], File),
+            ?LOG("Trace set up: ~p", [TTBRes]);
+        _ ->
+            ok
+    end.
+
 
 ttb_stop() ->
     Dir = aesc_ttb:stop(),
@@ -3285,7 +3441,7 @@ peek_message_queue(L, Debug) ->
     case Msgs of
         [] -> ok;
         _ ->
-            log(Debug,
+            ?LOG(Debug,
                 "==================================================~n"
                 "~p: message Q: ~p~n"
                "==================================================~n", [L, Msgs])
@@ -3439,3 +3595,18 @@ positive_bh(Cfg) ->
               NNT + 1]),%% in the range
     shutdown_(IFinal, RFinal, Cfg),
     ok.
+
+%% should_responder_keep_running(Cfg) ->
+%%     maps:get(keep_running, proplists:get_value(responder_opts, Cfg, #{}), false).
+
+cfg_responder_keeps_running(Cfg) ->
+    cfg_responder_keeps_running(true, Cfg).
+
+cfg_responder_keeps_running(Bool, Cfg) when is_boolean(Bool) ->
+    K = responder_opts,
+    case lists:keyfind(K, 1, Cfg) of
+        false ->
+            [{K, #{keep_running => Bool}}|Cfg];
+        {_, Opts} when is_map(Opts) ->
+            lists:keyreplace(K, 1, Cfg, {K, Opts#{keep_running => Bool}})
+    end.

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -49,6 +49,7 @@
 %%%==================================================================
 
 patterns() ->
+    sc_ws_utils:patterns() ++
     sc_ws_api_jsonrpc:patterns() ++
         [{sc_ws_handler, init, 2, []} |
          [{?MODULE, F, A, []} || {F, A} <- [ {protocol, 0}

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -581,6 +581,7 @@ general_options(Read) ->
     [ Read(<<"minimum_depth">>, minimum_depth, #{type => integer, mandatory => false})
     , Read(<<"ttl">>, ttl, #{type => integer, mandatory => false})
     , Read(<<"keep_running">>, keep_running, #{type => boolean,
+                                               default => <<"true">>,
                                                mandatory => false})
     , Read(<<"reconnect_security">>, reconnect_security, #{mandatory => false,
                                                            type => atom,

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -136,7 +136,7 @@ websocket_init_reconnect(#{ job_id := JobId
     lager:debug("ReconnectTx = ~p", [ReconnectTx]),
     case check_reconnect_tx(ReconnectTx) of
         {ok, #{} = Opts} ->
-            lager:debug("Reconnect tx Opts = ~p", [Opts]),
+            lager:debug("Reconnect tx Opts = ~p", [aesc_utils:censor_init_opts(Opts)]),
             ReconnectOpts =
                 maps:merge(Params#{ job_id => JobId
                                   , protocol => sc_ws_api:protocol(Protocol) }, Opts),

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -8,6 +8,7 @@
 -export([terminate/3]).
 
 -include_lib("aecontract/include/hard_forks.hrl").
+-export([time_since_last_dispatch/1]).
 
 -record(handler, {fsm_pid            :: pid() | undefined,
                   fsm_mref           :: reference() | undefined,
@@ -24,6 +25,38 @@
 
 -define(ERROR_TO_CLIENT(Err), {?MODULE, send_to_client, {error, Err}}).
 -include_lib("aeutils/include/aeu_stacktrace.hrl").
+
+%% ===========================================================================
+%% @doc API to check if session is potentially hanging, waiting for socket close
+%%
+time_since_last_dispatch(HandlerPid) ->
+    %% We use the process dictionary for this. The cowboy_websocket module
+    %% maintains an inactivity timer, but this resides in the inner state,
+    %% which is not accessible to the handler. The info we're after is how
+    %% long since the handler was dispatched. This can be used to determine
+    %% whether we want to kill and replace an older, hung, websocket session.
+    case process_info(HandlerPid, dictionary) of
+        {_, Dict} ->
+            case lists:keyfind(timestamp_key(), 1, Dict) of
+                {_, TS} ->
+                    Now = erlang:monotonic_time(),
+                    erlang:convert_time_unit(Now - TS, native, millisecond);
+                _ ->
+                    undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+%% Called from websocket_handle()
+%%
+put_timestamp() ->
+    put(timestamp_key(), erlang:monotonic_time()).
+
+timestamp_key() ->
+    {?MODULE, last_dispatch}.
+
+%% ===========================================================================
 
 init(Req, _Opts) ->
     Parsed = cowboy_req:parse_qs(Req),
@@ -50,46 +83,158 @@ websocket_init(Params) ->
         {Handler, {error, Err}} ->
             handler_parsing_error(Err, Handler, Params);
         {Handler, ChannelOpts} ->
-            lager:debug("Starting Channel WS with params ~p",
-                [aesc_utils:censor_init_opts(Params)]),
-            lager:debug("ChannelOpts = ~p", [aesc_utils:censor_init_opts(ChannelOpts)]),
-            case start_link_fsm(Handler, ChannelOpts) of
-                {ok, FsmPid} ->
-                    MRef = erlang:monitor(process, FsmPid),
-                    {ok, Handler#handler{fsm_pid = FsmPid, fsm_mref = MRef}};
-                {error, Err} ->
-                    handler_init_error(Err, Handler)
+            case maps:is_key(existing_channel_id, ChannelOpts) of
+                true ->
+                    lager:debug("existing_channel_id key exists", []),
+                    case {derive_reconnect_opts(ChannelOpts), maps:find(offchain_tx, ChannelOpts)} of
+                        {{ok, ReconnectOpts}, {ok, _}} ->
+                            lager:debug("Will try to reconnect; ReconnectOpts = ~p",
+                                        [ReconnectOpts]),
+                            case reconnect_to_fsm_(ReconnectOpts, Handler,
+                                                   fun(E) ->
+                                                           {error, E}
+                                                   end) of
+                                {ok, _} = Ok ->
+                                    Ok;
+                                {error, ReconnError} ->
+                                    %% The reconnect_to_fsm_() case above tries a reestablish
+                                    %% if the fsm isn't running. Don't try another reestablish
+                                    %% if this fails, since reestablishing if there is
+                                    %% already an fsm would be bad.
+                                    handler_init_error(ReconnError, Handler)
+                            end;
+                        {{ok, ReconnectOpts}, error} ->
+                            %% take the same path as reconnect (maybe reestablish from cache)
+                            lager:debug("no reconnect_tx, but ReconnectOpts = ~p", [ReconnectOpts]),
+                            websocket_init_reconnect_(ReconnectOpts, Handler);
+                        {{error, _} = Err1, _} ->
+                            lager:debug("Error deriving reconnect opts: ~p", [Err1]),
+                            %% TODO: This is probably an error case, with insufficient info also
+                            %% for reestablish. Can it even happen?
+                            handler_init_error(not_found, Handler)
+                    end;
+                false ->
+                    websocket_init_parsed(Handler, ChannelOpts)
             end
     end.
 
-websocket_init_reconnect(#{ <<"reconnect_tx">> := ReconnectTx } = Params) ->
+websocket_init_parsed(Handler, ChannelOpts) ->
+    lager:debug("ChannelOpts = ~p", [aesc_utils:censor_init_opts(ChannelOpts)]),
+    case start_link_fsm(Handler, ChannelOpts) of
+        {ok, FsmPid} ->
+            MRef = erlang:monitor(process, FsmPid),
+            {ok, Handler#handler{fsm_pid = FsmPid, fsm_mref = MRef}};
+        {error, Err} ->
+            handler_init_error(Err, Handler)
+    end.
+
+websocket_init_reconnect(#{ job_id := JobId
+                          , <<"protocol">> := Protocol
+                          , <<"reconnect_tx">> := ReconnectTx } = Params0) ->
+    Read = sc_ws_utils:read_f(Params0),
+    Params = sc_ws_utils:check_params(read_state_password(Read)),
     lager:debug("ReconnectTx = ~p", [ReconnectTx]),
     case check_reconnect_tx(ReconnectTx) of
-        {ok, #{ channel_id := ChanId
-              , role       := Role
-              , pub_key    := Pubkey
-              , signed_tx  := SignedTx } = Opts} ->
-            Handler = reconnect_opts_to_handler(maps:merge(Params, Opts)),
-            case aesc_fsm:where(ChanId, Role) of
-                undefined ->
-                    lager:debug("where(~p, ~p) -> undefined", [ChanId, Role]),
-                    handler_init_error(not_found, Handler);
-                #{ fsm_pid := Fsm, pub_key := Pubkey } ->
-                    %% At this point, we haven't verified the signature.
-                    %% This is done by the fsm.
-                    lager:debug("Found FSM = ~p", [Fsm]),
-                    case aesc_fsm:reconnect_client(Fsm, self(), SignedTx) of
-                        ok ->
-                            MRef = erlang:monitor(process, Fsm),
-                            { ok, Handler#handler{ fsm_pid  = Fsm
-                                                 , fsm_mref = MRef } };
-                        {error, Err} ->
-                            handler_init_error(Err, Handler)
-                    end
-            end;
+        {ok, #{} = Opts} ->
+            lager:debug("Reconnect tx Opts = ~p", [Opts]),
+            ReconnectOpts =
+                maps:merge(Params#{ job_id => JobId
+                                  , protocol => sc_ws_api:protocol(Protocol) }, Opts),
+            lager:debug("ReconnectOpts = ~p",
+                        [aesc_utils:censor_init_opts(ReconnectOpts)]),
+            Handler = reconnect_opts_to_handler(ReconnectOpts),
+            lager:debug("Handler = ~p", [Handler]),
+            websocket_init_reconnect_(ReconnectOpts, Handler);
         {error, CheckError} ->
             lager:debug("CheckError = ~p", [CheckError]),
             {stop, undefined}
+    end.
+
+websocket_init_reconnect_(ReconnectOpts, Handler) ->
+    case reconnect_to_fsm_(ReconnectOpts, Handler, fun(E) -> {error, E} end) of
+        {ok, _} = Ok ->
+            Ok;
+        {error, {existing_client, OldClient}} ->
+            check_existing_client(OldClient, ReconnectOpts, Handler);
+        {error, Err} ->
+            handler_init_error(Err, Handler)
+    end.
+
+reconnect_to_fsm_(#{ channel_id := ChanId
+                   , role       := Role
+                   , pub_key    := Pubkey
+                   , signed_tx  := SignedTx } = Opts, Handler, OnError) ->
+    case aesc_fsm:where(ChanId, Role) of
+        undefined ->
+            lager:debug("where(~p, ~p) -> undefined", [ChanId, Role]),
+            maybe_reestablish(Opts, Handler, OnError);
+        #{ fsm_pid := Fsm, pub_key := Pubkey } ->
+            %% At this point, we haven't verified the signature.
+            %% This is done by the fsm.
+            lager:debug("Found FSM = ~p", [Fsm]),
+            case aesc_fsm:reconnect_client(Fsm, self(), SignedTx) of
+                ok ->
+                    MRef = erlang:monitor(process, Fsm),
+                    { ok, Handler#handler{ fsm_pid  = Fsm
+                                         , fsm_mref = MRef } };
+                {error, E} ->
+                    OnError(E)
+            end
+    end.
+
+%% The fsm is not running. Perhaps there is cached state, warranting a reestablish?
+%%
+maybe_reestablish(#{ channel_id := ChId
+                   , pub_key    := Pubkey } = ReconnectOpts, Handler0, OnError) ->
+    lager:debug("ReconnectOpts = ~p",
+                [aesc_utils:censor_init_opts(ReconnectOpts)]),
+    case maps:find(state_password, ReconnectOpts) of
+        {ok, Password} ->
+            case aesc_state_cache:reestablish(ChId, Pubkey, Password) of
+                {ok, State, Opts} ->
+                    lager:debug("Fetched state. Opts = ~p", [Opts]),
+                    Handler = update_handler_for_reestablish(Handler0, Opts),
+                    try aesc_offchain_state:get_latest_signed_tx(State) of
+                        {_, SignedTx} ->
+                            lager:debug("Latest tx = ~p", [SignedTx]),
+                            ExpandedOpts = expand_cached_opts(Opts),
+                            websocket_init_parsed(
+                              Handler,
+                              ExpandedOpts#{ existing_channel_id => ChId
+                                           , offchain_tx => SignedTx })
+                    catch
+                        error:_E ->
+                            lager:debug("Failed getting latest signed tx: ~p", [_E]),
+                            OnError(not_found)
+                    end;
+                {error, CacheError} ->
+                    lager:debug("No cached state", []),
+                    OnError(CacheError)
+            end;
+        error ->
+            lager:debug("No state_password specified", []),
+            OnError(not_found)
+    end.
+
+check_existing_client(Client, Opts, Handler) ->
+    OnError = fun(E) ->
+                      handler_init_error(E, Handler)
+              end,
+    T = time_since_last_dispatch(Client),
+    lager:debug("Time since last dispatch (~p): ~p", [Client, T]),
+    if is_integer(T), T < 5000 ->
+            handler_init_error(client_still_active, Handler);
+       is_integer(T) ->
+            %% It is actually a WS client
+            MRef = erlang:monitor(process, Client),
+            exit(Client, kill),
+            receive {'DOWN', MRef, _, _, _} ->
+                    timer:sleep(100),
+                    reconnect_to_fsm_(Opts, Handler, OnError)
+            end;
+       true ->
+            timer:sleep(100),
+            reconnect_to_fsm_(Opts, Handler, OnError)
     end.
 
 handler_parsing_error(Err, Handler, Params) ->
@@ -114,6 +259,7 @@ handler_parsing_error(Err, Handler, Params) ->
 
 handler_init_error(Err, Handler) ->
     HandledErrors =[{not_found                    , participant_not_found},
+                    {client_still_active          , client_still_active},
                     {insufficient_initiator_amount, value_too_low},
                     {insufficient_responder_amount, value_too_low},
                     {insufficient_amounts         , value_too_low},
@@ -121,6 +267,7 @@ handler_init_error(Err, Handler) ->
                     {push_amount_too_low          , value_too_low},
                     {lock_period_too_low          , value_too_low},
                     {invalid_password             , invalid_password},
+                    {bad_signature                , bad_signature},
                     {password_required_since_lima , {state_password, missing}}
                    ],
     case proplists:get_value(Err, HandledErrors, not_handled_error) of
@@ -140,12 +287,16 @@ handler_init_error(Err, Handler) ->
 
 
 -spec websocket_handle(term(), handler()) -> {ok, handler()}.
-websocket_handle({text, MsgBin}, #handler{fsm_pid = undefined} = H) ->
+websocket_handle(Data, Handler) ->
+    put_timestamp(),
+    websocket_handle_(Data, Handler).
+
+websocket_handle_({text, MsgBin}, #handler{fsm_pid = undefined} = H) ->
     %% the FSM has not been started, the connection is to die any moment now
     %% do not respond
     lager:debug("Not processing message ~p", [MsgBin]),
     {ok, H};
-websocket_handle({text, MsgBin}, #handler{protocol = Protocol,
+websocket_handle_({text, MsgBin}, #handler{protocol = Protocol,
                                           enc_channel_id = ChannelId,
                                           fsm_pid  = FsmPid} = H) ->
     case sc_ws_api:process_from_client(Protocol, MsgBin, FsmPid, ChannelId) of
@@ -153,7 +304,7 @@ websocket_handle({text, MsgBin}, #handler{protocol = Protocol,
         {reply, Resp}     -> {reply, {text, jsx:encode(Resp)}, H};
         stop              -> {stop, H}
     end;
-websocket_handle(_Data, H) ->
+websocket_handle_(_Data, H) ->
     {ok, H}.
 
 websocket_info(?ERROR_TO_CLIENT(Err), #handler{protocol = Protocol} = H) ->
@@ -227,6 +378,38 @@ start_link_fsm(#handler{role = initiator, host=Host, port=Port}, Opts) ->
 start_link_fsm(#handler{role = responder, port=Port}, Opts) ->
     aesc_fsm:respond(Port, Opts).
 
+derive_reconnect_opts(#{ <<"reconnect_tx">> := ReconnectTx } = Params) ->
+    lager:debug("Params = ~p", [Params]),
+    case check_reconnect_tx(ReconnectTx) of
+        {ok, #{} = Opts} ->
+            lager:debug("Reconnect tx Opts = ~p", [Opts]),
+            {ok, maps:merge(Params, Opts)};
+        {error, _} = Error ->
+            Error
+    end;
+derive_reconnect_opts(#{ existing_channel_id := ChId
+                       , role                := Role
+                       , initiator           := I
+                       , responder           := R } = Opts) ->
+    PubKey = case Role of
+                 initiator -> I;
+                 responder -> R
+             end,
+    Round = 1,
+    {ok, Tx} = aesc_client_reconnect_tx:new(#{ channel_id => aeser_id:create(channel, ChId)
+                                             , role       => Role
+                                             , pub_key    => aeser_id:create(account, PubKey)
+                                             , round      => Round }),
+    SignedTx = aetx_sign:new(Tx, []),
+    {ok, maps:merge(Opts, #{ channel_id => ChId
+                           , role       => Role
+                           , pub_key    => PubKey
+                           , round      => Round
+                           , signed_tx  => SignedTx })};
+derive_reconnect_opts(Params) ->
+    lager:debug("Params = ~p", [Params]),
+    {error, cannot_derive_reconnect_tx}.
+
 check_reconnect_tx(Tx0) ->
     case aeser_api_encoder:safe_decode(transaction, Tx0) of
         {ok, SignedTxBin} ->
@@ -256,19 +439,19 @@ set_field(H, host, Val)         -> H#handler{host = Val};
 set_field(H, role, Val)         -> H#handler{role = Val};
 set_field(H, port, Val)         -> H#handler{port = Val}.
 
-reconnect_opts_to_handler(#{ <<"protocol">> := Protocol
+reconnect_opts_to_handler(#{ protocol       := Protocol
+                           , role           := Role
                            , channel_id     := ChId
-                           , job_id         := JobId } = Params) ->
-    lager:debug("Params = ~p", [Params]),
+                           , job_id         := JobId }) ->
     %% We don't fill in values like host, port, etc. since we don't
     %% have them, and they aren't needed afaict.
-    #handler{ protocol       = sc_ws_api:protocol(Protocol)
+    #handler{ protocol       = Protocol
+            , role           = Role
             , channel_id     = ChId
             , enc_channel_id = aeser_api_encoder:encode(channel, ChId)
             , job_id         = JobId }.
 
 prepare_handler(#{<<"protocol">> := Protocol} = Params) ->
-    lager:debug("prepare_handler() Params = ~p", [aesc_utils:censor_init_opts(Params)]),
     Read =
         fun(Key, RecordField, Opts) ->
             fun(H) ->
@@ -308,6 +491,18 @@ prepare_handler(#{<<"protocol">> := Protocol} = Params) ->
 prepare_handler(_Protocol) ->
     {error, {protocol, missing}}.
 
+update_handler_for_reestablish(Handler, Opts) ->
+    lager:debug("Handler = ~p; Opts = ~p", [lager:pr(Handler, ?MODULE), Opts]),
+    Conn = maps:get(connection, Opts),
+    Handler#handler{
+       role = maps:get(role, Opts)
+     , host = maps:get(host, Conn, undefined)
+     , port = maps:get(port, Conn) }.
+
+expand_cached_opts(Opts) ->
+    {Conn, Opts1} = maps:take(connection, Opts),
+    maps:merge(Opts1, Conn).
+
 read_channel_options(Params) ->
     Read = sc_ws_utils:read_f(Params),
     Put = sc_ws_utils:put_f(),
@@ -334,16 +529,12 @@ read_channel_options(Params) ->
                                                      mandatory => false}),
     ReadBHDelta = ReadMap(block_hash_delta, <<"bh_delta">>, #{ type => integer
                                                             , mandatory => false }),
-    CheckStatePasswordF =
-        fun(M) ->
-            maps:remove(state_password, M)
-        end,
     OnChainOpts =
         case (sc_ws_utils:read_param(
                 <<"existing_channel_id">>, existing_channel_id,
                 #{type => {hash, channel}, mandatory => false}))(Params) of
             not_set ->  %Channel open scenario
-                [Read(<<"role">>, role, #{type => atom, enum => [responder, initiator]}),
+                [read_role(Read, true),
                  Read(<<"push_amount">>, push_amount, #{type => integer}),
                  %% Read(<<"initiator_id">>, initiator, #{type => {hash, account_pubkey}}),
                  ReadInitiator,
@@ -356,7 +547,9 @@ read_channel_options(Params) ->
                 case aec_chain:get_channel(ExistingID) of
                     {ok, Channel} ->
                         [Put(existing_channel_id, ExistingID),
-                         Read(<<"offchain_tx">>, offchain_tx, #{type => serialized_tx}),
+                         Read(<<"offchain_tx">>, offchain_tx, #{type => serialized_tx,
+                                                                mandatory => false}),
+                         read_role(Read, false),
                          % push_amount is only used in open and is not preserved.
                          % 0 guarantees passing checks (executed amount check is the
                          % same as onchain check)
@@ -374,18 +567,49 @@ read_channel_options(Params) ->
                 [Error(Err)]
         end,
     sc_ws_utils:check_params(
-      [Read(<<"minimum_depth">>, minimum_depth, #{type => integer, mandatory => false}),
-       Read(<<"ttl">>, ttl, #{type => integer, mandatory => false}),
-       %% The state_password is mandatory AFTER the lima fork - this is checked by CheckStatePasswordF
-       Read(<<"state_password">>, state_password, #{type => string, mandatory => false}),
-       CheckStatePasswordF,
-       Put(noise, [{noise, <<"Noise_NN_25519_ChaChaPoly_BLAKE2b">>}])
-      ] ++ OnChainOpts
+      [Put(noise, [{noise, <<"Noise_NN_25519_ChaChaPoly_BLAKE2b">>}])
+      ]
+      ++ OnChainOpts
       ++ lists:map(ReadTimeout, aesc_fsm:timeouts() ++ [awaiting_open,
                                                         initialized])
       ++ lists:map(ReadReport, aesc_fsm:report_tags())
       ++ lists:map(ReadBHDelta, aesc_fsm:bh_deltas())
+      ++ general_options(Read)
      ).
+
+general_options(Read) ->
+    [ Read(<<"minimum_depth">>, minimum_depth, #{type => integer, mandatory => false})
+    , Read(<<"ttl">>, ttl, #{type => integer, mandatory => false})
+    , Read(<<"keep_running">>, keep_running, #{type => boolean,
+                                               mandatory => false})
+    , Read(<<"reconnect_security">>, reconnect_security, #{mandatory => false,
+                                                           type => atom,
+                                                           enum => [none, signature],
+                                                           default => <<"none">>})
+    , Read(<<"slogan">>, slogan, #{type => string, mandatory => false})]
+        ++ read_state_password(Read).
+
+read_role(Read, Mandatory) ->
+    Read(<<"role">>, role, #{type => atom, enum => [responder, initiator],
+                             mandatory => Mandatory}).
+
+read_state_password(Read) ->
+    %% The state_password is mandatory AFTER the lima fork - this is checked by CheckStatePasswordF
+    CheckStatePasswordF
+        = fun(M) ->
+                  case aesc_fsm:check_state_password(M) of
+                      ok ->
+                          M;
+                      Err ->
+                          Err
+                  end
+          end,
+    [read_password(Read),
+     CheckStatePasswordF].
+
+read_password(Read) ->
+    Read(<<"state_password">>, state_password, #{type => string, mandatory => false,
+                                                 default => <<"correct horse battery staple">>}).
 
 jobs_ask() ->
     jobs:ask(sc_ws_handlers).

--- a/apps/aehttp/src/sc_ws_utils.erl
+++ b/apps/aehttp/src/sc_ws_utils.erl
@@ -8,6 +8,18 @@
         , read_param/3
         , check_type/3 ]).
 
+-export([patterns/0]).
+
+%%%==================================================================
+%%% Trace settings
+%%%==================================================================
+
+patterns() ->
+    [{?MODULE, F, A, []} || {F, A} <- [ {read_param, 3}
+                                      , {check_type, 3}
+                                      ]].
+
+
 check_params(Checks) ->
     check_params(Checks, #{}).
 
@@ -60,7 +72,12 @@ read_param(ParamName, RecordField, Options) ->
             undefined when Mandatory ->
                 {error, {RecordField, missing}};
             undefined when not Mandatory ->
-                not_set;
+                case maps:find(default, Options) of
+                    {ok, Default} ->
+                        check_type(Options, Default, RecordField);
+                    error ->
+                        not_set
+                end;
             Val ->
                 check_type(Options, Val, RecordField)
         end

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -1192,13 +1192,13 @@ sc_ws_leave_(Config) ->
     ReestablishOptions.
 
 
-sc_ws_reestablish_(ReestablOptions, Config) ->
-    ct:log("ReestablOptions = ~p~n"
-           "Config = ~p", [ReestablOptions, Config]),
+sc_ws_reestablish_(ReestablishOptions, Config) ->
+    ct:log("ReestablishOptions = ~p~n"
+           "Config = ~p", [ReestablishOptions, Config]),
     ResponderLeaves = proplists:get_value(responder_leaves, Config, true),
     RrConnPid
         = if ResponderLeaves ->
-                  {ok, RrCP} = channel_ws_start(responder, ReestablOptions, Config),
+                  {ok, RrCP} = channel_ws_start(responder, ReestablishOptions, Config),
                   RrCP;
              true ->
                   %% responder still running
@@ -1207,7 +1207,7 @@ sc_ws_reestablish_(ReestablOptions, Config) ->
     end,
     {ok, IrConnPid} = channel_ws_start(initiator, maps:put(
                                                     host, <<"localhost">>,
-                                                    ReestablOptions), Config),
+                                                    ReestablishOptions), Config),
     Config1 = lists:keystore(channel_clients, 1, Config,
                              {channel_clients, #{ initiator => IrConnPid
                                                 , responder => RrConnPid}}),
@@ -3208,8 +3208,8 @@ sc_ws_leave_reconnect(Config0) ->
     ct:log("Config1 = ~p", [Config1]),
     #{ existing_channel_id := ChId
      , offchain_tx         := _Tx }
-        = ReestOpts = sc_ws_leave_(Config1),
-    ct:log("ReestOpts = ~p", [ReestOpts]),
+        = ReestablishOpts = sc_ws_leave_(Config1),
+    ct:log("ReestablishOpts = ~p", [ReestablishOpts]),
     ct:log("*** Reconnecting ... ***", []),
     Config2 = reconnect_client_(ChId, initiator, Pub, Priv,
                                 [{reconnect_scenario, reestablish} | Config1]),

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -19,6 +19,7 @@
     sc_ws_min_depth_not_reached_timeout/1,
     sc_ws_min_depth_is_modifiable/1,
     sc_ws_basic_open_close/1,
+    sc_ws_basic_open_close_no_password/1,
     sc_ws_basic_open_close_server/1,
     sc_ws_failed_update/1,
     sc_ws_generic_messages/1,
@@ -30,6 +31,9 @@
     sc_ws_close_solo/1,
     sc_ws_slash/1,
     sc_ws_leave_reestablish/1,
+    sc_ws_leave_reestablish_responder_stays/1,
+    sc_ws_leave_reconnect/1,
+    sc_ws_password_changeable/1,
     sc_ws_ping_pong/1,
     sc_ws_deposit/1,
     sc_ws_withdraw/1,
@@ -42,6 +46,7 @@
     sc_ws_wrong_call_data/1,
     sc_ws_basic_client_reconnect_i/1,
     sc_ws_basic_client_reconnect_r/1,
+    sc_ws_basic_client_reconnect_i_w_reestablish/1,
     sc_ws_pinned_update/1,
     sc_ws_pinned_deposit/1,
     sc_ws_pinned_withdraw/1,
@@ -100,6 +105,9 @@
 
 -define(CACHE_DEFAULT_PASSWORD, "correct horse battery staple").
 
+-define(CHECK_INFO(Timeout), check_info(?LINE, Timeout)).
+-define(PEEK_MSGQ, peek_msgq(?LINE)).
+
 all() -> [{group, plain}, {group, aevm}, {group, fate}].
 
 groups() ->
@@ -109,6 +117,7 @@ groups() ->
         sc_ws_min_depth_not_reached_timeout,
         sc_ws_min_depth_is_modifiable,
         sc_ws_basic_open_close,
+        sc_ws_basic_open_close_no_password,
         sc_ws_basic_open_close_server,
         sc_ws_snapshot_solo,
         sc_ws_update_with_meta,
@@ -120,8 +129,12 @@ groups() ->
         sc_ws_slash,
         %% possible to leave and reestablish channel
         sc_ws_leave_reestablish,
+        sc_ws_leave_reestablish_responder_stays,
+        sc_ws_leave_reconnect,
+        sc_ws_password_changeable,
         {group, with_open_channel},
-        {group, client_reconnect}
+        {group, client_reconnect},
+        {group, client_reconnect_no_password}
       ]},
 
      {with_open_channel, [sequence],
@@ -178,7 +191,14 @@ groups() ->
 
      {client_reconnect, [sequence],
       [ sc_ws_basic_client_reconnect_i,
-        sc_ws_basic_client_reconnect_r
+        sc_ws_basic_client_reconnect_r,
+        sc_ws_basic_client_reconnect_i_w_reestablish
+      ]},
+
+     {client_reconnect_no_password, [sequence],
+      [ sc_ws_basic_client_reconnect_i,
+        sc_ws_basic_client_reconnect_r,
+        sc_ws_basic_client_reconnect_i_w_reestablish
       ]},
 
      {pinned_env, [sequence],
@@ -235,6 +255,8 @@ init_per_group(plain, Config) ->
     reset_participants(plain, Config);
 init_per_group(client_reconnect, Config) ->
     reset_participants(client_reconnect, Config);
+init_per_group(client_reconnect_no_password, Config) ->
+    reset_participants(client_reconnect, [{no_password, true}|Config]);
 init_per_group(pinned_env, Config) ->
     aect_test_utils:init_per_group(aevm, reset_participants(pinned_env, Config));
 init_per_group(_Grp, Config) ->
@@ -270,9 +292,15 @@ init_per_testcase(Case, Config) ->
     end,
     [{_, Node} | _] = ?config(nodes, Config),
     aecore_suite_utils:mock_mempool_nonce_offset(Node, 100),
+    ?CHECK_INFO(20),
     [{tc_start, os:timestamp()} | Config].
 
 end_per_testcase(_Case, Config) ->
+    case ?CHECK_INFO(20) of
+        [] -> ok;
+        [_|_] = L ->
+            ct:comment("~p unhandled messages", [length(L)])
+    end,
     [{_, Node} | _] = ?config(nodes, Config),
     aecore_suite_utils:unmock_mempool_nonce_offset(Node),
     Ts0 = ?config(tc_start, Config),
@@ -454,14 +482,17 @@ sc_ws_open_(Config, ChannelOpts0, MinBlocksToMine) ->
     {IStartAmt, RStartAmt} = channel_participants_balances(IPubkey, RPubkey),
 
     ChannelOpts = channel_options(IPubkey, RPubkey, IAmt, RAmt, ChannelOpts0, Config),
+    {IChanOpts, RChanOpts} = special_channel_opts(ChannelOpts),
+    ct:log("IChanOpts = ~p~n"
+           "RChanOpts = ~p~n", [IChanOpts, RChanOpts]),
     {ok, IConnPid} = channel_ws_start(initiator,
-                                           maps:put(host, <<"localhost">>, ChannelOpts), Config),
-
+                                           maps:put(host, <<"localhost">>, IChanOpts), Config),
+    ct:log("initiator spawned", []),
     ok = ?WS:register_test_for_channel_events(IConnPid, [info, get, sign,
                                                          on_chain_tx, update]),
 
-    {ok, RConnPid} = channel_ws_start(responder, ChannelOpts, Config),
-
+    {ok, RConnPid} = channel_ws_start(responder, RChanOpts, Config),
+    ct:log("responder spawned", []),
     ok = ?WS:register_test_for_channel_events(RConnPid, [info, get, sign,
                                                          on_chain_tx, update]),
 
@@ -863,12 +894,22 @@ channel_update_fail(#{initiator := IConnPid, responder :=RConnPid},
     Res.
 
 sc_ws_close_(ConfigList) ->
+    %% We cannot simply close the ConnPid if we want to also bring down the fsm
+    %% since the fsm may be configured to allow the client to disconnect/reconnect.
     #{initiator := IConnPid,
       responder := RConnPid} = proplists:get_value(channel_clients, ConfigList),
-
-
-    ok = ?WS:stop(IConnPid),
-    ok = ?WS:stop(RConnPid),
+    Close = fun(Pid) ->
+                    try ?WS:json_rpc_call(
+                           Pid, #{ <<"method">> => <<"channels.system">>
+                                 , <<"params">> => #{<<"action">> => <<"stop">>}})
+                    catch
+                        error:{connpid_died, Reason} when Reason == {error,closed}
+                                                        ; Reason == normal ->
+                            ok
+                    end
+            end,
+    Close(IConnPid),
+    Close(RConnPid),
     ok.
 
 sc_ws_get_balance(ConnPid, PubKey, Config) ->
@@ -1003,13 +1044,16 @@ sc_ws_close_mutual_(Config, Closer) when Closer =:= initiator
 
     {ok, #{<<"tx">> := EncodedSignedMutualTx}} = wait_for_channel_event(IConnPid, on_chain_tx, Config),
     {ok, #{<<"tx">> := EncodedSignedMutualTx}} = wait_for_channel_event(RConnPid, on_chain_tx, Config),
-
+    ?PEEK_MSGQ,
     {ok, SSignedMutualTx} = aeser_api_encoder:safe_decode(transaction, EncodedSignedMutualTx),
     SignedMutualTx = aetx_sign:deserialize_from_binary(SSignedMutualTx),
     %% same transaction
     ShutdownTx = aetx_sign:tx(SignedMutualTx),
-
+    ?PEEK_MSGQ,
     {channel_close_mutual_tx, MutualTx} = aetx:specialize_type(ShutdownTx),
+
+    {ok, #{<<"event">> := <<"closing">>}} = wait_for_channel_event(IConnPid, info, Config),
+    {ok, #{<<"event">> := <<"closing">>}} = wait_for_channel_event(RConnPid, info, Config),
 
     ok = wait_for_signed_transaction_in_pool(SignedMutualTx),
 
@@ -1030,6 +1074,7 @@ sc_ws_close_mutual_(Config, Closer) when Closer =:= initiator
 
 sc_ws_close_solo_(Config, Closer) when Closer =:= initiator;
                                        Closer =:= responder ->
+    ?PEEK_MSGQ,
     ct:log("ConfigList = ~p", [Config]),
     #{initiator := #{pub_key  := IPubKey,
                      priv_key := IPrivKey},
@@ -1056,7 +1101,7 @@ sc_ws_close_solo_(Config, Closer) when Closer =:= initiator;
                       initiator -> CloseSolo(IConnPid, IPrivKey);
                       responder -> CloseSolo(RConnPid, RPrivKey)
                   end,
-
+    ?PEEK_MSGQ,
     {ok, [ #{<<"tx">> := EncodedSignedSoloTx}
          , #{<<"tx">> := EncodedSignedSoloTx} ]} =
         wait_for_onchain_tx_events(
@@ -1064,7 +1109,7 @@ sc_ws_close_solo_(Config, Closer) when Closer =:= initiator;
           fun() ->
                   ok = wait_for_signed_transaction_in_block(CloseSoloTx)
           end, Config),
-
+    ?PEEK_MSGQ,
     {ok, SSignedSoloTx} = aeser_api_encoder:safe_decode(transaction, EncodedSignedSoloTx),
     SignedSoloTx = aetx_sign:deserialize_from_binary(SSignedSoloTx),
     SoloTx = aetx_sign:tx(SignedSoloTx),
@@ -1073,7 +1118,7 @@ sc_ws_close_solo_(Config, Closer) when Closer =:= initiator;
     ct:log("Close_solo tx verified", []),
 
     {ok, 200, #{<<"transactions">> := []}} = get_pending_transactions(),
-
+    ?PEEK_MSGQ,
     settle_(Config, Closer),
 
     ok.
@@ -1095,12 +1140,13 @@ settle_(Config, Closer) when Closer =:= initiator;
                              <<"channels.settle_sign">>, PrivKey, Config),
 
     ok = wait_for_signed_transaction_in_block(SettleTx),
-
+    ?PEEK_MSGQ,
     aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 15),
-
+    ?CHECK_INFO(20),
     ok.
 
 sc_ws_leave_(Config) ->
+    ResponderLeaves = proplists:get_value(responder_leaves, Config, true),
     #{initiator := IConnPid,
       responder := RConnPid} = proplists:get_value(channel_clients, Config),
     ok = ?WS:register_test_for_channel_events(IConnPid, [leave, info]),
@@ -1115,13 +1161,29 @@ sc_ws_leave_(Config) ->
     {IDi, IDr} = {IDr, IDi},
     {StI, StR} = {StR, StI},
     {ok, #{<<"event">> := <<"died">>}} = wait_for_channel_event(IConnPid, info, Config),
-    {ok, #{<<"event">> := <<"died">>}} = wait_for_channel_event(RConnPid, info, Config),
+    if ResponderLeaves ->
+            {ok, #{<<"event">> := <<"died">>}} = wait_for_channel_event(RConnPid, info, Config);
+       true ->
+            {ok, #{<<"event">> := <<"peer_disconnected">>}}
+                = wait_for_channel_event(RConnPid, info, Config)
+    end,
     ok = ?WS:wait_for_event(IConnPid, websocket, closed),
-    ok = ?WS:wait_for_event(RConnPid, websocket, closed),
+    if ResponderLeaves ->
+            ok = ?WS:wait_for_event(RConnPid, websocket, closed);
+       true ->
+            %% RConnPid remains. Need to unregister events
+            ok = ?WS:unregister_test_for_channel_events(RConnPid, [leave, info]),
+            ok = ?WS:unregister_test_for_events(RConnPid, websocket, [closed]),
+            ok
+    end,
     %%
     Options = proplists:get_value(channel_options, Config),
     Port = maps:get(port, Options),
-    RPort = Port+1,
+    RPort = if ResponderLeaves ->
+                    Port+1;     % new port
+               true ->
+                    Port        % same port as before
+            end,
     ReestablishOptions = #{ existing_channel_id => IDi
                           , offchain_tx => StI
                           , port => RPort
@@ -1130,29 +1192,53 @@ sc_ws_leave_(Config) ->
     ReestablishOptions.
 
 
-sc_ws_reestablish_(ReestablishOptions, Config) ->
-    {ok, RrConnPid} = channel_ws_start(responder, ReestablishOptions, Config),
+sc_ws_reestablish_(ReestablOptions, Config) ->
+    ct:log("ReestablOptions = ~p~n"
+           "Config = ~p", [ReestablOptions, Config]),
+    ResponderLeaves = proplists:get_value(responder_leaves, Config, true),
+    RrConnPid
+        = if ResponderLeaves ->
+                  {ok, RrCP} = channel_ws_start(responder, ReestablOptions, Config),
+                  RrCP;
+             true ->
+                  %% responder still running
+                  #{responder := RCP} = proplists:get_value(channel_clients, Config),
+                  RCP
+    end,
     {ok, IrConnPid} = channel_ws_start(initiator, maps:put(
                                                     host, <<"localhost">>,
-                                                    ReestablishOptions), Config),
-    ok = ?WS:register_test_for_channel_events(RrConnPid, [info, update]),
-    ok = ?WS:register_test_for_channel_events(IrConnPid, [info, update]),
-    {ok, #{<<"event">> := <<"channel_reestablished">>}} =
-        wait_for_channel_event(IrConnPid, info, Config),
-    {ok, #{<<"event">> := <<"channel_reestablished">>}} =
-        wait_for_channel_event(RrConnPid, info, Config),
-    {ok, #{<<"event">> := <<"open">>}} =
-        wait_for_channel_event(IrConnPid, info, Config),
-    {ok, #{<<"event">> := <<"open">>}} =
-        wait_for_channel_event(RrConnPid, info, Config),
-    {ok, #{<<"state">> := NewState}} = wait_for_channel_event(IrConnPid, update, Config),
-    {ok, #{<<"state">> := NewState}} = wait_for_channel_event(RrConnPid, update, Config),
-    ChannelClients = #{initiator => IrConnPid,
-                       responder => RrConnPid},
-    ok = ?WS:unregister_test_for_channel_events(RrConnPid, [info, update]),
-    ok = ?WS:unregister_test_for_channel_events(IrConnPid, [info, update]),
-    [{channel_clients, ChannelClients} | Config].
+                                                    ReestablOptions), Config),
+    Config1 = lists:keystore(channel_clients, 1, Config,
+                             {channel_clients, #{ initiator => IrConnPid
+                                                , responder => RrConnPid}}),
+    ok = await_reestablish_reports(Config1),
+    Config1.
 
+await_reestablish_reports(Config) ->
+    ResponderLeaves = proplists:get_value(responder_leaves, Config, true),
+    #{initiator := IConnPid, responder := RConnPid}
+        = proplists:get_value(channel_clients, Config),
+    ok = ?WS:register_test_for_channel_events(RConnPid, [info, update]),
+    ok = ?WS:register_test_for_channel_events(IConnPid, [info, update]),
+    {ok, #{<<"event">> := <<"channel_reestablished">>}} =
+        wait_for_channel_event(IConnPid, info, Config),
+    {ok, #{<<"event">> := <<"channel_reestablished">>}} =
+        wait_for_channel_event(RConnPid, info, Config),
+    {ok, #{<<"event">> := <<"open">>}} =
+        wait_for_channel_event(IConnPid, info, Config),
+    {ok, #{<<"event">> := <<"open">>}} =
+        wait_for_channel_event(RConnPid, info, Config),
+    {ok, #{<<"state">> := NewState}} = wait_for_channel_event(IConnPid, update, Config),
+    if ResponderLeaves ->
+            {ok, #{<<"state">> := NewState}} = wait_for_channel_event(RConnPid, update, Config);
+       true ->
+            %% Responder doesn't issue a new update report, since its state didn't change
+            ok
+    end,
+    ok = ?WS:unregister_test_for_channel_events(RConnPid, [info, update]),
+    ok = ?WS:unregister_test_for_channel_events(IConnPid, [info, update]),
+    ?CHECK_INFO(20),
+    ok.
 
 sc_ws_deposit_(Config, Origin, XOpts) when Origin =:= initiator
                                     orelse Origin =:= responder ->
@@ -2497,6 +2583,11 @@ sc_ws_basic_open_close(Config0) ->
     ok = sc_ws_update_(Config),
     ok = sc_ws_close_(Config).
 
+sc_ws_basic_open_close_no_password(Config) ->
+    with_trace(fun(Cfg) -> 
+                       sc_ws_basic_open_close([{no_password, true}|Cfg])
+               end, Config, "sc_ws_basic_open_close_no_password").
+
 sc_ws_basic_open_close_server(Config0) ->
     Config = sc_ws_open_([server_mode|Config0]),
     ok = sc_ws_update_(Config),
@@ -2655,6 +2746,9 @@ sc_ws_basic_client_reconnect_i(Config) ->
 sc_ws_basic_client_reconnect_r(Config) ->
     sc_ws_basic_client_reconnect_(responder, Config).
 
+sc_ws_basic_client_reconnect_i_w_reestablish(Config) ->
+    sc_ws_basic_client_reconnect_(initiator, [{reconnect_method, reestablish}|Config]).
+
 sc_ws_basic_client_reconnect_(Role, Config0) ->
     Config = sc_ws_open_(Config0),
     #{ Role := #{ pub_key  := Pubkey
@@ -2674,6 +2768,7 @@ sc_ws_basic_client_reconnect_(Role, Config0) ->
     ok = update_with_client_disconnected(
            both, OtherRole, Clients#{Role => undefined},
            Participants, Config),
+    ct:log("Reconnecting client ..." , []),
     Config1 = reconnect_client_(ChId, Role, Pubkey, Privkey, Config),
     sc_ws_close_mutual_(Config1, Role).
 
@@ -2739,7 +2834,31 @@ other_role(responder) -> initiator;
 other_role(initiator) -> responder.
 
 reconnect_client_(ChId, Role, Pub, Priv, Config) ->
-    reconnect_client_(ChId, 1, Role, Pub, Priv, Config).
+    case proplists:get_value(reconnect_method, Config, reconnect) of
+        reconnect ->
+            reconnect_client_(ChId, 1, Role, Pub, Priv, Config);
+        reestablish ->
+            ct:log("Will reconnect via reestablish", []),
+            ?CHECK_INFO(20),
+            #{ initiator_id := I
+             , responder_id := R
+             , port         := Port } = proplists:get_value(channel_options, Config),
+            ReestablishOpts = maybe_add_password(
+                                #{ existing_channel_id => ChId
+                                 , role                => Role
+                                 , protocol            => sc_ws_protocol(Config)
+                                 , host                => <<"localhost">>
+                                 , port                => Port
+                                 , initiator_id        => I
+                                 , responder_id        => R }, Config),
+            ct:log("ReestablishOpts = ~p", [ReestablishOpts]),
+            {ok, ConnPid} = channel_ws_start(Role, ReestablishOpts, Config),
+            ct:log("New ConnPid = ~p", [ConnPid]),
+            Config1 = lists:keystore(channel_clients, 1, Config,
+                                     {channel_clients, maps:put(Role, ConnPid,
+                                                                ?config(channel_clients, Config))}),
+            Config1
+    end.
 
 reconnect_client_(ChId, Round, Role, Pub, Priv, Config) ->
     ct:log("reconnecting ChId = ~p, Role = ~p, Pub = ~p", [ChId, Role, Pub]),
@@ -2756,8 +2875,15 @@ reconnect_client_(ChId, Round, Role, Pub, Priv, Config) ->
     ChannelOpts = reconnect_channel_options(SignedTxBin, Config),
     {ok, ConnPid} = channel_ws_start(Role, ChannelOpts, Config),
     {_, ChannelClients} = lists:keyfind(channel_clients, 1, Config),
-    lists:keyreplace(channel_clients, 1, Config,
-                     {channel_clients, ChannelClients#{ Role => ConnPid }}).
+    Config1 = lists:keyreplace(channel_clients, 1, Config,
+                               {channel_clients, ChannelClients#{ Role => ConnPid }}),
+    case proplists:get_value(reconnect_scenario, Config1, reconnect) of
+        reconnect ->
+            ok;
+        reestablish ->
+            await_reestablish_reports(Config1)
+    end,
+    Config1.
 
 sc_ws_failed_update(Config) ->
     ChannelClients = proplists:get_value(channel_clients, Config),
@@ -2962,10 +3088,10 @@ sc_ws_slash_(Config, WhoCloses, WhoSlashes, WhoSettles) ->
 %% other(initiator) -> responder;
 %% other(responder) -> initiator.
 
-sign_slash_tx(ConnPid, Who, Config) ->
-    Participants = proplists:get_value(participants, Config),
-    #{priv_key := PrivKey} = maps:get(Who, Participants),
-    sign_tx(ConnPid, <<"slash_tx">>, <<"channels.slash_sign">>, PrivKey, Config).
+%% sign_slash_tx(ConnPid, Who, Config) ->
+%%     Participants = proplists:get_value(participants, Config),
+%%     #{priv_key := PrivKey} = maps:get(Who, Participants),
+%%     sign_tx(ConnPid, <<"slash_tx">>, <<"channels.slash_sign">>, PrivKey, Config).
 
 request_and_sign_slash_tx(ConnPid, Who, Config, ReqF) ->
     Participants = proplists:get_value(participants, Config),
@@ -3056,12 +3182,57 @@ sc_ws_cheating_close_solo_(Config, ChId, Poi, WhoCloses) ->
     ok.
 
 sc_ws_leave_reestablish(Config0) ->
-    Config = sc_ws_open_(Config0),
+    Config = sc_ws_open_([{slogan, ?SLOGAN}|Config0]),
     ReestablishOptions = sc_ws_leave_(Config),
-
+    ?CHECK_INFO(20),
     Config1 = sc_ws_reestablish_(ReestablishOptions, Config),
     ok = sc_ws_update_(Config1),
     ok = sc_ws_close_(Config1).
+
+sc_ws_leave_reestablish_responder_stays(Config0) ->
+    Config = sc_ws_open_([{slogan, ?SLOGAN}|Config0], #{responder_opts => #{keep_running => true}}),
+    Config1 = [{responder_leaves, false}|Config],
+    ReestablOptions = sc_ws_leave_(Config1),
+    Config2 = sc_ws_reestablish_(ReestablOptions, Config1),
+    ok = sc_ws_update_(Config2),
+    ok = sc_ws_close_(Config2).
+
+sc_ws_leave_reconnect(Config0) ->
+    ct:log("opening channel", []),
+    Config = sc_ws_open_([{slogan, ?SLOGAN}|Config0], #{responder_opts => #{keep_running => true}}),
+    ct:log("channel opened", []),
+    Participants = proplists:get_value(participants, Config),
+    #{ pub_key := Pub, priv_key := Priv } = maps:get(initiator, Participants),
+    ct:log("*** Leaving channel ***", []),
+    Config1 = [{responder_leaves, false}|Config],
+    ct:log("Config1 = ~p", [Config1]),
+    #{ existing_channel_id := ChId
+     , offchain_tx         := _Tx }
+        = ReestOpts = sc_ws_leave_(Config1),
+    ct:log("ReestOpts = ~p", [ReestOpts]),
+    ct:log("*** Reconnecting ... ***", []),
+    Config2 = reconnect_client_(ChId, initiator, Pub, Priv,
+                                [{reconnect_scenario, reestablish} | Config1]),
+    ct:log("*** Verifying that channel is operational ***", []),
+    ok = sc_ws_update_(Config2),
+    ct:log("*** Closing ... ***", []),
+    ok = sc_ws_close_(Config2).
+
+sc_ws_password_changeable(Config0) ->
+    Config = sc_ws_open_([{slogan, ?SLOGAN}|Config0]),
+    Options = proplists:get_value(channel_options, Config),
+    StatePasswordOld = maps:get(state_password, Options),
+    Config1 = sc_ws_change_password_(Config),
+    ReestablishOptions = sc_ws_leave_(Config1),
+    ReestablishOptionsOld = ReestablishOptions#{state_password => StatePasswordOld},
+
+    %% Reestablish with old password should fail
+    Roles = [initiator, responder],
+    [sc_ws_test_broken_params(Role, Config, ReestablishOptionsOld, <<"Invalid password">>, Config) || Role <- Roles],
+
+    Config2 = sc_ws_reestablish_(ReestablishOptions, Config1),
+    ok = sc_ws_update_(Config2),
+    ok = sc_ws_close_(Config2).
 
 sc_ws_change_password_(Config) ->
     ct:log("Changing password"),
@@ -3121,27 +3292,54 @@ sc_ws_withdraw(Config) ->
         end,
         [initiator, responder]).
 
-
 %% channel_options(IPubkey, RPubkey, IAmt, RAmt) ->
 %%     channel_options(IPubkey, RPubkey, IAmt, RAmt, #{}).
 
 channel_options(IPubkey, RPubkey, IAmt, RAmt, Other, Config) ->
-    maps:merge(#{ port => ?config(ws_port, Config),
-                  initiator_id => aeser_api_encoder:encode(account_pubkey, IPubkey),
-                  responder_id => aeser_api_encoder:encode(account_pubkey, RPubkey),
-                  lock_period => 10,
-                  push_amount => 1,
-                  initiator_amount => IAmt,
-                  responder_amount => RAmt,
-                  channel_reserve => 2,
-                  protocol => sc_ws_protocol(Config),
-                  state_password => ?CACHE_DEFAULT_PASSWORD
-                }, Other).
+    maybe_slogan(
+      maybe_add_password(
+        maps:merge(#{ port => ?config(ws_port, Config),
+                      initiator_id => aeser_api_encoder:encode(account_pubkey, IPubkey),
+                      responder_id => aeser_api_encoder:encode(account_pubkey, RPubkey),
+                      lock_period => 10,
+                      push_amount => 1,
+                      initiator_amount => IAmt,
+                      responder_amount => RAmt,
+                      channel_reserve => 2,
+                      protocol => sc_ws_protocol(Config)
+                    }, Other), Config), Config).
+
+maybe_add_password(#{state_password := _} = Map, _) ->
+    Map;
+maybe_add_password(Map, Config) ->
+    case proplists:get_value(no_password, Config, false) of
+        true ->
+            Map;
+        _ ->
+            Map#{state_password => ?CACHE_DEFAULT_PASSWORD}
+    end.
+
+maybe_slogan(#{slogan := _} = Map, _) ->
+    Map;
+maybe_slogan(Map, Config) ->
+    case proplists:get_value(slogan, Config) of
+        undefined ->
+            Map;
+        S ->
+            Map#{slogan => S}
+    end.
+
+special_channel_opts(Opts) ->
+    Opts1 = maps:without([initiator_opts, responder_opts], Opts),
+    {maps:merge(Opts1, maps:get(initiator_opts, Opts, #{})),
+     maps:merge(Opts1, maps:get(responder_opts, Opts, #{}))}.
 
 reconnect_channel_options(SignedTx, Config) ->
-    #{ port => ?config(ws_port, Config)
-     , reconnect_tx => SignedTx
-     , protocol => sc_ws_protocol(Config) }.
+    maybe_add_password(
+      #{ port => ?config(ws_port, Config)
+       , reconnect_tx => SignedTx
+       %% , state_password => StatePassword
+       , protocol => sc_ws_protocol(Config) }, Config).
 
 current_height() ->
     case rpc(aec_chain, top_header, []) of
@@ -3214,6 +3412,8 @@ log_basename(Config) ->
             with_open_channel ->
                 filename:join(Protocol, "continuous");
             client_reconnect ->
+                filename:join(Protocol, "reconnect");
+            client_reconnect_no_password ->
                 filename:join(Protocol, "reconnect");
             sc_contracts ->
                 filename:join(Protocol, "contracts");
@@ -3674,7 +3874,7 @@ account_type(Pubkey) ->
 sc_ws_test_broken_params(Role, Config, Opts, Error, Config) ->
     {ok, Pid} = channel_ws_start(Role,
                                        maps:put(host, <<"localhost">>,
-                                                Opts), Config),
+                                                Opts), [{slogan, ?SLOGAN}|Config]),
     ok = ?WS:register_test_for_channel_events(Pid, [closed, error]),
     {ok, #{<<"reason">> := Error}}
         = wait_for_channel_event(Pid, error, Config),
@@ -3955,3 +4155,19 @@ sc_ws_pinned_contract(Cfg) ->
            Delta <- [NNT, NOT, NNT + 1]],
     ok = sc_ws_close_(Config).
 
+check_info(L, Timeout) ->
+    receive
+        Msg ->
+            ct:log("[~p] UNEXPECTED: ~p", [L, Msg]),
+            [Msg|check_info(L, Timeout)]
+    after Timeout ->
+            []
+    end.
+
+peek_msgq(L) ->
+    case process_info(self(), messages) of
+        {_, []} ->
+            ok;
+        {_, Msgs} ->
+            ct:log("[~p] PEEK = ~p", [L, Msgs])
+    end.

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -3306,6 +3306,7 @@ channel_options(IPubkey, RPubkey, IAmt, RAmt, Other, Config) ->
                       initiator_amount => IAmt,
                       responder_amount => RAmt,
                       channel_reserve => 2,
+                      keep_running => false,
                       protocol => sc_ws_protocol(Config)
                     }, Other), Config), Config).
 

--- a/apps/aehttp/test/aehttp_ws_test_utils.erl
+++ b/apps/aehttp/test/aehttp_ws_test_utils.erl
@@ -60,7 +60,7 @@
                }).
 
 start_link(Host, Port) ->
-    WsAddress = "ws://" ++ Host ++ ":" ++ integer_to_list(Port) ++ "/websocket",
+    WsAddress = "wss://" ++ Host ++ ":" ++ integer_to_list(Port) ++ "/websocket",
     ct:log("connecting to ~p", [WsAddress]),
     {ok, Pid} = websocket_client:start_link(WsAddress, ?MODULE, self()),
     wait_for_connect(Pid).

--- a/apps/aehttp/test/aehttp_ws_test_utils.erl
+++ b/apps/aehttp/test/aehttp_ws_test_utils.erl
@@ -60,6 +60,7 @@
                }).
 
 start_link(Host, Port) ->
+    % TODO: Make it configurable whether to use `ws` or `wss`
     WsAddress = "wss://" ++ Host ++ ":" ++ integer_to_list(Port) ++ "/websocket",
     ct:log("connecting to ~p", [WsAddress]),
     {ok, Pid} = websocket_client:start_link(WsAddress, ?MODULE, self()),


### PR DESCRIPTION
See PR #2758 - commits squashed and cherry-picked onto the `aeuniverse-demo` branch.

Test suites pass locally. State password given a default value in the `sc_ws_handler` options parsing.