### PR TITLE
Added new metrics to cover more block and transaction information

### DIFF
--- a/apps/aecore/priv/exometer_predefined.script
+++ b/apps/aecore/priv/exometer_predefined.script
@@ -1,29 +1,40 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
 %%
-%% Predefined metrics for the aecore app
+%% Predefined metrics for the aecore app.
 %% Note that exometer entries can be added dynamically as well.
 %% See the docs at https://github.com/Feuerlabs/exometer_core
-%% for information about how to create, update and read metrics
-[
- {[ae,epoch,aecore,mining,blocks_mined]      , counter     , []},
- {[ae,epoch,aecore,mining,retries]           , counter     , []},
- {[ae,epoch,aecore,mining,interval]          , histogram   , []},
- {[ae,epoch,aecore,chain,height]             , gauge       , []},
- {[ae,epoch,aecore,chain,top_change,interval], histogram   , []},
- {[ae,epoch,aecore,peers,count]              , gauge       , []},
- {[ae,epoch,aecore,peers,inbound]            , gauge       , []},
- {[ae,epoch,aecore,peers,outbound]           , gauge       , []},
- {[ae,epoch,aecore,peers,verified]           , gauge       , []},
- {[ae,epoch,aecore,peers,unverified]         , gauge       , []},
- {[ae,epoch,aecore,peers,blocked]            , gauge       , []},
- {[ae,epoch,aecore,peers,errored]            , gauge       , []},
- {[ae,epoch,aecore,peers,ping,success]       , counter     , []},
- {[ae,epoch,aecore,peers,ping,failure]       , counter     , []},
- {[ae,epoch,aecore,tx_pool,push]             , counter     , []},
- {[ae,epoch,aecore,tx_pool,push,illegal]     , counter     , []},
- {[ae,epoch,aecore,tx_pool,push,error]       , counter     , []},
- {[ae,epoch,aecore,tx_pool,push,ignore]      , counter     , []},
- {[ae,epoch,aecore,tx_pool,gced]             , counter     , []},
- {[ae,epoch,aecore,tx_pool,origin_gced]      , counter     , []},
- {[ae,epoch,aecore,sync,progress]            , gauge       , []}
+%% for information about how to create, update and read metrics.
+[ {[ae,epoch,aecore,chain,height]                      , gauge       , []}
+, {[ae,epoch,aecore,chain,top_change,interval]         , histogram   , []}
+, {[ae,epoch,aecore,mining,blocks_mined]               , counter     , []}
+, {[ae,epoch,aecore,mining,interval]                   , histogram   , []}
+, {[ae,epoch,aecore,mining,retries]                    , counter     , []}
+, {[ae,epoch,aecore,peers,blocked]                     , gauge       , []}
+, {[ae,epoch,aecore,peers,count]                       , gauge       , []}
+, {[ae,epoch,aecore,peers,errored]                     , gauge       , []}
+, {[ae,epoch,aecore,peers,inbound]                     , gauge       , []}
+, {[ae,epoch,aecore,peers,outbound]                    , gauge       , []}
+, {[ae,epoch,aecore,peers,ping,failure]                , counter     , []}
+, {[ae,epoch,aecore,peers,ping,success]                , counter     , []}
+, {[ae,epoch,aecore,peers,unverified]                  , gauge       , []}
+, {[ae,epoch,aecore,peers,verified]                    , gauge       , []}
+, {[ae,epoch,aecore,sync,progress]                     , gauge       , []}
+, {[ae,epoch,aecore,tx_pool,gced]                      , counter     , []}
+, {[ae,epoch,aecore,tx_pool,origin_gced]               , counter     , []}
+, {[ae,epoch,aecore,tx_pool,push,error]                , counter     , []}
+, {[ae,epoch,aecore,tx_pool,push,ignore]               , counter     , []}
+, {[ae,epoch,aecore,tx_pool,push,illegal]              , counter     , []}
+, {[ae,epoch,aecore,tx_pool,push]                      , counter     , []}
+
+%% The execution time metrics are captured in micro-seconds.
+
+%% Keep 10 minutes of data, ~= 200 values, with a new micro-block every 3 seconds.
+, {[ae,epoch,aecore,blocks,micro,txs_execution_time,success]    , histogram , [{time_span, 10 * 60 * 1000}]}
+, {[ae,epoch,aecore,blocks,micro,txs_execution_time,error]      , histogram , [{time_span, 10 * 60 * 1000}]}
+, {[ae,epoch,aecore,blocks,micro,insert_execution_time,success] , histogram , [{time_span, 10 * 60 * 1000}]}
+, {[ae,epoch,aecore,blocks,micro,insert_execution_time,error]   , histogram , [{time_span, 10 * 60 * 1000}]}
+
+%% Keep 4 hours of data, ~= 120 values, with a new key-block every 2 minutes.
+, {[ae,epoch,aecore,blocks,key,insert_execution_time,success]   , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
+, {[ae,epoch,aecore,blocks,key,insert_execution_time,error]     , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
 ].

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -141,9 +141,15 @@ insert_block(Block, _Origin) ->
 do_insert_block(Block, Origin) ->
     aec_blocks:assert_block(Block),
     Node = wrap_block(Block),
-    try internal_insert(Node, Block, Origin)
-    catch throw:?internal_error(What) -> {error, What}
-    end.
+    {Time, Res} = timer:tc(fun() -> internal_insert(Node, Block, Origin) end),
+    Type = node_type(Node),
+    case Res of
+        {error, _} ->
+            aec_metrics:try_update([ae, epoch, aecore, blocks, Type, insert_execution_time, error], Time);
+        _Ok ->
+            aec_metrics:try_update([ae, epoch, aecore, blocks, Type, insert_execution_time, success], Time)
+    end,
+    Res.
 
 -spec hash_is_connected_to_genesis(binary()) -> boolean().
 hash_is_connected_to_genesis(Hash) ->
@@ -426,18 +432,19 @@ internal_insert(Node, Block, Origin) ->
             %% Only add the block if we can do the whole
             %% transitive operation (i.e., calculate all the state
             %% trees, and update the pointers)
-            Fun = fun() -> internal_insert_transaction(Node, Block, Origin)
+            Fun = fun() ->
+                          internal_insert_transaction(Node, Block, Origin)
                   end,
             try
                 aec_db:ensure_transaction(Fun)
             catch
                 exit:{aborted, {throw, ?internal_error(What)}} ->
-                    internal_error(What)
+                    ?internal_error(What)
             end;
         {ok, Node} ->
             {error, already_in_db};
         {ok, Old} ->
-            internal_error({same_key_different_content, Node, Old})
+            ?internal_error({same_key_different_content, Node, Old})
     end.
 
 internal_insert_transaction(Node, Block, Origin) ->
@@ -965,8 +972,9 @@ apply_micro_block_transactions(Node, FeesIn, Trees) ->
     KeyHeader = db_get_header(prev_key_hash(Node)),
     Env = aetx_env:tx_env_from_key_header(KeyHeader, prev_key_hash(Node),
                                           node_time(Node), prev_hash(Node)),
-    case aec_block_micro_candidate:apply_block_txs_strict(Txs, Trees, Env) of
-        {ok, _, NewTrees, Events} ->
+    case timer:tc(aec_block_micro_candidate, apply_block_txs_strict, [Txs, Trees, Env]) of
+        {Time, {ok, _, NewTrees, Events}} ->
+            aec_metrics:try_update([ae, epoch, aecore, blocks, micro, txs_execution_time, success], Time),
             if map_size(Events) > 0 -> lager:debug("tx_events = ~p", [Events]);
                true -> ok
             end,
@@ -976,7 +984,9 @@ apply_micro_block_transactions(Node, FeesIn, Trees) ->
                                   AccFee + Fee
                           end, FeesIn, Txs),
             {NewTrees, TotalFees, Events};
-        {error,_What} -> internal_error(invalid_transactions_in_block)
+        {Time, {error,_What}} ->
+            aec_metrics:try_update([ae, epoch, aecore, blocks, micro, txs_execution_time, error], Time),
+            internal_error(invalid_transactions_in_block)
     end.
 
 find_fork_point(Hash1, Hash2) ->

--- a/apps/aecore/src/aec_metrics.erl
+++ b/apps/aecore/src/aec_metrics.erl
@@ -404,7 +404,6 @@ reconnect_interval() ->
       [<<"metrics">>, <<"reconnect_interval">>],
       aecore, metrics_reconnect_interval, ?DEFAULT_RECONNECT_INTERVAL).
 
-
 %%=====================================================================
 %% Filter
 %%=====================================================================

--- a/apps/aemon/src/aemon_metrics.erl
+++ b/apps/aemon/src/aemon_metrics.erl
@@ -6,22 +6,26 @@
 -export([create/1]).
 
 %% specific metrics
--export([ fork_micro/1
+-export([ block_propagation_time/2
+        , block_time_since_prev/2
+        , block_tx_total/1
+        , block_gas_total/1
+        , block_gas_per_tx/1
+        , chain_top_difficulty/1
         , confirmation_delay/1
+        , fork_micro/1
+        , gen_stats_microblocks/1
         , gen_stats_tx/1
         , gen_stats_tx_monitoring/1
-        , gen_stats_microblocks/1
         , publisher_balance/1
         , publisher_post_tx/1
         , queue_size/1
         , ttl_expired/1
-        , block_propagation_time/2
-        , block_time_since_prev/2
-        , chain_top_difficulty/1
         ]).
 
 -define(HISTOGRAM_TIMESPAN_LONG, 60 * 60 * 1000). %% 1 hour, 60 values for updates every 1 minute
 -define(HISTOGRAM_TIMESPAN_SHORT, 10 * 60 * 1000). %% 10 minutes, 200 values for updates every 3 seconds
+-define(HISTOGRAM_TIMESPAN_2MIN, 2 * 60 * 1000). %% 2 minutes, 120 values for updates every 1 second
 
 %% ==================================================================
 %% generic API
@@ -35,12 +39,15 @@ create(on_chain) ->
     create([block, propagation_time, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_SHORT}]),
     create([block, time_since_prev, key], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_LONG}]),
     create([block, time_since_prev, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_SHORT}]),
