### PR TITLE
Improve noise stability and log errors

### DIFF
--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -76,9 +76,11 @@ handle_call({listen, Port, Responder, Opts}, {Pid,_Ref}, #st{ responders = Resps
         [#port{lsock = LSock}] ->
             MRef = erlang:monitor(process, Pid),
             Ports1 = db_insert(Ports, #port{key = {Port, Pid}, mref = MRef}),
-            Refs1 = db_insert(Refs, #ref{mref = MRef, port = Port,
-                                         responder = Responder,
-                                         lsock = LSock, pid = Pid}),
+            Refs1 = db_insert(Refs, #ref{ mref = MRef
+                                        , port = Port
+                                        , responder = Responder
+                                        , lsock = LSock
+                                        , pid = Pid}),
             Resps1 = db_insert(Resps, #resp{key = {Port, Responder, Pid}}),
             {reply, {ok, LSock}, St#st{ responders = Resps1
                                       , ports = Ports1

--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -80,7 +80,7 @@ handle_call({listen, Port, Responder, Opts}, {Pid,_Ref}, #st{ responders = Resps
                                         , port = Port
                                         , responder = Responder
                                         , lsock = LSock
-                                        , pid = Pid}),
+                                        , pid = Pid }),
             Resps1 = db_insert(Resps, #resp{key = {Port, Responder, Pid}}),
             {reply, {ok, LSock}, St#st{ responders = Resps1
                                       , ports = Ports1


### PR DESCRIPTION
This improves resilience of spawning the noise session for the `responder`: it allows 3 retry attempts. 
This PR also improves loging with regard of failed conenctions.
Fixes #2940
Fixes #2948