### PR TITLE
Adds new metrics to ae.epoch.aemon namespace

### DIFF
--- a/apps/aemon/src/aemon_config.erl
+++ b/apps/aemon/src/aemon_config.erl
@@ -1,13 +1,17 @@
 -module(aemon_config).
 
--export([privkey/0, pubkey/0]).
--export([is_active/0]).
--export([ amount/0
+%% API
+-export([ privkey/0
+        , pubkey/0
+        , is_active/0
+        , amount/0
         , autostart/0
         , interval/0
         , ttl/0
         ]).
 
+%% ==================================================================
+%% API
 
 pubkey() ->
     raw_key(<<"pubkey">>, publisher_pubkey, <<>>).
@@ -17,14 +21,18 @@ privkey() ->
 
 is_active() ->
     case pubkey() of
-        <<>> -> false;
-        _ -> env([<<"active">>], active, false)
+        <<>> ->
+            false;
+        _ ->
+            env([<<"active">>], active, false)
     end.
 
 autostart() ->
     case privkey() of
-        <<>> -> false;
-        _ -> env(<<"autostart">>, publisher_autostart, false)
+        <<>> ->
+            false;
+        _ ->
+            env(<<"autostart">>, publisher_autostart, false)
     end.
 
 amount() ->
@@ -36,18 +44,20 @@ interval() ->
 ttl() ->
     env(<<"ttl">>, publisher_spend_ttl, 10).
 
-%% internal
+%% ==================================================================
+%% internal functions
 
 raw_key(YKey, SKey, Default) ->
     Value = env(YKey, SKey, Default),
     raw_key(Value).
 
-raw_key(<<>>) -> <<>>;
+raw_key(<<>>) ->
+    <<>>;
 raw_key(Raw) ->
     {_, Key} = aeser_api_encoder:decode(Raw),
     Key.
 
-env(YKey, Key, Default) when is_binary(YKey)->
-    env([<<"publisher">>, YKey], Key, Default);
+env(YamlKey, Key, Default) when is_binary(YamlKey) ->
+    env([<<"publisher">>, YamlKey], Key, Default);
 env(YamlKey, Key, Default) ->
     aeu_env:user_config_or_env([<<"monitoring">> | YamlKey], aemon, Key, Default).

--- a/apps/aemon/src/aemon_metrics.erl
+++ b/apps/aemon/src/aemon_metrics.erl
@@ -1,64 +1,37 @@
+%% @doc This module provides helper functions which mask exometer and
+%% aec_metric calls for the user.
 -module(aemon_metrics).
 
+%% generic API
 -export([create/1]).
 
+%% specific metrics
 -export([ fork_micro/0
         , confirmation_delay/1
-        ]).
--export([ gen_stats_tx/1
+        , gen_stats_tx/1
         , gen_stats_tx_monitoring/1
         , gen_stats_microblocks/1
-        ]).
--export([ publisher_balance/1
+        , publisher_balance/1
         , publisher_post_tx/1
-        ]).
--export([ queue_size/1
+        , queue_size/1
         , ttl_expired/1
+        , block_propagation_time/2
+        , block_time_since_prev/2
+        , chain_top_difficulty/1
         ]).
 
-%% on chain forks & confirmation delay
+%% ==================================================================
+%% generic API
 
-fork_micro() ->
-    update([fork, micro], 1).
-
-confirmation_delay(Count) ->
-    update([confirmation, delay], Count).
-
-%% generation stats
-
-gen_stats_tx(Count) ->
-    update([gen_stats, tx, total], Count).
-
-gen_stats_tx_monitoring(Count) ->
-    update([gen_stats, tx, monitoring], Count).
-
-gen_stats_microblocks(Count) ->
-    update([gen_stats, microblocks, total], Count).
-
-
-%% publisher
-
-publisher_balance(Error) when is_atom(Error) ->
-    update([publisher, balance, Error], 1);
-publisher_balance(Balance) ->
-    update([publisher, balance], Balance).
-
-publisher_post_tx(Action) ->
-    update([publisher, post_tx, Action], 1).
-
-%% ttl
-
-queue_size(Count) ->
-    update([publisher, queue, size], Count).
-
-ttl_expired(Count) ->
-    update([publisher, queue, ttl_expired], Count).
-
-%% on start metric creation
-
+%% @doc Creates a set of metrics based on the given group identifier.
 create(on_chain) ->
     create([forks, micro], counter),
     create([confirmation, delay], histogram),
+    create([block, propagation_time, key], histogram),
+    create([block, propagation_time, micro], histogram),
+    create([block, time_since_prev, key], histogram),
+    create([block, time_since_prev, micro], histogram),
+    create([chain, top, difficulty], gauge),
     ok;
 create(gen_stats) ->
     create([gen_stats, tx, total], histogram),
@@ -77,11 +50,58 @@ create(ttl) ->
     create([publisher, queue, ttl_expired], histogram),
     ok.
 
-%% internals
+%% ==================================================================
+%% specific metrics
+
+fork_micro() ->
+    update([fork, micro], 1).
+
+confirmation_delay(Count) ->
+    update([confirmation, delay], Count).
+
+gen_stats_tx(Count) ->
+    update([gen_stats, tx, total], Count).
+
+gen_stats_tx_monitoring(Count) ->
+    update([gen_stats, tx, monitoring], Count).
+
+gen_stats_microblocks(Count) ->
+    update([gen_stats, microblocks, total], Count).
+
+publisher_balance(Error) when is_atom(Error) ->
+    update([publisher, balance, Error], 1);
+publisher_balance(Balance) ->
+    update([publisher, balance], Balance).
+
+publisher_post_tx(Action) ->
+    update([publisher, post_tx, Action], 1).
+
+queue_size(Count) ->
+    update([publisher, queue, size], Count).
+
+ttl_expired(Count) ->
+    update([publisher, queue, ttl_expired], Count).
+
+block_propagation_time(Type, Time) when Time < 1 ->
+    lager:debug("Ignoring metric update of block_propagation_time.~p, Time = ~p", [Type, Time]),
+    ok;
+block_propagation_time(Type, Time) when Type =:= key; Type =:= micro ->
+    update([block, propagation_time, Type], Time).
+
+block_time_since_prev(Type, Time) when Time < 1 ->
+    lager:debug("Ignoring metric update of block_time_since_prev.~p, Time = ~p", [Type, Time]),
+    ok;
+block_time_since_prev(Type, Time) when Type =:= key; Type =:= micro ->
+    update([block, time_since_prev, Type], Time).
+
+chain_top_difficulty(Difficulty) ->
+    update([chain, top, difficulty], Difficulty).
+
+%% ==================================================================
+%% internal functions
 
 create(Name, Type) ->
-    exometer:ensure(metric(Name), Type, []),
-    ok.
+    ok = exometer:ensure(metric(Name), Type, []).
 
 update(Name, Value) ->
     aec_metrics:try_update(metric(Name), Value).

--- a/apps/aemon/src/aemon_metrics.erl
+++ b/apps/aemon/src/aemon_metrics.erl
@@ -20,18 +20,20 @@
         , chain_top_difficulty/1
         ]).
 
