### PR TITLE
Bump aesophia test dependencies

### DIFF
--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -368,8 +368,8 @@ compiler_cmd(Vsn) ->
         ?SOPHIA_ROMA      -> filename:join([BaseDir, "v1.4.0", "aesophia_cli"]);
         ?SOPHIA_MINERVA   -> filename:join([BaseDir, "v2.1.0", "aesophia_cli"]);
         ?SOPHIA_FORTUNA   -> filename:join([BaseDir, "v3.2.0", "aesophia_cli"]);
-        ?SOPHIA_LIMA_AEVM -> filename:join([BaseDir, "v4.1.0", "aesophia_cli"]) ++ " --backend=aevm";
-        ?SOPHIA_LIMA_FATE -> filename:join([BaseDir, "v4.1.0", "aesophia_cli"])
+        ?SOPHIA_LIMA_AEVM -> filename:join([BaseDir, "v4.2.0", "aesophia_cli"]) ++ " --backend=aevm";
+        ?SOPHIA_LIMA_FATE -> filename:join([BaseDir, "v4.2.0", "aesophia_cli"])
     end.
 
 tempfile_name(Prefix, Opts) ->

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -119,11 +119,12 @@ protocols_from_network_id(<<"local_minerva_testnet">>) ->
      %%, ?LIMA_PROTOCOL_VSN     => Excluded for testing old protocol
      %%, ?IRIS_PROTOCOL_VSN     => Excluded for testing old protocol
      };
-protocols_from_network_id(<<"local_lima_testnet">>) ->
+protocols_from_network_id(<<"local_fortuna_testnet">>) ->
     #{ ?ROMA_PROTOCOL_VSN     => 0
      %%, ?MINERVA_PROTOCOL_VSN  => Excluded for testing old protocol
-     %%, ?FORTUNA_PROTOCOL_VSN  => Excluded for testing old protocol
-     , ?LIMA_PROTOCOL_VSN     => 1
+     , ?FORTUNA_PROTOCOL_VSN  => 1
+     %%, ?LIMA_PROTOCOL_VSN     => Excluded for testing old protocol
+     %%, ?IRIS_PROTOCOL_VSN     => Excluded for testing old protocol
      };
 protocols_from_network_id(<<"local_iris_testnet">>) ->
     #{ ?ROMA_PROTOCOL_VSN     => 0

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -41,7 +41,7 @@ mine_block_test_() ->
                  Nonce = case aec_hard_forks:protocol_effective_at_height(Height + 1) of
                              ?ROMA_PROTOCOL_VSN    -> 1566115190779737391;
                              ?MINERVA_PROTOCOL_VSN -> 15836920403692179639;
-                             ?FORTUNA_PROTOCOL_VSN -> 17610692498953653789;
+                             ?FORTUNA_PROTOCOL_VSN -> 5292874560123497905;
                              ?LIMA_PROTOCOL_VSN    -> 7581966166914665576;
                              ?IRIS_PROTOCOL_VSN    -> 7150225445313991888
                          end,

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1169,7 +1169,7 @@ remote_gas_test_contract(Config) ->
     call_get(APub, APriv, EncC2Pub, Contract, 100),
     force_fun_calls(Node),
     Balance1 = get_balance(APub),
-    ?assertMatchVM(1600596, 1600596, 1600596, 1600916, 1600042, (Balance0 - Balance1) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(1600596, 1600596, 1600596, 1600916, 1600022, (Balance0 - Balance1) div ?DEFAULT_GAS_PRICE),
 
     %% Test remote call with limited gas
     %% Call contract remote set function with limited gas
@@ -1177,7 +1177,7 @@ remote_gas_test_contract(Config) ->
     call_get(APub, APriv, EncC2Pub, Contract, 1),
     force_fun_calls(Node),
     Balance2 = get_balance(APub),
-    ?assertMatchVM(1610855, 1610855, 1610855, 1611335, 1600271, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
+    ?assertMatchVM(1610855, 1610855, 1610855, 1611335, 1600231, (Balance1 - Balance2) div ?DEFAULT_GAS_PRICE),
 
     %% Test remote call with limited gas (3) that fails (out of gas).
     [] = call_func(APub, APriv, EncC1Pub, Contract, "call", [EncC2Pub, "2", "3"], error),

--- a/rebar.config
+++ b/rebar.config
@@ -204,8 +204,8 @@
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "a4fb3db"}}},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"1c24a70"}}},
-                            {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {tag, "v4.1.0"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"43013ec"}}},
+                            {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {tag, "v4.2.0"}}},
                             {aestratum_client, {git, "git://github.com/aeternity/aestratum_client", {ref, "d017dea"}}}
                            ]}
                    ]},


### PR DESCRIPTION
Bumping `aesophia` and `aesophia_cli`.

Also found out that we haven't really been running any CT-tests on Fortuna since Lima became the default, so that is also fixed!