### PR TITLE
New transaction - PayingForTx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -798,7 +798,10 @@ jobs:
           key: dialyzer-cache-v2-{{ .Branch }}-{{ .Revision }}
           paths:
             - *container_otp_plt
-      - run: make dialyzer
+      - run:
+          name: Run dialyzer
+          no_output_timeout: 20m
+          command: make dialyzer
       - run: make python-env
       - run: ./rebar3 xref || true
       - run:
@@ -826,7 +829,10 @@ jobs:
           key: dialyzer-otp21-cache-v2-{{ .Branch }}-{{ .Revision }}
           paths:
             - *container_otp21_plt
-      - run: make dialyzer
+      - run:
+          name: Run dialyzer
+          no_output_timeout: 20m
+          command: make dialyzer
       - run:
           name: Check OTP version (for effective CI caching)
           # How to retrieve OTP version in installed OTP development system: http://erlang.org/doc/system_principles/versions.html

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -158,7 +158,8 @@ tx_base_gas(name_update_tx, _)            -> ?TX_BASE_GAS;
 tx_base_gas(oracle_extend_tx, _)          -> ?TX_BASE_GAS;
 tx_base_gas(oracle_query_tx, _)           -> ?TX_BASE_GAS;
 tx_base_gas(oracle_register_tx, _)        -> ?TX_BASE_GAS;
-tx_base_gas(oracle_response_tx, _)        -> ?TX_BASE_GAS.
+tx_base_gas(oracle_response_tx, _)        -> ?TX_BASE_GAS;
+tx_base_gas(paying_for_tx, _)             -> ?TX_BASE_GAS div 5.
 
 store_byte_gas() ->
     ?STORE_BYTE_GAS.

