### PR TITLE
Remove protocol_effective_at_height from aetx module

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -4814,8 +4814,8 @@ min_tx_fee(Tx) ->
     max(MinTxFee, MinGasRequirements).
 
 min_gas(Tx) ->
-    CurrHeight = curr_height(),
-    MinGas = aetx:min_gas(Tx, CurrHeight),
+    {CurrHeight, CurrProtocol} = curr_height_and_protocol(),
+    MinGas = aetx:min_gas(Tx, CurrHeight, CurrProtocol),
     MinMinerGasPrice = aec_tx_pool:minimum_miner_gas_price(),
     MinGas * MinMinerGasPrice.
 

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1551,11 +1551,12 @@ new_onchain_tx_for_signing_(Type, Opts, OnErr, D) ->
     Opts1 = maps:merge(Defaults, Opts),
     {BlockHash, OnChainEnv, OnChainTrees} = pick_onchain_env(Opts, D),
     PinnedHeight = aetx_env:height(OnChainEnv),
+    PinnedProtocol = aetx_env:consensus_version(OnChainEnv),
     TxRes = new_onchain_tx(Type, Opts1, D, BlockHash, OnChainEnv,
                            OnChainTrees),
     case {TxRes, OnErr} of
         {{ok, Tx, Updates}, _} ->
-            case {aetx:min_fee(Tx, PinnedHeight), aetx:fee(Tx)} of
+            case {aetx:min_fee(Tx, PinnedHeight, PinnedProtocol), aetx:fee(Tx)} of
                 {MinFee, Fee} when MinFee =< Fee ->
                     {ok, Tx, Updates, BlockHash};
                 {MinFee, Fee} ->
@@ -1912,7 +1913,7 @@ get_nonce(Pubkey) ->
     end.
 
 %% @doc the default fee will be used as a base for adjustment, once
-%% we have an actual transaction record (required by aetx:min_fee/2).
+%% we have an actual transaction record (required by aetx:min_fee/3).
 %% The default should err on the side of being too low.
 default_fee(_Tx) ->
     CurrProtocol = curr_protocol(),
@@ -1938,6 +1939,10 @@ curr_hash_and_height() ->
     {ok, Hash} = aec_headers:hash_header(TopHeader),
     Height = aec_headers:height(TopHeader),
     {Hash, Height}.
+
+curr_height_and_protocol() ->
+    TopHeader = aec_chain:top_header(),
+    {aec_headers:height(TopHeader), aec_headers:version(TopHeader)}.
 
 -spec curr_height() -> aec_blocks:height().
 curr_height() ->
@@ -4803,8 +4808,8 @@ default_minimum_depth(Strategy) ->
     end.
 
 min_tx_fee(Tx) ->
-    CurrHeight = curr_height(),
-    MinTxFee = aetx:min_fee(Tx, CurrHeight),
+    {CurrHeight, CurrProtocol} = curr_height_and_protocol(),
+    MinTxFee = aetx:min_fee(Tx, CurrHeight, CurrProtocol),
     MinGasRequirements = min_gas(Tx),
     max(MinTxFee, MinGasRequirements).
 

--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -500,6 +500,7 @@ verify_signature_onchain_(SignerId, AuthContractId, MetaTx, Trees, Env)
   {ok, binary(), aetx_sign:signed_tx()} | {error, atom()}.
 verify_meta_tx(SignerId, StoreKey, AuthContractId, MetaTx, Trees, Env, TxType)
     when StoreKey =/= undefined, AuthContractId =/= undefined ->
+    Protocol = aetx_env:consensus_version(Env),
     Height = aetx_env:height(Env),
     {_, SignerPK} = aeser_id:specialize(SignerId),
     {_, AuthContractPK} = aeser_id:specialize(AuthContractId),
@@ -511,7 +512,7 @@ verify_meta_tx(SignerId, StoreKey, AuthContractId, MetaTx, Trees, Env, TxType)
         {{value, Contract}, {ok, Store}} ->
             CallDef = #{ caller      => SignerPK
                        , contract    => AuthContractPK
-                       , gas         => aega_meta_tx:gas_limit(MetaTx, Height)
+                       , gas         => aega_meta_tx:gas_limit(MetaTx, Height, Protocol)
                        , gas_price   => aega_meta_tx:gas_price(MetaTx)
                        , call_data   => aega_meta_tx:auth_data(MetaTx)
                        , amount      => 0

