### PR TITLE
Better channel example generation

### DIFF
--- a/apps/aehttp/test/aehttp_ws_test_utils.erl
+++ b/apps/aehttp/test/aehttp_ws_test_utils.erl
@@ -783,6 +783,10 @@ log_msg(info, Msg, Role) ->
     io_lib:format("~n"
                   "#### ~w info~n"
                   "> ~s~n", [Role, Msg]);
+log_msg(disc = Dir, _Msg, Role) ->
+    io_lib:format(
+      "~n"
+      "#### ~s~n", [log_header_str(Dir, Role)]);
 log_msg(Dir, Msg, Role) ->
     {Lang, MsgStr} = try {"javascript", jsx:prettify(Msg)}
                      catch error:_ -> {"", Msg}


### PR DESCRIPTION
This PR skips the message body for connection closed events:
https://github.com/aeternity/protocol/search?utf8=%E2%9C%93&q=closes+WebSocket+connection&type=