### PR TITLE
Initial implementation of fork height metrics

### DIFF
--- a/apps/aecore/src/aec_chain_metrics_probe.erl
+++ b/apps/aecore/src/aec_chain_metrics_probe.erl
@@ -23,6 +23,7 @@
 -include("blocks.hrl").
 
 -define(DATAPOINTS, [ total_difficulty
+                    , n_forks
                     , rel_fork_heights
                     , tot_fork_heights ]).
 
@@ -207,7 +208,8 @@ group_forks(Forks, Top) ->
                   end
           end, {Acc0, Acc0}, Rest),
     [ {rel_fork_heights, RelHeights}
-    , {tot_fork_heights, TotHeights} ].
+    , {tot_fork_heights, TotHeights}
+    , {n_forks, length(TotHeights)} ].
 
 height(Hash) ->
     {value, Hdr} = aec_db:find_header(Hash),

--- a/apps/aecore/src/aec_metrics.erl
+++ b/apps/aecore/src/aec_metrics.erl
@@ -233,7 +233,6 @@ exometer_unsubscribe(_Metric, _DataPoint, _Extra, St) ->
     {ok, St}.
 
 exometer_report(Metric, DataPoint, Extra, Value, St) ->
-    lager:debug("Metric = ~p, DP = ~p, Value = ~p", [Metric, DataPoint, Value]),
     Key = metric_key(Metric, DataPoint),
     Type = case exometer_util:report_type(Key, Extra, St#st.type_map) of
                {ok, T} -> T;
@@ -285,9 +284,7 @@ line(#{name := Name, value := Value, type := Type, extra := Extra}) ->
 
 add_tags(Extra, Map) ->
     AllTags = tags_from_extra(Extra) ++ maps:get(tags, Map, []),
-    Fmt = fmt_tags(AllTags),
-    lager:debug("Fmt = ~p", [Fmt]),
-    Fmt.
+    fmt_tags(AllTags).
 
 add_tags(undefined) -> [];
 add_tags(Extra) when is_list(Extra) ->
@@ -381,7 +378,6 @@ statsd_handle_msg({statsd, Msg} = Data, S) ->
     end.
 
 statsd_handle_data(#{} = Data, S) ->
-    lager:debug("Data = ~p", [Data]),
     case Data of
         #{type := distribution, value := [#{}|_] = Vs} ->
             [try_send(line(Data#{value => V}), S)

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -541,11 +541,14 @@ check_sample(Rel0, Tot0) ->
     Tot1 = tot_fork_heights(Sample),
     {rel, Rel1, Rel0} = {rel, Rel0, Rel1},
     {tot, Tot1, Tot0} = {tot, Tot0, Tot1},
+    [_] = lists:ukeysort(2, [ {rel0, length(Rel0)}
+                            , {tot0, length(Tot0)}
+                            , {n_forks, proplists:get_value(n_forks, Sample)}]),
     %% The main fork tag (fork ID) has the same relative as total height
     [MainForkTag] =
-        [Tag || #{value := V, tag := Tag}
+        [Tag || #{value := V, tags := [Tag]}
                     <- proplists:get_value(tot_fork_heights, Sample),
-                #{value := V1, tag := Tag1}
+                #{value := V1, tags := [Tag1]}
                     <- proplists:get_value(rel_fork_heights, Sample),
                 (V =:= V1) andalso (Tag =:= Tag1)],
     MainForkTag.


### PR DESCRIPTION
Todo:
* Make the measurement range configurable? (currently, hard-coded to `2`)
* Add a fork count gauge

The format of the reported height metrics is currently (from `aeternity_metrics.log`):
```
19:53:30.667 ae.epoch.aecore.chain.rel_fork_heights:7|d|#id:kh_2KhFJSdz1BwrvEWe9fFBRBpWoweoaZuTiYLWwUPh21ptuDE8UQ
19:53:30.668 ae.epoch.aecore.chain.tot_fork_heights:7|d|#id:kh_2KhFJSdz1BwrvEWe9fFBRBpWoweoaZuTiYLWwUPh21ptuDE8UQ
```