### PR TITLE
Fetch tmp channel id from fsm instead

### DIFF
--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -315,12 +315,16 @@ set_half_signed_tx(SignedTx, #state{}=State) ->
 
 -spec get_latest_half_signed_tx(state()) -> aetx_sign:signed_tx().
 get_latest_half_signed_tx(#state{half_signed_tx = Tx}) when Tx =/= ?NO_TX ->
-    Tx.
+    Tx;
+get_latest_half_signed_tx(#state{half_signed_tx = ?NO_TX}) ->
+    error(no_tx).
 
 -spec get_latest_signed_tx(state()) -> {non_neg_integer(), aetx_sign:signed_tx()}.
 get_latest_signed_tx(#state{signed_tx = LastSignedTx})
     when LastSignedTx =/= ?NO_TX ->
-    {tx_round(LastSignedTx), LastSignedTx}.
+    {tx_round(LastSignedTx), LastSignedTx};
+get_latest_signed_tx(#state{signed_tx = ?NO_TX}) ->
+    error(no_tx).
 
 -spec get_latest_trees(state()) -> aec_trees:trees().
 get_latest_trees(#state{trees = Trees}) ->

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1290,13 +1290,12 @@ multiple_channels_t(NumCs, FromPort, Msg, {slogan, Slogan}, Cfg) ->
     aecore_suite_utils:mock_mempool_nonce_offset(Node, NumCs),
     MinerHelper = spawn_miner_helper(),
     {ok, Nonce} = rpc(dev1, aec_next_nonce, pick_for_account, [Initiator]),
-    MultiChCfg0 = [ {ack_to, Me}
+    MultiChCfg0 = [ {port, FromPort}
+                  , {ack_to, Me}
                   | Cfg ],
     MultiChCfg1 = set_configs([{minimum_depth_factor, 0}], MultiChCfg0),
-    %% Ensure that the channels run on separate ports or spawn the channels sequentially.
-    Cs = [create_multi_channel([ {port, FromPort + N}
-                               , {nonce, Nonce + N - 1}
-                               , {slogan, {Slogan, N}}
+    Cs = [create_multi_channel([ {nonce, Nonce + N - 1}
+                               , {slogan, {Slogan,N}}
                                | MultiChCfg1 ],
                                #{mine_blocks => {ask, MinerHelper}, debug => Debug})
           || N <- lists:seq(1, NumCs)],
@@ -2242,8 +2241,6 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg, MinDepth) ->
         fun() ->
             RProxy = spawn_responder(Port, RSpec, R, UseAny, Debug),
             IProxy = spawn_initiator(Port, ISpec, I, Debug),
-            IProxy ! {self(), responder_proxy, RProxy},
-            RProxy ! {self(), initiator_proxy, IProxy},
             ?LOG("RProxy = ~p, IProxy = ~p", [RProxy, IProxy]),
             #{ i := #{ fsm := WFsmI } = WI1
              , r := #{ fsm := WFsmR } = WR1 } = Info
@@ -2316,16 +2313,10 @@ spawn_responder(Port, Spec, R, UseAny, Debug) ->
     Me = self(),
     spawn_link(fun() ->
                        ?LOG("responder spawned: ~p", [Spec]),
-                       IProxy = receive
-                            {Me, initiator_proxy, Pid} ->
-                                Pid
-                        after ?TIMEOUT ->
-                            error(timeout)
-                        end,
                        Spec1 = maybe_use_any(UseAny, Spec#{ client => self() }),
                        Spec2 = move_password_to_spec(R, Spec1),
                        {ok, Fsm} = rpc(dev1, aesc_fsm, respond, [Port, Spec2], Debug),
-                       responder_instance_(Fsm, IProxy, Spec2, R, Me, Debug)
+                       responder_instance_(Fsm, Spec2, R, Me, Debug)
                end).
 
 maybe_use_any(true, Spec) ->
@@ -2337,17 +2328,11 @@ spawn_initiator(Port, Spec, I, Debug) ->
     Me = self(),
     spawn_link(fun() ->
                        ?LOG(Debug, "initiator spawned: ~p", [Spec]),
-                       RProxy = receive
-                                    {Me, responder_proxy, Pid} ->
-                                        Pid
-                                after ?TIMEOUT ->
-                                    error(timeout)
-                                end,
                        Spec1 = Spec#{ client => self() },
                        Spec2 = move_password_to_spec(I, Spec1),
                        {ok, Fsm} = rpc(dev1, aesc_fsm, initiate,
                                        ["localhost", Port, Spec2], Debug),
-                       initiator_instance_(Fsm, RProxy, Spec2, I, Me, Debug)
+                       initiator_instance_(Fsm, Spec2, I, Me, Debug)
                end).
 
 move_password_to_spec(#{state_password := StatePassword}, Spec) ->
@@ -2365,35 +2350,33 @@ match_responder_and_initiator(RProxy, Debug) ->
             error(timeout)
     end.
 
-responder_instance_(Fsm, IProxy, Spec, R0, Parent, Debug) ->
+responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
     R = fsm_map(Fsm, Spec, R0),
-    {ok, _} = receive_from_fsm(info, R, channel_open, ?TIMEOUT, Debug),
-    ?LOG(Debug, "Got ChOpen~nSpec = ~p", [Spec]),
+    {ok, ChOpen} = receive_from_fsm(info, R, channel_open, ?TIMEOUT, Debug),
+    ?LOG(Debug, "Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     R1 = R#{ proxy => self(), parent => Parent },
-    IProxy ! {self(), responder_ready, Parent},
-    I1 = receive
-             {IProxy, initiator_ready, I} ->
-                 I
-         after
-             ?TIMEOUT ->
-                 error(timeout)
-         end,
-    Parent ! {channel_up, self(), #{ i => I1#{parent => Parent}, r => R1}},
-    fsm_relay(R1, Parent, Debug).
+    gproc:reg({n,l,{?MODULE,TmpChanId,responder}}, #{ r => R1 }),
+    {_IPid, #{ i := I1 , channel_accept := ChAccept }}
+        = gproc:await({n,l,{?MODULE,TmpChanId,initiator}}, ?TIMEOUT),
+    Parent ! {channel_up, self(), #{ i => I1#{parent => Parent}
+                                     , r => R1
+                                     , channel_accept => ChAccept
+                                     , channel_open   => ChOpen }},
+    fsm_relay(R, Parent, Debug).
 
-initiator_instance_(Fsm, RProxy, Spec, I0, Parent, Debug) ->
+initiator_instance_(Fsm, Spec, I0, Parent, Debug) ->
     I = fsm_map(Fsm, Spec, I0),
-    {ok, _} = receive_from_fsm(info, I, channel_accept, ?TIMEOUT, Debug),
-    ?LOG(Debug, "Got ChAccept~nSpec = ~p", [Spec]),
+    {ok, ChAccept} = receive_from_fsm(info, I, channel_accept, ?TIMEOUT, Debug),
+    ?LOG(Debug, "Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     I1 = I#{ proxy => self() },
-    RProxy ! {self(), initiator_ready, I1},
-    NewParent = receive
-         {RProxy, responder_ready, NewParent1} ->
-             NewParent1
-     after
-         ?TIMEOUT ->
-             error(timeout)
-     end,
+    gproc:reg({n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I1
+                                                    , channel_accept => ChAccept }),
+    {_RPid, #{ r := #{parent := NewParent}}}
+        = gproc:await({n,l,{?MODULE,TmpChanId,responder}}, ?TIMEOUT),
     unlink(Parent),
     link(NewParent),
     fsm_relay(I1#{parent => NewParent}, NewParent, Debug).


### PR DESCRIPTION
Alternative approach to #2833 

I would prefer to keep the current setup for `multiple_channels`, since it's currently the only significant stress test of the concurrency issues in the initiator/responder pairing when reusing the listen port. Also, it's especially convenient when running scalability tests.

The alternative approach fetches the temporary channel id from the `get_state` method. This required a few changes to that method, since it would actually crash if called too early. In the modified version, it returns `round => 0` and the temporary channel id, if there is not yet any signed tx in the offchain state, or an onchain id to report.