### PR TITLE
Make aeoracle_SUITE mock cleanup more generic. closes #3160

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -8,6 +8,8 @@
 %% common_test exports
 -export([ all/0
         , groups/0
+        , init_per_suite/1
+        , end_per_suite/1
         , init_per_group/2
         , end_per_group/2
         , init_per_testcase/2
@@ -517,6 +519,13 @@ init_tests(Release, VMName) ->
     Cfg = [{sophia_version, Sophia}, {vm_version, VM},
            {abi_version, ABI}, {protocol, Release}],
     init_per_testcase_common(interactive, Cfg).
+
+init_per_suite(Config) ->
+    aec_test_utils:ensure_no_mocks(),
+    Config.
+
+end_per_suite(_Config) ->
+    aec_test_utils:ensure_no_mocks().
 
 init_per_group(aevm, Cfg) ->
     aect_test_utils:init_per_group(aevm, Cfg, fun(X) -> X end);

--- a/apps/aecore/test/aec_eunit_SUITE.erl
+++ b/apps/aecore/test/aec_eunit_SUITE.erl
@@ -57,10 +57,12 @@ suite() ->
     [].
 
 init_per_suite(Config) ->
+    aec_test_utils:ensure_no_mocks(),
     eunit:start(),
     Config.
 
 end_per_suite(_Config) ->
+    aec_test_utils:ensure_no_mocks(),
     ok.
 
 init_per_group(_Grp, Config) ->

--- a/apps/aens/test/aens_SUITE.erl
+++ b/apps/aens/test/aens_SUITE.erl
@@ -10,6 +10,8 @@
 %% common_test exports
 -export([all/0,
          groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
          init_per_group/2,
          end_per_group/2
         ]).
@@ -88,6 +90,13 @@ groups() ->
 
 -define(NAME, <<"詹姆斯詹姆斯"/utf8>>).
 -define(PRE_CLAIM_HEIGHT, 1).
+
+init_per_suite(Config) ->
+    aec_test_utils:ensure_no_mocks(),
+    Config.
+
+end_per_suite(_Config) ->
+    aec_test_utils:ensure_no_mocks().
 
 init_per_group(transactions, Cfg) ->
     %% Disable name auction

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -94,14 +94,12 @@ init_per_testcase(query_oracle_via_name, Config) ->
         _ -> {skip, requires_lima}
     end;
 init_per_testcase(register_oracle_negative, Config) ->
-    meck:new(aec_governance, [passthrough]),
-    Config;
+    meck_new([aec_governance], Config);
 init_per_testcase(Test, Config) when Test =:= query_response_negative_dynamic_fee
                               orelse Test =:= query_oracle_negative_dynamic_fee
                               orelse Test =:= extend_oracle_negative_dynamic_fee
                               orelse Test =:= register_oracle_negative_dynamic_fee ->
-    meck:new(aec_governance, [passthrough]),
-    meck:new(aec_tx_pool, [passthrough]),
+    Config1 = meck_new([aec_governance, aec_tx_pool], Config),
     % those tests are sensitive to the minimum fee required for including a tx.
     % The correct fee is a function of various components, one of which is the
     % gas price. Modifying the minimum gas price can change the size of the
@@ -109,23 +107,21 @@ init_per_testcase(Test, Config) when Test =:= query_response_negative_dynamic_fe
     % thus the mecks
     meck:expect(aec_governance, minimum_gas_price, fun(_) -> 1000000 end),
     meck:expect(aec_tx_pool, minimum_miner_gas_price, fun() -> 1 end),
-    Config;
+    Config1;
 init_per_testcase(_, Config) ->
     Config.
 
-end_per_testcase(register_oracle_negative, _Config) ->
-    meck:unload(aec_governance),
-    ok;
-end_per_testcase(Test, _Config) when Test =:= query_response_negative_dynamic_fee
-                              orelse Test =:= query_oracle_negative_dynamic_fee
-                              orelse Test =:= extend_oracle_negative_dynamic_fee
-                              orelse Test =:= register_oracle_negative_dynamic_fee ->
-
-    meck:unload(aec_governance),
-    meck:unload(aec_tx_pool),
-    ok;
-end_per_testcase(_,_Config) ->
+end_per_testcase(_, Config) ->
+    [meck:unload(M) || M <- meck_modules(Config)],
     ok.
+
+meck_new(Ms, Config) ->
+    Prev = meck_modules(Config),
+    [meck:new(M, [passthrough]) || M <- Ms],
+    lists:keystore(meck_modules, 1, Config, {meck_modules, Prev ++ Ms}).
+
+meck_modules(Config) ->
+    proplists:get_value(meck_modules, Config, []).
 
 %%%===================================================================
 %%% Register oracle

--- a/apps/aeoracle/test/aeoracle_SUITE.erl
+++ b/apps/aeoracle/test/aeoracle_SUITE.erl
@@ -8,6 +8,8 @@
 %% common_test exports
 -export([ all/0
         , groups/0
+        , init_per_suite/1
+        , end_per_suite/1
         , init_per_testcase/2
         , end_per_testcase/2
         ]).
@@ -87,6 +89,12 @@ groups() ->
                    ]}
     ].
 
+init_per_suite(Config) ->
+    aec_test_utils:ensure_no_mocks(),
+    Config.
+
+end_per_suite(_Config) ->
+    aec_test_utils:ensure_no_mocks().
 
 init_per_testcase(query_oracle_via_name, Config) ->
     case aect_test_utils:latest_protocol_version() >= ?IRIS_PROTOCOL_VSN of


### PR DESCRIPTION
See issue #3160.

Not really sure what is causing the intermittent failures, but the mocking setup has been made a little bit more generic.