### PR TITLE
Responder sends channels.update report after reestablish

### DIFF
--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -684,7 +684,7 @@ awaiting_reestablish(cast, {?CH_REESTABL, Msg}, #data{ role = responder
                          lager:debug("Already running - don't re-register", []),
                          D2
                  end,
-            next_state(open, send_reestablish_ack_msg(D3));
+            next_state(open, force_update_report(send_reestablish_ack_msg(D3)));
         {error, _} = Error ->
             close(Error, D)
     end;
@@ -3319,6 +3319,9 @@ handle_change_config(log_keep, Keep, #data{log = L} = D)
     {ok, D#data{log = aesc_window:change_keep(Keep, L)}};
 handle_change_config(_, _, _) ->
     {error, invalid_config}.
+
+force_update_report(D) ->
+    D#data{last_reported_update = undefined}.
 
 report_update(#data{state = State, last_reported_update = Last} = D) ->
     case aesc_offchain_state:get_latest_signed_tx(State) of

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -3963,7 +3963,8 @@ reestablish_(Info, SignedTx, Port, Debug) ->
                           case IsSoloClosing of
                               true -> R2;
                               false ->
-                                  _R3 = await_open_report(R2, ?TIMEOUT, Debug)
+                                  R21 = await_open_report(R2, ?TIMEOUT, Debug),
+                                  _R3 = await_update_report(R21, ?TIMEOUT, Debug)
                           end,
                       {I3, R3};
                   true ->


### PR DESCRIPTION
Closes #3233 

The test suites pass unchanged. This is mainly due to two things:
1. While the aesc_fsm_SUITE does check the message histories, and should fail there, the `leave_reestablish_responder_stays()` test is actually faulty, in that it passes the `keep_running` parameter in the wrong way. As a result, the responder is made to leave as well, so the case where the responder sticks around after `leave` isn't actually tested there.
2. In the aehttp_sc_SUITE, it _is_ tested, but the checking of received reports is more lax.

Anyway, this was seen in the `aehttp_sc_SUITE:leave_reestablish_responder_stays()` test output:
```
*** User 2020-04-21 13:35:55.090 ***
[responder] Received msg #{<<"jsonrpc">> => <<"2.0">>,
                           <<"method">> => <<"channels.info">>,
                           <<"params">> =>
                               #{<<"channel_id">> =>
                                     <<"ch_2aQnJxKTQ9oKA26u5g6KLJKbqweEEBUpTFCmS4Hdd7cmNrGTmB">>,
                                 <<"data">> =>
                                     #{<<"event">> =>
                                           <<"channel_reestablished">>}},
                           <<"version">> => 1}
...
*** User 2020-04-21 13:35:55.091 ***
[responder] Received msg #{<<"jsonrpc">> => <<"2.0">>,
                           <<"method">> => <<"channels.info">>,
                           <<"params">> =>
                               #{<<"channel_id">> =>
                                     <<"ch_2aQnJxKTQ9oKA26u5g6KLJKbqweEEBUpTFCmS4Hdd7cmNrGTmB">>,
                                 <<"data">> => #{<<"event">> => <<"open">>}},
                           <<"version">> => 1}
...
*** User 2020-04-21 13:35:55.093 ***
[responder] Received msg #{<<"jsonrpc">> => <<"2.0">>,
                           <<"method">> => <<"channels.update">>,
                           <<"params">> =>
                               #{<<"channel_id">> =>
                                     <<"ch_2aQnJxKTQ9oKA26u5g6KLJKbqweEEBUpTFCmS4Hdd7cmNrGTmB">>,
                                 <<"data">> =>
                                     #{<<"state">> =>
                                           <<"tx_+QENCwH4hLhAiHATKjXseBzi6JSzXA9QKc6Kx7adehXv/47hkF4HPyzsOlKE8stq19dsws2HAAECmKsYglcLjp8J2YvgJ4LyBLhA8/GqER6gAOyWNsLGPsdbwot2MXCzidIZnSdvB2T/TXAF+UKSaC7p/V3DXy7fu38Dc6zqsUq/2ZDgF9C4a0rYBLiD+IEyAaEBvEaqwhRORZNdyxBn8NuPZZcysNs8Tlt2nv1suoikKDmGP6olImAAoQF1PW3YZ6EkBqVeUA0YEKcWl9Ez5SDWV2d+UuCa58PWEoYkYTnKgAACCgCGEAZ510gAwKDEJDUxjRWrpw4d3Azw00rltRyY36GG4laZmcUh9DqHSBd5w+Gm">>}},
                           <<"version">> => 1}
```