### PR TITLE
Assert that non-ga signers are really basic accounts

### DIFF
--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -39,6 +39,8 @@
         , meta_meta_fail/1
         , meta_meta_spend/1
         , attach_second/1
+        , meta_sc_create/1
+        , meta_sc_create_fail/1
         , meta_4_fail/1
         , mempool/1
         , mempool_rejects_normal_tx/1
@@ -78,6 +80,9 @@ groups() ->
       , meta_meta_fail
       , meta_meta_spend
       , meta_4_fail
+      , attach_second
+      , meta_sc_create
+      , meta_sc_create_fail
       ]},
 
      {ga_info, [sequence],
@@ -448,6 +453,61 @@ meta_4_fail(Config) ->
     ?assertEqual(ExpBal, ABal1),
     ok.
 
+meta_sc_create(Config) ->
+    %% Get account information.
+    #{acc_a := #{pub_key := APub, priv_key := APriv},
+      acc_b := #{pub_key := BPub, priv_key := BPriv}} = proplists:get_value(accounts, Config),
+    ABal0 = get_balance(APub),
+    MGP = aec_test_utils:min_gas_price(),
+
+    #{tx_hash := MetaTx} = post_ga_sc_create_tx(APub, APriv, "11", BPub, BPriv, "1"),
+
+    ?MINE_TXS([MetaTx]),
+
+    ABal1 = get_balance(APub),
+
+    %% test that we can return GAMetaTx via http interface
+    {ok, 200, #{<<"tx">> := #{<<"type">> := <<"GAMetaTx">>}}} = get_tx(MetaTx),
+
+    {ok, 200, #{<<"ga_info">> := #{<<"return_type">> := <<"ok">>,
+                                   <<"gas_used">> := Gas} = GI}} =
+        get_contract_call_object(MetaTx),
+
+    ct:pal("GAS: ~p\n", [Gas]),
+    ct:pal("Cost1: ~p", [ABal0 - ABal1]),
+    ct:pal("~p + ~p + ~p", [100000 * MGP, Gas * MGP, 20000 * MGP]),
+    ct:pal("GInfo: ~p\n", [GI]),
+    ExpBal = ABal0 - (100000 * MGP + Gas * 1000 * MGP + 20000 * MGP + 20000),
+    ?assertEqual(ExpBal, ABal1),
+    ok.
+
+meta_sc_create_fail(Config) ->
+    %% Get account information.
+    #{acc_a := #{pub_key := APub, priv_key := APriv},
+      acc_b := #{pub_key := BPub, priv_key := BPriv}} = proplists:get_value(accounts, Config),
+    ABal0 = get_balance(APub),
+
+    #{tx_hash := MetaTx} = post_ga_sc_create_fail_tx(APub, APriv, "12", BPub, BPriv),
+
+    ?MINE_TXS([MetaTx]),
+
+    %% test that we can return GAMetaTx via http interface
+    {ok, 200, #{<<"tx">> := #{<<"type">> := <<"GAMetaTx">>}}} = get_tx(MetaTx),
+
+    {ok, 200, #{<<"ga_info">> := #{<<"return_type">> := ReturnType}}} =
+        get_contract_call_object(MetaTx),
+
+    %% Until LIMA it was possible to use a GA account (as responder)
+    %% and sign with the private key...
+    case aect_test_utils:latest_protocol_version() of
+      Vsn when Vsn < ?LIMA_PROTOCOL_VSN ->
+        ?assertEqual(<<"ok">>, ReturnType);
+      _ ->
+        ?assertEqual(<<"error">>, ReturnType)
+    end,
+
+    ok.
+
 %% Test the minimum gas price check
 mempool(Config) ->
     %% Get account information.
@@ -513,8 +573,6 @@ get_account_by_pubkey_and_height(Config) ->
     ?assertEqual(<<"generalized">>, maps:get(<<"kind">>, Account2)),
     ok.
 
-
-
 %% Internal access functions.
 
 get_balance(Pubkey) ->
@@ -571,6 +629,43 @@ ga_spend_tx([Nonce|Nonces], AccPK, AccSK, InnerTx, MetaFee, AuthGas) ->
                     #{ gas => AuthGas, auth_data => AuthData,
                        tx => aetx_sign:new(InnerTx, []), fee => MetaFee }),
     ga_spend_tx(Nonces, AccPK, AccSK, MetaTx, MetaFee, AuthGas).
