### PR TITLE
future proof rebar.lock.script

### DIFF
--- a/rebar.lock.script
+++ b/rebar.lock.script
@@ -23,8 +23,8 @@ case CONFIG of
     [] ->
         %% no lock file present, usually during unlock/upgrade
         CONFIG;
-    [{Version, Deps}, [{pkg_hash, Pkgs}]] ->
+    [{Version, Deps}, [{pkg_hash, Pkgs} | Rest] | Rest1] ->
         Deps1 = FilterRocksDb(Deps),
         Pkgs1 = FilterRocksDb(Pkgs),
-        [{Version, Deps1}, [{pkg_hash, Pkgs1}]]
+        [{Version, Deps1}, [{pkg_hash, Pkgs1} | Rest] | Rest1]
 end.


### PR DESCRIPTION
The upcoming rebar3 release expands on the hashes kept in `rebar.lock` to be safer. This patch ensures that that change and any future addition to the lock file won't crash the script. 