### PR TITLE
Allow SC reconnect after signing create_tx

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -69,7 +69,8 @@
         ]).
 
 %% Used by noise session
--export([message/2]).
+-export([ message/2
+        , noise_connected/1]).
 
 %% Used by client
 -export([ signing_response/3          %% (Fsm, Tag, Obj)
@@ -96,6 +97,7 @@
         , accepted/3
         , awaiting_leave_ack/3
         , awaiting_locked/3
+        , awaiting_connect/3
         , awaiting_open/3
         , awaiting_reestablish/3
         , awaiting_signature/3
@@ -348,6 +350,9 @@ message(Fsm, {T, _} = Msg) when ?KNOWN_MSG_TYPE(T) ->
     lager:debug("message(~p, ~p)", [Fsm, Msg]),
     gen_statem:cast(Fsm, Msg).
 
+noise_connected(Fsm) ->
+    gen_statem:cast(Fsm, {noise_connected, self()}).
+
 %% ==================================================================
 %% Used by client
 
@@ -482,6 +487,7 @@ accepted(enter, _OldSt, _D) -> keep_state_and_data;
 accepted(cast, {?FND_CREATED, Msg}, #data{role = responder} = D) ->
     case check_funding_created_msg(Msg, D) of
         {ok, SignedTx, Updates, BlockHash, D1} ->
+            try
             report(info, funding_created, D1),
             lager:debug("funding_created: ~p", [SignedTx]),
             case request_signing_(?FND_CREATED, SignedTx, Updates, BlockHash, D1) of
@@ -489,6 +495,9 @@ accepted(cast, {?FND_CREATED, Msg}, #data{role = responder} = D) ->
                     next_state(awaiting_signature, D2, Actions);
                 {error, _} = Error ->
                     close(Error, D)
+            end
+            ?CATCH_LOG(_E)
+              error(_E)
             end;
         {error, Error} ->
              close(Error, D)
@@ -586,6 +595,23 @@ awaiting_locked(cast, {Error, _} = Msg, #data{ state = State} = D)
 awaiting_locked(Type, Msg, D) ->
     lager:debug("Unexpected ~p: Msg = ~p, Op = ~p", [Type, Msg, D#data.op]),
     handle_common_event(Type, Msg, error, D).
+
+awaiting_connect(enter, _OldSt, _D) -> keep_state_and_data;
+awaiting_connect(cast, {noise_connected, Pid}, #data{ peer_connected = false
+                                                    , role    = initiator
+                                                    , session = Pid
+                                                    , op      = Op } = D) ->
+    lager:debug("Op = ~p", [Op]),
+    D1 = D#data{op = ?NO_OP, peer_connected = true},
+    case Op of
+        #op_reestablish{mode = {connect, ReestablishOpts}} ->
+            next_state(reestablish_init, send_reestablish_msg(
+                                           ReestablishOpts, D1));
+        ?NO_OP ->
+            next_state(initialized, send_open_msg(D1))
+    end;
+awaiting_connect(Type, Msg, D) ->
+    handle_common_event(Type, Msg, postpone, D).
 
 awaiting_open(enter, _OldSt, _D) -> keep_state_and_data;
 awaiting_open(cast, {?CH_OPEN, Msg}, #data{role = responder} = D) ->
@@ -689,12 +715,14 @@ awaiting_signature(cast, {?SIGNED, create_tx, SignedTx} = Msg,
     #op_data{updates = Updates} = OpData0,
     maybe_check_sigs_create(SignedTx, Updates, initiator,
         fun() ->
+            %% At this point, the initiator can glean the on_chain_id
+            {_, D1} = on_chain_id(D, SignedTx),
             OpData = OpData0#op_data{signed_tx = SignedTx},
             next_state(half_signed, send_funding_created_msg(
                 SignedTx, log(rcv, ?SIGNED, Msg,
-                              D#data{ op = #op_ack{ tag = create_tx
-                                                  , data = OpData}
-                                    , client_may_disconnect = true })))
+                              D1#data{ op = #op_ack{ tag = create_tx
+                                                   , data = OpData}
+                                     , client_may_disconnect = true })))
         end, D);
 awaiting_signature(cast, {?SIGNED, deposit_tx, SignedTx} = Msg,
                    #data{op = #op_sign{ tag = deposit_tx
@@ -1336,7 +1364,8 @@ send_open_msg(#data{ opts    = Opts
            , responder            => Responder
            },
     aesc_session_noise:channel_open(Sn, Msg),
-    Data#data{ channel_id = ChannelPubKey
+    Data#data{ channel_id   = ChannelPubKey
+             , temp_chan_id = ChannelPubKey
              , log = log_msg(snd, ?CH_OPEN, Msg, Log) }.
 
 check_open_msg(#{ chain_hash           := ChainHash
@@ -1361,6 +1390,7 @@ check_open_msg(#{ chain_hash           := ChainHash
                      , responder_amount   => ResponderAmt
                      , channel_reserve    => ChanReserve},
             {ok, Data#data{ channel_id     = ChanId
+                          , temp_chan_id   = ChanId
                           , opts           = Opts1
                           , peer_connected = true
                           , log            = log_msg(rcv, ?CH_OPEN, Msg, Log) }};
@@ -2147,7 +2177,7 @@ both_accounts(Data) ->
     [other_account(Data),
      my_account(Data)].
 
-send_funding_created_msg(SignedTx, #data{ channel_id = Ch
+send_funding_created_msg(SignedTx, #data{ temp_chan_id = Ch
                                         , session    = Sn
                                         , op = #op_ack{ tag  = create_tx
                                                       , data = OpData}} = Data) ->
