### PR TITLE
Test cleanup and hitting TTL serialization

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -5589,7 +5589,7 @@ sophia_aens_transactions(Cfg) ->
 
     ok.
 
-sophia_aens_update_transaction(Cfg) ->
+sophia_aens_update_transaction(_Cfg) ->
     %% AENS transactions from contract
     state(aect_test_utils:new_state()),
     Acc      = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1623,7 +1623,9 @@ create_spend_tx(SenderId, RecipientId, Amount, Fee, Payload) ->
                    recipient_id => RecipientId,
                    amount => Amount,
                    fee => Fee,
-                   payload => Payload}).
+                   payload => Payload,
+                   %% Just to test serialize_for_client with some TTL other than 0
+                   ttl => 100000}).
 
 get_account_by_pubkey(Id) ->
     Host = external_address(),

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -479,7 +479,6 @@ meta_sc_create_fail(Config) ->
     %% Get account information.
     #{acc_a := #{pub_key := APub, priv_key := APriv},
       acc_b := #{pub_key := BPub, priv_key := BPriv}} = proplists:get_value(accounts, Config),
-    ABal0 = get_balance(APub),
 
     #{tx_hash := MetaTx} = post_ga_sc_create_fail_tx(APub, APriv, "12", BPub, BPriv),
 
@@ -757,4 +756,3 @@ do_dry_run(STx, ExpRes) ->
             ct:pal("Dry-run call failed with reason: ~s", [Reason]),
             ?assertMatch(ExpRes, error)
     end.
-

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -4025,7 +4025,7 @@ setup_name_pointing_to_oracle(NameNoPrefix, OraclePubKey) ->
 
     %% Submit name claim tx and check it is in mempool
     Protocol = aec_hard_forks:protocol_effective_at_height(Height),
-    {ClaimData, NameFee} =
+    {ClaimData, _NameFee} =
         case Protocol >= ?LIMA_PROTOCOL_VSN of
             true ->
                 {#{account_id => PubKeyEnc,


### PR DESCRIPTION
In the Python tests we did use a TTL different from 0. The `serialization_for_client` therefore hit that special case.

It's easy to hit this as well with the Elrang tests, but we may want some future QuickCheck tests that generate arbitrary transactions and serializes them for client, checking some sensible properties on what should be in these serializations.