### PR TITLE
Fix ST

### DIFF
--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -52,6 +52,7 @@ check_env() ->
     check_env([{[<<"logging">>, <<"hwm">>]     , fun set_hwm/1},
                {[<<"logging">>, <<"level">>]   , fun set_level/1},
                {[<<"mining">>, <<"autostart">>], {set_env, autostart}},
+               {[<<"mining">>, <<"strictly_follow_top">>], {set_env, strictly_follow_top}},
                {[<<"mining">>, <<"attempt_timeout">>], {set_env, mining_attempt_timeout}},
                {[<<"chain">>, <<"persist">>]   , {set_env, persist}},
                {[<<"chain">>, <<"db_path">>]   , fun set_mnesia_dir/1}]).

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -554,6 +554,12 @@
                     "default": 480,
                     "minimum" : 0
                 },
+                "strictly_follow_top" : {
+                    "description" :
+                    "If true, removes the risk of a race condition with eventual forking in fast mining context",
+                    "type" : "boolean",
+                    "default": false
+                },
                 "cuckoo" : {
                     "type" : "object",
                     "additionalProperties" : false,

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -149,6 +149,7 @@ mining:
     max_auth_fun_gas: 50000
     # Public key of beneficiary account that will receive fees from mining on a node.
     beneficiary: "ak_DummyPubKeyDoNotEverUse999999999999999999999999999"
+    strictly_follow_top: false
     cuckoo:
         # Number of bits used for representing an edge in the Cuckoo Cycle problem.
         edge_bits: 29

--- a/system_test/common/aest_channels_SUITE.erl
+++ b/system_test/common/aest_channels_SUITE.erl
@@ -183,8 +183,9 @@ simple_channel_test(ChannelOpts, InitiatorNodeBaseSpec, ResponderNodeBaseSpec, C
 
     MikePubkey = aeser_api_encoder:encode(account_pubkey, maps:get(pubkey, ?MIKE)),
     NodeConfig = #{ beneficiary => MikePubkey },
-    setup([spec(node1, [], InitiatorNodeBaseSpec),
-           spec(node2, [node1], ResponderNodeBaseSpec#{mining => #{autostart => false}})],
+    StrictMining = #{strictly_follow_top => true},
+    setup([spec(node1, [], InitiatorNodeBaseSpec#{mining => StrictMining}),
+           spec(node2, [node1], ResponderNodeBaseSpec#{mining => StrictMining#{autostart => false}})],
           NodeConfig, Cfg),
     NodeNames = [INodeName, RNodeName],
     start_node(node1, Cfg),

--- a/system_test/common/aest_channels_SUITE_data/aeternity.yaml.mustache
+++ b/system_test/common/aest_channels_SUITE_data/aeternity.yaml.mustache
@@ -33,6 +33,7 @@ chain:
 
 mining:
     autostart: {{mining.autostart}}
+    strictly_follow_top: {{mining.strictly_follow_top}}
     beneficiary: {{config.beneficiary}}
     beneficiary_reward_delay: 2
     micro_block_cycle: 100

--- a/system_test/common/helpers/aest_docker.erl
+++ b/system_test/common/helpers/aest_docker.erl
@@ -83,7 +83,8 @@
     % Mind that using custom_command cancels usage of mine_rate (default mine_rate is used).
     % Technically mine_rate is passed as a command to Docker, which is overwritten by custom_command (if used).
     custom_command => [string(), ...],
-    mining => #{autostart => boolean()}
+    mining => #{autostart => boolean(),
+                strictly_follow_top => boolean()}
 }.
 
 %% State of a node
@@ -206,6 +207,7 @@ setup_node(Spec, BackendState) ->
 
     ConfigFileName = format("aeternity_~s.yaml", [Name]),
     ConfigFileHostPath = filename:join([TempDir, "config", ConfigFileName]),
+    ct:log("~p will be using config ~p", [Name, ConfigFileHostPath]),
     TemplateFile = filename:join(DataDir, ?CONFIG_FILE_TEMPLATE),
     PeerVars = lists:map(fun (Addr) -> #{peer => Addr} end, Peers),
     CuckooMinerVars =
@@ -234,7 +236,8 @@ setup_node(Spec, BackendState) ->
                       #{present => false,
                         hard_fork_info => []}}
         end,
-    Mining = maps:merge(#{autostart => true}, maps:get(mining, Spec, #{})),
+    Mining = maps:merge(#{autostart => true,
+                          strictly_follow_top => false}, maps:get(mining, Spec, #{})),
     ct:log("~p has set mining ~p", [Name, Mining]),
     ForkManagementVars =
         case maps:find(fork_management, Spec) of


### PR DESCRIPTION
In the case of participants using 2 different nodes in the context of fast mining on slow containers, we experienced ST failures.

I've checked and indeed the config is correct for both nodes: in order to exclude the possibility of forking, only one of the nodes is mining. This works as expected.

It happens that in a fast mining context a slow node can produce a fork by itself: while it produces a microblock, it also produces a keyblock that is still pointing to the previous block. Hence the last microblock is kicked out of the chain. We've already experienced this in the context of [`aehttp_sc_SUITE`](https://github.com/aeternity/aeternity/blob/master/apps/aehttp/test/aehttp_sc_SUITE.erl#L1630): where it was solved by requiring the conductor to strictly follow the chain and not to produce forks by itself.

This PR exposes this to the config and applies it to `aest_channels_SUITE`.