### PR TITLE
Return Max gas when ABI version is undefined

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -623,6 +623,10 @@ create_contract_negative(_Cfg) ->
 
     {error, account_not_found} = aetx:process(RTx1, Trees, Env),
 
+    %% Bogus ABI
+    BTx1             = create_tx(PubKey, #{abi_version => 42}, S1),
+    {error, illegal_vm_version} = aetx:process(BTx1, Trees, Env),
+
     %% Insufficient funds
     S2     = aect_test_utils:set_account_balance(PubKey, 0, S1),
     Trees2 = aect_test_utils:trees(S2),

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -104,25 +104,30 @@ min_tx_gas() -> ?TX_BASE_GAS.
 -spec tx_base_gas(aetx:tx_type(), aec_hard_forks:protocol_vsn(), aect_contracts:abi_version()) ->
     non_neg_integer().
 %% Make sure we fail when we get unknown tx type
+%% Use Max gas if ABI is unknown, the tx will be invalidated later
 tx_base_gas(contract_create_tx, _Protocol, ABI) ->
     case ABI of
         ?ABI_FATE_SOPHIA_1 -> 5 * ?TX_BASE_GAS;
-        ?ABI_AEVM_SOPHIA_1 -> 5 * ?TX_BASE_GAS
+        ?ABI_AEVM_SOPHIA_1 -> 5 * ?TX_BASE_GAS;
+        _ -> 5 * ?TX_BASE_GAS       %% Max gas
     end;
 tx_base_gas(contract_call_tx, _Protocol, ABI) ->
     case ABI of
         ?ABI_FATE_SOPHIA_1 -> 12 * ?TX_BASE_GAS;
-        ?ABI_AEVM_SOPHIA_1 -> 30 * ?TX_BASE_GAS
+        ?ABI_AEVM_SOPHIA_1 -> 30 * ?TX_BASE_GAS;
+        _ -> 30 * ?TX_BASE_GAS      %% Max gas
     end;
 tx_base_gas(ga_attach_tx, _Protocol, ABI) ->
     case ABI of
         ?ABI_FATE_SOPHIA_1 -> 5 * ?TX_BASE_GAS;
-        ?ABI_AEVM_SOPHIA_1 -> 5 * ?TX_BASE_GAS
+        ?ABI_AEVM_SOPHIA_1 -> 5 * ?TX_BASE_GAS;
+        _ -> 5 * ?TX_BASE_GAS      %% Max gas
     end;
 tx_base_gas(ga_meta_tx, _Protocol, ABI) ->
     case ABI of
         ?ABI_FATE_SOPHIA_1 -> 5 * ?TX_BASE_GAS;
-        ?ABI_AEVM_SOPHIA_1 -> 5 * ?TX_BASE_GAS
+        ?ABI_AEVM_SOPHIA_1 -> 5 * ?TX_BASE_GAS;
+        _ -> 5 * ?TX_BASE_GAS      %% Max gas
     end.
 
 


### PR DESCRIPTION
Resolves #2916 

Note that, even though we touch aec_governance, this is not concensus breaking. We would always fail with the wrong ABI given, now we fail nicely.