+-define(HISTOGRAM_TIMESPAN, 60 * 60 * 1000). %% 1 hour
+
 %% ==================================================================
 %% generic API
 
 %% @doc Creates a set of metrics based on the given group identifier.
 create(on_chain) ->
     create([forks, micro, count], counter),
-    create([forks, micro, height], histogram, [{time_span, 60 * 60 * 1000}]), %% keep 1 hour of data
+    create([forks, micro, height], histogram, [{time_span, ?HISTOGRAM_TIMESPAN}]),
     create([confirmation, delay], histogram),
-    create([block, propagation_time, key], histogram),
-    create([block, propagation_time, micro], histogram),
-    create([block, time_since_prev, key], histogram),
-    create([block, time_since_prev, micro], histogram),
+    create([block, propagation_time, key], histogram, [{time_span, ?HISTOGRAM_TIMESPAN}]),
+    create([block, propagation_time, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN}]),
+    create([block, time_since_prev, key], histogram, [{time_span, ?HISTOGRAM_TIMESPAN}]),
+    create([block, time_since_prev, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN}]),
     create([chain, top, difficulty], gauge),
     ok;
 create(gen_stats) ->

--- a/apps/aemon/src/aemon_metrics.erl
+++ b/apps/aemon/src/aemon_metrics.erl
@@ -57,8 +57,8 @@ create(ttl) ->
 %% specific metrics
 
 fork_micro(Height) ->