--- a/apps/aecore/src/aec_block_fork.erl
+++ b/apps/aecore/src/aec_block_fork.erl
@@ -155,7 +155,9 @@ contract_create_tx(#{ amount       := Amount
                call_data   => CallData,
                fee         => 1000000000000000}, %% Overshoot the size of the actual fee
     {ok, DummyTx} = aect_create_tx:new(TxSpec),
-    MinFee        = aetx:min_fee(DummyTx, aetx_env:height(TxEnv)),
+    Height = aetx_env:height(TxEnv),
+    Protocol = aetx_env:consensus_version(TxEnv),
+    MinFee        = aetx:min_fee(DummyTx, Height, Protocol),
     {ok, Tx}      = aect_create_tx:new(TxSpec#{fee => MinFee}),
     %% Make sure the transaction will give the expected pubkey.
     case aect_contracts:compute_contract_pubkey(OwnerPubkey, Nonce) of

--- a/apps/aecore/src/aec_block_fork.erl
+++ b/apps/aecore/src/aec_block_fork.erl
@@ -155,10 +155,10 @@ contract_create_tx(#{ amount       := Amount
                call_data   => CallData,
                fee         => 1000000000000000}, %% Overshoot the size of the actual fee
     {ok, DummyTx} = aect_create_tx:new(TxSpec),
-    Height = aetx_env:height(TxEnv),
+    Height   = aetx_env:height(TxEnv),
     Protocol = aetx_env:consensus_version(TxEnv),
-    MinFee        = aetx:min_fee(DummyTx, Height, Protocol),
-    {ok, Tx}      = aect_create_tx:new(TxSpec#{fee => MinFee}),
+    MinFee   = aetx:min_fee(DummyTx, Height, Protocol),
+    {ok, Tx} = aect_create_tx:new(TxSpec#{fee => MinFee}),
     %% Make sure the transaction will give the expected pubkey.
     case aect_contracts:compute_contract_pubkey(OwnerPubkey, Nonce) of
         ExpectedPubkey -> Tx;

--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -202,7 +202,9 @@ add_txs_to_trees(MaxGas, Trees, Txs, Env) ->
 add_txs_to_trees(_MaxGas, Trees, [], Acc, Env) ->
     {lists:reverse(Acc), Trees, Env};
 add_txs_to_trees(MaxGas, Trees, [Tx | Txs], Acc, Env) ->
-    TxGas = aetx:gas_limit(aetx_sign:tx(Tx), aetx_env:height(Env)),
+    Protocol = aetx_env:consensus_version(Env),
+    Height = aetx_env:height(Env),
+    TxGas = aetx:gas_limit(aetx_sign:tx(Tx), Height, Protocol),
     case TxGas =< MaxGas of
         true ->
             case aec_trees:apply_txs_on_state_trees([Tx], Trees, Env) of

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -421,10 +421,11 @@ validate_gas_limit(#mic_block{} = Block) ->
 
 -spec validate_txs_fee(block()) -> ok | {error, invalid_minimal_tx_fee}.
 validate_txs_fee(#mic_block{header = Header, txs = STxs}) ->
+    Protocol = aec_headers:version(Header),
     Height = aec_headers:height(Header),
     case lists:all(fun(STx) ->
                            Tx = aetx_sign:tx(STx),
-                           aetx:fee(Tx) >= aetx:min_fee(Tx, Height)
+                           aetx:fee(Tx) >= aetx:min_fee(Tx, Height, Protocol)
                    end, STxs) of
         true -> ok;
         false -> {error, invalid_minimal_tx_fee}

--- a/apps/aecore/src/aec_blocks.erl
+++ b/apps/aecore/src/aec_blocks.erl
@@ -235,8 +235,9 @@ difficulty(Block) ->
 
 -spec gas(micro_block()) -> non_neg_integer().
 gas(#mic_block{txs = Txs} = Block) ->
-    Height = aec_headers:height(to_header(Block)),
-    lists:foldl(fun(Tx, Acc) -> aetx:gas_limit(aetx_sign:tx(Tx), Height) + Acc end, 0, Txs).
+    Version = aec_blocks:version(Block),
+    Height = aec_blocks:height(Block),
+    lists:foldl(fun(Tx, Acc) -> aetx:gas_limit(aetx_sign:tx(Tx), Height, Version) + Acc end, 0, Txs).
 
 -spec time_in_msecs(block()) -> non_neg_integer().
 time_in_msecs(Block) ->

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -43,6 +43,11 @@ protocols() ->
 check_env() ->
     assert_protocols(protocols()).
 
+%% This function is supposed to be used only when:
+%% - a new block is being added to the database (in aec_conductor);
+%% - a new key block candidate is prepared (aec_block_key_candidate).
+%% The function shouldn't be used elsewhere (apart from tests). With community
+%% forks the function can return different protocol versions at the same height.
 -spec protocol_effective_at_height(aec_blocks:height()) -> version().
 protocol_effective_at_height(H) ->
     protocol_effective_at_height(H, protocols()).

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -883,9 +883,10 @@ get_account(AccountKey, {block_hash, BlockHash}) ->
     aec_chain:get_account_at_hash(AccountKey, BlockHash).
 
 check_minimum_fee(Tx, _TxHash, Block, _BlockHash, _Trees, _Event) ->
+    Protocol = aec_blocks:version(Block),
     Height = aec_blocks:height(Block),
     Tx1 = aetx_sign:tx(Tx),
-    case aetx:fee(Tx1) >= aetx:min_fee(Tx1, Height) of
+    case aetx:fee(Tx1) >= aetx:min_fee(Tx1, Height, Protocol) of
         true  -> ok;
         false -> {error, too_low_fee}
     end.

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -475,7 +475,7 @@ check_candidate(Db, #dbs{gc_db = GCDb} = _Dbs,
                 Acc = #{ tree := AccTree, txs := AccTxs }) ->
     Tx1 = aetx_sign:tx(Tx),
     TxTTL = aetx:ttl(Tx1),
-    TxGas = aetx:gas_limit(Tx1, Height),
+    TxGas = aetx:gas_limit(Tx1, Height, Protocol),
     case Height < TxTTL andalso TxGas > 0
          andalso ok =:= int_check_account(Tx, AccountsTree, check_candidate)
          andalso MinMinerGasPrice =< aetx:min_gas_price(Tx1, Height, Protocol) of

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -428,37 +428,37 @@ int_get_candidate(Db, Gas, MinTxGas, MinMinerGasPrice, Trees, Header, DBs, Acc)
     int_get_candidate_fold(Gas, MinTxGas, MinMinerGasPrice, Db, DBs,
                            ets:select(Db, Pat, 20),
                            {account_trees, aec_trees:accounts(Trees)},
-                           aec_headers:height(Header), Acc);
+                           aec_headers:height(Header), aec_headers:version(Header), Acc);
 int_get_candidate(Gas, _, _, _, _, _, _, Acc) ->
     {ok, Gas, Acc}.
 
 int_get_candidate_fold(Gas, MinTxGas, _MinMinerGasPrice, _Db, _Dbs, _Txs,
-                       _ATrees, _Height, Acc) when Gas =< MinTxGas ->
+                       _ATrees, _Height, _Protocol, Acc) when Gas =< MinTxGas ->
     {ok, Gas, Acc};
 int_get_candidate_fold(Gas, MinTxGas, MinMinerGasPrice, Db, Dbs = #dbs{}, {Txs, Cont},
-                       AccountsTree, Height, Acc) when Gas > MinTxGas ->
+                       AccountsTree, Height, Protocol, Acc) when Gas > MinTxGas ->
     {RemGas, NewAcc} = fold_txs(Txs, Gas, MinTxGas, MinMinerGasPrice, Db, Dbs,
-                                AccountsTree, Height, Acc),
+                                AccountsTree, Height, Protocol, Acc),
     int_get_candidate_fold(RemGas, MinTxGas, MinMinerGasPrice, Db, Dbs, ets:select(Cont),
-                           AccountsTree, Height, NewAcc);
+                           AccountsTree, Height, Protocol, NewAcc);
 int_get_candidate_fold(RemGas, _GL, _MMGP, _Db, _Dbs, '$end_of_table', _AccountsTree,
-                       _Height, Acc) ->
+                       _Height, _Protocol, Acc) ->
     {ok, RemGas, Acc}.
 
-fold_txs([Tx|Txs], Gas, MinTxGas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Acc) ->
+fold_txs([Tx|Txs], Gas, MinTxGas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Protocol, Acc) ->
     if Gas > MinTxGas ->
             {Gas1, Acc1} =
                 int_get_candidate_(
-                  Tx, Gas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Acc),
-            fold_txs(Txs, Gas1, MinTxGas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Acc1);
+                  Tx, Gas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Protocol, Acc),
+            fold_txs(Txs, Gas1, MinTxGas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Protocol, Acc1);
        true ->
             {Gas, Acc}
     end;