--- a/apps/aecore/src/aec_paying_for_tx.erl
+++ b/apps/aecore/src/aec_paying_for_tx.erl
@@ -1,0 +1,213 @@
+%%%=============================================================================
+%%% @copyright 2019, Aeternity Anstalt
+%%% @doc
+%%%    Module defining the PayingForTX
+%%% @end
+%%%=============================================================================
+-module(aec_paying_for_tx).
+
+-behavior(aetx).
+
+-include("../../aecontract/include/aecontract.hrl").
+-include("../../aecontract/include/hard_forks.hrl").
+
+%% Behavior API
+-export([new/1,
+         type/0,
+         fee/1,
+         gas/1,
+         ttl/1,
+         nonce/1,
+         origin/1,
+         check/3,
+         process/3,
+         signers/2,
+         version/1,
+         serialization_template/1,
+         serialize/1,
+         deserialize/2,
+         for_client/1,
+         valid_at_protocol/2
+        ]).
+%% Additional getters
+-export([payer_id/1,
+         payer_pubkey/1,
+         tx/1
+        ]).
+
+-export([set_tx/2
+        ]).
+
+-define(PAYING_FOR_TX_VSN, 1).
+-define(PAYING_FOR_TX_TYPE, paying_for_tx).
+
+%% Should this be in a header file somewhere?
+-define(PUB_SIZE, 32).
+
+-define(is_non_neg_integer(X), (is_integer(X) andalso (X >= 0))).
+
+-type amount() :: aect_contracts:amount().
+
+-record(paying_for_tx, {
+          payer_id    :: aeser_id:id(),
+          nonce       :: non_neg_integer(),
+          fee         :: non_neg_integer(),
+          tx          :: aetx_sign:signed_tx()
+        }).
+
+-opaque tx() :: #paying_for_tx{}.
+
+-export_type([tx/0]).
+
+%%%===================================================================
+%%% Getters
+
+-spec payer_id(tx()) -> aeser_id:id().
+payer_id(#paying_for_tx{payer_id = PayerId}) ->
+    PayerId.
+
+-spec payer_pubkey(tx()) -> aec_keys:pubkey().
+payer_pubkey(#paying_for_tx{payer_id = PayerId}) ->
+    aeser_id:specialize(PayerId, account).
+
+-spec gas(tx()) -> amount().
+gas(#paying_for_tx{}) ->
+    0.
+
+-spec tx(tx()) -> aetx_sign:signed_tx().
+tx(#paying_for_tx{tx = Tx}) ->
+    Tx.
+
+-spec set_tx(aetx_sign:signed_tx(), tx()) -> tx().
+set_tx(NewTx, Tx) ->
+    Tx#paying_for_tx{tx = NewTx}.
+
+%%%===================================================================
+%%% Behavior API
+
+-spec fee(tx()) -> integer().
+fee(#paying_for_tx{fee = Fee}) ->
+    Fee.
+
+-spec ttl(tx()) -> aetx:tx_ttl().
+ttl(#paying_for_tx{tx = STx}) ->
+    aetx:ttl(aetx_sign:tx(STx)).
+
+-spec new(map()) -> {ok, aetx:tx()}.
+new(#{payer_id := PayerId,
+      nonce    := Nonce,
+      fee      := Fee,
+      tx       := InnerTx}) ->
+    account = aeser_id:specialize_type(PayerId),
+    Tx = #paying_for_tx{payer_id = PayerId,
+                        nonce    = Nonce,
+                        fee      = Fee,
+                        tx       = InnerTx},
+    {ok, aetx:new(?MODULE, Tx)}.
+
+-spec type() -> atom().
+type() ->
+    ?PAYING_FOR_TX_TYPE.
+
+-spec nonce(tx()) -> non_neg_integer().
+nonce(#paying_for_tx{nonce = Nonce}) ->
+    Nonce.
+
+-spec origin(tx()) -> aec_keys:pubkey().
+origin(#paying_for_tx{} = Tx) ->
+    payer_pubkey(Tx).
+
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
+check(#paying_for_tx{}, Trees, _Env) ->
+    %% Checks in process/3
+    {ok, Trees}.
+
+-spec signers(tx(), aec_trees:trees()) -> {ok, [aec_keys:pubkey()]}.
+signers(#paying_for_tx{} = Tx, _) ->
+    {ok, [payer_pubkey(Tx)]}.
+
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees(), aetx_env:env()}.
+process(#paying_for_tx{tx = STx} = Tx, Trees, Env0) ->
+    case check_tx(STx) of
+        ok ->
+            PInstr = aeprimop:paying_for_tx_instructions(payer_pubkey(Tx), nonce(Tx), fee(Tx)),
+            case aeprimop:eval(PInstr, Trees, Env0) of
+                {ok, Trees1, Env1} ->
+                    Env2 = aetx_env:set_payer(Env1, payer_pubkey(Tx)),
+                    case aetx_sign:verify_w_env(STx, Trees1, Env2) of
+                        ok ->
+                            aetx:process(aetx_sign:tx(STx), Trees1, Env2);
+                        Err = {error, _} ->
+                            Err
+                    end;
+                Err = {error, _} ->
+                    Err
+            end;
+        Err = {error, _} ->
+            Err
+    end.
+
+serialize(#paying_for_tx{payer_id = PayerId,
+                         nonce    = Nonce,
+                         fee      = Fee,
+                         tx       = InnerTx} = Tx) ->
+    SerTx = aetx_sign:serialize_to_binary(InnerTx),
+    {version(Tx),
+     [ {payer_id, PayerId}
+     , {nonce, Nonce}
+     , {fee, Fee}
+     , {tx, SerTx}
+     ]}.
+
+deserialize(?PAYING_FOR_TX_VSN,
+            [ {payer_id, PayerId}
+            , {nonce, Nonce}
+            , {fee, Fee}
+            , {tx, SerTx}]) ->
+    account = aeser_id:specialize_type(PayerId),
+    InnerTx = aetx_sign:deserialize_from_binary(SerTx),
+    ok      = check_tx(InnerTx),
+    #paying_for_tx{payer_id = PayerId,
+                   nonce    = Nonce,
+                   fee      = Fee,
+                   tx       = InnerTx}.
+
+serialization_template(?PAYING_FOR_TX_VSN) ->
+    [ {payer_id, id}
+    , {nonce, int}
+    , {fee, int}
+    , {tx, binary}
+    ].
+
+for_client(#paying_for_tx{ payer_id = PayerId,
+                           nonce    = Nonce,
+                           fee      = Fee,
+                           tx       = InnerTx}) ->
+    #{<<"payer_id">>  => aeser_api_encoder:encode(id_hash, PayerId),
+      <<"nonce">>     => Nonce,
+      <<"fee">>       => Fee,
+      <<"tx">>        => aetx_sign:serialize_for_client_inner(InnerTx, #{})}.
+
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
+    ?PAYING_FOR_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(P, #paying_for_tx{ tx = STx }) ->
+    P >= ?IRIS_PROTOCOL_VSN andalso
+        aetx:valid_at_protocol(P, aetx_sign:tx(STx)).
+
+%%%===================================================================
+%%% Internal functions
+
+check_tx(STx) ->
+    Tx = aetx_sign:tx(STx),
+    {Type, InnerTx} = aetx:specialize_type(Tx),
+    case Type of
+        paying_for_tx                   -> {error, not_allowed_to_pay_for_recursively};
+        ga_meta_tx                      -> check_tx(aega_meta_tx:tx(InnerTx));
+        X = channel_offchain_tx         -> {error, {not_allowed_to_pay_for, X}};
+        X = channel_client_reconnect_tx -> {error, {not_allowed_to_pay_for, X}};
+        _X                              -> ok
+    end.
+

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -68,6 +68,10 @@
         , channel_slash/1
         , channel_force_progress/1
 
+        , paying_for_inner/1
+        , paying_for_outer/1
+        , paying_for_inner_outer/1
+
         , wrap_unrelated_tx/1
         , cripple_auth/1
         ]).
@@ -109,6 +113,7 @@ groups() ->
                  , {group, oracle}
                  , {group, channel}
                  , {group, multi_wrap}
+                 , {group, paying_for}
                  , {group, negative}
                  ]}
     , {fate, [], [ {group, simple}
@@ -118,6 +123,7 @@ groups() ->
                  , {group, oracle}
                  , {group, channel}
                  , {group, multi_wrap}
+                 , {group, paying_for}
                  , {group, negative}
                  ]}
 
@@ -164,6 +170,11 @@ groups() ->
                        , multi_wrap_sc_solo_snapshot
                        ]}
 
+    , {paying_for, [], [ paying_for_inner
+                       , paying_for_outer
+                       , paying_for_inner_outer
+                       ]}
+
     , {channel, [], [ channel_create
                     , channel_deposit
                     , channel_withdraw
@@ -190,6 +201,11 @@ init_per_group(VM, Cfg) when VM == aevm; VM == fate ->
 init_per_group(ethereum, Cfg) ->
     case aect_test_utils:latest_protocol_version() of
         Vsn when Vsn < ?LIMA_PROTOCOL_VSN -> {skip, ethereum_style_ecverify_not_pre_lima};
+        _Vsn -> Cfg
+    end;
+init_per_group(paying_for, Cfg) ->
+    case aect_test_utils:latest_protocol_version() of
+        Vsn when Vsn < ?IRIS_PROTOCOL_VSN -> {skip, paying_for_not_pre_iris};
         _Vsn -> Cfg
     end;
 init_per_group(_Grp, Cfg) ->
@@ -947,6 +963,88 @@ channel_force_progress(_Cfg) ->
     ok.
 
 %%%===================================================================
+%%% PayingForTx test cases
+%%%===================================================================
+paying_for_inner(_Cfg) ->
+    state(aect_test_utils:new_state()),
+    MinGP   = aec_test_utils:min_gas_price(),
+    Acc1 = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
+    Acc2 = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
+    {ok, _} = ?call(attach, Acc1, "basic_auth", "authorize", []),
+    Auth = fun(N) -> #{ prep_fun => fun(Tx) -> ?call(basic_auth, Acc1, N, Tx) end } end,
+
+    SpendTx = aega_test_utils:spend_tx(#{sender_id    => aeser_id:create(account, Acc1),
+                                         recipient_id => aeser_id:create(account, Acc2),
+                                         amount       => 2000,
+                                         fee          => 20000 * MinGP,
+                                         nonce        => 0}),
+
+    {_AuthData2, _InnerTx2, MetaTx} = prep_meta(Acc1, Auth("1"), SpendTx),
+
+    SMetaTx = aetx_sign:new(MetaTx, []),
+    PreBalance  = ?call(account_balance, Acc1),
+    ok = ?call(paying_for, Acc2, SMetaTx, 10000 * MinGP),
+    PostBalance = ?call(account_balance, Acc1),
+    ?assertEqual(2000, PreBalance - PostBalance),
+    ok.
+
+paying_for_outer(_Cfg) ->
+    state(aect_test_utils:new_state()),
+    MinGP   = aec_test_utils:min_gas_price(),
+    Acc1    = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
+    Acc2    = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
+    {ok, _} = ?call(attach, Acc1, "basic_auth", "authorize", []),
+    Auth    = fun(N) -> #{ prep_fun => fun(Tx) -> ?call(basic_auth, Acc1, N, Tx) end } end,
+
+    State   = state(),
+    SpendTx = aega_test_utils:spend_tx(
+                #{sender_id    => aeser_id:create(account, Acc2),
+                  recipient_id => aeser_id:create(account, Acc1),
+                  amount       => 2000,
+                  fee          => 20000 * MinGP,
+                  nonce        => aect_test_utils:next_nonce(Acc2, State)}),
+
+    PrivKey  = aect_test_utils:priv_key(Acc2, State),
+    SignedTx = aec_test_utils:sign_tx(SpendTx, PrivKey),
+
+    PreBalance  = ?call(account_balance, Acc2),
+    {ok, #{tx_res := ok}} =
+        ?call(ga_paying_for, Acc1, Auth("1"), 10000 * MinGP, SignedTx),
+    PostBalance = ?call(account_balance, Acc2),
+
+    ?assertEqual(2000, PreBalance - PostBalance),
+
+    ok.
+
+paying_for_inner_outer(_Cfg) ->
+    state(aect_test_utils:new_state()),
+    MinGP   = aec_test_utils:min_gas_price(),
+    Acc1 = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
+    Acc2 = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
+    {ok, _} = ?call(attach, Acc1, "basic_auth", "authorize", []),
+    {ok, _} = ?call(attach, Acc2, "basic_auth", "authorize", []),
+    Auth1 = fun(N) -> #{ prep_fun => fun(Tx) -> ?call(basic_auth, Acc1, N, Tx) end } end,
+    Auth2 = fun(N) -> #{ prep_fun => fun(Tx) -> ?call(basic_auth, Acc2, N, Tx) end } end,
+
+    SpendTx = aega_test_utils:spend_tx(#{sender_id    => aeser_id:create(account, Acc1),
+                                         recipient_id => aeser_id:create(account, Acc2),
+                                         amount       => 2000,
+                                         fee          => 20000 * MinGP,
+                                         nonce        => 0}),
+
+    {_AuthData2, _InnerTx2, MetaTx} = prep_meta(Acc1, Auth1("1"), SpendTx),
+    SMetaTx = aetx_sign:new(MetaTx, []),
+
+    PreBalance  = ?call(account_balance, Acc1),
+    {ok, #{tx_res := ok}} =
+        ?call(ga_paying_for, Acc2, Auth2("1"), 10000 * MinGP, SMetaTx),
+    PostBalance = ?call(account_balance, Acc1),
+
+    ?assertEqual(2000, PreBalance - PostBalance),
+    ok.
+
+
+%%%===================================================================
 %%% Negative tests
 %%%===================================================================
 wrap_unrelated_tx(_Cfg) ->
@@ -1055,6 +1153,11 @@ attach(Owner, Contract, AuthFun, Args, Opts, S) ->
             error(bad_contract)
     end.
 
+paying_for(Payer, Tx, Fee, S) ->
+    PayingTx = paying_for_tx(Payer, aect_test_utils:next_nonce(Payer, S), Fee, Tx),
+    S1 = sign_and_apply_tx(false, Payer, PayingTx, #{}, S),
+    {ok, S1}.
+
 ga_spend(From, AuthOpts, To, Amount, Fee, S) ->
     ga_spend(From, AuthOpts, To, Amount, Fee, #{}, S).
 
@@ -1065,6 +1168,13 @@ ga_spend(From, AuthOpts, To, Amount, Fee, Opts, S) ->
                                          fee          => Fee,
                                          nonce        => 0}),
     meta(From, AuthOpts, SpendTx, Opts, S).
+
+ga_paying_for(Payer, AuthOpts, Fee, Tx, S) ->
+    ga_paying_for(Payer, AuthOpts, Fee, Tx, #{}, S).
+
+ga_paying_for(Payer, AuthOpts, Fee, Tx, Opts, S) ->
+    PayingTx = paying_for_tx(Payer, 0, Fee, Tx),
+    meta(Payer, AuthOpts, PayingTx, Opts, S).
 
 ga_create(Owner, AuthOpts, ContractName, InitArgs, S) ->
     ga_create(Owner, AuthOpts, ContractName, InitArgs, #{}, S).
@@ -1356,7 +1466,8 @@ do_meta(Owner, AuthData, InnerTx, MetaTx, Opts, S) ->
                          Tx == channel_deposit_tx; Tx == channel_withdraw_tx;
                          Tx == channel_snapshot_solo_tx; Tx == channel_close_mutual_tx;
                          Tx == channel_close_solo_tx; Tx == channel_settle_tx;
-                         Tx == channel_slash_tx; Tx == ga_attach_tx; Tx == ga_meta_tx ->
+                         Tx == channel_slash_tx; Tx == ga_attach_tx;
+                         Tx == ga_meta_tx; Tx == paying_for_tx ->
                 {ok, Res0}
         end,
     {Res, S1}.
@@ -1431,6 +1542,14 @@ call_tx_default() ->
      , fee         => 500000 * aec_test_utils:min_gas_price()
      , amount      => 0
      , gas         => 10000 }.
+
+paying_for_tx(Payer, Nonce, Fee, Tx) ->
+    {ok, PayingTx} =
+        aec_paying_for_tx:new(#{ payer_id => aeser_id:create(account, Payer),
+                                 nonce    => Nonce,
+                                 fee      => Fee,
+                                 tx       => Tx }),
+    PayingTx.
 
 %%%===================================================================
 %%% Test framework/machinery

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -284,7 +284,7 @@ meta_fail(Config) ->
 
     %% Fail inner tx by spending (far) too much
     #{tx_hash := MetaTx} =
-        post_ga_spend_tx(APub, APriv, ["1"], BPub, 1000 * MGP * MGP, MGP * 15000, MetaFee),
+        post_ga_spend_tx(APub, APriv, ["1"], BPub, 1000 * MGP * MGP, MGP * 20000, MetaFee),
 
     ?MINE_TXS([MetaTx]),
 
@@ -361,7 +361,7 @@ meta_meta_fail(Config) ->
     MGP = aec_test_utils:min_gas_price(),
     MetaFee = (5 * 15000 + 30000) * MGP,
 
-    #{tx_hash := MetaTx} = post_ga_spend_tx(APub, APriv, ["4", "5"], BPub, 1000 * MGP * MGP, 15000 * MGP, MetaFee),
+    #{tx_hash := MetaTx} = post_ga_spend_tx(APub, APriv, ["4", "5"], BPub, 1000 * MGP * MGP, 20000 * MGP, MetaFee),
 
     ?MINE_TXS([MetaTx]),
 
@@ -423,7 +423,7 @@ meta_4_fail(Config) ->
     MGP = aec_test_utils:min_gas_price(),
     MetaFee = (5 * 15000 + 30000) * MGP,
 
-    #{tx_hash := MetaTx} = post_ga_spend_tx(APub, APriv, ["8", "9", "10", "12"], APub, 10000, 15000 * MGP, MetaFee),
+    #{tx_hash := MetaTx} = post_ga_spend_tx(APub, APriv, ["8", "9", "10", "12"], APub, 10000, 20000 * MGP, MetaFee),
 
     ?MINE_TXS([MetaTx]),
 
@@ -520,7 +520,13 @@ mempool(Config) ->
                                     MetaFee, aec_tx_pool:maximum_auth_fun_gas() + 1),
 
     %% Test with exactly the lowest possible fee... Note that there isn't any size gas!
-    #{tx_hash := _MetaTx} = post_ga_spend_tx(APub, APriv, ["1"], BPub, 10001, MGP * 15000, MetaFee),
+    %% This only works pre-IRIS
+    case aect_test_utils:latest_protocol_version() of
+        Vsn when Vsn =< ?LIMA_PROTOCOL_VSN ->
+            #{tx_hash := _MetaTx} = post_ga_spend_tx(APub, APriv, ["1"], BPub, 10001, MGP * 15000, MetaFee);
+        _ ->
+            ok
+    end,
 
     ok.
 

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -586,8 +586,9 @@ spend_fee_op(From, Amount) when ?IS_HASH(From),
                                 ?IS_NON_NEG_INTEGER(Amount) ->
     {spend_fee, {From, Amount, 0}}.
 
-spend_fee_op(From, DelegatedAmount, Amount)
-        when ?IS_HASH(From), ?IS_NON_NEG_INTEGER(DelegatedAmount + Amount) ->
+spend_fee_op(From, DelegatedAmount, Amount) when ?IS_HASH(From)
+                                               , ?IS_NON_NEG_INTEGER(DelegatedAmount)
+                                               , ?IS_NON_NEG_INTEGER(Amount) ->
     {spend_fee, {From, DelegatedAmount, Amount}}.
 
 spend_fee({From, DelegatedAmount, Amount}, #state{} = S)

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -82,7 +82,8 @@
                  | channel_settle_tx
                  | channel_snapshot_solo_tx
                  | channel_offchain_tx
-                 | channel_client_reconnect_tx.
+                 | channel_client_reconnect_tx
+                 | paying_for_tx.
 
 -type tx_instance() :: aec_spend_tx:tx()
                      | aeo_register_tx:tx()

--- a/apps/aetx/src/aetx_env.erl
+++ b/apps/aetx/src/aetx_env.erl
@@ -35,6 +35,7 @@
         , ga_tx_hash/1
         , height/1
         , key_hash/1
+        , payer/1
         , signed_tx/1
         , time_in_msecs/1
         , events/1
@@ -51,6 +52,7 @@
         , set_dry_run/2
         , set_ga_tx_hash/2
         , set_height/2
+        , set_payer/2
         , set_signed_tx/2
         , tx_event/2
         , set_events/2
@@ -76,6 +78,7 @@
              , ga_auth_ids = []  :: [aec_keys:pubkey()]
              , ga_nonces = []    :: [{aec_keys:pubkey(), binary()}]
              , ga_tx_hash        :: undefined | binary()
+             , payer             :: undefined | aec_keys:pubkey()
              , difficulty        :: aeminer_pow:difficulty()
              , dry_run = false   :: boolean()
              , height            :: aec_blocks:height()
@@ -216,6 +219,14 @@ height(#env{height = X}) -> X.
 
 -spec set_height(env(), aec_blocks:height()) -> env().
 set_height(Env, X) -> Env#env{height = X}.
+
+%%------
+
+-spec payer(env()) -> undefined | aec_keys:pubkey().
+payer(#env{payer = X}) -> X.
+
+-spec set_payer(env(), undefined | aec_keys:pubkey()) -> env().
+set_payer(Env, X) -> Env#env{payer = X}.
 
 %%------
 

--- a/rebar.config
+++ b/rebar.config
@@ -70,7 +70,7 @@
         {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "b040dcc"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                          {ref,"47aaa8f"}}},
+                          {ref,"80ff8a4"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
                          {ref, "96ffd9a"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"47aaa8f5434b365c50a35bfd1490340b19241991"}},
+      {ref,"80ff8a49f4765db390d6194beae4662e6872ad85"}},
   0},
  {<<"aestratum_lib">>,
   {git,"https://github.com/aeternity/aestratum_lib.git",


### PR DESCRIPTION
Allows an account to pay for a transaction on behalf of someone else.
Paying for fees and gas cost, will not cover the amount spent by the
transaction, just "the cost of the transaction" (and the extra size
added by wrapping the original transaction).

Note: this changes how "gas" for transaction size is calculated for GAs
from IRIS onwards. Instead of the outer/wrapping TX paying the size-gas
the whole TX it just has to cover its own part of the TX. This should be
less confusing, and easier to reason about. 

Closes #2851 