### PR TITLE
Catch inner aetx:process crash in aega_meta_tx

### DIFF
--- a/docs/release-notes/next/catch_inner_process_crashes_in_ga_meta.md
+++ b/docs/release-notes/next/catch_inner_process_crashes_in_ga_meta.md
@@ -1,0 +1,2 @@
+* From Lima, catch crashes when processing inner transaction in GAMetaTx; the user should pay for
+  a successful authentication despite the inner Tx crashing.


### PR DESCRIPTION
QuickCheck finally convinced me that this is a potential issue - with this approach we can detect crashes and convert them into proper errors without changing consensus.