### PR TITLE
Add throughput test for aec_chain_state:insert_block

### DIFF
--- a/apps/aecore/test/aec_block_key_candidate_tests.erl
+++ b/apps/aecore/test/aec_block_key_candidate_tests.erl
@@ -27,20 +27,23 @@ new_key_block_test_() ->
                %% Previous block is a key block, so it
                %% has miner and height.
                RawBlock  = raw_key_block(),
+               Target = 17,
                PrevBlock1 = aec_blocks:set_height(RawBlock, 11),
-               PrevBlock2 = aec_blocks:set_target(PrevBlock1, 17),
+               PrevBlock2 = aec_blocks:set_target(PrevBlock1, Target),
                PrevBlock = aec_blocks:set_miner(PrevBlock2, ?MINER_PUBKEY),
                BlockHeader = aec_blocks:to_header(PrevBlock),
 
+               BlockCfg = #{target => Target},
                {NewBlock, _} = aec_test_utils:create_keyblock_with_state(
-                                 [{PrevBlock, aec_trees:new()}], ?MINER_PUBKEY, ?BENEFICIARY_PUBKEY),
+                                 [{PrevBlock, aec_trees:new()}], ?MINER_PUBKEY,
+                                 ?BENEFICIARY_PUBKEY, BlockCfg),
 
                ?assertEqual(12, aec_blocks:height(NewBlock)),
                SerializedBlockHeader = aec_headers:serialize_to_binary(BlockHeader),
                ?assertEqual(aec_hash:hash(header, SerializedBlockHeader),
                             aec_blocks:prev_hash(NewBlock)),
                ?assertError(_, aec_blocks:txs(NewBlock)),
-               ?assertEqual(17, aec_blocks:target(NewBlock)),
+               ?assertEqual(Target, aec_blocks:target(NewBlock)),
                ?assertEqual(aec_hard_forks:protocol_effective_at_height(12),
                             aec_blocks:version(NewBlock)),
                ?assertEqual(?MINER_PUBKEY, aec_blocks:miner(NewBlock)),

--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -333,78 +333,6 @@ fork_chain(fork_at_signalling_start_block) ->
     application:unset_env(aecore, fork),
     ok.
 
-throughput_test_() ->
-    {setup,
-     fun() ->
-             aec_test_utils:start_chain_db(),
-             aec_test_utils:mock_genesis_and_forks(),
-             aec_test_utils:dev_reward_setup(true, true, 100),
-             TmpDir = aec_test_utils:aec_keys_setup(),
-             {ok, PubKey} = aec_keys:pubkey(),
-             ok = application:set_env(aecore, beneficiary, aeser_api_encoder:encode(account_pubkey, PubKey)),
-             TmpDir
-     end,
-     fun(TmpDir) ->
-             ok = application:unset_env(aecore, beneficiary),
-             aec_test_utils:unmock_genesis_and_forks(),
-             aec_test_utils:stop_chain_db(),
-             aec_test_utils:aec_keys_cleanup(TmpDir)
-     end,
-     [{"Throughput test building chain with 1000 blocks in ram",
-       fun() ->
-               %% Setup
-               TotalBlockCount = 1000,
-               TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
-               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
-               run_throughput_test(TestFun, Blocks, "in ram"),
-
-               ok
-       end}
-     ]}.
-
-run_throughput_test(TestFun, Blocks, Info) ->
-    InsertBlockFun = fun(B0, AccTime) ->
-                             T0 = erlang:system_time(microsecond),
-                             TestFun(B0),
-                             T1 = erlang:system_time(microsecond),
-                             [T1 - T0 | AccTime]
-                     end,
-
-    %% Run timings
-    Timings = lists:foldl(InsertBlockFun, [], Blocks),
-
-    %% Prepare and print data
-    TotalRuntime = lists:sum(Timings),
-    [Min | _] = TimingsSorted = lists:sort(Timings),
-    Max = lists:last(TimingsSorted),
-    Range = Max - Min,
-    Mean = TotalRuntime div length(Timings),
-    Median = lists:nth(ceil(length(Timings) / 2), TimingsSorted),
-    Counts = lists:foldl(
-               fun(N, Acc) ->
-                       case lists:keyfind(N, 1, Acc) of
-                           false ->
-                               [{N, 1} | Acc];
-                           {N, Count} ->
-                               lists:keyreplace(N, 1, Acc, {N, Count + 1})
-                       end
-               end, [], Timings),
-    [{Mode, _} | _] = lists:keysort(2, Counts),
-
-    io:format(user,
-              "~nThroughput testing results (in microseconds) " ++ Info ++ "~n~n"
-              "# of blocks inserted\t= ~p~n"
-              "Total runtime\t\t= ~p~n~n"
-              "Min\t= ~p~n"
-              "Max\t= ~p~n"
-              "Mean\t= ~p~n"
-              "Mode\t= ~p~n"
-              "Range\t= ~p~n"
-              "Median\t= ~p~n",
-              [length(Blocks), TotalRuntime, Min, Max, Mean, Mode, Range, Median]
-             ),
-    ok.
-
 write_blocks_to_chain([H | T]) ->
     ok = insert_block(H),
     write_blocks_to_chain(T);
