### PR TITLE
Avoid processing (and logging) gossiped blocks while syncing

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1100,6 +1100,9 @@ handle_add_block(Block, Hash, Prev, State, Origin) ->
                 {error, Reason} when Origin == block_created; Origin == micro_block_created ->
                     lager:error("Couldn't insert created block (~p)", [Reason]),
                     {{error, Reason}, State};
+                {error, Reason = {illegal_orphan, H}} ->
+                    lager:info("Couldn't insert received block ({not_attached_to_chain, ~s})", [aeu_debug:pp(H)]),
+                    {{error, Reason}, State};
                 {error, Reason} ->
                     lager:info("Couldn't insert received block (~p)", [Reason]),
                     {{error, Reason}, State}

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -169,8 +169,7 @@ accept_init(Ref, TcpSock, ranch_tcp, Opts) ->
                       , host => list_to_binary(inet:ntoa(Addr))
                       , version => Version
                       , genesis => Genesis },
-            S = #{ version := Version, genesis := Genesis,
-                   pubkey := PubKey } = ensure_genesis(S0),
+            S = #{ genesis := Genesis, pubkey := PubKey } = ensure_genesis(S0),
 
             %% ======  Entering critical section with Private keys in memory. ======
             PrevSensitive = process_flag(sensitive, true),

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -29,6 +29,7 @@
         , send_block/2
         , send_tx/2
         , stop/1
+        , set_sync_height/2
         ]).
 
 %% API Mempool sync
@@ -114,6 +115,10 @@ send_tx(PeerId, SerTx) ->
 
 send_block(PeerId, SerBlock) ->
     cast(PeerId, {send_block, SerBlock}).
+
+%% Indicate that we are syncing, and that gossips should be dropped.
+set_sync_height(PeerId, Height) ->
+    cast(PeerId, {set_sync_height, Height}).
 
 stop(PeerCon) ->
     gen_server:cast(PeerCon, stop).
@@ -231,6 +236,10 @@ handle_cast({send_tx, SerTx}, State) ->
 handle_cast({send_block, SerBlock}, State) ->
     send_send_block(State, SerBlock),
     {noreply, State};