+    create([block, tx, total, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_SHORT}]),
+    create([block, gas, total, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_SHORT}]),
+    create([block, gas, per_tx, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_2MIN}]),
     create([chain, top, difficulty], gauge),
     ok;
 create(gen_stats) ->
-    create([gen_stats, tx, total], histogram),
-    create([gen_stats, tx, monitoring], histogram),
-    create([gen_stats, microblocks, total], histogram),
+    create([gen_stats, tx, total], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_LONG}]),
+    create([gen_stats, tx, monitoring], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_LONG}]),
+    create([gen_stats, microblocks, total], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_LONG}]),
     ok;
 create(publisher) ->
     create([publisher, balance], gauge),
@@ -58,49 +65,75 @@ create(ttl) ->
 %% specific metrics
 
 fork_micro(Height) ->
-    log_error(update([forks, micro, count], 1), "Could not update micro fork count"),
-    log_error(update([forks, micro, height], Height), "Could not update micro fork height").
+    log_error(update([forks, micro, count], 1),
+              "Could not update micro fork count"),
+    log_error(update([forks, micro, height], Height),
+              "Could not update micro fork height").
 
 confirmation_delay(Count) ->
-    update([confirmation, delay], Count).
+    log_error(update([confirmation, delay], Count),
+              "Could not update confirmation delay").
 
 gen_stats_tx(Count) ->