-    ok = update([forks, micro, count], 1),
-    ok = update([forks, micro, height], Height).
+    log_error(update([forks, micro, count], 1), "Could not update micro fork count"),
+    log_error(update([forks, micro, height], Height), "Could not update micro fork height").
 
 confirmation_delay(Count) ->
     update([confirmation, delay], Count).
@@ -108,10 +108,16 @@ create(Name, Type) ->
     create(Name, Type, []).
 
 create(Name, Type, Opts) ->
-    ok = exometer:ensure(metric(Name), Type, Opts).
+    log_error(exometer:ensure(metric(Name), Type, Opts), "Could not create metric").
 
 update(Name, Value) ->
     aec_metrics:try_update(metric(Name), Value).
 
 metric(Name) ->
     [ae, epoch, aemon | Name ].
+
+log_error(ok, _) ->
+    ok;
+log_error(Err, Msg) ->
+    lager:error(Msg ++ " with error = ~p", [Err]),
+    ok.

--- a/apps/aemon/src/aemon_mon.erl
+++ b/apps/aemon/src/aemon_mon.erl
@@ -1,7 +1,13 @@
+%% @doc This module implements a watcher process which monitors the chain
+%% changes and forwards new heights to the known metrics workers.
 -module(aemon_mon).
+
 -behaviour(gen_server).
 
+%% API
 -export([start_link/0]).
