### PR TITLE
Remove lager_transform when running eqc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ debian/changelog
 debian/files
 eqc-lib
 eqc
+eqc_lager_mock.log
+.eqc-info
+current_counterexample.eqc
 /docs/.tools/
 /docs/state-channels/*.svg
 .contracts_test_cache

--- a/rebar.config
+++ b/rebar.config
@@ -20,13 +20,12 @@
 
 {project_app_dirs, ["apps/*"]}.
 
-{overrides, [{override, [ {erl_opts, [debug_info, {parse_transform, lager_transform},
-                                      {lager_extra_sinks, [ epoch_mining
-                                                          , epoch_metrics
-                                                          , epoch_sync
-                                                          , aestratum
-                                                          ]}]}
-                        ]}]}.
+{erl_opts, [debug_info, {parse_transform, lager_transform},
+            {lager_extra_sinks, [ epoch_mining
+                                , epoch_metrics
+                                , epoch_sync
+                                , aestratum
+                                ]}]}.
 
 %% NOTE: When possible deps are referenced by Git ref to ensure consistency between builds.
 {deps, [

--- a/rebar.config
+++ b/rebar.config
@@ -20,11 +20,13 @@
 
 {project_app_dirs, ["apps/*"]}.
 
-{erl_opts, [debug_info, {parse_transform, lager_transform},
-            {lager_extra_sinks, [epoch_mining,
-                                 epoch_metrics,
-                                 epoch_sync,
-                                 aestratum]}]}.
+{overrides, [{override, [ {erl_opts, [debug_info, {parse_transform, lager_transform},
+                                      {lager_extra_sinks, [ epoch_mining
+                                                          , epoch_metrics
+                                                          , epoch_sync
+                                                          , aestratum
+                                                          ]}]}
+                        ]}]}.
 
 %% NOTE: When possible deps are referenced by Git ref to ensure consistency between builds.
 {deps, [
@@ -229,13 +231,16 @@
                 ]},
                 {ct_opts, [{create_priv_dir, auto_per_tc}]}
             ]},
-            {eqc, [{project_app_dirs, ["eqc_test"]},
-                   {extra_src_dirs, [ "eqc/aecore_eqc"
-                                    , "eqc/aega_eqc"
-                                    , "eqc/aeminer_eqc"
-                                    , "eqc/aesophia_eqc"
-                                    , "eqc/aeutils_eqc"
-                                    ]}]}
+            {eqc, [ {project_app_dirs, ["eqc_test"]}
+                  , {extra_src_dirs, [ "eqc/aecore_eqc"
+                                     , "eqc/aega_eqc"
+                                     , "eqc/aeminer_eqc"
+                                     , "eqc/aechannel_eqc"
+                                     , "eqc/aesophia_eqc"
+                                     , "eqc/aeutils_eqc"
+                                     ]}
+                  , {overrides, [{override, [{erl_opts, [debug_info]}]}]}
+                  ]}
            ]
 }.
 
@@ -267,7 +272,7 @@
   {post, [{compile, escriptize}]}]}.
 
 {pre_hooks, [
-	     {compile, "make -C ./otp_patches all"},
+             {compile, "make -C ./otp_patches all"},
              {compile, "erlc test/ct_eunit_xform.erl"} %% {ct_first_files, _} does not work
             ]}.
 


### PR DESCRIPTION
This allows the mocking of calls to `lager`.