### PR TITLE
Fix fate call caller

### DIFF
--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -194,10 +194,11 @@ call_gr(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, EngineState) ->
 
 remote_call_common(Contract, Function, ?FATE_TYPEREP({tuple, ArgTypes}), ?FATE_TYPEREP(RetType), Value, EngineState) ->
     Current   = aefa_engine_state:current_contract(EngineState),
+    Caller    = aeb_fate_data:make_address(Current),
     Arity     = length(ArgTypes),
     ES1       = aefa_fate:unfold_store_maps_in_args(Arity, EngineState),
     ES2       = aefa_fate:check_remote(Contract, ES1),
-    ES3       = aefa_fate:set_remote_function(Contract, Function, Value > 0, true, ES2),
+    ES3       = aefa_fate:set_remote_function(Caller, Contract, Function, Value > 0, true, ES2),
     Signature = aefa_fate:get_function_signature(Function, ES3),
     ES4       = aefa_fate:check_signature_and_bind_args(Arity, Signature, ES3),
     TVars     = aefa_engine_state:current_tvars(ES4),

--- a/docs/release-notes/next/fix_fate_call_caller.md
+++ b/docs/release-notes/next/fix_fate_call_caller.md
@@ -1,0 +1,1 @@
+* Fixes a bug in FATE VM - Call.caller was incorrectly set when returning from a remote contract call.

--- a/test/contracts/call_caller.aes
+++ b/test/contracts/call_caller.aes
@@ -1,0 +1,31 @@
+contract Identity =
+  entrypoint main : (int) => int
+
+contract Middle =
+  entrypoint call_id : (Identity) => int
+  entrypoint call_id_check : (Identity) => bool
+
+contract CallCaller =
+  entrypoint f1() =
+    Call.caller
+
+  entrypoint f2(r : Identity) =
+    r.main(42)
+    Call.caller
+
+  entrypoint f3(r : Identity, m : Middle) =
+    m.call_id(r)
+    Call.caller
+
+  entrypoint f4(r : Identity, m : Middle) =
+    let a = Call.caller
+    let res1 = m.call_id_check(r)
+    res1 && (a == Call.caller)
+
+  entrypoint call_id(r : Identity) =
+    r.main(42)
+
+  entrypoint call_id_check(r : Identity) =
+    let a = Call.caller
+    r.main(42)
+    Call.caller == a

--- a/test/contracts/sophia_2/call_caller.aes
+++ b/test/contracts/sophia_2/call_caller.aes
@@ -1,0 +1,31 @@
+contract Identity =
+  function main : (int) => int
+
+contract Middle =
+  function call_id : (Identity) => int
+  function call_id_check : (Identity) => bool
+
+contract CallCaller =
+  function f1() =
+    Call.caller
+
+  function f2(r : Identity) =
+    r.main(42)
+    Call.caller
+
+  function f3(r : Identity, m : Middle) =
+    m.call_id(r)
+    Call.caller
+
+  function f4(r : Identity, m : Middle) =
+    let a = Call.caller
+    let res1 = m.call_id_check(r)
+    res1 && (a == Call.caller)
+
+  function call_id(r : Identity) =
+    r.main(42)
+
+  function call_id_check(r : Identity) =
+    let a = Call.caller
+    r.main(42)
+    Call.caller == a


### PR DESCRIPTION
Correct handling of Call.caller in FATE

When returning from a remote contract call we have
to reset the Caller from the call_stack.