@@ -417,3 +345,33 @@ insert_block(Block) ->
 insert_block_ret({ok,_}     ) -> ok;
 insert_block_ret({pof,Pof,_}) -> {pof,Pof};
 insert_block_ret(Other      ) -> Other.
+
+%%%===================================================================
+%%% Test case - throughput test (ram)
+%%%===================================================================
+
+throughput_ram_test_() ->
+    {setup,
+     fun() ->
+             aec_test_utils:start_chain_db(),
+             aec_test_utils:mock_genesis_and_forks(),
+             aec_test_utils:dev_reward_setup(true, true, 100),
+             aec_test_utils:aec_keys_setup()
+     end,
+     fun(TmpDir) ->
+             aec_test_utils:unmock_genesis_and_forks(),
+             aec_test_utils:stop_chain_db(),
+             aec_test_utils:aec_keys_cleanup(TmpDir)
+     end,
+     [{"Throughput test building chain with 1000 key blocks in ram",
+       fun() ->
+               %% Setup
+               TotalBlockCount = 1000,
+               TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
+               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
+               Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block}},
+               aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
+
+               ok
+       end}
+     ]}.

--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -375,3 +375,43 @@ throughput_ram_test_() ->
                ok
        end}
      ]}.
+
+%%%===================================================================
+%%% Test case - throughput test (disc)
+%%%===================================================================
+
+throughput_disc_test_() ->
+    {setup,
+     fun() ->
+             Persist = application:get_env(aecore, persist),
+             application:set_env(aecore, persist, true),
+             {ok, _} = aec_db_error_store:start_link(),
+             aec_db:check_db(),
+             aec_db:clear_db(),
+             TmpDir = aec_test_utils:aec_keys_setup(),
+             ok = meck:new(mnesia_rocksdb_lib, [passthrough]),
+             aec_test_utils:mock_genesis_and_forks(),
+             aec_test_utils:dev_reward_setup(true, true, 100),
+             {TmpDir, Persist}
+     end,
+     fun({TmpDir, Persist}) ->
+             application:stop(mnesia),
+             aec_test_utils:unmock_genesis_and_forks(),
+             aec_test_utils:aec_keys_cleanup(TmpDir),
+             application:set_env(aecore, persist, Persist),
+             ok = aec_db_error_store:stop(),
+             ok = meck:unload(mnesia_rocksdb_lib),
+             ok = mnesia:delete_schema([node()])
+     end,
+     [{"Throughput test building chain with 100 key blocks on disc",
+       fun() ->
+               %% Setup
+               TotalBlockCount = 100,
+               TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
+               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
+               Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block}},
+               aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
+
+               ok
+       end}
+     ]}.

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -475,7 +475,15 @@ get_n_key_headers(_Chain, N, Acc) when length(Acc) =:= N ->
 adjust_timestamp([{PrevBlock, _} | _Rest]) ->
     case aec_blocks:height(PrevBlock) + 1 of
         1 -> aeu_time:now_in_msecs();
