### PR TITLE
Refactor aec_dev_reward:activated

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -899,10 +899,10 @@ grant_fees(Node, Trees, Delay, FraudStatus, State) ->
         calc_rewards(FraudStatus1, FraudStatus2, KeyFees, MineReward2,
                      FraudReward1, node_is_genesis(KeyNode1, State)),
 
-    OldestBeneficiaryHeight = node_height(KeyNode1),
+    OldestBeneficiaryVersion = version(KeyNode1),
     {{AdjustedReward1, AdjustedReward2}, DevRewards} =
         aec_dev_reward:split(BeneficiaryReward1, BeneficiaryReward2,
-                             OldestBeneficiaryHeight),
+                             OldestBeneficiaryVersion),
 
     Trees1 = lists:foldl(
                fun({K, Amt}, TreesAccum) when Amt > 0 ->

--- a/apps/aecore/src/aec_dev_reward.erl
+++ b/apps/aecore/src/aec_dev_reward.erl
@@ -70,10 +70,10 @@ allocated_shares() ->
     {ok, V} = aeu_env:get_env(aecore, dev_reward_allocated_shares),
     V.
 
-activated(Height) ->
+activated(Protocol) ->
     case env(dev_reward_activated, undefined) of %% for eunit to avoid mocking
         undefined ->
-            aec_hard_forks:protocol_effective_at_height(Height) >= ?FORTUNA_PROTOCOL_VSN;
+            Protocol >= ?FORTUNA_PROTOCOL_VSN;
         Val when is_boolean(Val) ->
             Val
     end.

--- a/apps/aecore/src/aec_dev_reward.erl
+++ b/apps/aecore/src/aec_dev_reward.erl
@@ -111,8 +111,8 @@ parse_beneficiaries([_|_] = BeneficiarySharesStrs) ->
     end.
 
 
-split(BeneficiaryReward1, BeneficiaryReward2, NewestNodeHeight) ->
-    case enabled() andalso activated(NewestNodeHeight) of
+split(BeneficiaryReward1, BeneficiaryReward2, NewestNodeVersion) ->
+    case enabled() andalso activated(NewestNodeVersion) of
         true ->
             split_int(BeneficiaryReward1, BeneficiaryReward2,
                       allocated_shares(), total_shares(),

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -308,8 +308,9 @@ grant_fees(FromHeight, Chain, TreesIn, BeneficiaryAccount) ->
     Beneficiary1Reward = round(0.4 * Fees),
     BlockReward = aec_governance:block_mine_reward(FromHeight + 1),
     Beneficiary2Reward = Fees - Beneficiary1Reward + BlockReward,
+    Protocol = aec_hard_forks:protocol_effective_at_height(FromHeight),
     {{Benefits1, Benefits2}, BenefitsProto} =
-        case aec_dev_reward:enabled() andalso aec_dev_reward:activated(FromHeight) of
+        case aec_dev_reward:enabled() andalso aec_dev_reward:activated(Protocol) of
             true ->
                 AllocShares = 100,
                 TotalShares = 1000,


### PR DESCRIPTION
[PT-168779254](https://www.pivotaltracker.com/n/projects/2124891/stories/168779254)

Preparatory PR for fork signalling.

`aec_hard_forks:protocol_effective_at_height` is not needed in `aec_dev_reward:activated`.