### PR TITLE
GH-3006 Fix compiler version "unknown"

### DIFF
--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -364,7 +364,7 @@ check_account(FromPK, Payer, Trees, Nonce, Amount, Env) ->
 
 
 check_code_serialization(Code, #{abi := ABI}, Protocol) ->
-    case aect_sophia:deserialize(Code) of
+    case aeser_contract_code:deserialize(Code) of
         Deserialized ->
             case aect_contracts:is_legal_serialization_at_protocol(
                    ABI, maps:get(contract_vsn, Deserialized, 1), Protocol) of

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -5887,7 +5887,7 @@ sophia_aens_resolve(Cfg) ->
 
     ok.
 
-sophia_aens_lookup(Cfg) ->
+sophia_aens_lookup(_Cfg) ->
     state(aect_test_utils:new_state()),
     Acc      = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
     Ct       = ?call(create_contract, Acc, aens_lookup, {}, #{ amount => 20000000000000 * aec_test_utils:min_gas_price() }),
@@ -5895,12 +5895,6 @@ sophia_aens_lookup(Cfg) ->
     Salt1           = rand:uniform(10000),
     {ok, NameAscii} = aens_utils:to_ascii(Name1),
     CHash           = aens_hash:commitment_hash(NameAscii, Salt1),
-    NHash           = aens_hash:name_hash(NameAscii),
-    GetNameRecord   = fun () ->
-                              NSTree = aec_trees:ns(aect_test_utils:trees(state())),
-                              {value, Rec} = aens_state_tree:lookup_name(NHash, NSTree),
-                              Rec
-                      end,
 
     {} = ?call(call_contract, Acc, Ct, preclaim, {tuple, []}, {Ct, ?hsh(CHash)}, #{ height => 10 }),
     %% FATE_SOPHIA_1 had a bug that set TTL for preclaims to 0 - check it is fixed in FATE_SOPHIA_2

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -2157,12 +2157,12 @@ timed_contract_call(Type, Fun, CallData, CTVersion) ->
 
     {Call, State}.
 
-process_timed_contract_call(Time, Type, Call, CallData, State,
+process_timed_contract_call(Time, Type, Call, CallData, _State,
                             #{vm := CtVMVsn, abi := CtABIVsn}) ->
     ReturnType = aect_call:return_type(Call),
     GasUsed = aect_call:gas_used(Call),
     CallDataSize = byte_size(CallData),
-    CtPK = aect_call:contract_pubkey(Call),
+    % CtPK = aect_call:contract_pubkey(Call),
     Metrics = [ {gas_used, GasUsed}
               , {execution_time, Time}
               , {call_data_size, CallDataSize}

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -1453,7 +1453,7 @@ init_contract(Context, OwnerId, Code, Contract, GasLimit, GasPrice, CallData,
 
 %% Prepare 2 contracts, one for the InitCall and one (without the init
 %% function) to store on chain.
-prepare_init_call(Code, Contract, S) ->
+prepare_init_call(Code, Contract, S = #state{protocol = Protocol}) ->
     case aect_contracts:ct_version(Contract) of
         #{vm := V} when ?IS_FATE_SOPHIA(V) ->
             #{ byte_code := ByteCode } = Code,
@@ -1461,7 +1461,13 @@ prepare_init_call(Code, Contract, S) ->
             FateCode1 = aeb_fate_code:strip_init_function(FateCode),
             ByteCode1 = aeb_fate_code:serialize(FateCode1),
             Code1     = Code#{ byte_code := ByteCode1 },
-            SerCode   = aect_sophia:serialize(Code1, 3),
+            %% The serialization was broken in the Lima release - setting the
+            %% compiler version to "unknown" regardless of the actual value.
+            Code2     = case Protocol =< ?LIMA_PROTOCOL_VSN of
+                            true  -> Code1#{ compiler_version := <<"unknown">> };
+                            false -> Code1
+                        end,
+            SerCode   = aeser_contract_code:serialize(Code2),
 
             %% In FATE we need to set up the store before the init call. This
             %% is because the FATE init function writes to the store explicitly
@@ -1476,7 +1482,13 @@ prepare_init_call(Code, Contract, S) ->
             #{ type_info := TypeInfo } = Code,
             TypeInfo1 = lists:keydelete(<<"init">>, 2, TypeInfo),
             Code1     = Code#{ type_info := TypeInfo1 },
-            SerCode   = aect_sophia:serialize(Code1, 3),
+            %% The serialization was broken in the Lima release - setting the
+            %% compiler version to "unknown" regardless of the actual value.
+            Code2     = case Protocol =< ?LIMA_PROTOCOL_VSN of
+                            true  -> Code1#{ compiler_version := <<"unknown">> };
+                            false -> Code1
+                        end,
+            SerCode   = aeser_contract_code:serialize(Code2),
             Contract1 = aect_contracts:set_code(SerCode, Contract),
             {Contract, Contract1, S};
         _ ->
@@ -1945,7 +1957,7 @@ assert_name_claimed(Name) ->
 assert_ga_attach_byte_code(ABIVersion, SerializedCode, CallData, FunHash, #state{protocol = Protocol})
   when ABIVersion =:= ?ABI_AEVM_SOPHIA_1;
        ABIVersion =:= ?ABI_FATE_SOPHIA_1 ->
-    try aect_sophia:deserialize(SerializedCode) of
+    try aeser_contract_code:deserialize(SerializedCode) of
         #{type_info := TypeInfo, contract_vsn := Vsn, byte_code := ByteCode} = Code ->
             case aect_sophia:is_legal_serialization_at_protocol(Vsn, Protocol) of
                 true ->
@@ -1961,7 +1973,7 @@ assert_ga_attach_byte_code(ABIVersion, SerializedCode, CallData, FunHash, #state
 assert_contract_byte_code(ABIVersion, SerializedCode, CallData, #state{protocol = Protocol})
   when ABIVersion =:= ?ABI_AEVM_SOPHIA_1;
        ABIVersion =:= ?ABI_FATE_SOPHIA_1 ->
-    try aect_sophia:deserialize(SerializedCode) of
+    try aeser_contract_code:deserialize(SerializedCode) of
         #{contract_vsn := Vsn} = Code ->
             case aect_sophia:is_legal_serialization_at_protocol(Vsn, Protocol) of
                 true ->

--- a/docs/release-notes/next-iris/GH-3006-compiler_version_unknown.md
+++ b/docs/release-notes/next-iris/GH-3006-compiler_version_unknown.md
@@ -1,0 +1,2 @@
+* Fix buggy serialization of contract information - this means compiler version is actually
+  stored on chain, and isn't replaced by "unknown".


### PR DESCRIPTION
Fixes #3006

Replaces the buggy serialization in `aect_sophia` with the one from `aeserialization`. And keeps the buggy behavior for LIMA by explicitly setting the compiler version to "unknown"...