-    update([gen_stats, tx, total], Count).
+    log_error(update([gen_stats, tx, total], Count),
+              "Could not update transactions per generation").
 
 gen_stats_tx_monitoring(Count) ->
-    update([gen_stats, tx, monitoring], Count).
+    log_error(update([gen_stats, tx, monitoring], Count),
+              "Could not update monitoring transactions per generation").
 
 gen_stats_microblocks(Count) ->
-    update([gen_stats, microblocks, total], Count).
+    log_error(update([gen_stats, microblocks, total], Count),
+              "Could not update microblocks per generation").
 
 publisher_balance(Error) when is_atom(Error) ->
-    update([publisher, balance, Error], 1);
+    log_error(update([publisher, balance, Error], 1),
+              "Could not update publisher balance error");
 publisher_balance(Balance) ->
-    update([publisher, balance], Balance).
+    log_error(update([publisher, balance], Balance),
+              "Could not update publisher balance").
 
 publisher_post_tx(Action) ->
-    update([publisher, post_tx, Action], 1).
+    log_error(update([publisher, post_tx, Action], 1),
+              "Could not update publisher post transaction count").
 
 queue_size(Count) ->
-    update([publisher, queue, size], Count).
+    log_error(update([publisher, queue, size], Count),
+              "Could not update publisher queue size").
 
 ttl_expired(Count) ->