+
+sc_create_tx(APK, BPK) ->
+    SCMap = #{ initiator_id => aeser_id:create(account, APK),
+               responder_id => aeser_id:create(account, BPK),
+               nonce => 0,
+               initiator_amount => 20000,
+               responder_amount => 20000,
+               fee => 20000 * aec_test_utils:min_gas_price(),
+               channel_reserve => 100,
+               state_hash => <<0:32/unit:8>>,
+               lock_period => 42 },
+    {ok, Tx} = aesc_create_tx:new(SCMap),
+    Tx.
+
+post_ga_sc_create_tx(APK, ASK, NonceA, BPK, BSK, NonceB) ->
+    InnerTx = sc_create_tx(APK, BPK),
+    SMetaTx1 = ga_meta_tx(APK, ASK, NonceA, InnerTx, []),
+    SMetaTx2 = ga_meta_tx(BPK, BSK, NonceB, SMetaTx1, []),
+    post_aetx(aetx_sign:new(SMetaTx2, [])).
+
+%% Incorrectly use signature for "responder"
+post_ga_sc_create_fail_tx(APK, ASK, NonceA, BPK, BSK) ->
+    InnerTx = sc_create_tx(APK, BPK),
+    SigTx   = aec_test_utils:sign_tx(InnerTx, BSK),
+    [Sig]   = aetx_sign:signatures(SigTx),
+    SMetaTx1 = ga_meta_tx(APK, ASK, NonceA, InnerTx, [Sig]),
+    post_aetx(aetx_sign:new(SMetaTx1, [])).
+
+ga_meta_tx(PK, SK, Nonce, InnerTx, Sigs) ->
+    TxHash = aec_hash:hash(tx, aec_governance:add_network_id(aetx:serialize_to_binary(InnerTx))),
+    Sig    = aega_test_utils:basic_auth_sign(list_to_integer(Nonce), TxHash, SK),
+    Auth   = aega_test_utils:make_calldata("basic_auth", "authorize",
+                    [Nonce, aega_test_utils:to_hex_lit(64, Sig)]),
+    aega_test_utils:ga_meta_tx(PK, #{ gas => 10000, auth_data => Auth,
+                                      tx => aetx_sign:new(InnerTx, Sigs),
+                                      fee => 100000 * aec_test_utils:min_gas_price() }).
+
 
 sign_and_post_aetx(PrivKey, Tx) ->
     SignedTx = aec_test_utils:sign_tx(Tx, PrivKey),

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -911,6 +911,7 @@ channel_create({InitiatorPubkey, InitiatorAmount,
             end,
     {InitAccount, S1} = get_account(InitiatorPubkey, S),
     {RespAccount, S2} = get_account(ResponderPubkey, S1),
+    assert_party_kind(ResponderPubkey, RespAccount, S2),
     Channel = aesc_channels:new(InitiatorPubkey, InitiatorAmount,
                                 ResponderPubkey, ResponderAmount,
                                 InitAccount, RespAccount,
@@ -945,6 +946,7 @@ channel_deposit({FromPubkey, ChannelPubkey, Amount, StateHash, Round}, S) ->
     {Channel, S1} = get_channel(ChannelPubkey, S),
     assert_channel_active(Channel),
     assert_is_channel_peer(Channel, FromPubkey),
+    assert_other_party_kind(Channel, FromPubkey, S1),
     assert_channel_round(Channel, Round, deposit),
     Channel1 = aesc_channels:deposit(Channel, Amount, Round, StateHash),
     put_channel(Channel1, S1).
@@ -963,6 +965,7 @@ channel_withdraw({ToPubkey, ChannelPubkey, Amount, StateHash, Round}, S) ->
     {Channel, S1} = get_channel(ChannelPubkey, S),
     assert_channel_active(Channel),
     assert_is_channel_peer(Channel, ToPubkey),
+    assert_other_party_kind(Channel, ToPubkey, S1),
     assert_channel_withdraw_amount(Channel, Amount),
     assert_channel_round(Channel, Round, withdrawal),
     Channel1 = aesc_channels:withdraw(Channel, Amount, Round, StateHash),
@@ -986,7 +989,8 @@ channel_close_mutual_op(FromPubkey, ChannelPubkey,
 channel_close_mutual({FromPubkey, ChannelPubkey,
                       InitiatorAmount, ResponderAmount, Fee, ConsensusVersion}, S) ->
     {Channel, S1} = get_channel(ChannelPubkey, S),
-    assert_channel_origin(Channel, FromPubkey),
+    assert_is_channel_peer(Channel, FromPubkey),
+    assert_other_party_kind(Channel, FromPubkey, S1),
     assert_channel_active_before_fork(Channel, ConsensusVersion, ?LIMA_PROTOCOL_VSN),
     TotalAmount = InitiatorAmount + ResponderAmount + Fee,
     ChannelAmount = aesc_channels:channel_amount(Channel),
@@ -1536,6 +1540,26 @@ assert_ga_env(Pubkey, Nonce, #state{tx_env = Env}) ->
        true            -> ok
     end.
 
+assert_other_party_kind(Channel, PartyPubkey, S) ->
+    %% Run after assert_is_channel_peer
+    [OtherPartyPubkey] = aesc_channels:peers(Channel) -- [PartyPubkey],
+    {OtherAccount, _S} = get_account(OtherPartyPubkey, S),
+    assert_party_kind(OtherPartyPubkey, OtherAccount, S).
+
+assert_party_kind(Pubkey, Account, #state{ protocol = P, tx_env = Env }) ->
+    case P < ?LIMA_PROTOCOL_VSN of
+        true -> ok;
+        false ->
+            Kind       = aec_accounts:type(Account),
+            IsGaAuthed = lists:member(Pubkey, aetx_env:ga_auth_ids(Env)),
+            case {Kind, IsGaAuthed} of
+                {basic, false}       -> ok;
+                {generalized, true}  -> ok;
+                {generalized, false} -> runtime_error(ga_using_signature_not_allowed)
+                %% {basic, true} is impossible, if we get there we should crash
+            end
+    end.
+
 assert_account_nonce(Account, Nonce) ->
     case aec_accounts:nonce(Account) of
         N when N + 1 =:= Nonce -> ok;
@@ -1917,13 +1941,6 @@ assert_channel_reserve_amount(ReserveAmount, InitiatorAmount, ResponderAmount) -
             runtime_error(insufficient_responder_amount);
         true ->
             ok
-    end.
-
-assert_channel_origin(Channel, FromPubkey) ->
-    case (aesc_channels:initiator_pubkey(Channel) =:= FromPubkey
-          orelse aesc_channels:responder_pubkey(Channel) =:= FromPubkey) of
-        true  -> ok;
-        false -> runtime_error(illegal_origin)
     end.
 
 assert_channel_active(Channel) ->

--- a/docs/release-notes/next/fix_sc_signature_check.md
+++ b/docs/release-notes/next/fix_sc_signature_check.md
@@ -1,0 +1,2 @@
+* Add assertion that checks that we are not using a Generalized account like a basic
+  account, i.e. don't allow to use private key signature.


### PR DESCRIPTION
This PR lacks a release note and a proper test case. It has been tested locally with QuickCheck.