### PR TITLE
Let names/<name> endpoint return name owner

### DIFF
--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -2096,6 +2096,8 @@ definitions:
     properties:
       id:
         $ref: '#/definitions/EncodedValue'
+      owner:
+        $ref: '#/definitions/EncodedPubkey'
       ttl:
         $ref: '#/definitions/UInt64'
       pointers:

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -547,8 +547,10 @@ handle_request_('GetNameEntryByName', Params, _Context) ->
     case aec_chain:name_entry(Name) of
         {ok, #{id       := Id,
                ttl      := TTL,
+               owner    := Owner,
                pointers := Pointers}} ->
             {200, [], #{<<"id">>       => aeser_api_encoder:encode(id_hash, Id),
+                        <<"owner">>    => aeser_api_encoder:encode(account_pubkey, Owner),
                         <<"ttl">>      => TTL,
                         <<"pointers">> => [aens_pointer:serialize_for_client(P) || P <- Pointers]}};
         {error, name_not_found} ->

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3188,6 +3188,7 @@ naming_system_manage_name(_Config) ->
     ExpectedTTL1 = (Height3 - 1) + aec_governance:name_claim_max_expiration(),
     {ok, 200, #{<<"id">>       := EncodedNHash,
                 <<"ttl">>      := ExpectedTTL1,
+                <<"owner">>    := PubKeyEnc,
                 <<"pointers">> := []}} = get_names_entry_by_name_sut(Name),
 
     %% Submit name updated tx and check it is in mempool

--- a/apps/aens/src/aens.erl
+++ b/apps/aens/src/aens.erl
@@ -105,6 +105,7 @@ name_entry(NameRecord) ->
         claimed ->
             {ok, #{id       => aens_names:id(NameRecord),
                    ttl      => aens_names:ttl(NameRecord),
+                   owner    => aens_names:owner_pubkey(NameRecord),
                    pointers => aens_names:pointers(NameRecord)}};
         revoked ->
             {error, name_revoked}

--- a/docs/release-notes/next/GH-XXXX-name-owner.md
+++ b/docs/release-notes/next/GH-XXXX-name-owner.md
@@ -1,0 +1,1 @@
+* HTTP endpoint `names/<name>` now also returns a field `owner` containing the account owning the name.


### PR DESCRIPTION
Idea from the discussion here https://forum.aeternity.com/t/the-problem-of-who-owns-a-domain-name/7152

We don't have good traceability of transaction inside contract calls (yet!) - this at least makes it possible to check after the fact that a transfer really took place. 