-    update([publisher, queue, ttl_expired], Count).
+    log_error(update([publisher, queue, ttl_expired], Count),
+              "Could not update publisher queue ttl expired").
 
 block_propagation_time(Type, Time) when Time < 1 ->
     lager:debug("Ignoring metric update of block_propagation_time.~p, Time = ~p", [Type, Time]),
     ok;
 block_propagation_time(Type, Time) when Type =:= key; Type =:= micro ->
-    update([block, propagation_time, Type], Time).
+    log_error(update([block, propagation_time, Type], Time),
+              "Could not update block propagation time").
 
 block_time_since_prev(Type, Time) when Time < 1 ->
     lager:debug("Ignoring metric update of block_time_since_prev.~p, Time = ~p", [Type, Time]),
     ok;
 block_time_since_prev(Type, Time) when Type =:= key; Type =:= micro ->
-    update([block, time_since_prev, Type], Time).
+    log_error(update([block, time_since_prev, Type], Time),
+              "Could not update block time since previous block").
+
+block_tx_total(N) ->
+    log_error(update([block, tx, total, micro], N),
+              "Could not update transactions per microblock").
+
+block_gas_total(N) ->
+    log_error(update([block, gas, total, micro], N),
+              "Could not update gas per microblock").
+
+block_gas_per_tx(N) ->
+    log_error(update([block, gas, per_tx, micro], N),
+              "Could not update gas per transaction in a microblock").
 
 chain_top_difficulty(Difficulty) ->
-    update([chain, top, difficulty], Difficulty).
+    log_error(update([chain, top, difficulty], Difficulty),
+              "Could not update chain top difficulty").
 
 %% ==================================================================
 %% internal functions

--- a/apps/aemon/src/aemon_mon.erl
+++ b/apps/aemon/src/aemon_mon.erl
@@ -16,7 +16,7 @@
         , code_change/3
         ]).
 
--record(st, {height = 0 :: non_neg_integer() }).
+-record(st, {height = 0 :: non_neg_integer()}).
 
 -define(METRIC_WORKERS, [aemon_mon_on_chain, aemon_mon_gen_stats]).
 

--- a/apps/aemon/src/aemon_mon_gen_stats.erl
+++ b/apps/aemon/src/aemon_mon_gen_stats.erl
@@ -1,9 +1,15 @@
+%% @doc This module provides a process for calculating generation metrics when new generations are
+%% ready.
 -module(aemon_mon_gen_stats).
 
 -behaviour(gen_server).
 
--export([notify/3]).
--export([start_link/0]).
+%% API
+-export([ start_link/0
+        , notify/3
+        ]).
+
+%% gen_server callbacks
 -export([ init/1
         , handle_call/3
         , handle_cast/2
@@ -12,18 +18,24 @@
         , code_change/3
         ]).
 
+-record(st, {pubkey = <<>> :: binary()}).
+
+%% ==================================================================
+%% API
+
 notify(Height, Type, Hash) ->
     gen_server:cast(?MODULE, {gen, Height, Type, Hash}).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-%% gen_server callback
+%% ==================================================================
+%% gen_server callbacks
 
 init(_) ->
     aemon_metrics:create(gen_stats),
     PubKey = aemon_config:pubkey(),
