### PR TITLE
Added metrics providing contract data

### DIFF
--- a/apps/aecontract/src/aect_contracts_store.erl
+++ b/apps/aecontract/src/aect_contracts_store.erl
@@ -15,6 +15,7 @@
 -type val() :: binary().
 
 -export([ contents/1,
+          size/1,
           get/2,
           mtree/1,
           new/0,
@@ -65,6 +66,11 @@ put_map(Map, Store = #store{ cache = Cache }) ->
 -spec contents(store()) -> #{key() := val()}.
 contents(Store) ->
     subtree(<<>>, Store).
+
+-spec size(store()) -> non_neg_integer().
+size(Store) ->
+    Contents = contents(Store),
+    lists:foldl(fun(V, Acc) -> byte_size(V) + Acc end, 0, maps:values(Contents)).
 
 %% Returns a map of all the key/value pairs with the given key as a strict
 %% prefix.

--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -336,7 +336,7 @@ compile_(SophiaVsn, File) when SophiaVsn == ?SOPHIA_IRIS_FATE ->
     Source = binary_to_list(AsmBin),
     case aeso_compiler:from_string(Source, [{backend, fate}]) of
         {ok, Map} -> {ok, aect_sophia:serialize(Map, latest_sophia_contract_version())};
-        {error, E} = Err -> io:format("~s\n", [E]), Err
+        {error, E} = Err -> io:format("~p\n", [E]), Err
     end;
 compile_(LegacyVersion, File) ->
     case legacy_compile(LegacyVersion, File) of

--- a/apps/aecore/priv/exometer_defaults.script
+++ b/apps/aecore/priv/exometer_defaults.script
@@ -1,0 +1,15 @@
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
+%%
+%% Metrics templates for the aecore app.
+%% We use these primarily for metrics which have data-driven parts in their
+%% names.
+
+%% Keep 1 minute of data to not overload each metric in case of higher load.
+%% The placeholders are (in order) for ABI version, VM version, return type and
+%% actual info type. The info type can be `gas_used`, `execution_time` in
+%% microseconds, `state_size` or `call_data_size`, both in bytes.
+[ {[ae,epoch,aecore,contracts,'_','_',ga_meta,'_','_']         , histogram, []}
+, {[ae,epoch,aecore,contracts,'_','_',ga_attach,'_','_']       , histogram, []}
+, {[ae,epoch,aecore,contracts,'_','_',contract_call,'_','_']   , histogram, []}
+, {[ae,epoch,aecore,contracts,'_','_',contract_create,'_','_'] , histogram, []}
+].

--- a/apps/aecore/priv/exometer_defaults.script
+++ b/apps/aecore/priv/exometer_defaults.script
@@ -6,8 +6,10 @@
 
 %% Keep 1 minute of data to not overload each metric in case of higher load.
 %% The placeholders are (in order) for ABI version, VM version, return type and
-%% actual info type. The info type can be `gas_used`, `execution_time` in
-%% microseconds, `state_size` or `call_data_size`, both in bytes.
+%% actual info type.
+%% The return type may be `ok`, `return` or `revert`.
+%% The info type may be `gas_used`, `execution_time` in microseconds,
+%% `state_size` or `call_data_size`, both in bytes.
 [ {[ae,epoch,aecore,contracts,'_','_',ga_meta,'_','_']         , histogram, []}
 , {[ae,epoch,aecore,contracts,'_','_',ga_attach,'_','_']       , histogram, []}
 , {[ae,epoch,aecore,contracts,'_','_',contract_call,'_','_']   , histogram, []}

--- a/apps/aecore/src/aec_metrics.erl
+++ b/apps/aecore/src/aec_metrics.erl
@@ -2,8 +2,10 @@
 -behaviour(exometer_report).
 -behavior(exometer_report_logger).
 
--export([update/2,
-         try_update/2]).
+-export([ update/2
+        , try_update/2
+        , try_update_or_create/2
+        ]).
 
 %% exometer_report_logger callbacks
 -export([logger_init_input/1,
@@ -55,11 +57,23 @@ default_dests() ->
 update(Metric, Value) ->
     exometer:update(Metric, Value).
 
+update_or_create(Metric, Value) ->
+    exometer:update_or_create(Metric, Value).
+
 -spec try_update(exometer:name(), number()) -> ok | {error, not_found}.
 try_update(Metric, Value) ->
     try update(Metric, Value)
     catch
         error:_ ->
+            ok
+    end.
+
+-spec try_update_or_create(exometer:name(), number()) -> ok | {error, any()}.
+try_update_or_create(Metric, Value) ->
+    try update_or_create(Metric, Value)
+    catch
+        error:Err ->
+            lager:debug("exometer failed : ~p -> ~p", [Metric, Err]),
             ok
     end.
 

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -50,6 +50,8 @@
   {env, [
          {exometer_predefined,
           {script, "$PRIV_DIR/exometer_predefined.script"}},
+         {exometer_defaults,
+          {script, "$PRIV_DIR/exometer_defaults.script"}},
          {exometer_subscribers,
           [
            {select,

--- a/apps/aemon/src/aemon_metrics.erl
+++ b/apps/aemon/src/aemon_metrics.erl
@@ -6,11 +6,12 @@
 -export([create/1]).
 
 %% specific metrics
--export([ block_propagation_time/2
+-export([ block_gas_per_tx/1
+        , block_gas_total/1
+        , block_propagation_time/2
+        , block_size_per_tx/1
         , block_time_since_prev/2
         , block_tx_total/1
-        , block_gas_total/1
-        , block_gas_per_tx/1
         , chain_top_difficulty/1
         , confirmation_delay/1
         , fork_micro/1
@@ -42,6 +43,7 @@ create(on_chain) ->
     create([block, tx, total, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_SHORT}]),
     create([block, gas, total, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_SHORT}]),
     create([block, gas, per_tx, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_2MIN}]),
+    create([block, size, per_tx, micro], histogram, [{time_span, ?HISTOGRAM_TIMESPAN_2MIN}]),
     create([chain, top, difficulty], gauge),
     ok;
 create(gen_stats) ->
@@ -130,6 +132,10 @@ block_gas_total(N) ->
 block_gas_per_tx(N) ->
     log_error(update([block, gas, per_tx, micro], N),
               "Could not update gas per transaction in a microblock").
+
+block_size_per_tx(N) ->
+    log_error(update([block, size, per_tx, micro], N),
+              "Could not update size per transaction in a microblock").
 
 chain_top_difficulty(Difficulty) ->
     log_error(update([chain, top, difficulty], Difficulty),

--- a/apps/aemon/src/aemon_mon_on_chain.erl
+++ b/apps/aemon/src/aemon_mon_on_chain.erl
@@ -122,10 +122,15 @@ handle_micro_block(micro, Hash) ->
 
     Gas = lists:foldl(
       fun(Tx, Acc) ->
-              GasTx = aetx:gas_limit(aetx_sign:tx(Tx), Height, Version),
+              Tx1 = aetx_sign:tx(Tx),
 
               %% Update metric: gas per tx
+              GasTx = aetx:gas_limit(Tx1, Height, Version),
               aemon_metrics:block_gas_per_tx(GasTx),
+
+              %% Update metric: size per tx
+              SizeTx = aetx:size(Tx1),
+              aemon_metrics:block_size_per_tx(SizeTx),
 
               Acc + GasTx
       end, 0, Txs),

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -34,7 +34,8 @@
         , specialize_callback/1
         , update_tx/2
         , valid_at_protocol/2
-        , check_protocol/2]).
+        , check_protocol/2
+        ]).
 
 -ifdef(TEST).
 -export([tx/1]).

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -38,6 +38,7 @@ Name                               | Type      | Description
 `block.tx.total.micro`             | histogram | Number of transactions in a microblock
 `block.gas.total.micro`            | histogram | Gas used per microblock
 `block.gas.per_tx.micro`           | histogram | Gas used per transaction in a microblock
+`block.size.per_tx.micro`          | histogram | Size of transactions in a microblock in bytes
 `chain.top.difficulty`             | gauge     | Difficulty of the top block
 
 ## How to read metrics

--- a/docs/release-notes/next/add_metrics_block_execution.md
+++ b/docs/release-notes/next/add_metrics_block_execution.md
@@ -2,6 +2,7 @@
 ** `ae.epoch.aemon.block.tx.total.micro` : Number of transactions in a microblock
 ** `ae.epoch.aemon.block.gas.total.micro` : Gas used per microblock
 ** `ae.epoch.aemon.block.gas.per_tx.micro` : Gas used per transaction in a microblock
+** `ae.epoch.aemon.block.size.per_tx.micro` : Size of transactions in a microblock in bytes
 ** `ae.epoch.aecore.blocks.micro.txs_execution_time.success` : Execution time of all transaction in a microblock in microseconds
 ** `ae.epoch.aecore.blocks.micro.txs_execution_time.error` : Execution time of all transaction in a microblock in microseconds, when an error was encountered
 ** `ae.epoch.aecore.blocks.micro.insert_execution_time.success` : Execution time of insertion of a microblock in microseconds

--- a/docs/release-notes/next/add_metrics_contract_calls.md
+++ b/docs/release-notes/next/add_metrics_contract_calls.md
@@ -1,0 +1,11 @@
+* Added new metrics covering contract call information
+  The following names act as templates for multiple specific metrics.
+  The placeholders in these names are (in order) for ABI version, VM version,
+  return type and actual info type.
+  The return type may be `ok`, `return` or `revert`.
+  The info type may be `gas_used`, `execution_time` in microseconds,
+  `state_size` or `call_data_size`, both in bytes.
+** `ae.epoch.aecore.contracts._._.ga_meta._._`
+** `ae.epoch.aecore.contracts._._.ga_attach._._`
+** `ae.epoch.aecore.contracts._._.contract_call._._`
+** `ae.epoch.aecore.contracts._._.contract_create._._`


### PR DESCRIPTION
- contract call data size
- contract state size
- contract execution time
- contract gas used
- size of transactions per microblock

To measure the overhead I instrumented the instrumentations, here are the raw numbers:

```
10:01:59.055 ae.epoch.aecore.contracts.update_metrics_fun.n:1079|g
10:01:59.055 ae.epoch.aecore.contracts.update_metrics_fun.mean:1249|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.min:62|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.max:10048|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.median:1364|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.50:1364|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.75:1789|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.90:2168|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.95:2683|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.99:4968|g
10:01:59.056 ae.epoch.aecore.contracts.update_metrics_fun.999:10048|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.n:1079|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.mean:10|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.min:6|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.max:60|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.median:9|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.50:9|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.75:10|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.90:15|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.95:21|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.99:26|g
10:01:59.057 ae.epoch.aecore.contracts.update_metrics_proc.999:41|g
```

In summary the direct impact of starting the process after the contract calls is mean 10usec, while the actual update of the metrics in a separate process takes mean 1.3msec.

Refs #3079