-fold_txs([], Gas, _, _, _, _, _, _, Acc) ->
+fold_txs([], Gas, _, _, _, _, _, _, _, Acc) ->
     {Gas, Acc}.
 
 int_get_candidate_({?KEY(_, _, Account, Nonce, _) = Key, Tx},
-                   Gas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height,
+                   Gas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Protocol,
                    Acc = #{ tree := AccTree }) ->
     case gb_trees:is_defined({Account, Nonce}, AccTree) of
         true when Nonce > 0 ->
@@ -466,19 +466,19 @@ int_get_candidate_({?KEY(_, _, Account, Nonce, _) = Key, Tx},
             {Gas, Acc};
         false ->
             check_candidate(
-              Db, Dbs, Key, Tx, AccountsTree, Height, Gas, MinMinerGasPrice, Acc)
+              Db, Dbs, Key, Tx, AccountsTree, Height, Gas, MinMinerGasPrice, Protocol, Acc)
     end.
 
 check_candidate(Db, #dbs{gc_db = GCDb} = _Dbs,
                 ?KEY(_, _, Account, Nonce, TxHash) = Key, Tx,
-                AccountsTree, Height, Gas, MinMinerGasPrice,
+                AccountsTree, Height, Gas, MinMinerGasPrice, Protocol,
                 Acc = #{ tree := AccTree, txs := AccTxs }) ->
     Tx1 = aetx_sign:tx(Tx),
     TxTTL = aetx:ttl(Tx1),
     TxGas = aetx:gas_limit(Tx1, Height),
     case Height < TxTTL andalso TxGas > 0
          andalso ok =:= int_check_account(Tx, AccountsTree, check_candidate)
-         andalso MinMinerGasPrice =< aetx:min_gas_price(Tx1, Height) of
+         andalso MinMinerGasPrice =< aetx:min_gas_price(Tx1, Height, Protocol) of
         true ->
             case Gas - TxGas of
                 RemGas when RemGas >= 0 ->
@@ -892,9 +892,11 @@ check_minimum_fee(Tx, _TxHash, Block, _BlockHash, _Trees, _Event) ->
     end.
 
 check_minimum_miner_gas_price(Tx, _TxHash, Block, _BlockHash, _Trees, _Event) ->
+    Protocol = aec_blocks:version(Block),
     Height = aec_blocks:height(Block),
     MinMinerGasPrice = aec_tx_pool:minimum_miner_gas_price(),
-    case aetx:min_gas_price(aetx_sign:tx(Tx), Height) >= MinMinerGasPrice of
+    STx = aetx_sign:tx(Tx),
+    case aetx:min_gas_price(STx, Height, Protocol) >= MinMinerGasPrice of
         true  -> ok;
         false -> {error, too_low_gas_price_for_miner}
     end.

--- a/apps/aecore/test/aec_block_micro_candidate_tests.erl
+++ b/apps/aecore/test/aec_block_micro_candidate_tests.erl
@@ -120,6 +120,8 @@ block_extension_test_() ->
         end},
        {"Updating a block does not exceed microblock gas limit",
         fun() ->
+            Height = 10,
+            Protocol = aec_hard_forks:protocol_effective_at_height(Height),
             SpendTx = fun(Data) -> aec_test_utils:sign_tx(spend_tx(Data), ?TEST_PRIV) end,
             Gas = fun(Txs) -> lists:sum(lists:map(fun(T) -> aetx:gas_limit(aetx_sign:tx(T),
                                                                            _Height = 10) end, Txs)) end,
@@ -131,7 +133,9 @@ block_extension_test_() ->
             PayloadSize = 10 * trunc(Gas([SmallSpendTx]) / aec_governance:byte_gas()),
             Payload = << <<0>> || _ <- lists:seq(1, PayloadSize) >>,
 
-            Tx = fun(N) -> SpendTx(#{nonce => N, payload => Payload, fee => 20 * aetx:min_fee(aetx_sign:tx(SmallSpendTx), 10)}) end,
+            Tx = fun(N) -> SpendTx(#{nonce   => N,
+                                     payload => Payload,
+                                     fee     => 20 * aetx:min_fee(aetx_sign:tx(SmallSpendTx), Height, Protocol)}) end,
 
             %% Compute txs for filling up block.
             MaxGas = aec_governance:block_gas_limit(),

--- a/apps/aecore/test/aec_block_micro_candidate_tests.erl
+++ b/apps/aecore/test/aec_block_micro_candidate_tests.erl
@@ -123,8 +123,10 @@ block_extension_test_() ->
             Height = 10,
             Protocol = aec_hard_forks:protocol_effective_at_height(Height),
             SpendTx = fun(Data) -> aec_test_utils:sign_tx(spend_tx(Data), ?TEST_PRIV) end,
-            Gas = fun(Txs) -> lists:sum(lists:map(fun(T) -> aetx:gas_limit(aetx_sign:tx(T),
-                                                                           _Height = 10) end, Txs)) end,
+            Gas = fun(Txs) -> lists:sum(
+                                lists:map(
+                                  fun(T) -> aetx:gas_limit(aetx_sign:tx(T), Height, Protocol) end, Txs))
+                  end,
 
             %% Reduce number of spend txs necessary for filling up block
             %% (hence reduce time necessary for running test)

--- a/apps/aecore/test/aec_spend_tx_tests.erl
+++ b/apps/aecore/test/aec_spend_tx_tests.erl
@@ -189,7 +189,9 @@ process_test_() ->
                                                   nonce => 11,
                                                   payload => <<"foo bar">>}),
 
