### PR TITLE
Unify the WS and FSM client messages

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -4319,14 +4319,18 @@ handle_call_(channel_closing, shutdown, From, #data{strict_checks = Strict} = D)
             %% Backwards compatibility
             keep_state(D, [{reply, From, {error, unknown_request}}])
     end;
-handle_call_(_, get_state, From, #data{ on_chain_id = ChanId
-                                      , opts        = Opts
+handle_call_(_, get_state, From, #data{ opts        = Opts
                                       , state       = State } = D) ->
     #{initiator := Initiator, responder := Responder} = Opts,
+    ChanId = cur_channel_id(D),
     {ok, IAmt} = aesc_offchain_state:balance(Initiator, State),
     {ok, RAmt} = aesc_offchain_state:balance(Responder, State),
     StateHash = aesc_offchain_state:hash(State),
-    {Round, _} = aesc_offchain_state:get_latest_signed_tx(State),
+    {Round, _} = try aesc_offchain_state:get_latest_signed_tx(State)
+                 catch
+                     error:no_tx ->
+                         {0, no_tx}
+                 end,
     Result =
         #{ channel_id => ChanId
          , initiator  => Initiator

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -470,7 +470,7 @@ initialized(cast, {?CH_ACCEPT, Msg}, #data{role = initiator} = D) ->
         {ok, D1} ->
             lager:debug("Valid channel_accept: ~p", [Msg]),
             gproc_register(D1),
-            report(info, channel_accept, Msg, D1),
+            report(info, channel_accept, D1),
             {ok, CTx, Updates, BlockHash} = create_tx_for_signing(D1),
             case request_signing(create_tx, CTx, Updates, BlockHash, D1) of
                 {ok, D2, Actions} ->
@@ -572,7 +572,7 @@ awaiting_open(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_open(cast, {?CH_OPEN, Msg}, #data{role = responder} = D) ->
     case check_open_msg(Msg, D) of
         {ok, D1} ->
-            report(info, channel_open, Msg, D1),
+            report(info, channel_open, D1),
             gproc_register(D1),
             next_state(accepted, send_channel_accept(D1));
         {error, _} = Error ->
@@ -3151,12 +3151,6 @@ report(Tag, Info, D) ->
     report_info(do_rpt(Tag, D), #{ type => report
                                  , tag  => Tag
                                  , info => Info }, D).
-
-report(Tag, St, Msg, D) ->
-    report_info(do_rpt(Tag, D), #{ type => report
-                                 , tag  => Tag
-                                 , info => St
-                                 , data => Msg }, D).
 
 report_info(DoRpt, Msg, #data{client_connected = false}) ->
     lager:debug("No client. DoRpt = ~p, Msg = ~p", [DoRpt, Msg]),

--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -315,12 +315,16 @@ set_half_signed_tx(SignedTx, #state{}=State) ->
 
 -spec get_latest_half_signed_tx(state()) -> aetx_sign:signed_tx().
 get_latest_half_signed_tx(#state{half_signed_tx = Tx}) when Tx =/= ?NO_TX ->
-    Tx.
+    Tx;
+get_latest_half_signed_tx(#state{half_signed_tx = ?NO_TX}) ->
+    error(no_tx).
 
 -spec get_latest_signed_tx(state()) -> {non_neg_integer(), aetx_sign:signed_tx()}.
 get_latest_signed_tx(#state{signed_tx = LastSignedTx})
     when LastSignedTx =/= ?NO_TX ->
-    {tx_round(LastSignedTx), LastSignedTx}.
+    {tx_round(LastSignedTx), LastSignedTx};
+get_latest_signed_tx(#state{signed_tx = ?NO_TX}) ->
+    error(no_tx).
 
 -spec get_latest_trees(state()) -> aec_trees:trees().
 get_latest_trees(#state{trees = Trees}) ->

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1290,13 +1290,12 @@ multiple_channels_t(NumCs, FromPort, Msg, {slogan, Slogan}, Cfg) ->
     aecore_suite_utils:mock_mempool_nonce_offset(Node, NumCs),
     MinerHelper = spawn_miner_helper(),
     {ok, Nonce} = rpc(dev1, aec_next_nonce, pick_for_account, [Initiator]),
-    MultiChCfg0 = [ {ack_to, Me}
+    MultiChCfg0 = [ {port, FromPort}
+                  , {ack_to, Me}
                   | Cfg ],
     MultiChCfg1 = set_configs([{minimum_depth_factor, 0}], MultiChCfg0),
-    %% Ensure that the channels run on separate ports or spawn the channels sequentially.
-    Cs = [create_multi_channel([ {port, FromPort + N}
-                               , {nonce, Nonce + N - 1}
-                               , {slogan, {Slogan, N}}
+    Cs = [create_multi_channel([ {nonce, Nonce + N - 1}
+                               , {slogan, {Slogan,N}}
                                | MultiChCfg1 ],
                                #{mine_blocks => {ask, MinerHelper}, debug => Debug})
           || N <- lists:seq(1, NumCs)],
@@ -2242,8 +2241,6 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg, MinDepth) ->
         fun() ->
             RProxy = spawn_responder(Port, RSpec, R, UseAny, Debug),
             IProxy = spawn_initiator(Port, ISpec, I, Debug),
-            IProxy ! {self(), responder_proxy, RProxy},
-            RProxy ! {self(), initiator_proxy, IProxy},
             ?LOG("RProxy = ~p, IProxy = ~p", [RProxy, IProxy]),
             #{ i := #{ fsm := WFsmI } = WI1
              , r := #{ fsm := WFsmR } = WR1 } = Info
@@ -2316,16 +2313,10 @@ spawn_responder(Port, Spec, R, UseAny, Debug) ->
     Me = self(),
     spawn_link(fun() ->
                        ?LOG("responder spawned: ~p", [Spec]),
-                       IProxy = receive
-                            {Me, initiator_proxy, Pid} ->
-                                Pid
-                        after ?TIMEOUT ->
-                            error(timeout)
-                        end,
                        Spec1 = maybe_use_any(UseAny, Spec#{ client => self() }),
                        Spec2 = move_password_to_spec(R, Spec1),
                        {ok, Fsm} = rpc(dev1, aesc_fsm, respond, [Port, Spec2], Debug),
-                       responder_instance_(Fsm, IProxy, Spec2, R, Me, Debug)
+                       responder_instance_(Fsm, Spec2, R, Me, Debug)
                end).
 
 maybe_use_any(true, Spec) ->
@@ -2337,17 +2328,11 @@ spawn_initiator(Port, Spec, I, Debug) ->
     Me = self(),
     spawn_link(fun() ->
                        ?LOG(Debug, "initiator spawned: ~p", [Spec]),
-                       RProxy = receive
-                                    {Me, responder_proxy, Pid} ->
-                                        Pid
-                                after ?TIMEOUT ->
-                                    error(timeout)
-                                end,
                        Spec1 = Spec#{ client => self() },
                        Spec2 = move_password_to_spec(I, Spec1),
                        {ok, Fsm} = rpc(dev1, aesc_fsm, initiate,
                                        ["localhost", Port, Spec2], Debug),
-                       initiator_instance_(Fsm, RProxy, Spec2, I, Me, Debug)
+                       initiator_instance_(Fsm, Spec2, I, Me, Debug)
                end).
 
 move_password_to_spec(#{state_password := StatePassword}, Spec) ->
@@ -2365,35 +2350,33 @@ match_responder_and_initiator(RProxy, Debug) ->
             error(timeout)
     end.
 
-responder_instance_(Fsm, IProxy, Spec, R0, Parent, Debug) ->
+responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
     R = fsm_map(Fsm, Spec, R0),
-    {ok, _} = receive_from_fsm(info, R, channel_open, ?TIMEOUT, Debug),
-    ?LOG(Debug, "Got ChOpen~nSpec = ~p", [Spec]),
+    {ok, ChOpen} = receive_from_fsm(info, R, channel_open, ?TIMEOUT, Debug),
+    ?LOG(Debug, "Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     R1 = R#{ proxy => self(), parent => Parent },
-    IProxy ! {self(), responder_ready, Parent},
-    I1 = receive
-             {IProxy, initiator_ready, I} ->
-                 I
-         after
-             ?TIMEOUT ->
-                 error(timeout)
-         end,
-    Parent ! {channel_up, self(), #{ i => I1#{parent => Parent}, r => R1}},
-    fsm_relay(R1, Parent, Debug).
+    gproc:reg({n,l,{?MODULE,TmpChanId,responder}}, #{ r => R1 }),
+    {_IPid, #{ i := I1 , channel_accept := ChAccept }}
+        = gproc:await({n,l,{?MODULE,TmpChanId,initiator}}, ?TIMEOUT),
+    Parent ! {channel_up, self(), #{ i => I1#{parent => Parent}
+                                     , r => R1
+                                     , channel_accept => ChAccept
+                                     , channel_open   => ChOpen }},
+    fsm_relay(R, Parent, Debug).
 
-initiator_instance_(Fsm, RProxy, Spec, I0, Parent, Debug) ->
+initiator_instance_(Fsm, Spec, I0, Parent, Debug) ->
     I = fsm_map(Fsm, Spec, I0),
-    {ok, _} = receive_from_fsm(info, I, channel_accept, ?TIMEOUT, Debug),
-    ?LOG(Debug, "Got ChAccept~nSpec = ~p", [Spec]),
+    {ok, ChAccept} = receive_from_fsm(info, I, channel_accept, ?TIMEOUT, Debug),
+    ?LOG(Debug, "Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     I1 = I#{ proxy => self() },
-    RProxy ! {self(), initiator_ready, I1},
-    NewParent = receive
-         {RProxy, responder_ready, NewParent1} ->
-             NewParent1
-     after
-         ?TIMEOUT ->
-             error(timeout)
-     end,
+    gproc:reg({n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I1
+                                                    , channel_accept => ChAccept }),
+    {_RPid, #{ r := #{parent := NewParent}}}
+        = gproc:await({n,l,{?MODULE,TmpChanId,responder}}, ?TIMEOUT),
     unlink(Parent),
     link(NewParent),
     fsm_relay(I1#{parent => NewParent}, NewParent, Debug).


### PR DESCRIPTION
This PR unifies the info reports sent from the ws client and the fsm. This results in a reduction of the amount of data copied between processes when opening a channel and removes gproc from the fsm suite when opening a channel.