-    {ok, PubKey}.
+    {ok, #st{pubkey = PubKey}}.
 
 terminate(_Reason, _St) ->
     ok.
@@ -34,23 +46,28 @@ code_change(_FromVsn, St, _Extra) ->
 handle_call(_Req, _From, St) ->
     {reply, {error, unknown_request}, St}.
 
-handle_cast({gen, Height, _Type, _Hash}, PubKey) ->
+handle_cast({gen, Height, key, _Hash}, #st{pubkey = PubKey} = St) ->
     {ok, #{micro_blocks := Blocks}} = aec_chain:get_generation_by_height(Height, forward),
-    aemon_metrics:gen_stats_microblocks(erlang:length(Blocks)),
-
-    {TxCount, TxMonCount} = lists:foldl(fun(MB, {AccTxC, AccTxMC}) ->
-        AccTxs = [ aetx_sign:tx(AccTx) || AccTx <- aec_blocks:txs(MB) ],
-        AccTxsMon = [ AccTx || AccTx <- AccTxs, aetx:origin(AccTx) == PubKey ],
-        {AccTxC  + length(AccTxs),
-         AccTxMC + length(AccTxsMon)}
-        end, {0,0}, Blocks),
+    {TxCount, TxMonCount} = tx_count_in_generation(Blocks, PubKey),
 
     aemon_metrics:gen_stats_tx(TxCount),
     aemon_metrics:gen_stats_tx_monitoring(TxMonCount),
+    aemon_metrics:gen_stats_microblocks(erlang:length(Blocks)),
 
-    {noreply, PubKey};
+    {noreply, St};
 handle_cast(_Msg, St) ->
     {noreply, St}.
 
 handle_info(_Msg, St) ->
     {noreply, St}.
+
+%% ==================================================================
+%% internal functions
+
+tx_count_in_generation(Blocks, PubKey) ->
+    lists:foldl(
+      fun(MB, {AccTxC, AccTxMC}) ->
+              AccTxs = [ aetx_sign:tx(AccTx) || AccTx <- aec_blocks:txs(MB) ],
+              AccTxsMon = [ AccTx || AccTx <- AccTxs, aetx:origin(AccTx) == PubKey ],
+              {AccTxC  + length(AccTxs), AccTxMC + length(AccTxsMon)}
+      end, {0, 0}, Blocks).

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -21,9 +21,9 @@ Name                               | Type      | Description
 `confirmation.delay`               | histogram | Number of keyblock created before signing transaction
 `forks.micro.count`                | counter   | Count of observed micro-forks
 `forks.micro.height`               | histogram | Height difference of observed micro-forks
-`gen_stats.microblocks.total`      | histogram | Number of microblock in generation
-`gen_stats.tx.monitoring`          | histogram | Number of monitoring transaction in generation
-`gen_stats.tx.total`               | histogram | Number of all transaction in generation
+`gen_stats.microblocks.total`      | histogram | Number of microblocks in a generation
+`gen_stats.tx.monitoring`          | histogram | Number of monitoring transactions in a generation
+`gen_stats.tx.total`               | histogram | Number of transactions in a generation
 `publisher.balance`                | gauge     | Publisher balance
 `publisher.post_tx.max_adjustment` | counter   | Transaction posting error:
 `publisher.post_tx.nonce_too_high` | counter   | Transaction posting error:
@@ -35,6 +35,9 @@ Name                               | Type      | Description
 `block.propagation_time.micro`     | histogram | Time until micro-blocks reached this node in milliseconds
 `block.time_since_prev.key`        | histogram | Time between key-blocks in milliseconds
 `block.time_since_prev.micro`      | histogram | Time between micro-blocks in milliseconds
+`block.tx.total.micro`             | histogram | Number of transactions in a microblock
+`block.gas.total.micro`            | histogram | Gas used per microblock
+`block.gas.per_tx.micro`           | histogram | Gas used per transaction in a microblock
 `chain.top.difficulty`             | gauge     | Difficulty of the top block
 
 ## How to read metrics


### PR DESCRIPTION
- `ae.epoch.aemon.block.tx.total.micro`             : Number of transactions in a microblock
- `ae.epoch.aemon.block.gas.total.micro`            : Gas used per microblock
- `ae.epoch.aemon.block.gas.per_tx.micro`           : Gas used per transaction in a microblock
- `ae.epoch.aecore.blocks.micro.txs_execution_time.success` : Execution time of all transaction in a microblock in microseconds
- `ae.epoch.aecore.blocks.micro.txs_execution_time.error` : Execution time of all transaction in a microblock in microseconds, when an error was encountered
- `ae.epoch.aecore.blocks.micro.insert_execution_time.success` : Execution time of insertion of a microblock in microseconds
- `ae.epoch.aecore.blocks.micro.insert_execution_time.error` : Execution time of failed insertion of a microblock in microseconds
- `ae.epoch.aecore.blocks.key.insert_execution_time.success` : Execution time of insertion of a keyblock in microseconds
- `ae.epoch.aecore.blocks.key.insert_execution_time.error` : Execution time of failed insertion of a keyblock in microseconds

Refs #3071 