-        _N -> aec_blocks:time_in_msecs(PrevBlock) + 3000
+        _N -> aec_blocks:time_in_msecs(PrevBlock) + expected_mine_rate()
+    end.
+
+expected_mine_rate() ->
+    case aeu_env:get_env(aecore, expected_mine_rate, undefined) of
+        ExpectedMineRate when ExpectedMineRate =/= undefined ->
+            ExpectedMineRate;
+        undefined ->
+            100
     end.
 
 extend_block_chain_with_state(Chain, Data) ->

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -421,11 +421,12 @@ create_keyblock_with_state([{PrevBlock, TreesIn} | _] = Chain, MinerAccount, Ben
                       micro -> aec_blocks:prev_key_hash(PrevBlock);
                       key   -> PrevBlockHash
                   end,
-    %% Dummy block to calculate the fees.
-    Target = get_config(target, BlockCfg, fun() -> pick_prev_target(Chain) end),
+    Target = get_config(target, BlockCfg, fun() -> adjust_target(Chain) end),
     Info = get_config(info, BlockCfg, fun() -> default end),
+    Timestamp = get_config(timestamp, BlockCfg, fun() -> adjust_timestamp(Chain) end),
+    %% Dummy block to calculate the fees.
     Block = aec_blocks:new_key(Height, PrevBlockHash, PrevKeyHash, aec_trees:hash(TreesIn),
-                               Target, 0, aeu_time:now_in_msecs(), Info, Protocol,
+                               Target, 0, Timestamp, Info, Protocol,
                                MinerAccount, BeneficiaryAccount),
     Trees2 = case Height > Delay of
                  true ->
@@ -435,17 +436,47 @@ create_keyblock_with_state([{PrevBlock, TreesIn} | _] = Chain, MinerAccount, Ben
                      Trees1
              end,
     Block1 = aec_blocks:new_key(Height, PrevBlockHash, PrevKeyHash, aec_trees:hash(Trees2),
-                                Target, 0, aeu_time:now_in_msecs(), Info, Protocol,
+                                Target, 0, Timestamp, Info, Protocol,
                                 MinerAccount, BeneficiaryAccount),
     {Block1, Trees2}.
 
-pick_prev_target([{Block, _}|Left]) ->
+adjust_target([{PrevBlock, _} | _Rest] = Chain) ->
+    Height = aec_blocks:height(PrevBlock) + 1,
+    N = aec_governance:key_blocks_to_check_difficulty_count() + 1,
+    case Height =< N of
+        true ->
+            aec_block_genesis:target();
+        false ->
+            Headers = get_n_key_headers(Chain, N, []),
+            aec_target:recalculate(Headers)
+    end;
+adjust_target([]) ->
+    aec_block_genesis:target().
+
+pick_prev_target([{Block, _} | Rest]) ->
     case aec_blocks:type(Block) of
         key   -> aec_blocks:target(Block);
-        micro -> pick_prev_target(Left)
+        micro -> pick_prev_target(Rest)
     end;
 pick_prev_target([]) ->
     aec_block_genesis:target().
+
+get_n_key_headers([{Block, _} | Rest], N, Acc) when length(Acc) < N ->
+    case aec_blocks:type(Block) of
+        key ->
+            Header = aec_blocks:to_header(Block),
+            get_n_key_headers(Rest, N, [Header | Acc]);
+        micro ->
+            get_n_key_headers(Rest, N,  Acc)
+    end;
+get_n_key_headers(_Chain, N, Acc) when length(Acc) =:= N ->
+    lists:reverse(Acc).
+
+adjust_timestamp([{PrevBlock, _} | _Rest]) ->
+    case aec_blocks:height(PrevBlock) + 1 of
+        1 -> aeu_time:now_in_msecs();
+        _N -> aec_blocks:time_in_msecs(PrevBlock) + 3000
+    end.
 
 extend_block_chain_with_state(Chain, Data) ->
     {ok, Pubkey, PrivKey} = wait_for_pubkey(),
@@ -518,7 +549,9 @@ next_block_with_state([{PB,_PBS} | _] = Chain, Target, Time0, TxsFun, Nonce,
     Txs = TxsFun(Height),
     %% NG: if a block X used to have Txs, now put them in micro-blocks after
     %% the key-block at height X. Every transaction is put in a separate micro-block.
-    {B, S} = create_keyblock_with_state(Chain, PubKey, BeneficiaryPubKey),
+    BlockCfg = #{target => pick_prev_target(Chain),
+                 timestamp => aeu_time:now_in_msecs()},
+    {B, S} = create_keyblock_with_state(Chain, PubKey, BeneficiaryPubKey, BlockCfg),
     Chain1 = [begin
                   B1 = aec_blocks:set_target(B, Target),
                   B2 = aec_blocks:set_nonce(B1, Nonce),


### PR DESCRIPTION
Closes #3039 

`aec_chain_state:insert_block` (only key blocks) results:
```
Tested function		= aec_chain_state:insert_block
# of blocks inserted	= 1000
Total runtime		= 1624485

Min	= 1231
Max	= 4727
Mean	= 1624
Mode	= 1245
Range	= 3496
Median	= 1558
```
```
Throughput testing results (in microseconds) on disc

Tested function		= aec_chain_state:insert_block
# of blocks inserted	= 100
Total runtime		= 214480

Min	= 1861
Max	= 2524
Mean	= 2144
Mode	= 2282
Range	= 663
Median	= 2147
```

`aec_db:write_block` results:
```
Throughput testing results (in microseconds) in ram

Tested function		= aec_db:write_block
# of blocks inserted	= 1000
Total runtime		= 34807

Min	= 28
Max	= 510
Mean	= 34
Mode	= 90
Range	= 482
Median	= 32
```
```
Throughput testing results (in microseconds) on disc

Tested function		= aec_db:write_block
# of blocks inserted	= 100
Total runtime		= 27331

Min	= 82
Max	= 16760
Mean	= 273
Mode	= 386
Range	= 16678
Median	= 95
```
