### PR TITLE
Add throughput test for aec_chain_state:insert_block (micro blocks)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,7 @@ references:
     - *restore_build_cache
     - run:
         name: Test
+        no_output_timeout: 20m
         command: |
           epmd -daemon
           make ${MAKE_TARGET:?}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,6 @@ references:
     - *restore_build_cache
     - run:
         name: Test
-        no_output_timeout: 20m
         command: |
           epmd -daemon
           make ${MAKE_TARGET:?}

--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -351,10 +351,10 @@ insert_block_ret(Other      ) -> Other.
 %%%===================================================================
 
 throughput_ram_test_() ->
-    {setup,
+    {foreach,
      fun() ->
              aec_test_utils:start_chain_db(),
-             aec_test_utils:mock_genesis_and_forks(),
+             aec_test_utils:mock_genesis_and_forks(genesis_accounts()),
              aec_test_utils:dev_reward_setup(true, true, 100),
              aec_test_utils:aec_keys_setup()
      end,
@@ -368,8 +368,20 @@ throughput_ram_test_() ->
                %% Setup
                TotalBlockCount = 1000,
                TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
-               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
-               Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block}},
+               Blocks = prep_key_blocks(TotalBlockCount),
+               Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block},
+                        block_type => key},
+               aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
+
+               ok
+       end},
+      {"Throughput test building chain with 1000 micro blocks in ram",
+       fun() ->
+               TotalBlockCount = 1000,
+               TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
+               Blocks = prep_micro_blocks(TotalBlockCount),
+               Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block},
+                        block_type => micro, txs_per_block => 1},
                aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
 
                ok
@@ -381,7 +393,7 @@ throughput_ram_test_() ->
 %%%===================================================================
 
 throughput_disc_test_() ->
-    {setup,
+    {foreach,
      fun() ->
              Persist = application:get_env(aecore, persist),
              application:set_env(aecore, persist, true),
@@ -390,7 +402,7 @@ throughput_disc_test_() ->
              aec_db:clear_db(),
              TmpDir = aec_test_utils:aec_keys_setup(),
              ok = meck:new(mnesia_rocksdb_lib, [passthrough]),
-             aec_test_utils:mock_genesis_and_forks(),
+             aec_test_utils:mock_genesis_and_forks(genesis_accounts()),
              aec_test_utils:dev_reward_setup(true, true, 100),
              {TmpDir, Persist}
      end,
@@ -408,10 +420,70 @@ throughput_disc_test_() ->
                %% Setup
                TotalBlockCount = 100,
                TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
-               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
-               Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block}},
+               Blocks = prep_key_blocks(TotalBlockCount),
+               Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block},
+                        block_type => key},
+               aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
+
+               ok
+       end},
+      {"Throughput test building chain with 100 micro blocks on disc",
+       fun() ->
+               TotalBlockCount = 100,
+               TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
+               Blocks = prep_micro_blocks(TotalBlockCount),
+               Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block},
+                        block_type => micro, txs_per_block => 1},
                aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
 
                ok
        end}
      ]}.
+
+prep_key_blocks(Count) ->
+    aec_test_utils:gen_blocks_only_chain(Count, genesis_accounts()).
+
+prep_micro_blocks(Count) ->
+    #{pubkey := PubKey, privkey := PrivKey} = patron(),
+
+    Fee = 20000 * aec_test_utils:min_gas_price(),
+    Amount = 1,
+    SpendTxs = [sign_tx(make_spend_tx(PubKey, Nonce, PubKey, Fee, Amount), PrivKey)
+                || Nonce <- lists:seq(1, Count)],
+
+    Chain0 = [{B0, _}, {B1, _}] =
+        aec_test_utils:gen_block_chain_with_state(2, genesis_accounts()),
+    [{B0, _}, {B1, _} | Rest] =
+        aec_test_utils:extend_block_chain_with_micro_blocks(Chain0, SpendTxs),
+
+    {ok, _} = aec_chain_state:insert_block(B0),
+    {ok, _} = aec_chain_state:insert_block(B1),
+
+    aec_test_utils:blocks_only_chain(Rest).
+
+genesis_accounts() ->
+    #{pubkey := PubKey} = patron(),
+    [{PubKey, 10000000000000000000 * aec_test_utils:min_gas_price()}].
+
+patron() ->
+    #{pubkey  => <<206,167,173,228,112,201,249,157,157,78,64,8,128,168,111,29,
+                   73,187,68,75,98,241,26,158,187,100,187,207,235,115,254,243>>,
+      privkey => <<230,169,29,99,60,119,207,87,113,50,157,51,84,179,188,239,27,
+                   197,224,50,196,61,112,182,211,90,249,35,206,30,183,77,206,
+                   167,173,228,112,201,249,157,157,78,64,8,128,168,111,29,73,
+                   187,68,75,98,241,26,158,187,100,187,207,235,115,254,243>>}.
+
+make_spend_tx(Sender, SenderNonce, Recipient, Fee, Amount) ->
+    SenderId = aeser_id:create(account, Sender),
+    RecipientId = aeser_id:create(account, Recipient),
+    Args = #{sender_id => SenderId,
+             recipient_id => RecipientId,
+             amount => Amount,
+             fee => Fee,
+             nonce => SenderNonce,
+             payload => <<"spend">>},
+    {ok, SpendTx} = aec_spend_tx:new(Args),
+    SpendTx.
+
+sign_tx(Tx, PrivKey) ->
+    aec_test_utils:sign_tx(Tx, PrivKey).