+handle_cast({set_sync_height, none}, State) ->
+    {noreply, maps:remove(sync_height, State)};
+handle_cast({set_sync_height, Height}, State) when is_integer(Height) ->
+    {noreply, State#{ sync_height => Height }};
 handle_cast({expand_micro_block, MicroBlockFragment}, State) ->
     {noreply, expand_micro_block(State, MicroBlockFragment)};
 handle_cast(stop, State) ->
@@ -944,9 +953,13 @@ handle_new_key_block(S, Msg) ->
     try
         {ok, KeyBlock} = deserialize_key_block(maps:get(key_block, Msg)),
         Header = aec_blocks:to_header(KeyBlock),
-        {ok, HH} = aec_headers:hash_header(Header),
-        epoch_sync:debug("Got new block: ~s", [pp(HH)]),
-        aec_conductor:post_block(KeyBlock)
+        case check_gossiped_header_height(S, Header) of
+            drop -> ok;
+            ok ->
+                {ok, HH} = aec_headers:hash_header(Header),
+                epoch_sync:debug("Got new block: ~s", [pp(HH)]),
+                aec_conductor:post_block(KeyBlock)
+        end
     catch _:_ ->
         ok
     end,
@@ -958,50 +971,66 @@ handle_new_micro_block(S, Msg) ->
             false ->
                 {ok, MicroBlock} = deserialize_micro_block(maps:get(micro_block, Msg)),
                 Header = aec_blocks:to_header(MicroBlock),
-                {ok, HH} = aec_headers:hash_header(Header),
-                epoch_sync:debug("Got new block: ~s", [pp(HH)]),
-                %% in the full micro block case - conductor will do the necessary checks
-                aec_conductor:post_block(MicroBlock);
+                case check_gossiped_header_height(S, Header) of
+                    drop -> ok;
+                    ok ->
+                        {ok, HH} = aec_headers:hash_header(Header),
+                        epoch_sync:debug("Got new block: ~s", [pp(HH)]),
+                        %% in the full micro block case - conductor will do the necessary checks
+                        aec_conductor:post_block(MicroBlock)
+                end;
             true ->
                 {ok, #{ header := Header, tx_hashes := TxHashes, pof := PoF }} =
                     deserialize_light_micro_block(maps:get(micro_block, Msg)),
-                %% Before assembling the block, check if it is known, and valid
-                case pre_assembly_check(Header) of
-                    known ->
-                        ok;
-                    E = {error, _} ->
-                        {ok, HH} = aec_headers:hash_header(Header),
-                        epoch_sync:info("Got invalid light micro_block (~s): ~p", [pp(HH), E]),
-                        case aec_chain:get_header(aec_headers:prev_key_hash(Header)) of
-                            {ok, PrevHeader} ->
-                                epoch_sync:debug("miner beneficiary: ~p", [aec_headers:beneficiary(PrevHeader)]),
-                                ok;
-                            _ ->
-                                ok
-                        end;
-
-                    ok ->
-                        case get_micro_block_txs(TxHashes) of
-                            {all, Txs} ->
-                                MicroBlock = aec_blocks:new_micro_from_header(Header, Txs, PoF),
-                                {ok, HH} = aec_headers:hash_header(Header),
-                                epoch_sync:debug("Got new block: ~s", [pp(HH)]),
-                                aec_conductor:post_block(MicroBlock);
-                            {some, TxsAndTxHashes} ->
-                                epoch_sync:info("Missing txs: ~p",
-                                                [[ TH || TH <- TxsAndTxHashes, is_binary(TH) ]]),
-                                cast(self(), {expand_micro_block, #{ header => Header,
-                                                                     tx_data => TxsAndTxHashes,
-                                                                     pof => PoF
-                                                                   }}),
-                                ok
-                        end
+                case check_gossiped_header_height(S, Header) of
+                    drop -> ok;
+                    ok   -> handle_light_micro_block(S, Header, TxHashes, PoF)
                 end
         end
     catch _:_ ->
         ok
     end,
     S.
+
+check_gossiped_header_height(S, Header) ->
+    case aec_headers:height(Header) - 1 =< maps:get(sync_height, S, infinity) of
+        true  -> ok;
+        false -> drop
+    end.
+
+handle_light_micro_block(_S, Header, TxHashes, PoF) ->
+    %% Before assembling the block, check if it is known, and valid
+    case pre_assembly_check(Header) of
+        known ->
+            ok;
+        E = {error, _} ->
+            {ok, HH} = aec_headers:hash_header(Header),
+            epoch_sync:info("Dropping gossiped light micro_block (~s): ~p", [pp(HH), E]),
+            case aec_chain:get_header(aec_headers:prev_key_hash(Header)) of
+                {ok, PrevHeader} ->
+                    epoch_sync:debug("miner beneficiary: ~p", [aec_headers:beneficiary(PrevHeader)]),
+                    ok;
+                _ ->
+                    ok
+            end;
+
+        ok ->
+            case get_micro_block_txs(TxHashes) of
+                {all, Txs} ->
+                    MicroBlock = aec_blocks:new_micro_from_header(Header, Txs, PoF),
+                    {ok, HH} = aec_headers:hash_header(Header),
+                    epoch_sync:debug("Got new block: ~s", [pp(HH)]),
+                    aec_conductor:post_block(MicroBlock);
+                {some, TxsAndTxHashes} ->
+                    epoch_sync:info("Missing txs: ~p",
+                                    [[ TH || TH <- TxsAndTxHashes, is_binary(TH) ]]),
+                    cast(self(), {expand_micro_block, #{ header => Header,
+                                                         tx_data => TxsAndTxHashes,
+                                                         pof => PoF
+                                                       }}),
+                    ok
+            end
+    end.
 
 %% -- Get block txs ----------------------------------------------------------
 

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -332,7 +332,11 @@ handle_last_result(ST, {get_generation, Height, Hash, PeerId, {ok, Block}}) ->
     ST#sync_task{ pool = Pool1 };
 handle_last_result(ST, {post_blocks, ok}) ->
     ST#sync_task{ adding = [] };