+
+%% gen_server callbacks
 -export([ init/1
         , handle_call/3
         , handle_cast/2
@@ -12,24 +18,21 @@
 
 -record(st, {height = 0 :: non_neg_integer() }).
 
+-define(METRIC_WORKERS, [aemon_mon_on_chain, aemon_mon_gen_stats]).
+
+%% ==================================================================
+%% API
+
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-%% notify monitoring workers
-
-notify(Height) ->
-    aemon_mon_on_chain:notify(Height),
-    aemon_mon_gen_stats:notify(Height),
-    ok.
-
-%% gen_server callback
+%% ==================================================================
+%% gen_server callbacks
 
 init(_) ->
-    aec_events:subscribe(top_changed),
-
+    true = aec_events:subscribe(top_changed),
     {ok, Block} = aec_chain:top_key_block(),
     Height = aec_blocks:height(Block),
-
     {ok, #st{height = Height}}.
 
 terminate(_Reason, _St) ->
@@ -44,11 +47,46 @@ handle_call(_Req, _From, St) ->
 handle_cast(_Msg, St) ->
     {noreply, St}.
 
-handle_info({gproc_ps_event, top_changed, #{info :=
-                #{block_type := key, height := NewHeight}
-            }}, St = #st{ height = Height}) ->
+handle_info({gproc_ps_event, top_changed,
+             #{info := #{block_type := key, block_hash := Hash, height := NewHeight}}},
+            St = #st{height = Height}) ->
     Gens = lists:seq(Height, NewHeight-1),
-    [ notify(Gen) || Gen <- Gens ],
-    {noreply, St#st{ height = NewHeight }};
+    [notify(Gen) || Gen <- Gens],
+    {ok, Block} = aec_chain:get_block(Hash),
+    update_block_propagation_time(Block),
+    update_chain_top_difficulty(Block),
+    {ok, PrevBlock} = aec_chain:get_key_block_by_height(NewHeight-1),
+    update_block_time_since_prev(key, Block, PrevBlock),
+    {noreply, St#st{height = NewHeight}};
+handle_info({gproc_ps_event, top_changed,
+             #{info := #{block_type := micro, block_hash := Hash}}},
+            St) ->
+    {ok, Block} = aec_chain:get_block(Hash),
+    update_block_propagation_time(Block),
+    {ok, PrevBlock} = aec_chain:get_block(aec_blocks:prev_hash(Block)),
+    update_block_time_since_prev(micro, Block, PrevBlock),
+    {noreply, St};
 handle_info(_Msg, St) ->
     {noreply, St}.
+
+%% ==================================================================
+%% internal functions
+
+notify(Height) ->
+    [ok = Worker:notify(Height) || Worker <- ?METRIC_WORKERS],
+    ok.
+
+update_block_propagation_time(Block) ->
+    Type = aec_blocks:type(Block),
+    Time = aec_blocks:time_in_msecs(Block),
+    Now = aeu_time:now_in_msecs(),
+    ok = aemon_metrics:block_propagation_time(Type, Now - Time).
+
+update_chain_top_difficulty(Block) ->
+    N = aec_blocks:difficulty(Block),
+    ok = aemon_metrics:chain_top_difficulty(N).
+
+update_block_time_since_prev(Type, Block, PrevBlock) ->
+    Time = aec_blocks:time_in_msecs(Block),
+    PrevTime = aec_blocks:time_in_msecs(PrevBlock),
+    ok = aemon_metrics:block_time_since_prev(Type, Time - PrevTime).

--- a/apps/aemon/src/aemon_mon_gen_stats.erl
+++ b/apps/aemon/src/aemon_mon_gen_stats.erl
@@ -1,7 +1,8 @@
 -module(aemon_mon_gen_stats).
+
 -behaviour(gen_server).
 
--export([notify/1]).
+-export([notify/3]).
 -export([start_link/0]).
 -export([ init/1
         , handle_call/3
@@ -11,8 +12,8 @@
         , code_change/3
         ]).
 
-notify(Height) ->
-    gen_server:cast(?MODULE, {gen, Height}).
+notify(Height, Type, Hash) ->
+    gen_server:cast(?MODULE, {gen, Height, Type, Hash}).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
@@ -33,7 +34,7 @@ code_change(_FromVsn, St, _Extra) ->
 handle_call(_Req, _From, St) ->
     {reply, {error, unknown_request}, St}.
 
-handle_cast({gen, Height}, PubKey) ->
+handle_cast({gen, Height, _Type, _Hash}, PubKey) ->
     {ok, #{micro_blocks := Blocks}} = aec_chain:get_generation_by_height(Height, forward),
     aemon_metrics:gen_stats_microblocks(erlang:length(Blocks)),
 

--- a/apps/aemon/src/aemon_mon_on_chain.erl
+++ b/apps/aemon/src/aemon_mon_on_chain.erl
@@ -1,8 +1,15 @@
+%% @doc This module implements metric worker process which calculates
+%% on-chain metrics based on chain height changes.
 -module(aemon_mon_on_chain).
+
 -behaviour(gen_server).
 
--export([notify/1]).
--export([start_link/0]).
+%% API
+-export([ start_link/0
+        , notify/1
+        ]).
+
+%% gen_server callbacks
 -export([ init/1
         , handle_call/3
         , handle_cast/2
@@ -11,13 +18,17 @@
         , code_change/3
         ]).
 
-notify(Height) ->
-    gen_server:cast(?MODULE, {gen, Height}).
+%% ==================================================================
+%% API
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-%% gen_server callback
+notify(Height) ->
+    gen_server:cast(?MODULE, {gen, Height}).
+
+%% ==================================================================
+%% gen_server callbacks
 
 init(_) ->
     aemon_metrics:create(on_chain),
@@ -42,61 +53,72 @@ handle_cast(_Msg, St) ->
 handle_info(_Msg, St) ->
     {noreply, St}.
 
-%% internals
+%% ==================================================================
+%% internal functions
 
 handle_gen(Height, PubKey) ->
     try
         {ok, #{micro_blocks := Blocks}} = aec_chain:get_generation_by_height(Height, forward),
+        %% Calculate metrics which require the transaction as input
         [ handle_tx(Height, Tx, aetx_sign:hash(SignTx)) ||
           Block <- Blocks,
           SignTx <- aec_blocks:txs(Block),
           Tx <- [ aetx_sign:tx(SignTx) ],
           aetx:origin(Tx) == PubKey
         ],
-        ttl_gen(Height)
+        %% Forward chain height info to ttl metric worker
+        forward_ttl_gen(Height)
     catch
-        error:badarith -> ok; %% error on payload decode
+        error:badarith ->
+            ok; %% error on payload decode
         _:Reason ->
             lager:error("~p handle_gen error: ~p", [?MODULE, Reason])
     end.
 
 handle_tx(Height, Tx, TxHash) ->
-    ttl_tx(TxHash),
+    %% Forward transaction hash to ttl metric worker
+    forward_ttl_tx(TxHash),
+    %% Update metric: transaction confirmation delay
     PayloadData = decode_payload(Tx),
-    confirmation_delay(Height, PayloadData),
-    forks(Height, PayloadData).
+    update_confirmation_delay(Height, PayloadData),
+    %% Update metric: micro fork counter
+    ok = update_forks(Height, PayloadData),
+    ok.
 
-ttl_gen(Height) ->
+forward_ttl_gen(Height) ->
     aemon_mon_ttl:on_chain_height(Height).
 
-ttl_tx(TxHash) ->
+forward_ttl_tx(TxHash) ->
     aemon_mon_ttl:on_chain_tx(TxHash).
 
 decode_payload(Tx) ->
     {spend_tx, Spend} = aetx:specialize_type(Tx),
     Payload = aec_spend_tx:payload(Spend),
     [Height, KeyBlock, MicroBlock, Timestamp] = binary:split(Payload, <<":">>, [global]),
-    {erlang:binary_to_integer(Height),
-     aeser_api_encoder:decode(KeyBlock),
-     aeser_api_encoder:decode(MicroBlock),
-     erlang:binary_to_integer(Timestamp)
+    { erlang:binary_to_integer(Height)
+    , aeser_api_encoder:decode(KeyBlock)
+    , aeser_api_encoder:decode(MicroBlock)
+    , erlang:binary_to_integer(Timestamp)
     }.
 
-confirmation_delay(GenHeight, {TxHeight, _, _, _}) ->
-    aemon_metrics:confirmation_delay(GenHeight - TxHeight).
+update_confirmation_delay(GenHeight, {TxHeight, _, _, _}) ->
+    ok = aemon_metrics:confirmation_delay(GenHeight - TxHeight).
 
-forks(_, {Height, {_, KeyHash}, TopBlock, _}) ->
+update_forks(_, {Height, {_, KeyHash}, TopBlock, _}) ->
     {ok, #{key_block := KeyBlock, micro_blocks := MicroBlocks}} = aec_chain:get_generation_by_height(Height, forward),
     {ok, KeyHash} = aec_blocks:hash_internal_representation(KeyBlock),
-    fork_micro(TopBlock, MicroBlocks).
+    case is_micro_fork(TopBlock, MicroBlocks) of
+        true ->
+            aemon_metrics:fork_micro();
+        false ->
+            ok
+    end.
 
-fork_micro({micro_block_hash, MicroHash}, MicroBlocks) ->
-    HashList = lists:map(fun(Block) ->
-            {ok, Hash} = aec_blocks:hash_internal_representation(Block),
-            Hash
-        end, MicroBlocks),
-    case lists:member(MicroHash, HashList) of
-        false -> aemon_metrics:fork_micro();
-        true -> ok
-    end;
-fork_micro({key_block_hash, _}, _) -> ok.
+is_micro_fork({micro_block_hash, MicroHash}, MicroBlocks) ->
+    Hashes = lists:map(fun(Block) ->
+                               {ok, Hash} = aec_blocks:hash_internal_representation(Block),
+                               Hash
+                       end, MicroBlocks),
+    not lists:member(MicroHash, Hashes);
+is_micro_fork({key_block_hash, _}, _) ->
+    false.

--- a/apps/aemon/src/aemon_mon_ttl.erl
+++ b/apps/aemon/src/aemon_mon_ttl.erl
@@ -1,4 +1,5 @@
 -module(aemon_mon_ttl).
+
 -behaviour(gen_server).
 
 -export([publisher_tx/2]).

--- a/apps/aemon/src/aemon_sup.erl
+++ b/apps/aemon/src/aemon_sup.erl
@@ -1,28 +1,38 @@
 -module(aemon_sup).
+
 -behaviour(supervisor).
 
+%% API
 -export([start_link/0]).
--export([init/1]).
 
+%% supervisor callbacks
+-export([init/1]).
 
 -define(SERVER, ?MODULE).
 -define(CHILD(Mod,N,Type), {Mod,{Mod,start_link,[]},permanent,N,Type,[Mod]}).
 
+%% ==================================================================
+%% API
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
+%% ==================================================================
+%% supervisor callbacks
+
 init(_) ->
-    ChildSpecs = case aemon_config:is_active() of
-        false -> [];
-        true -> [
-                 ?CHILD(aemon_mon_ttl, 5000, worker),
-                 ?CHILD(aemon_mon_on_chain, 5000, worker),
-                 ?CHILD(aemon_mon_gen_stats, 5000, worker),
-                 ?CHILD(aemon_mon, 5000, worker),
-
-                 ?CHILD(aemon_publisher, 5000, worker)
-                ]
-    end,
-
+    ChildSpecs = child_specs(aemon_config:is_active()),
     {ok, {{one_for_one, 5, 10}, ChildSpecs}}.
+
+%% ==================================================================
+%% internal functions
+
+child_specs(false) ->
+    [];
+child_specs(true) ->
+    [ ?CHILD(aemon_mon_ttl, 5000, worker)
+    , ?CHILD(aemon_mon_on_chain, 5000, worker)
+    , ?CHILD(aemon_mon_gen_stats, 5000, worker)
+    , ?CHILD(aemon_mon, 5000, worker)
+    , ?CHILD(aemon_publisher, 5000, worker)
+    ].

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -19,7 +19,8 @@ Each metric uses `ae.epoch.aemon.` prefix.
 Name                               | Type      | Description
 ---------------------------------- | --------- | -----------
 `confirmation.delay`               | histogram | Number of keyblock created before signing transaction
-`forks.micro`                      | counter   | Count of list microblocks i.e. microforks
+`forks.micro.count`                | counter   | Count of observed micro-forks
+`forks.micro.height`               | histogram | Height difference of observed micro-forks
 `gen_stats.microblocks.total`      | histogram | Number of microblock in generation
 `gen_stats.tx.monitoring`          | histogram | Number of monitoring transaction in generation
 `gen_stats.tx.total`               | histogram | Number of all transaction in generation

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -17,7 +17,7 @@ Monitoring uses statsd backend provided by `apps/aecore/src/aec_metrics.erl`. Se
 Each metric uses `ae.epoch.aemon.` prefix.
 
 Name                               | Type      | Description
----------------------------------- | --------- | ---
+---------------------------------- | --------- | -----------
 `confirmation.delay`               | histogram | Number of keyblock created before signing transaction
 `forks.micro`                      | counter   | Count of list microblocks i.e. microforks
 `gen_stats.microblocks.total`      | histogram | Number of microblock in generation
@@ -28,8 +28,13 @@ Name                               | Type      | Description
 `publisher.post_tx.nonce_too_high` | counter   | Transaction posting error:
 `publisher.post_tx.nonce_too_low`  | counter   | Transaction posting error:
 `publisher.post_tx.success`        | counter   | Successful transaction posts
-`publisher.queue.size`             | histogram | Number of transaction posted but not signed on chain
-`publisher.queue.ttl_expired`      | histogram | Number of transaction with expired ttl
+`publisher.queue.size`             | histogram | Number of transactions posted but not signed on chain
+`publisher.queue.ttl_expired`      | histogram | Number of transactions with expired ttl
+`block.propagation_time.key`       | histogram | Time until key-blocks reached this node in milliseconds
+`block.propagation_time.micro`     | histogram | Time until micro-blocks reached this node in milliseconds
+`block.time_since_prev.key`        | histogram | Time between key-blocks in milliseconds
+`block.time_since_prev.micro`      | histogram | Time between micro-blocks in milliseconds
+`chain.top.difficulty`             | gauge     | Difficulty of the top block
 
 ## How to read metrics
 


### PR DESCRIPTION
- `block.propagation_time.key`   : Time until key-blocks reached this node in milliseconds
- `block.propagation_time.micro` : Time until micro-blocks reached this node in milliseconds
- `block.time_since_prev.key`    : Time between key-blocks in milliseconds
- `block.time_since_prev.micro`  : Time between micro-blocks in milliseconds
- `chain.top.difficulty`         : Difficulty of the top block
- `forks.micro.count`             : Count of observed micro-forks
- `forks.micro.height`             : Height difference of observed micro-forks


Refs #3070 