### PR TITLE
Exposes Force Progress call result to HTTP API

### DIFF
--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -189,7 +189,7 @@ gas_price(#channel_force_progress_tx{update = Update}) ->
     end.
 
 -spec contract_pubkey_and_caller(tx()) ->
-    {aect_contracts:pubkey(), aec_accounts:pubkey()} | undefined.
+    {aect_contracts:pubkey(), aec_keys:pubkey()} | undefined.
 contract_pubkey_and_caller(#channel_force_progress_tx{update = Update}) ->
     case aesc_offchain_update:extract_call(Update) of
         {ContractPubkey, Caller} ->

--- a/apps/aechannel/src/aesc_force_progress_tx.erl
+++ b/apps/aechannel/src/aesc_force_progress_tx.erl
@@ -28,7 +28,8 @@
          valid_at_protocol/2
         ]).
 
--export([gas_price/1]).
+-export([gas_price/1,
+         contract_pubkey_and_caller/1]).
 
 % aesc_signable_transaction callbacks
 -export([channel_id/1,
@@ -183,6 +184,16 @@ gas_price(#channel_force_progress_tx{update = Update}) ->
     case aesc_offchain_update:extract_amounts(Update) of
         {_Amount, GasPrice, _Gas} ->
             GasPrice;
+        not_call ->
+            undefined
+    end.
+
+-spec contract_pubkey_and_caller(tx()) ->
+    {aect_contracts:pubkey(), aec_accounts:pubkey()} | undefined.
+contract_pubkey_and_caller(#channel_force_progress_tx{update = Update}) ->
+    case aesc_offchain_update:extract_call(Update) of
+        {ContractPubkey, Caller} ->
+            {ContractPubkey, Caller};
         not_call ->
             undefined
     end.

--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -31,12 +31,8 @@
          count_authentications/1,
          channel_pubkey/1,
          censor_init_opts/1,
-         censor_ws_req/1
-        ]).
-
--ifdef(TEST).
--export([tx_hash_to_contract_pubkey/1]).
--endif.
+         censor_ws_req/1,
+         tx_hash_to_contract_pubkey/1]).
 
 -ifdef(COMMON_TEST).
 -define(TEST_LOG(Format, Data),

--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -943,6 +943,7 @@ set_channel(Channel, Trees) ->
     ChannelsTree1 = aesc_state_tree:enter(Channel, ChannelsTree0),
     aec_trees:set_channels(Trees, ChannelsTree1).
 
+-spec tx_hash_to_contract_pubkey(binary()) -> binary().
 tx_hash_to_contract_pubkey(TxHash) ->
     ByteSize = aeser_api_encoder:byte_size_for_type(contract_pubkey),
     case TxHash of

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -252,7 +252,7 @@ get_contract(PubKey) ->
         error -> {error, no_state_trees}
     end.
 
--spec get_contract_call(aect_contracts:id(), aect_call:id(), binary()) ->
+-spec get_contract_call(aect_contracts:id() | binary(), aect_call:id(), binary()) ->
                                {'ok', aect_call:call()} |
                                {'error', atom()}.
 get_contract_call(ContractId, CallId, BlockHash) ->

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -417,7 +417,8 @@ handle_request_('GetTransactionInfoByHash', Params, _Config) ->
                             #{<<"ga_info">> => aega_call:serialize_for_client(Info)};
                        (#{info := Info, tx_type := TxType}) when TxType =:= contract_create_tx;
                                                                  TxType =:= contract_call_tx;
-                                                                 TxType =:= ga_attach_tx ->
+                                                                 TxType =:= ga_attach_tx;
+                                                                 TxType =:= channel_force_progress_tx ->
                             #{<<"call_info">> => aect_call:serialize_for_client(Info)};
                        (#{info := Info, tx_type := _}) ->
                             %% info is assumed to be a binary

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -303,7 +303,7 @@ get_info_object_signed_tx(BlockHash, STx, GAIds, OrigTx) ->
                 aesc_force_progress_tx:contract_pubkey_and_caller(FPTx),
             Round = aesc_force_progress_tx:round(FPTx),
             TxHash = aetx_sign:hash(OrigTx),
-            TxHashUsedInsteadOfContract =aesc_utils:tx_hash_to_contract_pubkey(TxHash),
+            TxHashUsedInsteadOfContract = aesc_utils:tx_hash_to_contract_pubkey(TxHash),
             CallId =
                 case maps:get(Caller, GAIds, not_found) of
                     not_found -> %% not GA

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -283,6 +283,9 @@ get_info_object_from_tx(TxKey, TypeKey, CallKey) ->
     end.
 
 get_info_object_signed_tx(BlockHash, STx) ->
+    get_info_object_signed_tx(BlockHash, STx, #{}, STx).
+
+get_info_object_signed_tx(BlockHash, STx, GAIds, OrigTx) ->
     Tx = aetx_sign:tx(STx),
     case aetx:specialize_type(Tx) of
         {TxType, _} when TxType =:= contract_create_tx;
@@ -294,13 +297,28 @@ get_info_object_signed_tx(BlockHash, STx) ->
             aec_chain:get_contract_call(Contract, CallId, BlockHash);
         {ga_meta_tx, _} ->
             {CB, CTx} = aetx:specialize_callback(Tx),
-            get_ga_meta_tx_info(BlockHash, CB, CTx);
+            get_ga_meta_tx_info(BlockHash, CB, CTx, GAIds, OrigTx);
+        {channel_force_progress_tx, FPTx} ->
+            {Contract, Caller} =
+                aesc_force_progress_tx:contract_pubkey_and_caller(FPTx),
+            Round = aesc_force_progress_tx:round(FPTx),
+            TxHash = aetx_sign:hash(OrigTx),
+            TxHashUsedInsteadOfContract =aesc_utils:tx_hash_to_contract_pubkey(TxHash),
+            CallId =
+                case maps:get(Caller, GAIds, not_found) of
+                    not_found -> %% not GA
+                        aect_call:id(Caller, Round,
+                                     TxHashUsedInsteadOfContract);
+                    GAId -> %% had been wrapped in a GA
+                        aect_call:ga_id(GAId, TxHashUsedInsteadOfContract)
+                end,
+            aec_chain:get_contract_call(TxHashUsedInsteadOfContract, CallId, BlockHash);
         {_TxType, _} ->
             {error, transaction_without_info}
     end.
 
 
-get_ga_meta_tx_info(BlockHash, CB, CTx) ->
+get_ga_meta_tx_info(BlockHash, CB, CTx, GAIds, OrigTx) ->
     Owner     = CB:origin(CTx),
     AuthId    = CB:auth_id(CTx),
     case aec_chain:get_ga_call(Owner, AuthId, BlockHash) of
@@ -309,7 +327,9 @@ get_ga_meta_tx_info(BlockHash, CB, CTx) ->
             {InnerTxType, _} = aetx:specialize_type(aetx_sign:tx(SInnerTx)),
             case aega_call:return_type(GAObject) of
                 ok ->
-                    case get_info_object_signed_tx(BlockHash, SInnerTx) of
+                    case get_info_object_signed_tx(BlockHash, SInnerTx,
+                                                   GAIds#{Owner => AuthId},
+                                                   OrigTx) of
                         {error, _} ->
                             %% Type is all we know from inner transaction
                             {ok, aega_call:set_inner(InnerTxType, GAObject)};

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -78,6 +78,7 @@
    [
     get_transaction_by_hash/1,
     get_transaction_info_by_hash/1,
+    get_transaction_info_by_hash_sut/1,
     post_spend_tx/1,
     post_spend_tx_w_hash_sig/1,
     post_contract_and_call_tx/1,
@@ -1472,6 +1473,10 @@ post_contract_and_call_tx(_Config) ->
 get_transactions_by_hash_sut(Hash) ->
     Host = external_address(),
     http_request(Host, get, "transactions/" ++ http_uri:encode(Hash), []).
+
+get_transaction_info_by_hash_sut(Hash) ->
+    Host = external_address(),
+    http_request(Host, get, "transactions/" ++ http_uri:encode(Hash) ++ "/info", []).
 
 post_transactions_sut(Tx) ->
     Host = external_address(),

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -5581,6 +5581,17 @@ sc_ws_force_progress_(Origin, ContractPubkey,
             end),
     TxHash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(SignedTx)),
     wait_for_tx_hash_on_chain(TxHash),
+    {ok, 200, #{ <<"call_info">> :=
+                     #{<<"caller_id">> := _,
+                       <<"caller_nonce">> := _,
+                       <<"contract_id">> := _,
+                       <<"gas_price">> := _,
+                       <<"gas_used">> := _,
+                       <<"height">> := _,
+                       <<"log">> := _,
+                       <<"return_type">> := <<"ok">>,
+                       <<"return_value">> := _}}} =
+        aehttp_integration_SUITE:get_transaction_info_by_hash_sut(binary_to_list(TxHash)),
 
     %% ensure channel object changed
     {ok, Channel1} = get_channel(ChannelId),

--- a/docs/release-notes/next/GH-3229_missing_FP_info.md
+++ b/docs/release-notes/next/GH-3229_missing_FP_info.md
@@ -1,0 +1,1 @@
+* Exposes the channel force progress transaction call result to HTTP API


### PR DESCRIPTION
Note the funny way we circumvent the non-existing conctract on-chain but yet having its call result on-chain: it is noth the contract pubkey being used but rather the hash of the signed transaction. This is a even more enjoyable with `generalized` accounts in mind.