### PR TITLE
Fix community fork system test

### DIFF
--- a/system_test/common/aest_community_fork_SUITE.erl
+++ b/system_test/common/aest_community_fork_SUITE.erl
@@ -34,7 +34,7 @@
 -define(SIGNALLING_END_HEIGHT, 15).
 -define(SIGNALLING_BLOCK_COUNT, 9).
 -define(INFO_FIELD, 1234).
--define(VERSION, 4).
+-define(VERSION, 3).
 
 -define(FORK_HEIGHT, ?SIGNALLING_END_HEIGHT).
 

--- a/system_test/common/aest_community_fork_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/common/aest_community_fork_SUITE_data/aeternity.yaml.mustache
@@ -22,6 +22,9 @@ keys:
 
 chain:
     persist: true
+    hard_forks:
+        "1": 0
+        "2": 1
 
 mining:
     autostart: {{mining.autostart}}


### PR DESCRIPTION
`chain > hard_forks` is defined, so it won't pick the default protocols from `aec_hard_forks` module anymore. The fork is configured to upgrade from version 2 to version 3.

The issue was:
```
            #{ ?ROMA_PROTOCOL_VSN  => 0
             , ?LIMA_PROTOCOL_VSN  => 1 %% Update after switching to IRIS
             };
```
and the community fork config used version 4 which is not allowed as Lima protocol is version 4 as well (community fork version must be greater than the last protocol version).