### PR TITLE
SC FSM: Fix channel_close_mutual optional fee

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1716,7 +1716,7 @@ check_mutual_close_with_wrong_amounts(Cfg) ->
      , r := #{fsm := FsmR} = R } =
         create_channel_from_spec(Si, Sr, Spec, Port, Debug, Cfg),
     %% We don't have enough funds to cover the closing fee
-    {error, insufficient_funds} = rpc(dev1, aesc_fsm, shutdown, [FsmI, #{}]),
+    {error, insufficient_balance} = rpc(dev1, aesc_fsm, shutdown, [FsmI, #{}]),
     timer:sleep(50),
     %% Fsms should be unaffected
     true = (rpc(dev1, erlang, process_info, [FsmI]) =/= undefined),

--- a/docs/release-notes/next/fix_close_mutual_fee_issue.md
+++ b/docs/release-notes/next/fix_close_mutual_fee_issue.md
@@ -1,0 +1,5 @@
+* Fixes a State Channel WebSocket API issue: if a user provided a fee, it was
+  ignored
+* Fixes a State Channel WebSocket API issue: when participants try closing a
+  channel with insufficient channel balance to cover the fee, a proper error
+  is being sent.


### PR DESCRIPTION
No GitHub issue, issue was reported in [forum](https://forum.aeternity.com/t/error-code-32603-on-channel-close/6842/12)

Two orthogonal small bugs here:
* optional fee/gas_price was ignored if provided
* there was a mismatch between the message being emitted by the FSM (`{error, insufficient_funds}`) and the one being expected by [the client-facing JSON-RPC lib](https://github.com/aeternity/aeternity/blob/02fa3c6b546b0865c9169ee913515560bbddb1d3/apps/aehttp/src/sc_ws_api_jsonrpc.erl#L175). As a result, the API was returning a misleading default message - `Internal error`.