### PR TITLE
Gh3190 responder accept crash

### DIFF
--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -417,6 +417,7 @@ accept_tcp(LSock, Port, R, AcceptTimeout) ->
         {ok, _} = Ok ->
             Ok;
         {error, timeout} ->
+            lager:debug("Timeout on accept call; see if we should retry", []),
             case aesc_listeners:lsock_info(LSock, [port, responders]) of
                 #{ port := Port, responders := Rs } ->
                     case lists:member(R, Rs) of
@@ -427,7 +428,8 @@ accept_tcp(LSock, Port, R, AcceptTimeout) ->
                             lager:debug("No listeners for ~p on this port", [R]),
                             {error, accept_timeout}
                     end;
-                _ ->
+                _Other ->
+                    lager:debug("_Other = ~p", [_Other]),
                     {error, accept_timeout}
             end;
         Error ->

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -23,6 +23,7 @@
 -export([
           create_channel/1
         , multiple_responder_keys_per_port/1
+        , responder_accept_timeout/1
         , channel_insufficent_tokens/1
         , inband_msgs/1
         , upd_transfer/1
@@ -255,6 +256,7 @@ transactions_sequence() ->
       [
         create_channel
       , multiple_responder_keys_per_port
+      , responder_accept_timeout
       , channel_insufficent_tokens
       , inband_msgs
       , upd_transfer
@@ -554,6 +556,19 @@ multiple_responder_keys_per_port(Cfg) ->
      end || P <- Cs],
     ok = stop_miner_helper(MinerHelper),
     ok.
+
+responder_accept_timeout(Cfg) ->
+    Slogan = ?SLOGAN,
+    Debug = get_debug(Cfg),
+    ROptsF = fun(Spec1) ->
+                     ?LOG(Debug, "Modifying ~p", [Spec1]),
+                     NOpts0 = maps:get(noise, Spec1, []),
+                     NOpts1 = lists:keystore(accept_timeout, 1, NOpts0, {accept_timeout, 100}),
+                     #{noise => NOpts1}
+             end,
+    create_channel_([ ?SLOGAN
+                    , {spawn_interval, 500}
+                    , {responder_opts, ROptsF} | Cfg]).
 
 -record(miner, { parent
                , mining = false
@@ -2327,9 +2342,27 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
     ?LOG("Spec = ~p", [Spec]),
     RSpec = customize_spec(responder, Spec, Cfg),
     ISpec = customize_spec(initiator, Spec, Cfg),
-    RProxy = spawn_responder(Port, RSpec, R, UseAny, Debug),
-    timer:sleep(100),
-    IProxy = spawn_initiator(Port, ISpec, I, Debug),
+    ?LOG(Debug, "RSpec = ~p~nISpec = ~p", [RSpec, ISpec]),
+    SpawnInterval = proplists:get_value(spawn_interval, Cfg, 100),
+    SpawnR = fun() ->
+                        spawn_responder(Port, RSpec, R, UseAny, Debug)
+                end,
+    SpawnI = fun() ->
+                     spawn_initiator(Port, ISpec, I, Debug)
+             end,
+    {RProxy, IProxy} =
+        case proplists:get_value(spawn_first, Cfg, responder) of
+            responder ->
+                RPx = SpawnR(),
+                timer:sleep(SpawnInterval),
+                IPx = SpawnI(),
+                {RPx, IPx};
+            initiator ->
+                IPx = SpawnI(),
+                timer:sleep(SpawnInterval),
+                RPx = SpawnR(),
+                {RPx, IPx}
+        end,
     ?LOG("RProxy = ~p, IProxy = ~p", [RProxy, IProxy]),
     Timeout = proplists:get_value(timeout, Cfg, ?TIMEOUT),
     Info = match_responder_and_initiator(RProxy, Debug, Timeout),
@@ -2393,12 +2426,17 @@ create_channel_from_spec(I, R, Spec, Port, UseAny, Debug, Cfg) ->
                                                          responder_opts])])).
 
 customize_spec(Role, Spec, Cfg) ->
-    maps:merge(Spec, custom_spec_opts(Role, Cfg)).
+    maps:merge(Spec, custom_spec_opts(Role, Cfg, Spec)).
 
-custom_spec_opts(responder, Cfg) ->
-    proplists:get_value(responder_opts, Cfg, #{});
-custom_spec_opts(initiator, Cfg) ->
-    proplists:get_value(initiator_opts, Cfg, #{}).
+custom_spec_opts(responder, Cfg, Spec) ->
+    maybe_apply_f(proplists:get_value(responder_opts, Cfg, #{}), Spec);
+custom_spec_opts(initiator, Cfg, Spec) ->
+    maybe_apply_f(proplists:get_value(initiator_opts, Cfg, #{}), Spec).
+
+maybe_apply_f(F, Spec) when is_function(F, 1) ->
+    F(Spec);
+maybe_apply_f(Map, _) when is_map(Map) ->
+    Map.
 
 spawn_responder(Port, Spec, R, UseAny, Debug) ->
     Me = self(),

--- a/docs/release-notes/next-iris/GH-3190-state-channel-acceptor-crash.md
+++ b/docs/release-notes/next-iris/GH-3190-state-channel-acceptor-crash.md
@@ -1,0 +1,1 @@
+* When a State Channel responder acceptor times out (accept_timeout), it checks to see whether it should give up or keep trying. This logic was faulty and has now been fixed.


### PR DESCRIPTION
Closes #3190 - SC acceptor crash when retrying

A test case has been added, and preparation for also testing connector timeout and retry.
This would need a fix present in #3169 (not yet merged) and code to make `connect_timeout` configurable in the same way as `accept_timeout`.