+handle_last_result(ST, {post_blocks, {ok, NewTop}}) ->
+    inform_workers(ST, {new_top, NewTop}),
+    ST#sync_task{ adding = [] };
 handle_last_result(ST, {post_blocks, {error, BlockFromPeerId, Height}}) ->
+    inform_workers(ST, {new_top, Height}),
     #sync_task{ adding = Add, pending = Pends, pool = Pool
               , chain = Chain
               } = ST,
@@ -346,6 +350,8 @@ handle_last_result(ST, {post_blocks, {error, BlockFromPeerId, Height}}) ->
 
     ST1#sync_task{ chain = Chain#chain{ peers = Chain#chain.peers -- [BlockFromPeerId] }}.
 
+inform_workers(#sync_task{ workers = Ws }, {new_top, Height}) ->
+    [ aec_peer_connection:set_sync_height(P, Height) || #worker{ peer_id = P } <- Ws ].
 
 split_pool(Pool) ->
     lists:splitwith(fun(#pool_item{ got = X }) -> X =/= false end, Pool).
@@ -442,6 +448,7 @@ do_update_sync_task(State, STId, Update) ->
                     {done, PeerId} ->
                         Chain#chain{ peers = Chain#chain.peers -- [PeerId] };
                     {error, PeerId} ->
+                        aec_peer_connection:set_sync_height(PeerId, none),
                         Chain#chain{ peers = Chain#chain.peers -- [PeerId] }
                 end,
             maybe_end_sync_task(State, ST#sync_task{ chain = Chain1 });
@@ -752,9 +759,12 @@ post_blocks([]) -> ok;
 post_blocks([#pool_item{ height = StartHeight } | _] = Blocks) ->
     post_blocks(StartHeight, StartHeight, Blocks).
 
+post_blocks(To, To, []) ->
+    epoch_sync:info("Synced block  ~p", [To]),
+    {ok, To};
 post_blocks(From, To, []) ->
     epoch_sync:info("Synced blocks ~p - ~p", [From, To]),
-    ok;
+    {ok, To};
 post_blocks(From, _To, [#pool_item{ height = Height, got = {_PeerId, local} } | Blocks]) ->
     post_blocks(From, Height, Blocks);
 post_blocks(From, To, [#pool_item{ height = Height, got = {PeerId, Block} } | Blocks]) ->
@@ -832,6 +842,7 @@ agree_on_height(PeerId, RHash0, RH, CheckHeight, Max, Min, AgreedHash) when RH =
 fill_pool(PeerId, StartHash, TargetHash, ST) ->
     case aec_peer_connection:get_n_successors(PeerId, StartHash, TargetHash, ?MAX_HEADERS_PER_CHUNK) of
         {ok, []} ->
+            aec_peer_connection:set_sync_height(PeerId, none),
             do_get_generation(PeerId, StartHash),
             update_sync_task({done, PeerId}, ST),
             epoch_sync:info("Sync done (according to ~p)", [ppp(PeerId)]),

--- a/docs/release-notes/next/GH-2978-less_noise_while_syncing.md
+++ b/docs/release-notes/next/GH-2978-less_noise_while_syncing.md
@@ -1,0 +1,2 @@
+* Optimize sync, by being more aggressive and drop gossiped blocks that are far
+  in the future. This also reduces the amount of noise in the console.


### PR DESCRIPTION
Closes #2978 

It should even reduce the load of the syncing node, since we skip some processing of the gossiped blocks.