### PR TITLE
Fix CI naming of windows builds for versioned releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1172,9 +1172,6 @@ jobs:
       - store_artifacts:
           path: *windows_artifacts
           destination: packages-<< parameters.otp_version >>
-      - run:
-          name: Add experimental suffix to artifacts
-          command: 'FOR %_ IN (<< parameters.artifacts_path >>\*.*) DO REN %_ %~n_-experimental%~x_'
       - persist_to_workspace:
           root: *windows_artifacts
           paths:

--- a/.circleci/windows/build.sh
+++ b/.circleci/windows/build.sh
@@ -32,7 +32,7 @@ time make prod-build
 
 echo -e "${bold}Create package environment${reset}"
 NODE_VERSION=`cat ${PROJECT_ROOT}/VERSION`
-sed "s/^version =.*$/version = ${NODE_VERSION}/g" .circleci/windows/package.cfg > ${WORK_ROOT}/package.cfg
+sed "s/VERSION_PLACEHOLDER/${NODE_VERSION}/g" .circleci/windows/package.cfg > ${WORK_ROOT}/package.cfg
 
 time styrene -o ${WORK_ROOT} ${WORK_ROOT}/package.cfg
 
@@ -56,9 +56,12 @@ time styrene -o ${WORK_ROOT} ${WORK_ROOT}/package.cfg
 
 echo -e "${bold}Copy artifacts to $PACKAGES_PATH${reset}"
 
-PACKAGE_VERSION=`cat ${WORK_PATH}/REVISION`
+VERSION=${CIRCLE_SHA1:-unknown}
+if [[ -n $CIRCLE_TAG && $CIRCLE_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9\.\+]+)*)$ ]]; then
+    VERSION=${BASH_REMATCH[1]}
+fi
 
 mkdir -p ${PACKAGES_PATH}
-cp ${WORK_ROOT}/aeternity-*.zip ${PACKAGES_PATH}/aeternity-${PACKAGE_VERSION}-windows-x86_64.zip
-cp ${WORK_ROOT}/aeternity-*.exe ${PACKAGES_PATH}/aeternity-${PACKAGE_VERSION}-windows-x86_64.exe
+cp ${WORK_ROOT}/aeternity-*.zip ${PACKAGES_PATH}/aeternity-${VERSION}-windows-x86_64-experimental.zip
+cp ${WORK_ROOT}/aeternity-*.exe ${PACKAGES_PATH}/aeternity-${VERSION}-windows-x86_64-experimental.exe
 echo -e "${bold}Done.${reset}"


### PR DESCRIPTION
Fix a bug where Windows artifact names will not properly include VERSION but rather use commit hash in filenames even when it is a versioned release.

The bug is only related to windows builds for versioned releases. e.g. https://circleci.com/gh/aeternity/aeternity/98060

Also always build with `-experimental.zip` as suffix (instead of renaming)