@@ -2165,7 +2195,7 @@ check_funding_created_msg(#{ temporary_channel_id := ChanId
                            , data                 := #{ tx      := TxBin
                                                       , updates := UpdatesBin }} = Msg
                            , #data{ state = State
-                                  , channel_id = ChanId } = Data) ->
+                                  , temp_chan_id = ChanId } = Data) ->
     Updates = [aesc_offchain_update:deserialize(U) || U <- UpdatesBin],
     try SignedTx = aetx_sign:deserialize_from_binary(TxBin),
         Checks =
@@ -3066,10 +3096,13 @@ request_signing_(Tag, SignedTx, Updates, BlockHash, #data{client = Client} = D0,
             {error, client_disconnected}
     end.
 
-maybe_add_channel_info(Tag, #{signed_tx := SignedTx} = Info, D) when Tag =:= create_tx;
-                                                                     Tag =:= ?FND_CREATED ->
-    {M, Tx} = aetx:specialize_callback(aetx_sign:tx(SignedTx)),
-    ChId = M:channel_pubkey(Tx),
+%% We add channel_id and fsm_id to the 'funding_created' (responder's) signing request.
+%% For the initiator's signing request, the channel id may not yet be available
+%% (if initiator is GA, in which case it first needs to sign the tx, as the channel id
+%% in that case depends on the initiator's (but not the responder's) auth.)
+%%
+maybe_add_channel_info(Tag, #{signed_tx := SignedTx} = Info, D) when Tag =:= ?FND_CREATED ->
+    {ok, ChId} = aesc_utils:channel_pubkey(SignedTx),
     {Info#{fsm_id => D#data.fsm_id_wrapper}, D#data{on_chain_id = ChId}};
 maybe_add_channel_info(_, Info, D) ->
     {Info, D}.
@@ -3193,8 +3226,19 @@ watch_req() ->
 on_chain_id(#data{on_chain_id = ID} = D, _) when ID =/= undefined ->
     {ID, D};
 on_chain_id(D, SignedTx) ->
-    {ok, PubKey} = aesc_utils:channel_pubkey(SignedTx),
-    {PubKey, D#data{on_chain_id = PubKey}}.
+    try aesc_utils:channel_pubkey(SignedTx) of
+        {ok, PubKey} ->
+            {PubKey, D#data{on_chain_id = PubKey}}
+    ?CATCH_LOG(_E)
+        if D#data.strict_checks == false ->
+                %% We can't derive a channel ID, but this is presumably a testing
+                %% scenario. The intention of non-strict checks is that we shouldn't
+                %% crash on validation errors, so leave things alone.
+                {D#data.on_chain_id, D};
+           true ->
+                error(_E)
+        end
+    end.
 
 initialize_cache(#data{ on_chain_id    = ChId
                       , state          = State
@@ -3794,11 +3838,11 @@ prepare_initial_state(Opts, State, SessionPid, ReestablishOpts) ->
         end,
     NextState = case {Role, Reestablish} of
         {initiator, true} ->
-            Data1 = Data#data{opts = Opts#{channel_reserve => ChannelReserve}},
-            ok_next(reestablish_init, send_reestablish_msg(ReestablishOpts,
-                                                           Data1));
+            Data1 = Data#data{ opts = Opts#{channel_reserve => ChannelReserve}
+                             , op = #op_reestablish{mode = {connect, ReestablishOpts}}},
+            ok_next(awaiting_connect, Data1);
         {initiator, false} ->
-            ok_next(initialized, send_open_msg(Data));
+            ok_next(awaiting_connect, Data);
         {responder, true} ->
             ChanId = maps:get(existing_channel_id, ReestablishOpts),
             Data1 = Data#data{ channel_id  = ChanId
@@ -4668,6 +4712,7 @@ handle_call_(_St, _Req, From, D) ->
 
 -ifdef(TEST).
 get_state_implementation(From, #data{ opts  = Opts
+                                    , temp_chan_id   = TmpChanId
                                     , channel_status = Status
                                     , state = State } = D) ->
     #{initiator := Initiator, responder := Responder} = Opts,
@@ -4693,7 +4738,8 @@ get_state_implementation(From, #data{ opts  = Opts
         _ -> error({inconsistency, state_hash})
     end,
     Result =
-        #{ channel_id     => ChanId
+        #{ temporary_channel_id => TmpChanId
+         , channel_id     => ChanId
          , initiator      => Initiator
          , responder      => Responder
          , init_amt       => IAmt

--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -47,6 +47,7 @@
         awaiting_initial_state  -> accept;
         awaiting_leave_ack      -> accept;
         awaiting_locked         -> funding_lock;
+        awaiting_connect        -> accept;
         awaiting_open           -> idle;
         awaiting_reestablish    -> idle;
         awaiting_signature      -> sign;
@@ -151,6 +152,7 @@
               , opts                            :: map()
               , fsm_id_wrapper                  :: undefined | aesc_fsm_id:wrapper()
               , channel_id                      :: undefined | binary()
+              , temp_chan_id                    :: undefined | binary()
               , on_chain_id                     :: undefined | binary()
               , create_tx                       :: undefined | any()
               , watcher_registered = false      :: boolean()
@@ -254,7 +256,7 @@
                   }).
 
 -record(op_reestablish, { offchain_tx :: aetx_sign:signed_tx() | undefined
-                        , mode = restart :: restart | remain
+                        , mode = restart :: restart | remain | {connect, map()}
                         }).
 
 -record(op_close, { data :: #op_data{}

--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -152,7 +152,6 @@
               , opts                            :: map()
               , fsm_id_wrapper                  :: undefined | aesc_fsm_id:wrapper()
               , channel_id                      :: undefined | binary()
-              , temp_chan_id                    :: undefined | binary()
               , on_chain_id                     :: undefined | binary()
               , create_tx                       :: undefined | any()
               , watcher_registered = false      :: boolean()

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -403,6 +403,7 @@ establish({connect, Host, Port, Opts}, St) ->
             lager:debug("EnoiseOpts (connect) = ~p", [EnoiseOpts]),
             case enoise:connect(TcpSock, EnoiseOpts) of
                 {ok, EConn, _FinalSt} ->
+                    aesc_fsm:noise_connected(St#st.fsm),
                     St1 = St#st{econn = EConn},
                     {ok, St1};
                 Err1 ->

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -2445,7 +2445,7 @@ responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
     FsmId = receive_fsm_id(dev1, R, Debug),
     {ok, ChOpen} = receive_from_fsm(info, R, channel_open, ?LONG_TIMEOUT, Debug),
     ?LOG(Debug, "Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
-    {ok, #{ temporary_channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
     ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     R1 = R#{ proxy => self(), parent => Parent, fsm_id => FsmId },
     gproc:reg(GprocR = {n,l,{?MODULE,TmpChanId,responder}}, #{ r => R1 }),
@@ -2464,7 +2464,7 @@ initiator_instance_(Fsm, Spec, I0, Parent, Debug) ->
     FsmId = receive_fsm_id(dev1, I, Debug),
     {ok, ChAccept} = receive_from_fsm(info, I, channel_accept, ?LONG_TIMEOUT, Debug),
     ?LOG(Debug, "Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
-    {ok, #{ temporary_channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
     ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     I1 = I#{ proxy => self(), fsm_id => FsmId },
     gproc:reg(GprocI = {n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I1

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -2332,7 +2332,7 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
     IProxy = spawn_initiator(Port, ISpec, I, Debug),
     ?LOG("RProxy = ~p, IProxy = ~p", [RProxy, IProxy]),
     Timeout = proplists:get_value(timeout, Cfg, ?TIMEOUT),
-    Info = match_responder_and_initiator(RProxy, Debug, Timeout),
+    Info = match_responder_and_initiator(RProxy, IProxy, Debug, Timeout),
     #{ i := #{ fsm := FsmI, fsm_id := IFsmId } = I1
      , r := #{ fsm := FsmR, fsm_id := RFsmId } = R1 } = Info,
     %% Assert that the ID's are different
@@ -2427,13 +2427,16 @@ spawn_initiator(Port, Spec, I, Debug) ->
 move_fsm_id_to_spec(#{fsm_id := FsmId}, Spec) ->
     Spec#{existing_fsm_id_wrapper => aesc_fsm_id:from_binary(FsmId)}.
 
-match_responder_and_initiator(RProxy, Debug, Timeout) ->
+match_responder_and_initiator(RProxy, IProxy, Debug, Timeout) ->
     receive
         {channel_up, RProxy, Info} ->
             ?LOG(Debug, "Matched initiator/responder pair: ~p", [Info]),
             Info
     after Timeout ->
+            ?PEEK_MSGQ(true),
             ?LOG(Debug, "Timed out waiting for matched pair", []),
+            ?LOG(Debug, "RProxy: ~p", [process_info(RProxy, messages)]),
+            ?LOG(Debug, "IProxy: ~p", [process_info(IProxy, messages)]),
             error(timeout)
     end.
 
@@ -2442,12 +2445,14 @@ responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
     FsmId = receive_fsm_id(dev1, R, Debug),
     {ok, ChOpen} = receive_from_fsm(info, R, channel_open, ?LONG_TIMEOUT, Debug),
     ?LOG(Debug, "Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
-    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    {ok, #{ temporary_channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
     ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     R1 = R#{ proxy => self(), parent => Parent, fsm_id => FsmId },
-    gproc:reg({n,l,{?MODULE,TmpChanId,responder}}, #{ r => R1 }),
+    gproc:reg(GprocR = {n,l,{?MODULE,TmpChanId,responder}}, #{ r => R1 }),
+    GprocI = {n,l,{?MODULE,TmpChanId,initiator}},
+    ?LOG(Debug, "Registered as ~p, waiting for ~p", [GprocR, GprocI]),
     {_IPid, #{ i := I1 , channel_accept := ChAccept }}
-        = gproc:await({n,l,{?MODULE,TmpChanId,initiator}}, ?TIMEOUT),
+        = gproc:await(GprocI, ?TIMEOUT),
     Parent ! {channel_up, self(), #{ i => I1#{parent => Parent}
                                      , r => R1
                                      , channel_accept => ChAccept
@@ -2459,15 +2464,18 @@ initiator_instance_(Fsm, Spec, I0, Parent, Debug) ->
     FsmId = receive_fsm_id(dev1, I, Debug),
     {ok, ChAccept} = receive_from_fsm(info, I, channel_accept, ?LONG_TIMEOUT, Debug),
     ?LOG(Debug, "Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
-    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    {ok, #{ temporary_channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
     ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     I1 = I#{ proxy => self(), fsm_id => FsmId },
-    gproc:reg({n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I1
-                                                    , channel_accept => ChAccept }),
+    gproc:reg(GprocI = {n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I1
+                                                             , channel_accept => ChAccept }),
+    GprocR = {n,l,{?MODULE,TmpChanId,responder}},
+    ?LOG(Debug, "Registered as ~p, waiting for ~p", [GprocI, GprocR]),
     {_RPid, #{ r := #{parent := NewParent}}}
-        = gproc:await({n,l,{?MODULE,TmpChanId,responder}}, ?TIMEOUT),
+        = gproc:await(GprocR, ?TIMEOUT),
     unlink(Parent),
     link(NewParent),
+    ?LOG(Debug, "IProxy entering relay loop", []),
     fsm_relay(I1#{parent => NewParent}, NewParent, Debug).
 
 set_proxy_debug(Bool, #{proxy := P}) when is_boolean(Bool) ->

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -11,7 +11,8 @@
          create_config/4,
          make_multi/2,
          node_shortcut/2,
-         shortcut_dir/1]).
+         shortcut_dir/1,
+         symlink/2]).
 
 -export([cmd/3, cmd/4, cmd/5, cmd/6,
          cmd_res/1,

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -152,7 +152,7 @@ process_fsm(#{msg := Msg,
 process_fsm_(#{type := sign,
                tag  := Tag,
                info := #{signed_tx := STx,
-                         updates := Updates}},
+                         updates := Updates} = Info},
                 ChannelId, Protocol) when Tag =:= create_tx
                                    orelse Tag =:= deposit_tx
                                    orelse Tag =:= deposit_created
@@ -186,8 +186,8 @@ process_fsm_(#{type := sign,
     notify(Protocol,
            #{action  => <<"sign">>,
              tag => Tag1,
-             payload => #{signed_tx => EncTx,
-                          updates => SerializedUpdates}},
+             payload => maybe_add_fsm_id(Info, #{signed_tx => EncTx,
+                                                 updates => SerializedUpdates})},
            ChannelId);
 process_fsm_(#{type := report,
                tag  := Tag,
@@ -247,3 +247,8 @@ process_fsm_(#{type := Type, tag := Tag, info := Event}, _, _) ->
 non_undefined_channel_id(undefined) -> null;
 non_undefined_channel_id(Val)       -> Val.
 
+maybe_add_fsm_id(#{fsm_id := FsmIdWrapper}, Msg) ->
+    FsmId = aesc_fsm_id:retrieve_for_client(FsmIdWrapper),
+    Msg#{fsm_id => FsmId};
+maybe_add_fsm_id(_, Msg) ->
+    Msg.

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -152,7 +152,7 @@ process_fsm(#{msg := Msg,
 process_fsm_(#{type := sign,
                tag  := Tag,
                info := #{signed_tx := STx,
-                         updates := Updates}},
+                         updates := Updates} = Info},
                 ChannelId, Protocol) when Tag =:= create_tx
                                    orelse Tag =:= deposit_tx
                                    orelse Tag =:= deposit_created
@@ -183,11 +183,12 @@ process_fsm_(#{type := sign,
             withdraw_created -> <<"withdraw_ack">>;
             T -> atom_to_binary(T, utf8)
         end,
+    Msg = #{signed_tx => EncTx,
+            updates => SerializedUpdates},
     notify(Protocol,
            #{action  => <<"sign">>,
              tag => Tag1,
-             payload => #{signed_tx => EncTx,
-                          updates => SerializedUpdates}},
+             payload => maybe_add_fsm_id(Info, maybe_add_channel_id(Info, Msg))},
            ChannelId);
 process_fsm_(#{type := report,
                tag  := Tag,
@@ -247,3 +248,14 @@ process_fsm_(#{type := Type, tag := Tag, info := Event}, _, _) ->
 non_undefined_channel_id(undefined) -> null;
 non_undefined_channel_id(Val)       -> Val.
 
+maybe_add_channel_id(#{channel_id := ChId}, Msg) ->
+    Msg#{channel_id => aeser_api_encoder:encode(channel, ChId)};
+maybe_add_channel_id(Info, Msg) ->
+    lager:debug("Info = ~p", [Info]),
+    Msg.
+
+maybe_add_fsm_id(#{fsm_id := FsmIdWrapper}, Msg) ->
+    FsmId = aesc_fsm_id:retrieve_for_client(FsmIdWrapper),
+    Msg#{fsm_id => FsmId};
+maybe_add_fsm_id(_, Msg) ->
+    Msg.

--- a/apps/aehttp/src/sc_ws_api.erl
+++ b/apps/aehttp/src/sc_ws_api.erl
@@ -191,14 +191,14 @@ process_fsm_(#{type := sign,
            ChannelId);
 process_fsm_(#{type := report,
                tag  := Tag,
-               info := Event}, ChannelId, Protocol) when Tag =:= info
-                                                  orelse Tag =:= update
-                                                  orelse Tag =:= conflict
-                                                  orelse Tag =:= message
-                                                  orelse Tag =:= leave
-                                                  orelse Tag =:= error
-                                                  orelse Tag =:= debug
-                                                  orelse Tag =:= on_chain_tx ->
+               info := Event} = Msg, ChannelId, Protocol) when Tag =:= info
+                                                        orelse Tag =:= update
+                                                        orelse Tag =:= conflict
+                                                        orelse Tag =:= message
+                                                        orelse Tag =:= leave
+                                                        orelse Tag =:= error
+                                                        orelse Tag =:= debug
+                                                        orelse Tag =:= on_chain_tx ->
     Mod = protocol_to_impl(Protocol),
     Payload =
         case {Tag, Event} of
@@ -206,7 +206,8 @@ process_fsm_(#{type := report,
             {info, {fsm_up, FsmIdWrapper}} ->
                 #{ event => <<"fsm_up">>
                  , fsm_id => aesc_fsm_id:retrieve_for_client(FsmIdWrapper)};
-            {info, _} when is_atom(Event) -> #{event => atom_to_binary(Event, utf8)};
+            {info, _} when is_atom(Event) ->
+                maybe_add_fsm_id(Msg, #{event => atom_to_binary(Event, utf8)});
             {info, #{event := _} = Info} ->
                 Info;
             {on_chain_tx, #{tx := Tx} = Info} ->

--- a/apps/aehttp/src/sc_ws_api_jsonrpc.erl
+++ b/apps/aehttp/src/sc_ws_api_jsonrpc.erl
@@ -104,15 +104,7 @@ error_response(Reason, Req, ChannelId) ->
              , <<"error">>      => json_rpc_error_object(Reason, Req) }
     }.
 
-notify(Msg0, ChannelId0) ->
-    lager:debug("notify Msg0 = ~p, ChannelId0 = ~p", [Msg0, ChannelId0]),
-    {Msg, ChannelId} =
-        case {Msg0, ChannelId0} of
-            {#{payload := #{channel_id := Id} = P}, null} ->
-                {Msg0#{payload => maps:remove(channel_id, P)}, Id};
-            {_, Id} ->
-                {Msg0, Id}
-        end,
+notify(Msg, ChannelId) ->
     {reply, #{ <<"jsonrpc">> => ?JSONRPC_VERSION
              , <<"version">>    => ?VERSION
              , <<"method">>  => method_out(Msg)

--- a/apps/aehttp/src/sc_ws_api_jsonrpc.erl
+++ b/apps/aehttp/src/sc_ws_api_jsonrpc.erl
@@ -104,7 +104,15 @@ error_response(Reason, Req, ChannelId) ->
              , <<"error">>      => json_rpc_error_object(Reason, Req) }
     }.
 
-notify(Msg, ChannelId) ->
+notify(Msg0, ChannelId0) ->
+    lager:debug("notify Msg0 = ~p, ChannelId0 = ~p", [Msg0, ChannelId0]),
+    {Msg, ChannelId} =
+        case {Msg0, ChannelId0} of
+            {#{payload := #{channel_id := Id} = P}, null} ->
+                {Msg0#{payload => maps:remove(channel_id, P)}, Id};
+            {_, Id} ->
+                {Msg0, Id}
+        end,
     {reply, #{ <<"jsonrpc">> => ?JSONRPC_VERSION
              , <<"version">>    => ?VERSION
              , <<"method">>  => method_out(Msg)

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -485,16 +485,6 @@ locate_matching_fsm(ExistingID, Read, Put, Params) ->
             end
     end.
 
-read_role_id(Role, Read) ->
-    Key = case Role of
-              initiator ->
-                  <<"initiator_id">>;
-              responder ->
-                  <<"responder_id">>
-          end,
-    %% Field name is the same as the Role value
-    Read(Key, Role, #{type => {hash, account_pubkey}}).
-
 locate_on_chain(ExistingID, Read, Put, Error) ->
     case aec_chain:get_channel(ExistingID) of
         {ok, Channel} ->

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -326,7 +326,7 @@ start_link_fsm(#handler{role = responder, port=Port}, Opts) ->
     aesc_client:respond(Port, Opts).
 
 derive_reconnect_opts(#{ existing_channel_id := ChId
-                       , role                := Role
+                       , role                := _Role
                        , reconnect_to_fsm    := true } = Opts) ->
     {ok, Opts#{channel_id => ChId}};
 derive_reconnect_opts(#{ existing_channel_id := ChId
@@ -489,8 +489,6 @@ locate_on_chain(ExistingID, Read, Put, Error) ->
     case aec_chain:get_channel(ExistingID) of
         {ok, Channel} ->
             [ Put(existing_channel_id, ExistingID)
-            , Read(<<"offchain_tx">>, offchain_tx, #{ type => serialized_tx
-                                                    , mandatory => false })
             , read_role(Read, false)
             , Read(<<"existing_fsm_id">>, existing_fsm_id_wrapper, #{ type => fsm_id
                                                                     , mandatory => true })

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -269,7 +269,8 @@ websocket_info({aesc_fsm, FsmPid, Msg}, #handler{ fsm_pid = FsmPid
     #handler{enc_channel_id = ChannelId} = H1 = set_channel_id(Msg, H),
     case sc_ws_api:process_from_fsm(Protocol, Msg, ChannelId) of
         no_reply          -> {ok, H1};
-        {reply, Resp}     -> {reply, {text, jsx:encode(Resp)}, H1};
+        {reply, Resp}     ->
+            {reply, {text, jsx:encode(Resp)}, H1};
         stop              -> {stop, H1}
     end;
 websocket_info({'DOWN', MRef, _, _, _}, #handler{fsm_mref = MRef} = H) ->

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -54,6 +54,7 @@
     sc_ws_remote_call_contract/1,
     sc_ws_remote_call_contract_refering_onchain_data/1,
     sc_ws_wrong_call_data/1,
+    sc_ws_reconnect_early/1,
     sc_ws_basic_client_reconnect_i/1,
     sc_ws_basic_client_reconnect_r/1,
     sc_ws_basic_client_reconnect_i_w_reestablish/1,
@@ -182,6 +183,7 @@ groups() ->
         sc_ws_leave_reestablish_wrong_fsm_id,
         sc_ws_leave_reestablish_responder_stays,
         sc_ws_leave_reconnect,
+        sc_ws_reconnect_early,
         {group, force_progress},
         {group, with_open_channel},
         {group, with_meta},
@@ -688,17 +690,14 @@ sc_ws_open_(Config) ->
 sc_ws_open_(Config, Opts) ->
     sc_ws_open_(Config, Opts, ?DEFAULT_MIN_DEPTH).
 
+
 sc_ws_open_(Config, ChannelOpts0, MinBlocksToMine) ->
      sc_ws_open_(Config, ChannelOpts0, MinBlocksToMine, default_dir).
 
 sc_ws_open_(Config, ChannelOpts0, MinBlocksToMine, LogDir) ->
     #{initiator := #{pub_key := IPubkey},
       responder := #{pub_key := RPubkey}} = proplists:get_value(participants, Config),
-    TestPings = proplists:get_value(ping_pong, Config, false),
-    OptionallyPingPong =
-        fun(ConnPid) when TestPings =:= true -> ping_pong(ConnPid, Config);
-           (_) -> pass
-        end,
+    OptionallyPingPong = optionally_ping_pong(Config),
 
     {ok, 200, #{<<"balance">> := IStartAmt}} =
                  get_accounts_by_pubkey_sut(aeser_api_encoder:encode(account_pubkey, IPubkey)),
@@ -711,7 +710,7 @@ sc_ws_open_(Config, ChannelOpts0, MinBlocksToMine, LogDir) ->
 
     {IStartAmt, RStartAmt} = channel_participants_balances(IPubkey, RPubkey),
 
-    TestEvents = [info, get, sign, on_chain_tx, update],
+    TestEvents = sc_ws_open_events(),
     ChannelOpts = channel_options(IPubkey, RPubkey, IAmt, RAmt, ChannelOpts0, Config),
     {IChanOpts, RChanOpts} = special_channel_opts(ChannelOpts),
     ct:log("IChanOpts = ~p~n"
@@ -733,13 +732,73 @@ sc_ws_open_(Config, ChannelOpts0, MinBlocksToMine, LogDir) ->
     channel_send_conn_open_infos(RConnPid, IConnPid, Config),
 
     SignedCrTx = channel_create(Config, IConnPid, RConnPid),
-
     CrTx = aetx_sign:innermost_tx(SignedCrTx),
     {channel_create_tx, Tx} = aetx:specialize_type(CrTx),
+    ChId = aeser_api_encoder:encode(channel, aesc_create_tx:channel_pubkey(Tx)),
     IPubkey = aesc_create_tx:initiator_pubkey(Tx),
     RPubkey = aesc_create_tx:responder_pubkey(Tx),
-    ChannelCreateFee = aesc_create_tx:fee(Tx),
 
+    ok = ?WS:unregister_test_for_channel_events(IConnPid, TestEvents),
+    ok = ?WS:unregister_test_for_channel_events(RConnPid, TestEvents),
+    %% We stuff the channel id into the Clients map out of convenience
+    ChannelClients = #{ channel_id => ChId
+                      , initiator  => IConnPid
+                      , initiator_fsm_id => IFsmId
+                      , responder  => RConnPid
+                      , responder_fsm_id => RFsmId},
+    Config1 = [{channel_clients, ChannelClients},
+               {channel_start_amounts, #{ initiator => IStartAmt
+                                        , responder => RStartAmt }},
+               {create_tx, SignedCrTx},
+               {channel_options, ChannelOpts} | Config],
+    %%
+    case proplists:get_value(mine_create_tx, Config, true) of
+        true ->
+            finish_sc_ws_open(Config1, MinBlocksToMine);
+        false ->
+            ok
+    end,
+    Config1.
+
+optionally_ping_pong(Config) ->
+    TestPings = proplists:get_value(ping_pong, Config, false),
+    fun(ConnPid) when TestPings =:= true -> ping_pong(ConnPid, Config);
+       (_) -> pass
+    end.
+
+optionally_ping_pong(IConnPid, RConnPid, Config) ->
+    TestPings = proplists:get_value(ping_pong, Config, false),
+    fun() when TestPings =:= true ->
+            ping_pong(IConnPid, Config),
+            ping_pong(RConnPid, Config);
+       () -> pass
+    end.
+
+sc_ws_open_events() ->
+    [info, get, sign, on_chain_tx, update].
+
+finish_sc_ws_open(Config, MinBlocksToMine) ->
+    ct:log("finish_sc_ws_open", []),
+    #{ channel_id := ChId
+     , initiator  := IConnPid
+     , responder  := RConnPid } = proplists:get_value(channel_clients, Config),
+    #{ initiator_amount := IAmt
+     , responder_amount := RAmt } = ChannelOpts = proplists:get_value(channel_options, Config),
+    SignedCrTx = proplists:get_value(create_tx, Config),
+    %%
+    TestEvents = sc_ws_open_events(),
+    ok = ?WS:register_test_for_channel_events(IConnPid, TestEvents),
+    ok = ?WS:register_test_for_channel_events(RConnPid, TestEvents),
+    %%
+    ok = maybe_mine_create_tx(SignedCrTx, Config, IConnPid, RConnPid),
+    CrTx = aetx_sign:innermost_tx(SignedCrTx),
+    {channel_create_tx, Tx} = aetx:specialize_type(CrTx),
+    ChannelCreateFee = aesc_create_tx:fee(Tx),
+    IPubkey = aesc_create_tx:initiator_pubkey(Tx),
+    RPubkey = aesc_create_tx:responder_pubkey(Tx),
+    #{ initiator := IStartAmt
+     , responder := RStartAmt } = proplists:get_value(channel_start_amounts, Config),
+    %%
     make_two_gen_messages_volleys(IConnPid, IPubkey, RConnPid,
                                   RPubkey, Config),
 
@@ -756,27 +815,20 @@ sc_ws_open_(Config, ChannelOpts0, MinBlocksToMine, LogDir) ->
     assert_balance_at_most(IPubkey, IStartAmt - IAmt - ChannelCreateFee),
     assert_balance_at_most(RPubkey, RStartAmt - RAmt),
 
-    % mine min depth
+    %% mine min depth
     aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                        MinBlocksToMine),
 
     {ok, ChId} = channel_send_locking_infos(IConnPid, RConnPid, Config),
 
     channel_send_chan_open_infos(RConnPid, IConnPid, Config),
+    %%
+    ok = ?WS:unregister_test_for_channel_events(IConnPid, TestEvents),
+    ok = ?WS:unregister_test_for_channel_events(RConnPid, TestEvents),
+    %%
+    ok.
 
-    %% We stuff the channel id into the Clients map out of convenience
-    ChannelClients = #{ channel_id => ChId
-                      , initiator  => IConnPid
-                      , initiator_fsm_id => IFsmId
-                      , responder  => RConnPid
-                      , responder_fsm_id => RFsmId},
-    ok = ?WS:unregister_test_for_channel_events(IConnPid, [info, get, sign,
-                                                           on_chain_tx, update]),
-    ok = ?WS:unregister_test_for_channel_events(RConnPid, [info, get, sign,
-                                                           on_chain_tx, update]),
-    [{channel_clients, ChannelClients},
-     {create_tx, SignedCrTx},
-     {channel_options, ChannelOpts} | Config].
+
 
 make_two_gen_messages_volleys(IConnPid, IPubkey, RConnPid,
                                   RPubkey, Config) ->
@@ -847,12 +899,7 @@ channel_create(Config, IConnPid, RConnPid) ->
       responder := #{pub_key := RPubkey,
                     priv_key := RPrivkey}} = proplists:get_value(participants, Config),
     TestPings = proplists:get_value(ping_pong, Config, false),
-    OptionallyPingPong =
-        fun() when TestPings =:= true ->
-            ping_pong(IConnPid, Config),
-            ping_pong(RConnPid, Config);
-           () -> pass
-        end,
+    OptionallyPingPong = optionally_ping_pong(IConnPid, RConnPid, Config),
     %% initiator gets to sign a create_tx
     {IStartAmt, RStartAmt} = channel_participants_balances(IPubkey, RPubkey),
     OptionallyPingPong(),
@@ -888,14 +935,33 @@ channel_create(Config, IConnPid, RConnPid) ->
     assert_balance(IPubkey, IStartAmt),
     assert_balance(RPubkey, RStartAmt),
 
+    case proplists:get_value(mine_create_tx, Config, true) of
+        true ->
+            ct:log("Will mine create_tx", []),
+            ok = channel_create_mined(SignedCrTx, Config, IConnPid, RConnPid);
+        false ->
+            ct:log("Will not mine create_tx at this time", []),
+            ok
+    end,
+    SignedCrTx.
+
+maybe_mine_create_tx(SignedCrTx, Config, IConnPid, RConnPid) ->
+    case proplists:get_value(mine_create_tx, Config, true) of
+        false ->
+            %% This means we didn't mine it before - do it now!
+            channel_create_mined(SignedCrTx, Config, IConnPid, RConnPid);
+        true ->
+            ok
+    end.
+
+channel_create_mined(SignedCrTx, Config, IConnPid, RConnPid) ->
     % mine the create_tx
     ok = wait_for_signed_transaction_in_block(SignedCrTx),
 
     {ok, _, #{<<"tx">> := EncodedSignedCrTx}} = wait_for_channel_event(IConnPid, on_chain_tx, Config),
     {ok, _, #{<<"tx">> := EncodedSignedCrTx}} = wait_for_channel_event(RConnPid, on_chain_tx, Config),
-    OptionallyPingPong(),
-
-    SignedCrTx.
+    (optionally_ping_pong(IConnPid, RConnPid, Config))(),
+    ok.
 
 sc_ws_update_(Config) ->
     Participants = proplists:get_value(participants, Config),
@@ -2869,6 +2935,44 @@ sc_ws_min_depth_not_reached_timeout_(Config) ->
     ConnDied(RConnPid),
     ok.
 
+sc_ws_reconnect_early(Config) ->
+    S = ?SLOGAN,
+    Role = initiator,
+    MinBlocksToMine = 2,
+    #{initiator := #{pub_key := IPubkey},
+      responder := #{pub_key := RPubkey}} = proplists:get_value(participants, Config),
+
+    Config1 = sc_ws_open_([{mine_create_tx, false}|Config], #{ slogan => S
+                                                             , minimum_depth => 0},
+                          MinBlocksToMine),
+
+    ct:log("Channel set up, but tx not mined", []),
+
+    #{ channel_id       := ChId
+     , initiator_fsm_id := IFsmId
+     , responder_fsm_id := RFsmId
+     , initiator        := IConnPid } = proplists:get_value(channel_clients, Config1),
+    SignedTx = proplists:get_value(signed_tx, Config1),
+
+    ?WS:stop(IConnPid),
+    ct:log("IConnPid killed", []),
+    timer:sleep(100),
+    ct:log("Reconnecting client ..." , []),
+    Options = proplists:get_value(channel_options, Config1),
+    %% TODO: Port shouldn't matter when reconnecting
+    Port = maps:get(port, Options),
+    ReestablishOpts = #{ existing_channel_id => ChId
+                       , existing_fsm_id => [{initiator, IFsmId}, {responder, RFsmId}]
+                       , offchain_tx => SignedTx
+                       , port => Port
+                       , protocol => maps:get(protocol, Options)},
+    Config2 = reconnect_client_(ReestablishOpts, Role, [{scenario, reconnect} | Config1]),
+    %%
+    ok = finish_sc_ws_open(Config2, MinBlocksToMine),
+    sc_ws_close_mutual_(Config2, Role),
+    ok.
+
+
 sc_ws_min_depth_is_modifiable(Config0) ->
     Config = sc_ws_open_(Config0, #{minimum_depth => 0}, 2),
     ok = sc_ws_update_(Config),
@@ -3150,6 +3254,7 @@ other_role(initiator) -> responder.
 
 reconnect_client_(ReestablishOpts, Role, Config) ->
     ct:log("Trying to reconnect via reestablish", []),
+    ct:log("Config = ~p", [Config]),
     ?CHECK_INFO(20),
     ct:log("ReestablishOpts = ~p", [ReestablishOpts]),
     ReestablishOpts1 = case Role of
@@ -3162,6 +3267,7 @@ reconnect_client_(ReestablishOpts, Role, Config) ->
     ct:log("New ConnPid = ~p", [ConnPid]),
     ct:log("Check if reestablish resulted in a reconnect", []),
     OldClients = ?config(channel_clients, Config),
+    ct:log("OldClients = ~p", [OldClients]),
     {OldFsmId, NewClients} = case Role of
                                  initiator ->
                                      { maps:get(initiator_fsm_id, OldClients)
@@ -3674,8 +3780,10 @@ sc_ws_leave_reestablish_responder_stays(Config0) ->
 
 sc_ws_leave_reconnect(Config0) ->
     ct:log("opening channel", []),
+    ct:log("Config0 = ~p", [Config0]),
     Config = sc_ws_open_([{slogan, ?SLOGAN}|Config0], #{responder_opts => #{keep_running => true}}),
     ct:log("channel opened", []),
+    ct:log("Config = ~p", [Config]),
     ct:log("*** Leaving channel ***", []),
     Config1 = [{responder_leaves, false}|Config],
     ct:log("Config1 = ~p", [Config1]),

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -927,6 +927,8 @@ channel_create(Config, IConnPid, RConnPid) ->
     {channel_create_tx, Tx} = aetx:specialize_type(CrTx),
     IPubkey = aesc_create_tx:initiator_pubkey(Tx),
     RPubkey = aesc_create_tx:responder_pubkey(Tx),
+    ct:log("ChID (channel_create()) = ~p", [aeser_api_encoder:encode(
+                                              channel, aesc_create_tx:channel_pubkey(Tx))]),
 
     %% ensure the tx is in the mempool
     ok = wait_for_signed_transaction_in_pool(SignedCrTx),
@@ -2963,7 +2965,6 @@ sc_ws_reconnect_early(Config) ->
     Port = maps:get(port, Options),
     ReestablishOpts = #{ existing_channel_id => ChId
                        , existing_fsm_id => [{initiator, IFsmId}, {responder, RFsmId}]
-                       , offchain_tx => SignedTx
                        , port => Port
                        , protocol => maps:get(protocol, Options)},
     Config2 = reconnect_client_(ReestablishOpts, Role, [{scenario, reconnect} | Config1]),

--- a/docs/state-channels/fsm.puml
+++ b/docs/state-channels/fsm.puml
@@ -26,12 +26,15 @@ note as info
 end note
 
 state "Re-establish Init" as re_in
-[*] --> re_in                                             : [if role == initiator and re-established]
-[*] --> in                                                : [if role == initiator and  not re-established]
+[*] --> aw_co                                             : [if role == initiator]
 [*] --> aw_re                                             : [if role == responder and re-established]
 [*] --> aw_op                                             : [if role == responder and  not re-established]
 re_in --> op                                              : channel_reest_ack [if checks_ok]
 re_in --> te                                              : channel_reest_ack [if not checks_ok]
+
+state "Awaiting connect" as aw_co
+aw_co --> re_in                                           : [if re-established]
+aw_co --> in                                              : [if not re-established]
 
 state "Awaiting Open" as aw_op
 aw_op --> ac                                              : channel_open [if checks_ok]


### PR DESCRIPTION
See issue #3169 

Some refactoring of the sc suite, to allow for partial setup of a channel, pausing before the create_tx has been mined onto the chain.

In local test runs, `aehttp_sc_SUITE` fails with errors seemingly related to contract cache issues. This seems separate from the present fix.