### PR TITLE
Use GA tests to run with HTTP client cache disabled

### DIFF
--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -102,9 +102,13 @@ suite() ->
 
 init_per_suite(Config0) ->
     Forks = aecore_suite_utils:forks(),
+    %% We want to run some suites with and some suites without client side cache
+    %% Arbitrary run this suite with cache disabled.
     DefCfg = #{<<"chain">> =>
                    #{<<"persist">> => true,
-                     <<"hard_forks">> => Forks}},
+                     <<"hard_forks">> => Forks},
+              <<"http">> =>
+                   #{<<"cache">> => #{<<"enabled">> => false}}},
     Config1 = [{symlink_name, "latest.http_ga"}, {test_module, ?MODULE}] ++ Config0,
     Config2 = aecore_suite_utils:init_per_suite([?NODE], DefCfg, Config1),
     [{nodes, [aecore_suite_utils:node_tuple(?NODE)]}] ++ Config2.


### PR DESCRIPTION
Python tests used to run with http cache enabled false, but the Erlang tests use dev1/sys.config in which the cache is by default anabled.

We don't really test more than the code path, so there is room for some more testing of the actual client cache behaviour. This patch is created in a series to lift Python test logic to Erlang side.