### PR TITLE
Allow most TX types in dry-run

### DIFF
--- a/apps/aecore/src/aec_dry_run.erl
+++ b/apps/aecore/src/aec_dry_run.erl
@@ -6,6 +6,10 @@
 
 -export([dry_run/3]).
 
+-ifdef(TEST).
+-export([dry_run/4]).
+-endif.
+
 -include("blocks.hrl").
 -include("../../aecontract/include/aecontract.hrl").
 
@@ -59,7 +63,7 @@ dry_run_res(STx, Trees, ok) ->
             CallId    = CB:call_id(CTx),
             CallObj   = lookup_call_object(Contract, CallId, Trees),
             {Type, {ok, CallObj}};
-        spend_tx ->
+        Other when Other /= paying_for_tx, Other /= ga_meta_tx, Other /= offchain_tx ->
             {Type, ok}
     end;
 dry_run_res(STx, _Trees, Err) ->

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1657,7 +1657,7 @@ paths:
         - internal
         - debug
       operationId: 'DryRunTxs'
-      description: 'Dry-run transactions on top of a given block. Supports SpendTx, ContractCreateTx and ContractCallTx'
+      description: 'Dry-run transactions on top of a given block. Supports all TXs except GAMetaTx, PayingForTx and OffchainTx'
       consumes:
         - application/json
       produces:

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -582,8 +582,7 @@ dry_run_txs_([#{ <<"tx">> := ETx } | Txs], Acc) ->
         {ok, DTx} ->
             Tx = aetx:deserialize_from_binary(DTx),
             {Type, _} = aetx:specialize_type(Tx),
-            case lists:member(Type, [spend_tx, contract_create_tx, contract_call_tx,
-                                     ga_attach_tx]) of
+            case not lists:member(Type, [paying_for_tx, offchain_tx, ga_meta_tx]) of
                 true  -> dry_run_txs_(Txs, [{tx, Tx} | Acc]);
                 false -> {error, lists:concat(["Unsupported transaction type ", Type])}
             end;
@@ -614,10 +613,28 @@ dry_run_result(_Type, ok, Res) ->
 ok_err({error, _}) -> <<"error">>;
 ok_err(_)          -> <<"ok">>.
 
-type(spend_tx)           -> <<"spend">>;
-type(contract_create_tx) -> <<"contract_create">>;
-type(contract_call_tx)   -> <<"contract_call">>;
-type(ga_attach_tx)       -> <<"ga_attach">>.
+type(spend_tx)                  -> <<"spend">>;
+type(oracle_register_tx)        -> <<"oracle_register">>;
+type(oracle_extend_tx)          -> <<"oracle_extend">>;
+type(oracle_query_tx)           -> <<"oracle_query">>;
+type(oracle_response_tx)        -> <<"oracle_response">>;
+type(name_preclaim_tx)          -> <<"name_preclaim">>;
+type(name_claim_tx)             -> <<"name_claim">>;
+type(name_transfer_tx)          -> <<"name_transfer">>;
+type(name_update_tx)            -> <<"name_update">>;
+type(name_revoke_tx)            -> <<"name_revoke">>;
+type(contract_call_tx)          -> <<"contract_call">>;
+type(contract_create_tx)        -> <<"contract_create">>;
+type(ga_attach_tx)              -> <<"ga_attach">>;
+type(channel_create_tx)         -> <<"channel_create">>;
+type(channel_deposit_tx)        -> <<"channel_deposit">>;
+type(channel_withdraw_tx)       -> <<"channel_withdraw">>;
+type(channel_force_progress_tx) -> <<"channel_force_progress">>;
+type(channel_close_solo_tx)     -> <<"channel_close_solo">>;
+type(channel_close_mutual_tx)   -> <<"channel_close_mutual">>;
+type(channel_slash_tx)          -> <<"channel_slash">>;
+type(channel_settle_tx)         -> <<"channel_settle">>;
+type(channel_snapshot_solo_tx)  -> <<"channel_snapshot_solo">>.
 
 get_transaction(TxKey, TxStateKey) ->
     fun(_Req, State) ->

--- a/docs/release-notes/next/add_tx_types_to_dry_run.md
+++ b/docs/release-notes/next/add_tx_types_to_dry_run.md
@@ -1,0 +1,1 @@
+* Allow all TX types (except `ga_meta_tx`, `paying_for_tx` and `offchain_tx`) in `dry-run`


### PR DESCRIPTION
The observant reviewer will notice there is a lack of tests. But we really don't do anything TX specific, so testing `spend_tx` should be enough...

Also I have extended the QuickCheck model for transactions (found [here](https://github.com/Quviq/epoch-eqc/tree/new_txs_eqc) and can be run on top of [this aeternity branch](https://github.com/aeternity/aeternity/tree/fixes_for_eqc_txs_model) ).