### PR TITLE
SC: Add testing debug switch via `CT_DEBUG`

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -410,6 +410,7 @@ end_per_group(Group, Config) ->
     ok.
 
 init_per_testcase(_, Config) ->
+    Debug = (os:getenv("CT_DEBUG") == "1"),
     Config1 = load_idx(Config),
     Config2 = case is_above_roma_protocol() of
                   true ->
@@ -425,7 +426,7 @@ init_per_testcase(_, Config) ->
                       , {minimum_depth_strategy, ?MINIMUM_DEPTH_STRATEGY}
                       | Config1 ]
               end,
-    [ {debug, true} | Config2 ].
+    [ {debug, Debug} | Config2 ].
 
 end_per_testcase(T, _Config) when T==multiple_channels;
                                   T==many_chs_msg_loop ->


### PR DESCRIPTION
When running common_test on the `aesc_fsm_SUITE.erl` suite,
one can use `CT_DEBUG=1` to enable debug logging within
the test suite. By default these are disable due do their
high volume.

Fixes #2819