### PR TITLE
Refactor fsm message log and reporting

### DIFF
--- a/apps/aechannel/src/aesc_window.erl
+++ b/apps/aechannel/src/aesc_window.erl
@@ -1,14 +1,17 @@
 -module(aesc_window).
 
--export([new/0, new/1,
-         change_keep/2,
-         add/2,
-         pop/1,
-         size/1,
-         keyfind/3,
-         keymember/3,
-         info_find/3,
-         to_list/1]).
+-export([ new/0
+        , new/1
+        , change_keep/2
+        , add/2
+        , add_new/2
+        , pop/1
+        , size/1
+        , keyfind/3
+        , keymember/3
+        , info_find/3
+        , to_list/1
+        ]).
 
 -export([record_fields/1]).
 
@@ -70,6 +73,12 @@ add(Item, #w{na = N, a = A, keep = Keep} = W) when N < Keep ->
     W#w{na = N+1, a = [Item|A]};
 add(Item, #w{na = PrevNa, a = A} = W) ->
     W#w{na = 1, a = [Item], nb = PrevNa, b = A}.
+
+-spec add_new(Entry, window(Entry)) -> window(Entry) when Entry :: entry().
+add_new(Item, #w{a = [Item|_]} = W) ->
+    W;
+add_new(Item, W) ->
+    add(Item, W).
 
 -spec pop(window(Entry)) -> {Entry, window(Entry)} | error
   when Entry :: entry().

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -3931,8 +3931,8 @@ expected_fsm_logs(Name, Role) ->
 
 expected_fsm_logs(check_password_is_changeable, initiator = R, #{update_count := Count}) ->
     UpdateLog = [ {rcv, update_ack}
-                , {rcv, signed}
                 , {snd, update}
+                , {rcv, signed}
                 , {req, sign}
                 ],
     [ {evt, close}
@@ -3942,8 +3942,8 @@ expected_fsm_logs(check_password_is_changeable, initiator = R, #{update_count :=
     lists:flatten([UpdateLog || _ <- lists:seq(1, Count)]) ++
     expected_fsm_logs(channel_open, R);
 expected_fsm_logs(check_password_is_changeable, responder = R, #{update_count := Count}) ->
-    UpdateLog = [ {rcv, signed}
-                , {snd, update_ack}
+    UpdateLog = [ {snd, update_ack}
+                , {rcv, signed}
                 , {req, sign}
                 , {rcv, update}
                 ],
@@ -3985,16 +3985,16 @@ expected_fsm_logs(t_create_channel_, responder = R, _) ->
 expected_fsm_logs(leave_reestablish_close, initiator = R, _) ->
     expected_fsm_logs(channel_shutdown, R) ++
     [ {rcv, update_ack}
-    , {rcv, signed}
     , {snd, update}
+    , {rcv, signed}
     , {req, sign}
     , {rcv, channel_reest_ack}
     , {snd, channel_reestablish}
     ];
 expected_fsm_logs(leave_reestablish_close, responder = R, _) ->
     expected_fsm_logs(channel_shutdown, R) ++
-    [ {rcv, signed}
-    , {snd, update_ack}
+    [ {snd, update_ack}
+    , {rcv, signed}
     , {req, sign}
     , {rcv, update}
     , {snd, channel_reest_ack}
@@ -4004,8 +4004,8 @@ expected_fsm_logs(check_incorrect_update, R, #{depositor := D , malicious := M})
   when (R =:= initiator andalso D =:= R andalso M =:= R) orelse
        (R =:= responder andalso D =:= R andalso M =:= R) ->
     [ {rcv, update_error}
-    , {rcv, signed}
     , {snd, update}
+    , {rcv, signed}
     , {req, sign}
     , {snd, undefined}
     , {req, sign}
@@ -4023,8 +4023,8 @@ expected_fsm_logs(check_incorrect_update, R, #{depositor := D , malicious := M})
   when (R =:= initiator andalso D =:= R andalso M =/= R) orelse
        (R =:= responder andalso D =:= R andalso M =/= R) ->
     [ {snd, update_error}
-    , {rcv, signed}
     , {snd, update}
+    , {rcv, signed}
     , {req, sign}
     ] ++
     expected_fsm_logs(channel_open, R);
@@ -4033,8 +4033,8 @@ expected_fsm_logs(check_incorrect_update, R, #{depositor := D , malicious := M})
        (R =:= responder andalso D =/= R andalso M =:= R) ->
     [ {evt, close}
     , {rcv, disconnect}
-    , {rcv, signed}
     , {snd, update_ack}
+    , {rcv, signed}
     , {req, sign}
     , {rcv, update}
     ] ++
@@ -4056,7 +4056,7 @@ expected_fsm_logs(channel_open, responder, #{}) ->
     [ {rcv, funding_locked}
     , {snd, funding_locked}
     , {rcv, channel_changed}
-    , {snd, funding_created}
+    , {snd, funding_signed}
     , {rcv, signed}
     , {req, sign}
     , {rcv, funding_created}
@@ -4068,16 +4068,16 @@ expected_fsm_logs(channel_shutdown, initiator, #{}) ->
     , {optional, rcv, disconnect} % this can occur in case the min depth achieved is delayed
     , {rcv, channel_closed}
     , {rcv, shutdown_ack}
-    , {rcv, signed}
     , {snd, shutdown}
+    , {rcv, signed}
     , {req, sign}
     ];
 expected_fsm_logs(channel_shutdown, responder, #{}) ->
     [ {evt, close}
     , {optional, rcv, disconnect} % this can occur in case the min depth achieved is delayed
     , {rcv, channel_closed}
-    , {rcv, signed}
     , {snd, shutdown_ack}
+    , {rcv, signed}
     , {req, sign}
     , {rcv, shutdown}
     ];


### PR DESCRIPTION
This fixes the order of log messages and ensures that the chain watcher is
started before performing a dependent action.