### PR TITLE
Fix names system test

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -109,7 +109,7 @@ tx_base_gas(contract_create_tx, _Protocol, ABI) ->
         ?ABI_FATE_SOPHIA_1 -> 5 * ?TX_BASE_GAS;
         ?ABI_AEVM_SOPHIA_1 -> 5 * ?TX_BASE_GAS
     end;
-tx_base_gas(contract_call_tx, Protocol, ABI) ->
+tx_base_gas(contract_call_tx, _Protocol, ABI) ->
     case ABI of
         ?ABI_FATE_SOPHIA_1 -> 12 * ?TX_BASE_GAS;
         ?ABI_AEVM_SOPHIA_1 -> 30 * ?TX_BASE_GAS

--- a/system_test/common/aest_names_SUITE.erl
+++ b/system_test/common/aest_names_SUITE.erl
@@ -111,15 +111,15 @@ test_name_registration(Cfg) ->
     start_node(node1, Cfg),
     wait_for_startup([node1], Height = 4, Cfg),
 
-    Name = aens_test_utils:fullname(<<"richard">>, Height),
+    Name = aens_test_utils:fullname(<<"richard-no-auction-for-long-name">>, Height),  %% richard-no-auction
     NameSalt = 36346245,
     EncNameId = aeser_api_encoder:encode(name, aens_hash:name_hash(Name)),
 
     %% Generate tokens for Mike
-    wait_for_value({balance, MPubKey, 1000000 * GasPrice}, [node1], 10000, Cfg),
+    wait_for_value({balance, MPubKey, 10000000 * GasPrice}, [node1], 10000, Cfg),
 
     %% Give some tokens to the registrar account
-    post_spend_tx(node1, ?MIKE, ?RICHARD, 1, #{ amount => 600000 * GasPrice }),
+    post_spend_tx(node1, ?MIKE, ?RICHARD, 1, #{ amount => 6000000 * GasPrice }),
     wait_for_value({balance, RPubKey, 200}, [node1], 10000, Cfg),
 
     {ok, 404, #{ reason := <<"Name not found">> }} =
@@ -141,7 +141,8 @@ test_name_registration(Cfg) ->
         nonce     => 2,
         name      => Name,
         name_salt => NameSalt,
-        fee       => 20000 * GasPrice
+        fee       => 20000 * GasPrice,
+        name_fee  => 500000 * GasPrice
     }),
     aest_nodes:wait_for_value({txs_on_chain, [ClaimTxHash]}, [node1], 10000, []),
 
@@ -200,7 +201,7 @@ test_name_transfer(Cfg) ->
     start_node(node1, Cfg),
     wait_for_startup([node1], Height = 4, Cfg),
 
-    Name = aens_test_utils:fullname(<<"richard">>, Height),
+    Name = aens_test_utils:fullname(<<"richard-no-auction-and-long-name">>, Height),
     NameSalt = 36346245,
 
     %% Generate tokens for Mike
@@ -226,7 +227,8 @@ test_name_transfer(Cfg) ->
         nonce     => 2,
         name      => Name,
         name_salt => NameSalt,
-        fee       => Fee
+        fee       => Fee,
+        name_fee  => 20*Fee
     }),
     aest_nodes:wait_for_value({txs_on_chain, [ClaimTxHash]}, [node1], 10000, []),
 

--- a/system_test/common/aest_peers_SUITE.erl
+++ b/system_test/common/aest_peers_SUITE.erl
@@ -157,7 +157,7 @@ test_inbound_limitation(Cfg) ->
     wait_for_value({height, 0}, [node4], StartupTimeout, Cfg),
     wait_for_internal_api([node4], StartupTimeout),
 
-    wait_for_value({height, Length * 2 + 1}, [node1, node2, node3, node4], ?MINING_TIMEOUT * Length, Cfg),
+    wait_for_value({height, Length * 2 + 1}, [node1, node2, node3, node4], ?MINING_TIMEOUT * (Length + (Length div 10)), Cfg),
     T2 = erlang:system_time(millisecond),
 
     try_until(T2 + 3 * ping_interval(node1),


### PR DESCRIPTION
This fixes a failing name claim test

System tests are updated to run on Lima on height 1 (before Fortuna) meaning that only now they are actually testing the Lima features. Names need a name_fee and may trigger an auction.

The aest_peers tests need more time in order to mine 100 blocks. By increasing with 10% it works locally