### PR TITLE
Small improvements

### DIFF
--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -152,7 +152,6 @@
               , opts                            :: map()
               , fsm_id_wrapper                  :: undefined | aesc_fsm_id:wrapper()
               , channel_id                      :: undefined | binary()
-              , temp_chan_id                    :: undefined | binary()
               , on_chain_id                     :: undefined | binary()
               , create_tx                       :: undefined | any()
               , watcher_registered = false      :: boolean()

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -2445,7 +2445,7 @@ responder_instance_(Fsm, Spec, R0, Parent, Debug) ->
     FsmId = receive_fsm_id(dev1, R, Debug),
     {ok, ChOpen} = receive_from_fsm(info, R, channel_open, ?LONG_TIMEOUT, Debug),
     ?LOG(Debug, "Got ChOpen: ~p~nSpec = ~p", [ChOpen, Spec]),
-    {ok, #{ temporary_channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
     ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     R1 = R#{ proxy => self(), parent => Parent, fsm_id => FsmId },
     gproc:reg(GprocR = {n,l,{?MODULE,TmpChanId,responder}}, #{ r => R1 }),
@@ -2464,7 +2464,7 @@ initiator_instance_(Fsm, Spec, I0, Parent, Debug) ->
     FsmId = receive_fsm_id(dev1, I, Debug),
     {ok, ChAccept} = receive_from_fsm(info, I, channel_accept, ?LONG_TIMEOUT, Debug),
     ?LOG(Debug, "Got ChAccept: ~p~nSpec = ~p", [ChAccept, Spec]),
-    {ok, #{ temporary_channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
+    {ok, #{ channel_id := TmpChanId }} = rpc(dev1, aesc_fsm, get_state, [Fsm]),
     ?LOG(Debug, "TmpChanId = ~p", [TmpChanId]),
     I1 = I#{ proxy => self(), fsm_id => FsmId },
     gproc:reg(GprocI = {n,l,{?MODULE,TmpChanId,initiator}}, #{ i => I1


### PR DESCRIPTION
I rolled back the new ID as it is not needed.

Introduction of a new field in the FSM's `#data{}` is quite dangerous as it renders all existing state channels invalid. If we really have to do this, we must do it carefully and what is more important: make sure an old encrypted state could be loaded and the SC can be resumed on an upgraded node. I think in this case we can simply not go there and this would save us a lot of trouble.