### PR TITLE
Add nix expression to get working development environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ executors:
     docker:
       - image: aeternity/builder
         user: builder
+  builder_container_nix_alpine:
+    docker:
+      - image: nixorg/nix:circleci
   builder_container_1804:
     docker:
       - image: aeternity/builder:1804
@@ -127,6 +130,12 @@ references:
   restore_build_otp21_cache: &restore_build_otp21_cache
     restore_cache:
       key: *build_otp21_cache_key
+
+  build_nix_cache_key: &build_nix_cache_key build-nix-cache-v1-{{ .Revision }}
+  restore_build_nix_cache: &restore_build_nix_cache
+    restore_cache:
+      key: *build_nix_cache_key
+
 
   machine_build_cache_key: &machine_build_cache_key machine-build-cache-v9-{{ .Branch }}-{{ .Revision }}
   restore_machine_build_cache: &restore_machine_build_cache
@@ -627,6 +636,26 @@ jobs:
           command: make KIND=test
       - save_cache:
           key: *build_otp21_cache_key
+          paths:
+            - "_build"
+      - save_cache:
+          key: *rebar_cache_key
+          paths:
+            - .cache/rebar3
+      - *store_rebar3_crashdump
+      - *fail_notification
+
+  build_nix:
+    executor: builder_container_nix_alpine
+    <<: *container_config
+    steps:
+      - checkout
+      - *restore_rebar_cache
+      - run:
+          name: Build
+          command: nix-shell -j auto --run "make KIND=test"
+      - save_cache:
+          key: *build_nix_cache_key
           paths:
             - "_build"
       - save_cache:
@@ -1207,6 +1236,14 @@ workflows:
               only: *tag_regex
 
       - build_otp21:
+          filters:
+            branches:
+              ignore:
+                - env/dev1
+                - env/dev2
+                - system-tests
+
+      - build_nix:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,6 @@ references:
     restore_cache:
       key: *build_nix_cache_key
 
-
   machine_build_cache_key: &machine_build_cache_key machine-build-cache-v9-{{ .Branch }}-{{ .Revision }}
   restore_machine_build_cache: &restore_machine_build_cache
     restore_cache:
@@ -1246,10 +1245,8 @@ workflows:
       - build_nix:
           filters:
             branches:
-              ignore:
-                - env/dev1
-                - env/dev2
-                - system-tests
+              only:
+                - *master_branch
 
       - docker_smoke_tests:
           context: ae-node-builds

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+let
+  stable = import (fetchTarball { # 19.09
+    url = https://github.com/NixOS/nixpkgs-channels/archive/a22b0189002.tar.gz;
+    sha256 = "0rgd0cbxg9mrzb830hgjlvy134ivpfcnkyhbnlvvn8vl4y20zqmz";
+  }) {};
+in {
+  aeternityEnv = stable.stdenv.mkDerivation {
+    name = "aeternity";
+    ## required to compile the C parts of cuckoo
+    hardeningDisable = [ "format" ];
+    buildInputs = [
+      ## base
+      stable.stdenv
+      ## erlang
+      stable.erlangR21
+      ## crypto
+      stable.libsodium
+      ## rocksdb build deps
+      stable.automake
+      stable.autoconf
+    ];
+    ## required to start the node locally
+    shellHooks = ''
+      ulimit -n 24576
+    '';
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -12,12 +12,13 @@ in {
       ## base
       stable.stdenv
       ## erlang
-      stable.erlangR21
+      stable.erlangR21 # OTP 21.3.5.2
       ## crypto
       stable.libsodium
       ## rocksdb build deps
       stable.automake
       stable.autoconf
+      stable.which
     ];
     ## required to start the node locally
     shellHooks = ''


### PR DESCRIPTION
This enables users of [nix](https://nixos.org/nix/) (e.g. on [NixOS](https://nixos.org/)) to start a working
development environment by running `nix-shell` in the top folder.