### PR TITLE
Reconnect regardless of previous WS connection

### DIFF
--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -211,11 +211,9 @@ check_existing_client(Client, Opts, Handler) ->
             MRef = erlang:monitor(process, Client),
             exit(Client, kill),
             receive {'DOWN', MRef, _, _, _} ->
-                    timer:sleep(100),
                     reconnect_to_fsm_(Opts, Handler, OnError)
             end;
        true ->
-            timer:sleep(100),
             reconnect_to_fsm_(Opts, Handler, OnError)
     end.
 

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -206,9 +206,7 @@ check_existing_client(Client, Opts, Handler) ->
               end,
     T = time_since_last_dispatch(Client),
     lager:debug("Time since last dispatch (~p): ~p", [Client, T]),
-    if is_integer(T), T < 5000 ->
-            handler_init_error(client_still_active, Handler);
-       is_integer(T) ->
+    if is_integer(T) ->
             %% It is actually a WS client
             MRef = erlang:monitor(process, Client),
             exit(Client, kill),


### PR DESCRIPTION
We kill any previous WS connection when a reconnect happens.

Previously the old WS connection would block the reconnection which blocks a client which has lost that connection client-side.