--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -363,10 +363,10 @@ throughput_ram_test_() ->
              aec_test_utils:stop_chain_db(),
              aec_test_utils:aec_keys_cleanup(TmpDir)
      end,
-     [{"Throughput test building chain with 1000 key blocks in ram",
+     [{"Throughput test building chain with 100 key blocks in ram",
        fun() ->
                %% Setup
-               TotalBlockCount = 1000,
+               TotalBlockCount = 100,
                TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
                Blocks = prep_key_blocks(TotalBlockCount),
                Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block},
@@ -375,9 +375,9 @@ throughput_ram_test_() ->
 
                ok
        end},
-      {"Throughput test building chain with 1000 micro blocks in ram",
+      {"Throughput test building chain with 100 micro blocks in ram",
        fun() ->
-               TotalBlockCount = 1000,
+               TotalBlockCount = 100,
                TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
                Blocks = prep_micro_blocks(TotalBlockCount),
                Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block},
@@ -415,10 +415,10 @@ throughput_disc_test_() ->
              ok = meck:unload(mnesia_rocksdb_lib),
              ok = mnesia:delete_schema([node()])
      end,
-     [{"Throughput test building chain with 100 key blocks on disc",
+     [{"Throughput test building chain with 10 key blocks on disc",
        fun() ->
                %% Setup
-               TotalBlockCount = 100,
+               TotalBlockCount = 10,
                TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
                Blocks = prep_key_blocks(TotalBlockCount),
                Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block},
@@ -427,9 +427,9 @@ throughput_disc_test_() ->
 
                ok
        end},
-      {"Throughput test building chain with 100 micro blocks on disc",
+      {"Throughput test building chain with 10 micro blocks on disc",
        fun() ->
-               TotalBlockCount = 100,
+               TotalBlockCount = 10,
                TestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
                Blocks = prep_micro_blocks(TotalBlockCount),
                Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block},

--- a/apps/aecore/test/aec_db_tests.erl
+++ b/apps/aecore/test/aec_db_tests.erl
@@ -116,7 +116,8 @@ write_chain_test_() ->
                TotalBlockCount = 1000,
                TestFun = fun(B) -> ok = aec_db:write_block(B) end,
                [_GB | Blocks] = aec_test_utils:gen_blocks_only_chain(TotalBlockCount + 1),
-               Opts = #{db_mode => ram, test_fun => {aec_db, write_block}},
+               Opts = #{db_mode => ram, test_fun => {aec_db, write_block},
+                        block_type => key},
                aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
 
                ok
@@ -271,7 +272,8 @@ persisted_database_write_error_test_() ->
                TotalBlockCount = 100,
                TestFun = fun(B) -> ok = aec_db:write_block(B) end,
                [_GB | Blocks] = aec_test_utils:gen_blocks_only_chain(TotalBlockCount + 1),
-               Opts = #{db_mode => disc, test_fun => {aec_db, write_block}},
+               Opts = #{db_mode => disc, test_fun => {aec_db, write_block},
+                        block_type => key},
                aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
 
                ok

--- a/apps/aecore/test/aec_db_tests.erl
+++ b/apps/aecore/test/aec_db_tests.erl
@@ -110,10 +110,10 @@ write_chain_test_() ->
 
                ok
        end},
-      {"Throughput test building chain with 1000 blocks in ram",
+      {"Throughput test building chain with 100 blocks in ram",
        fun() ->
                %% Setup
-               TotalBlockCount = 1000,
+               TotalBlockCount = 100,
                TestFun = fun(B) -> ok = aec_db:write_block(B) end,
                [_GB | Blocks] = aec_test_utils:gen_blocks_only_chain(TotalBlockCount + 1),
                Opts = #{db_mode => ram, test_fun => {aec_db, write_block},
@@ -266,10 +266,10 @@ persisted_database_write_error_test_() ->
                %% Cleanup
                ok
        end},
-      {"Throughput test building chain with 100 blocks on disc",
+      {"Throughput test building chain with 10 blocks on disc",
        fun() ->
                %% Setup
-               TotalBlockCount = 100,
+               TotalBlockCount = 10,
                TestFun = fun(B) -> ok = aec_db:write_block(B) end,
                [_GB | Blocks] = aec_test_utils:gen_blocks_only_chain(TotalBlockCount + 1),
                Opts = #{db_mode => disc, test_fun => {aec_db, write_block},

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -814,10 +814,18 @@ run_throughput_test(TestFun, Blocks, Opts) ->
 
     {Mod, Fun} = maps:get(test_fun, Opts),
     TestFunInfo = atom_to_list(Mod) ++ [$:] ++ atom_to_list(Fun),
+    BlockInfo = case maps:get(block_type, Opts) of
+                    key ->
+                        "key";
+                    micro ->
+                        TxsPerBlock = maps:get(txs_per_block, Opts),
+                        "micro (txs per block: " ++ integer_to_list(TxsPerBlock) ++ ")"
+                end,
 
     io:format(user,
               "~nThroughput testing results (in microseconds) " ++ DbInfo ++ "~n~n"
               "Tested function\t\t= " ++ TestFunInfo ++ "~n"
+              "Block type inserted\t= " ++ BlockInfo ++ "~n"
               "# of blocks inserted\t= ~p~n"
               "Total runtime\t\t= ~p~n~n"
               "Min\t= ~p~n"


### PR DESCRIPTION
Closes #3057 

```
Throughput testing results (in microseconds) in ram

Tested function		= aec_chain_state:insert_block
Block type inserted	= key
# of blocks inserted	= 1000
Total runtime		= 1447133

Min	= 992
Max	= 3039
Mean	= 1447
Mode	= 1191
Range	= 2047
Median	= 1372
```
```
Throughput testing results (in microseconds) in ram

Tested function		= aec_chain_state:insert_block
Block type inserted	= micro (txs per block: 1)
# of blocks inserted	= 1000
Total runtime		= 4221654

Min	= 1100
Max	= 13574
Mean	= 4221
Mode	= 8049
Range	= 12474
Median	= 4182
```
```
Throughput testing results (in microseconds) on disc

Tested function		= aec_chain_state:insert_block
Block type inserted	= key
# of blocks inserted	= 100
Total runtime		= 193187

Min	= 1678
Max	= 2500
Mean	= 1931
Mode	= 1802
Range	= 822
Median	= 1915
```
```
Throughput testing results (in microseconds) on disc

Tested function		= aec_chain_state:insert_block
Block type inserted	= micro (txs per block: 1)
# of blocks inserted	= 100
Total runtime		= 371517

Min	= 2123
Max	= 6438
Mean	= 3715
Mode	= 2400
Range	= 4315
Median	= 3807
```

`aec_db` tests (just writing to db, no validations, etc.):
```
Throughput testing results (in microseconds) in ram

Tested function		= aec_db:write_block
Block type inserted	= key
# of blocks inserted	= 1000
Total runtime		= 40866

Min	= 28
Max	= 478
Mean	= 40
Mode	= 98
Range	= 450
Median	= 35
```
```
Throughput testing results (in microseconds) on disc

Tested function		= aec_db:write_block
Block type inserted	= key
# of blocks inserted	= 100
Total runtime		= 13787

Min	= 81
Max	= 400
Mean	= 137
Mode	= 400
Range	= 319
Median	= 122
```