-              ?assert(aetx:gas_limit(SpendTx1, 1) < aetx:gas_limit(SpendTx2, 1))
+              Height = 1,
+              Protocol = aec_hard_forks:protocol_effective_at_height(1),
+              ?assert(aetx:gas_limit(SpendTx1, Height, Protocol) < aetx:gas_limit(SpendTx2, Height, Protocol))
        end}]}.
 
 spend_tx(Data) ->

--- a/apps/aega/src/aega_meta_tx.erl
+++ b/apps/aega/src/aega_meta_tx.erl
@@ -37,7 +37,7 @@
          call_id/2,
          ga_id/1,
          ga_pubkey/1,
-         gas_limit/2,
+         gas_limit/3,
          gas_price/1,
          inner_tx_was_succesful/2,
          tx/1
@@ -90,9 +90,9 @@ abi_version(#ga_meta_tx{abi_version = ABI}) ->
 gas(#ga_meta_tx{gas = Gas}) ->
     Gas.
 
--spec gas_limit(tx(), non_neg_integer()) -> amount().
-gas_limit(#ga_meta_tx{gas = Gas, tx = InnerTx}, Height) ->
-    aetx:inner_gas_limit(aetx_sign:tx(InnerTx), Height) + Gas.
+-spec gas_limit(tx(), non_neg_integer(), aec_hard_forks:protocol_vsn()) -> amount().
+gas_limit(#ga_meta_tx{gas = Gas, tx = InnerTx}, Height, Protocol) ->
+    aetx:inner_gas_limit(aetx_sign:tx(InnerTx), Height, Protocol) + Gas.
 
 -spec gas_price(tx()) -> amount().
 gas_price(#ga_meta_tx{gas_price = GasPrice}) ->

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -432,7 +432,7 @@ basic_minimum_fee(_Cfg) ->
                                          amount       => 4711,
                                          height       => Height,
                                          nonce        => 0}),
-    MinimumSpendFee = aetx:min_fee(DummyTx, Height),
+    MinimumSpendFee = aetx:min_fee(DummyTx, Height, Protocol),
 
     %% When the transaction is wrapped in a meta transaction, the size of the
     %% inner transaction is paid for by the meta transaction.

--- a/apps/aemon/src/aemon_publisher.erl
+++ b/apps/aemon/src/aemon_publisher.erl
@@ -132,7 +132,7 @@ create_tx(Height, Protocol, Nonce, Payload) ->
 
 adjust_tx(Height, Protocol, Nonce, Payload, Tx0) ->
     GasPrice = aec_tx_pool:minimum_miner_gas_price(),
-    GasLimit = aetx:gas_limit(Tx0, Height),
+    GasLimit = aetx:gas_limit(Tx0, Height, Protocol),
     MinFee = aetx:min_fee(Tx0, Height, Protocol),
     MinGasFee = GasPrice * GasLimit,
 

--- a/apps/aemon/src/aemon_publisher.erl
+++ b/apps/aemon/src/aemon_publisher.erl
@@ -69,27 +69,27 @@ balance() ->
 
 post_tx() ->
     Timestamp = os:system_time(seconds),
-    {Height, HashKey, HashTop} = top_info(),
+    {Height, Protocol, HashKey, HashTop} = top_info(),
     Payload = to_payload(Height, HashKey, HashTop, Timestamp),
 
     Nonce = nonce(),
-    Tx = create_tx(Height, Nonce, Payload),
-    post_tx(Height, Nonce, Payload, Tx).
+    Tx = create_tx(Height, Protocol, Nonce, Payload),
+    post_tx(Height, Protocol, Nonce, Payload, Tx).
 
-post_tx(Height, Nonce, Payload, Tx) ->
-    post_tx(Height, Nonce, Payload, Tx, 5).
+post_tx(Height, Protocol, Nonce, Payload, Tx) ->
+    post_tx(Height, Protocol, Nonce, Payload, Tx, 5).
 
-post_tx(_, _, _, _, 0) ->
+post_tx(_, _, _, _, _, 0) ->
     aemon_metrics:publisher_post_tx(max_adjustment);
-post_tx(Height, Nonce, Payload, Tx, Adjustment) ->
+post_tx(Height, Protocol,  Nonce, Payload, Tx, Adjustment) ->
     SignTx = sign_tx(Tx),
     case aec_tx_pool:push(SignTx) of
         {error, too_low_fee} ->
-            NewTx = adjust_tx(Height, Nonce, Payload, Tx),
-            post_tx(Height, Nonce, Payload, NewTx, Adjustment-1);
+            NewTx = adjust_tx(Height, Protocol, Nonce, Payload, Tx),
+            post_tx(Height, Protocol, Nonce, Payload, NewTx, Adjustment-1);
         {error, too_low_gas_price_for_miner} ->
-            NewTx = adjust_tx(Height, Nonce, Payload, Tx),
-            post_tx(Height, Nonce, Payload, NewTx, Adjustment-1);
+            NewTx = adjust_tx(Height, Protocol, Nonce, Payload, Tx),
+            post_tx(Height, Protocol, Nonce, Payload, NewTx, Adjustment-1);
         {error, Error} ->
             aemon_metrics:publisher_post_tx(Error);
         ok ->
@@ -110,8 +110,9 @@ top_info() ->
     {ok, TopKeyBlock} = aec_chain:top_key_block(),
 
     {aec_blocks:height(TopBlock),
-        to_hash(TopKeyBlock),
-        to_hash(TopBlock)}.
+     aec_blocks:version(TopBlock),
+     to_hash(TopKeyBlock),
+     to_hash(TopBlock)}.
 
 to_hash(Block) ->
     {ok, Hash} = aec_blocks:hash_internal_representation(Block),
@@ -125,14 +126,14 @@ to_payload(Height, Key, Top, Timestamp) ->
     Format = io_lib:format("~p:~s:~s:~p", [Height, Key, Top, Timestamp]),
     iolist_to_binary(Format).
 
-create_tx(Height, Nonce, Payload) ->
+create_tx(Height, Protocol, Nonce, Payload) ->
     Tx = raw_tx(Height, Nonce, Payload, 1),
-    adjust_tx(Height, Nonce, Payload, Tx).
+    adjust_tx(Height, Protocol, Nonce, Payload, Tx).
 
-adjust_tx(Height, Nonce, Payload, Tx0) ->
+adjust_tx(Height, Protocol, Nonce, Payload, Tx0) ->
     GasPrice = aec_tx_pool:minimum_miner_gas_price(),
     GasLimit = aetx:gas_limit(Tx0, Height),
-    MinFee = aetx:min_fee(Tx0, Height),
+    MinFee = aetx:min_fee(Tx0, Height, Protocol),
     MinGasFee = GasPrice * GasLimit,
 
     Fee = lists:max([MinFee, MinGasFee]),

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -605,6 +605,7 @@ query_response_fee_depends_on_response_size(Cfg) ->
     {OracleKey, ID, S1} = query_oracle(Cfg, #{}, #{}),
     Trees               = aeo_test_utils:trees(S1),
     Env                 = aetx_env:tx_env(?ORACLE_RSP_HEIGHT),
+    Protocol            = aetx_env:consensus_version(Env),
 
     SmallResponse  = <<"small_response">>,
     BiggerResponse = <<"bigger_oracle_response">>,
@@ -612,7 +613,7 @@ query_response_fee_depends_on_response_size(Cfg) ->
 
     %% Deduce minimal fee for response tx with SmallResponse
     RTx0        = aeo_test_utils:response_tx(OracleKey, ID, SmallResponse, #{}, S1),
-    MinimalFee  = aetx:min_fee(RTx0, ?ORACLE_RSP_HEIGHT),
+    MinimalFee  = aetx:min_fee(RTx0, ?ORACLE_RSP_HEIGHT, Protocol),
 
     %% Test oracle response tx with SmallResponse is accepted with MinimalFee
     RTx1        = aeo_test_utils:response_tx(OracleKey, ID, SmallResponse, #{fee => MinimalFee}, S1),
@@ -621,13 +622,13 @@ query_response_fee_depends_on_response_size(Cfg) ->
 
     %% Test oracle response tx with BiggerResponse is not accepted with MinimalFee
     RTx2        = aeo_test_utils:response_tx(OracleKey, ID, BiggerResponse, #{fee => MinimalFee}, S1),
-    MinimalFee2 = aetx:min_fee(RTx2, ?ORACLE_RSP_HEIGHT),
+    MinimalFee2 = aetx:min_fee(RTx2, ?ORACLE_RSP_HEIGHT, Protocol),
     true        = MinimalFee2 > MinimalFee1,
     {error, too_low_fee} = aetx:process(RTx2, Trees, Env),
 
     %% Test oracle response tx with BiggerResponse is accepted with MinimalFee2
     RTx3        = aeo_test_utils:response_tx(OracleKey, ID, BiggerResponse, #{fee => MinimalFee2}, S1),
-    MinimalFee3 = aetx:min_fee(RTx3, ?ORACLE_RSP_HEIGHT),
+    MinimalFee3 = aetx:min_fee(RTx3, ?ORACLE_RSP_HEIGHT, Protocol),
     MinimalFee3 = MinimalFee2,
     {ok, _, _}  = aetx:process(RTx3, Trees, Env),
     ok.

--- a/system_test/only_local/aest_heavy_sync_SUITE.erl
+++ b/system_test/only_local/aest_heavy_sync_SUITE.erl
@@ -114,7 +114,9 @@ many_spend_txs(Cfg) ->
                                      , ttl => 10000000
                                      , nonce => 1000
                                      , payload => <<"node3">>}),
-    Gas = aetx:gas_limit(FakeTx, 0),
+    Height = 0,
+    Protocol = aec_hard_forks:protocol_effective_at_height(0),
+    Gas = aetx:gas_limit(FakeTx, Height, Protocol),
 
     TxsPerMB = aec_governance:block_gas_limit() div Gas,
     ct:log("We can put approx ~p Txs in a micro block (gas per spend ~p, ~p)\n", [TxsPerMB, Gas, FakeTx]),
@@ -202,7 +204,6 @@ add_spend_tx(Node, Sender, Nonce) ->
     %% create new receiver
     GasPrice = aest_nodes:gas_price(),
     #{ public := RecvPubKey, secret := _RecvSecKey } =  enacl:sign_keypair(),
-    #{ tx_hash := TxHash} = post_spend_tx(Node, Sender, #{pubkey => RecvPubKey}, Nonce, 
+    #{ tx_hash := TxHash} = post_spend_tx(Node, Sender, #{pubkey => RecvPubKey}, Nonce,
                                           #{amount => 1, fee => 20000 * GasPrice}),
     {Nonce, TxHash}.
-


### PR DESCRIPTION
[PT-168779945](https://www.pivotaltracker.com/n/projects/2124891/stories/168779945)

Preparatory PR for fork signalling.

It removes calls to `aec_hard_forks:protocol_effective_at_height` from `aetx` module.