### PR TITLE
Change order of process start/stop for aec_tx_pool and its GC

### DIFF
--- a/apps/aecore/src/aecore_sup.erl
+++ b/apps/aecore/src/aecore_sup.erl
@@ -65,8 +65,8 @@ init([]) ->
         ++ maybe_upnp_worker()
         ++ [?CHILD(aec_metrics_rpt_dest, 5000, worker),
             ?CHILD(aec_keys, 5000, worker),
-            ?CHILD(aec_tx_pool_gc, 5000, worker),
             ?CHILD(aec_tx_pool, 5000, worker),
+            ?CHILD(aec_tx_pool_gc, 5000, worker),
             ?CHILD(aec_db_error_store, 5000, worker),
             ?CHILD(aec_conductor_sup, 5000, supervisor),
             ?CHILD(aec_connection_sup, 5000, supervisor)


### PR DESCRIPTION
This fixes an issue where the GC would run while the database itself
was shutdown already.

Closes #3075 