### PR TITLE
WIP delay fsm_up until responder has channel id

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -678,6 +678,8 @@ t_create_channel_(Cfg) ->
 
     #{ i := #{channel_id := ChannelId} = I
      , r := #{} = R} = create_channel_(Cfg1, #{}, Debug),
+    FsmI = maps:get(fsm, I),
+    ?LOG("Gproc Regs (initiator) = ~p", [rpc(dev1, gproc,info,[FsmI, gproc])]),
     assert_empty_msgq(Debug),
 
     {ok, _} = rpc(dev1, aec_chain, get_channel, [ChannelId]),

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -81,9 +81,10 @@ websocket_init(Params) ->
             lager:debug("NotGood = ~p", [NotGood]),
             handler_parsing_error(Err, Handler, Params);
         {Handler, ChannelOpts} ->
-            case maps:is_key(existing_channel_id, ChannelOpts) of
+            case (maps:is_key(existing_channel_id, ChannelOpts) orelse
+                  maps:is_key(temporary_channel_id, ChannelOpts)) of
                 true ->
-                    lager:debug("existing_channel_id key exists", []),
+                    lager:debug("existing or temp channel_id key exists", []),
                     case derive_reconnect_opts(ChannelOpts) of
                         {ok, ReconnectOpts} ->
                             lager:debug("Will try to reconnect; ReconnectOpts = ~p",
@@ -342,7 +343,6 @@ derive_reconnect_opts(#{ existing_channel_id := ChId
                            , pub_key    => PubKey })};
 derive_reconnect_opts(#{ temporary_channel_id := ChId
                        , role                 := Role
-                       , fsm_id               := FsmId
                        , existing_fsm_id_wrapper := _
                        } = Opts) ->
     {ok, Opts#{ channel_id => ChId }};


### PR DESCRIPTION
First attempt at delaying the `fsm_up` message until the responder has the channel ID.
This implementation breaks the `leave_reestablish_responder_stays` test case.

See issue #3027 