### PR TITLE
Make ...blocks.key.info metric a histogram

### DIFF
--- a/apps/aecore/priv/exometer_predefined.script
+++ b/apps/aecore/priv/exometer_predefined.script
@@ -37,4 +37,5 @@
 %% Keep 4 hours of data, ~= 120 values, with a new key-block every 2 minutes.
 , {[ae,epoch,aecore,blocks,key,insert_execution_time,success]   , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
 , {[ae,epoch,aecore,blocks,key,insert_execution_time,error]     , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
+, {[ae,epoch,aecore,blocks,key,info]                            , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
 ].

--- a/apps/aecore/priv/exometer_predefined.script
+++ b/apps/aecore/priv/exometer_predefined.script
@@ -37,5 +37,5 @@
 %% Keep 4 hours of data, ~= 120 values, with a new key-block every 2 minutes.
 , {[ae,epoch,aecore,blocks,key,insert_execution_time,success]   , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
 , {[ae,epoch,aecore,blocks,key,insert_execution_time,error]     , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
-, {[ae,epoch,aecore,blocks,key,info]                            , histogram , [{time_span, 4 * 60 * 60 * 1000}]}
+, {[ae,epoch,aecore,blocks,key,info]                            , gauge     , []}
 ].

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1122,10 +1122,9 @@ handle_successfully_added_block(Block, Hash, Events, State, Origin) ->
         {micro_changed, State2 = #state{ consensus = Cons }} ->
             {ok, setup_loop(State2, false, Cons#consensus.leader, Origin)};
         {changed, BlockType, NewTopBlock, State2} ->
-            Origin == block_created andalso
+            (BlockType == key) andalso
                 aec_metrics:try_update(
-                  [ae,epoch,aecore,blocks,key,info],
-                  aec_headers:info(aec_blocks:to_key_header(NewTopBlock))),
+                  [ae,epoch,aecore,blocks,key,info], info_value(NewTopBlock)),
             IsLeader = is_leader(NewTopBlock),
             case IsLeader of
                 true ->
@@ -1137,6 +1136,13 @@ handle_successfully_added_block(Block, Hash, Events, State, Origin) ->
             {ok, setup_loop(State2, true, IsLeader, Origin)}
     end.
 
+info_value(Block) ->
+    case aec_headers:info(aec_blocks:to_key_header(Block)) of
+        I when is_integer(I) ->
+            I;
+        undefined ->
+            0
+    end.
 
 %% NG-TODO: This is pretty inefficient and can be helped with some info
 %%          in the state.


### PR DESCRIPTION
Ensure that metric is actually created (otherwise, `try_update()` will always fail), and make it a histogram with a 4-hr sliding window.

Example from the `aeternity_metrics.log` runnin the `aecore_sync_SUITE`:
```
12:31:45.544 ae.epoch.aecore.blocks.key.info.n:9|g
12:31:45.544 ae.epoch.aecore.blocks.key.info.mean:553|g
12:31:45.544 ae.epoch.aecore.blocks.key.info.min:553|g
12:31:45.544 ae.epoch.aecore.blocks.key.info.max:553|g
12:31:45.545 ae.epoch.aecore.blocks.key.info.median:553|g
12:31:45.545 ae.epoch.aecore.blocks.key.info.50:553|g
12:31:45.545 ae.epoch.aecore.blocks.key.info.75:553|g
12:31:45.545 ae.epoch.aecore.blocks.key.info.90:553|g
12:31:45.546 ae.epoch.aecore.blocks.key.info.95:553|g
12:31:45.546 ae.epoch.aecore.blocks.key.info.99:553|g
12:31:45.546 ae.epoch.aecore.blocks.key.info.999:553|g
```