### PR TITLE
Include channel IDs at fork point height

### DIFF
--- a/apps/aechannel/test/aesc_chain_watcher_SUITE.erl
+++ b/apps/aechannel/test/aesc_chain_watcher_SUITE.erl
@@ -569,7 +569,7 @@ add_microblock_(ForkId, Txs, #{forks := Forks} = Chain) ->
     PrevKeyHash = aec_headers:prev_key_hash(TopHdr),
     Height = aec_headers:height(TopHdr),
     NewHdr = aec_headers:new_micro_header(
-               Height + 1, PrevHash, PrevKeyHash,
+               Height, PrevHash, PrevKeyHash,
                root_hash(), 0, txs_hash(), pof_hash(), 0),
     {ok, BlockHash} = aec_headers:hash_header(NewHdr),
     Block = maybe_update_trees(ForkId, #{ hash   => BlockHash


### PR DESCRIPTION
Closes #3198 

The PR fixes a bug in the `aesc_chain_watcher_SUITE` chain simulation that incremented the height for each microblock. Once that was fixed, the test suite triggered the crash in the chain watcher, which was caused by not matching on affected channels at the fork point height.

Crashes manifested e.g. in the `aest_channels_SUITE` in system test, at least occasionally.