### PR TITLE
Handle client disconnect during signing (as client abort)

### DIFF
--- a/apps/aechannel/src/aesc_codec.hrl
+++ b/apps/aechannel/src/aesc_codec.hrl
@@ -62,11 +62,14 @@
 -define(CHANNEL_CLOSING, channel_closing).
 -define(CHANNEL_UNLOCKED, channel_unlocked).
 -define(CHANNEL_CLOSED, channel_closed).
+%%
+-define(CLIENT_DISCONNECTED, client_disconnected).
 
 %% Error codes
--define(ERR_VALIDATION        , 1).
--define(ERR_CONFLICT          , 2).
--define(ERR_TIMEOUT           , 3).
--define(ERR_ABORT             , 4).
--define(ERR_ONCHAIN_REJECTED  , 5).
+-define(ERR_VALIDATION         , 1).
+-define(ERR_CONFLICT           , 2).
+-define(ERR_TIMEOUT            , 3).
+-define(ERR_ABORT              , 4).
+-define(ERR_ONCHAIN_REJECTED   , 5).
+-define(ERR_CLIENT_DISCONNECTED, 6).
 -define(ERR_USER      , 128).  % anything >= 128 is a user error

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -4495,11 +4495,11 @@ close_(Reason, D) ->
          end,
     {stop, Reason, D1}.
 
-handle_call(_St, {?RECONNECT_CLIENT, Pid, FsmIdWrapper} = Msg, From,
+handle_call(_, {?RECONNECT_CLIENT, Pid, FsmIdWrapper} = Msg, From,
             #data{ client_connected = false
                  , client_mref      = undefined
                  , client           = undefined } = D0) ->
-    lager:debug("Client reconnect request with no client (cur state: ~p)", [_St]),
+    lager:debug("Client reconnect request with no client", []),
     D = log(rcv, msg_type(Msg), Msg, D0),
     case authenticate_reconnect(FsmIdWrapper, D) of
         true ->
@@ -4534,8 +4534,7 @@ handle_call(_St, _Req, From, D) ->
     keep_state(D, [{reply, From, {error, unknown_request}}]).
 
 handle_call_(awaiting_signature, {abort_update, Code, Tag}, From,
-             #data{ op = #op_sign{tag = Tag}
-                  , on_chain_id = ChannelId} = D) ->
+             #data{ op = #op_sign{tag = Tag}} = D) ->
     case { lists:member(Tag, ?CANCEL_SIGN_TAGS)
          , lists:member(Tag, ?CANCEL_ACK_TAGS )} of
         {SoloAction, AckAction} when SoloAction orelse AckAction ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -4541,7 +4541,7 @@ handle_call_(awaiting_signature, {abort_update, Code, Tag}, From,
         {SoloAction, AckAction} when SoloAction orelse AckAction ->
             D1 = report(info, aborted_update, D),
             lager:debug("update aborted", []),
-            NextState = next_state_after_abort(ChannelId),
+            NextState = next_state_after_abort(D),
             case SoloAction of
                 true ->
                     next_state(NextState, clear_ongoing(D1#data{op = ?NO_OP}),

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -1142,7 +1142,7 @@ op_with_signer_disconnect(Op, Args, SignTag1, RptTag2, SignTag2, Cfg) ->
     rpc(dev1, aesc_fsm, Op, Args(FsmR, 1, Spec)),
     {_, _} = await_signing_request(SignTag1, R, Debug, Cfg),
     {ok, _} = receive_from_fsm(info, I, RptTag2, ?TIMEOUT, Debug),
-    SignedTx = signer_disconnects(SignTag2, I, ?TIMEOUT, Debug),
+    _SignedTx = signer_disconnects(SignTag2, I, ?TIMEOUT, Debug),
     Pat = #{info => #{error_code => ?ERR_CLIENT_DISCONNECTED,
                       round => Round0}},
     {ok, _} = receive_from_fsm(conflict, R, Pat, ?TIMEOUT, Debug),
@@ -3041,9 +3041,6 @@ signer_disconnects(Tag, #{fsm := Fsm, proxy := Proxy}, Timeout, Debug) ->
             error(timeout)
     end.
 
-map_key(initiator) -> i;
-map_key(responder) -> r.
-
 sign_tx(Signer, Tx, Cfg) ->
     co_sign_tx(Signer, aetx_sign:new(Tx, []), Cfg).
 
@@ -3261,8 +3258,8 @@ match_msgs(Pat, M, Cont) when is_map(M), is_map(Pat) ->
     try match_info(M, Pat),
         {ok, M}
     catch
-        error:_E when Cont ->
-            ?LOG("CAUGHT ~p (M = ~p)", [_E, M]),
+        error:E when Cont ->
+            ?LOG("CAUGHT ~p (M = ~p)", [E, M]),
             throw(continue)
     end;
 match_msgs(_, _, true) ->


### PR DESCRIPTION
See Issue #3246 
Locally, the test suite fails on `force_progress_triggers_slash()`. It's not clear to me why.