### PR TITLE
Add build switch to skip compilation of rocksdb

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -2,21 +2,29 @@
 
 IsWindows = case os:type() of {win32, _} -> true; {_, _} -> false end,
 
+FilterRocksDbCheck = (IsWindows orelse os:getenv("DISABLE_ROCKSDB") == "1"),
+
 FilterRelxRocksDb = fun(Apps) ->
-                        case IsWindows of
+                        case FilterRocksDbCheck of
                             false ->
                                 Apps;
                             true ->
-                                Apps -- [rocksdb, mnesia_rocksdb]
+                                Apps -- [rocksdb, mnesia_rocksdb, {rocksdb, load}, {mnesia_rocksdb, load}]
                         end
                     end,
 
 FilterDepsRocksDb = fun(Deps) ->
-                        case IsWindows of
+                        case FilterRocksDbCheck of
                             false ->
                                 Deps;
                             true ->
-                                [D || {K, _} = D <- Deps, K =/= rocksdb, K =/= mnesia_rocksdb]
+                                lists:foldl(
+                                    fun(App, Acc) ->
+                                        lists:keydelete(App, 1, Acc)
+                                    end,
+                                    Deps,
+                                    [rocksdb, mnesia_rocksdb]
+                                )
                         end
                     end,
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -2,7 +2,7 @@
 
 IsWindows = case os:type() of {win32, _} -> true; {_, _} -> false end,
 
-FilterRocksDbCheck = (IsWindows orelse os:getenv("DISABLE_ROCKSDB") == "1"),
+FilterRocksDbCheck = (IsWindows orelse os:getenv("AE_DISABLE_ROCKSDB") =/= false),
 
 FilterRelxRocksDb = fun(Apps) ->
                         case FilterRocksDbCheck of

--- a/rebar.lock.script
+++ b/rebar.lock.script
@@ -1,0 +1,25 @@
+%% -*- erlang -*-
+
+IsWindows = case os:type() of {win32, _} -> true; {_, _} -> false end,
+
+FilterRocksDbCheck = (IsWindows orelse os:getenv("DISABLE_ROCKSDB") == "1"),
+
+FilterRocksDb = fun(Apps) ->
+                    case FilterRocksDbCheck of
+                        false ->
+                            Apps;
+                        true ->
+                            lists:foldl(
+                                fun(App, Acc) ->
+                                    lists:keydelete(App, 1, Acc)
+                                end,
+                                Apps,
+                                [<<"rocksdb">>, <<"mnesia_rocksdb">>]
+                            )
+                    end
+                end,
+
+[{Version, Deps}, [{pkg_hash, Pkgs}]] = CONFIG,
+Deps1 = FilterRocksDb(Deps),
+Pkgs1 = FilterRocksDb(Pkgs),
+[{Version, Deps1}, [{pkg_hash, Pkgs1}]].

--- a/rebar.lock.script
+++ b/rebar.lock.script
@@ -2,7 +2,7 @@
 
 IsWindows = case os:type() of {win32, _} -> true; {_, _} -> false end,
 
-FilterRocksDbCheck = (IsWindows orelse os:getenv("DISABLE_ROCKSDB") == "1"),
+FilterRocksDbCheck = (IsWindows orelse os:getenv("AE_DISABLE_ROCKSDB") =/= false),
 
 FilterRocksDb = fun(Apps) ->
                     case FilterRocksDbCheck of
@@ -19,7 +19,12 @@ FilterRocksDb = fun(Apps) ->
                     end
                 end,
 
-[{Version, Deps}, [{pkg_hash, Pkgs}]] = CONFIG,
-Deps1 = FilterRocksDb(Deps),
-Pkgs1 = FilterRocksDb(Pkgs),
-[{Version, Deps1}, [{pkg_hash, Pkgs1}]].
+case CONFIG of
+    [] ->
+        %% no lock file present, usually during unlock/upgrade
+        CONFIG;
+    [{Version, Deps}, [{pkg_hash, Pkgs}]] ->
+        Deps1 = FilterRocksDb(Deps),
+        Pkgs1 = FilterRocksDb(Pkgs),
+        [{Version, Deps1}, [{pkg_hash, Pkgs1}]]
+end.


### PR DESCRIPTION
By setting the environment variable `AE_DISABLE_ROCKSDB` to any value one can skip
building rocksdb entirely. This also requires the user to use another
database backend, as trying to use rocksdb would result in a runtime
error.

Fixes #2843