### PR TITLE
Use parse_transform w -pluggable() attrs

### DIFF
--- a/apps/aecore/include/aec_plugin.hrl
+++ b/apps/aecore/include/aec_plugin.hrl
@@ -1,14 +1,3 @@
 
--define(PLUGGABLE(Args, Default),
-        case aec_plugin:get_module(?MODULE) of
-            undefined ->
-                Default;
-            __M ->
-                case erlang:function_exported(
-                       __M, ?FUNCTION_NAME, ?FUNCTION_ARITY) of
-                    true ->
-                        __M:?FUNCTION_NAME Args;
-                    false ->
-                        Default
-                end
-        end).
+-compile({parse_transform, aec_plugin_xform}).
+

--- a/apps/aecore/rebar.config
+++ b/apps/aecore/rebar.config
@@ -1,0 +1,1 @@
+{erl_first_files, ["src/aec_plugin_xform.erl"]}.

--- a/apps/aecore/src/aec_plugin.erl
+++ b/apps/aecore/src/aec_plugin.erl
@@ -6,6 +6,21 @@
         , get_module/2
         ]).
 
+%% Pre-OTP 21 ==================================================
+-ifndef(OTP_RELEASE).
+
+register(_Map) ->
+    error(requires_OTP21).
+
+get_module(_Tag) ->
+    undefined.
+
+get_module(_Tag, _Default) ->
+    undefined.
+
+%% OTP 21 and later ============================================
+-else.
+
 tags() ->
     [aec_headers].
 
@@ -54,27 +69,12 @@ module_is_loaded(M) ->
 %% The functionality was introduced in OTP 21.2. Also in OTP 21, the
 %% predefined macro ?OTP_RELEASE was introduced. Let's assume that anyone
 %% using OTP 21 is using at least 21.2.
--ifdef(OTP_RELEASE).
 
 set_registry(R) ->
     persistent_term:put({?MODULE, registry}, R).
 
 get_registry() ->
     persistent_term:get({?MODULE, registry}, undefined).
-
--else.
-
-%% set_registry(R) ->
-%%     application:set_env(aecore, plugin_registry, R).
-
-%% get_registry() ->
-%%     application:get_env(aecore, plugin_registry, undefined).
-
-set_registry(_) ->
-    error(requires_OTP21).
-
-get_registry() ->
-    undefined.
 
 -endif.
 

--- a/apps/aecore/src/aec_plugin_xform.erl
+++ b/apps/aecore/src/aec_plugin_xform.erl
@@ -1,25 +1,104 @@
 -module(aec_plugin_xform).
 
 -export([parse_transform/2]).
-
+-export([format_error/1]).
 
 parse_transform(Forms, Opts) ->
     Ctxt = parse_trans:initial_context(Forms, Opts),
     Mod = parse_trans:context(module, Ctxt),
-    Pluggable = find_pluggable(Forms),
-    F = fun(Form) -> pt(Form, Pluggable) end,
-    NewForms0 = plain_transform(F, Forms),
-    LastL = get_pos(lists:last(NewForms0)),
-    NewForms = append_form(choice_f(Mod, LastL+1), NewForms0),
-    NewForms.
+    {Pluggable, Forms1} = find_pluggable(Forms),
+    case errors(Forms1) of
+        [] ->
+            case Pluggable of
+                [_|_] ->
+                    F = fun(Form) -> pt(Form, Pluggable) end,
+                    NewForms0 = plain_transform(F, Forms1),
+                    LastL = get_pos(lists:last(NewForms0)),
+                    append_form(choice_f(Mod, LastL+1), NewForms0);
+                [] ->
+                    case lists:keymember(error, 1, Forms1) of
+                        true ->
+                            Forms1;
+                        false ->
+                            Forms
+                    end
+            end;
+        Errors ->
+            {error, Errors, []}
+    end.
 
 find_pluggable(Forms) ->
-    lists:foldl(
-      fun({attribute,_,pluggable,Fs}, Acc) ->
-              Fs ++ Acc;
-         (_, Acc) ->
-              Acc
-      end, [], Forms).
+    {Blocks, Forms1} = pluggable_blocks(Forms),  % may insert error forms
+    Pluggable = try lists:foldl(
+                      fun({attribute,_,pluggable,all_exported}, _Acc) ->
+                              Exports = all_exports(Forms),
+                              throw(#{pluggable => Exports});
+                         ({attribute,_,pluggable,Fs}, Acc) ->
+                              Fs ++ Acc;
+                         (_, Acc) ->
+                              Acc
+                      end, [], Forms1)
+                catch
+                    throw:#{pluggable := Ps} -> Ps
+                end,
+    AllPluggable = lists:flatmap(fun({_, Funs}) -> Funs end, Blocks) ++ Pluggable,
+    {AllPluggable, Forms1}.
+
+pluggable_blocks(Forms) ->
+    #{acc := Acc, blocks := Blocks} = pluggable_blocks(Forms, #{acc => [], blocks => []}),
+    {Blocks, Acc}.
+    
+
+pluggable_blocks([{attribute,_,file,{File,_}} = F|Fs], #{acc := Acc0} = Acc) ->
+    pluggable_blocks(Fs, Acc#{file => File, acc => [F | Acc0]});
+pluggable_blocks([{attribute,L,pluggable_begin,Tag} = F|Fs],
+                 #{acc := Acc0} = Acc) ->
+    case maps:find(current_block, Acc) of
+        {ok, Prev} ->
+            File = maps:get(file, Acc),
+            Err = {error, {File, L}, {overlapping_pluggable_blocks, [Prev, Tag]}},
+            pluggable_blocks(Fs, Acc#{acc => [Err, F | Acc0]});
+        error ->
+            pluggable_blocks(Fs, Acc#{current_block => Tag,
+                                      acc => [F | Acc0]})
+    end;
+pluggable_blocks([{attribute,_,pluggable_end,Tag} = F|Fs],
+                 #{current_block := Tag,
+                   blocks := Blocks,
+                   acc := Acc0} = Acc) ->
+    Exports = maps:get(exports, Acc, []),
+    Acc1 = maps:remove(current_block, Acc),
+    pluggable_blocks(Fs, Acc1#{acc => [F | Acc0],
+                               blocks => [{Tag, Exports}|Blocks]});
+pluggable_blocks([{attribute,_,export,Funs} = F|Fs],
+                 #{ current_block := _
+                  , acc := Acc0} = Acc) ->
+    Exports = maps:get(exports, Acc, []),
+    pluggable_blocks(Fs, Acc#{exports => Exports ++ Funs, acc => [F|Acc0]});
+pluggable_blocks([{eof,L} = F], #{current_block := Tag, acc := Acc0} = Acc) ->
+    File = maps:get(file, Acc),
+    Acc#{acc => lists:reverse(
+                  [F,
+                   {error, {File, L}, {unterminated_pluggable_block, [Tag]}}
+                   | Acc0])};
+pluggable_blocks([F|Fs], #{acc := Acc0} = Acc) ->
+    pluggable_blocks(Fs, Acc#{acc := [F|Acc0]});
+pluggable_blocks([], #{acc := Acc0} = Acc) ->
+    Acc#{acc => lists:reverse(Acc0)}.
+
+all_exports(Forms) ->
+    case [1 || {attribute,_,compile,export_all} <- Forms] of
+        [] ->
+            all_explicit_exports(Forms);
+        [_|_] ->
+            all_functions(Forms)
+    end.
+
+all_explicit_exports(Forms) ->
+    lists:flatten([Fs || {attribute,_,export,Fs} <- Forms]).
+
+all_functions(Forms) ->
+    [{F,A} || {function,_,F,A,_} <- Forms].
 
 pt({function,L,Fun,Arity,Clauses} = Form, Pluggable) ->
     case lists:member({Fun,Arity}, Pluggable) of
@@ -121,3 +200,21 @@ append_form(F, Forms) ->
     [{eof,_}|RevForms] = lists:reverse(Forms),
     NewLastPos = get_pos(F),
     lists:reverse(RevForms) ++ [F,{eof,NewLastPos+1}].
+
+errors(Forms) ->
+    case [{F, {L, ?MODULE, E}} || {error, {F, L}, E} <- Forms] of
+        [] ->
+            [];
+        Errs ->
+            lists:foldl(fun append_err/2, orddict:new(), Errs)
+    end.
+
+append_err({F, E}, Acc) ->
+    orddict:append(F, E, Acc).
+
+format_error({overlapping_pluggable_blocks, Bs}) ->
+    io_lib:format("Overlapping 'pluggable' blocks: ~p", [Bs]);
+format_error({unterminated_pluggable_block, Tag}) ->
+    io_lib:format("Unterminated 'pluggable' block: ~p", [Tag]);
+format_error(Err) ->
+    io_lib:fwrite("~w", [Err]).

--- a/apps/aecore/src/aec_plugin_xform.erl
+++ b/apps/aecore/src/aec_plugin_xform.erl
@@ -1,6 +1,9 @@
 -module(aec_plugin_xform).
 
 -export([parse_transform/2]).
+
+-ifdef(OTP_RELEASE).
+
 -export([format_error/1]).
 
 parse_transform(Forms, Opts) ->
@@ -26,6 +29,15 @@ parse_transform(Forms, Opts) ->
         Errors ->
             {error, Errors, []}
     end.
+
+-else.
+
+parse_transform(Forms, _) ->
+    Forms.
+
+-endif.
+
+-ifdef(OTP_RELEASE). Support functions
 
 find_pluggable(Forms) ->
     {Blocks, Forms1} = pluggable_blocks(Forms),  % may insert error forms
@@ -218,3 +230,5 @@ format_error({unterminated_pluggable_block, Tag}) ->
     io_lib:format("Unterminated 'pluggable' block: ~p", [Tag]);
 format_error(Err) ->
     io_lib:fwrite("~w", [Err]).
+
+-endif.

--- a/apps/aecore/src/aec_plugin_xform.erl
+++ b/apps/aecore/src/aec_plugin_xform.erl
@@ -37,7 +37,7 @@ parse_transform(Forms, _) ->
 
 -endif.
 
--ifdef(OTP_RELEASE). Support functions
+-ifdef(OTP_RELEASE). %% Support functions
 
 find_pluggable(Forms) ->
     {Blocks, Forms1} = pluggable_blocks(Forms),  % may insert error forms

--- a/apps/aecore/src/aec_plugin_xform.erl
+++ b/apps/aecore/src/aec_plugin_xform.erl
@@ -1,0 +1,123 @@
+-module(aec_plugin_xform).
+
+-export([parse_transform/2]).
+
+
+parse_transform(Forms, Opts) ->
+    Ctxt = parse_trans:initial_context(Forms, Opts),
+    Mod = parse_trans:context(module, Ctxt),
+    Pluggable = find_pluggable(Forms),
+    F = fun(Form) -> pt(Form, Pluggable) end,
+    NewForms0 = plain_transform(F, Forms),
+    LastL = get_pos(lists:last(NewForms0)),
+    NewForms = append_form(choice_f(Mod, LastL+1), NewForms0),
+    NewForms.
+
+find_pluggable(Forms) ->
+    lists:foldl(
+      fun({attribute,_,pluggable,Fs}, Acc) ->
+              Fs ++ Acc;
+         (_, Acc) ->
+              Acc
+      end, [], Forms).
+
+pt({function,L,Fun,Arity,Clauses} = Form, Pluggable) ->
+    case lists:member({Fun,Arity}, Pluggable) of
+        true ->
+            Args0 = args(Arity, L),
+            %% F0 = list_to_atom(atom_to_list(Fun) ++ "___i"),
+            Clauses1 = [{clause, L, Args0, [],
+                         [{'case',L,
+                           {call,L,{atom,L,'--is_plugged--'},
+                            [{atom,L,Fun}, {integer,L,Arity}]},
+                           [{clause,L,[{atom,L,false}], [],
+                             [{'case',L,{tuple,L,Args0},
+                               [{clause,L1,[{tuple,L1,As}],Gs,B}
+                                || {clause,L1,As,Gs,B} <- Clauses]}
+                             ]},
+                            {clause,L,[{tuple,L,[{atom,L,true},
+                                                 {var,L,'__M__'}]}],
+                             [],
+                             [{call,L,{remote,L,{var,L,'__M__'},{atom,L,Fun}},
+                               Args0}]}]}]
+                        }],
+            {function,L,Fun,Arity,Clauses1};
+             %% {function,L,F0, Arity,Clauses}];
+        false ->
+            Form
+    end;
+pt(Form, _) ->
+    Form.
+
+args(N, L) ->
+    [{var,L,v(X)} || X <- lists:seq(1,N)].
+
+v(X) ->
+    list_to_atom("$V_" ++ integer_to_list(X)).
+
+choice_f(Mod, L) ->
+    {function,L,'--is_plugged--',2,
+     [{clause,L,
+       [{var,L,'Fun'},{var,L,'Arity'}],
+       [],
+       [{'case',L,
+         {call,L,
+          {remote,L,{atom,L,aec_plugin},{atom,L,get_module}},
+          [{atom,L,Mod}]},
+         [{clause,L,[{atom,L,undefined}],[],[{atom,L,false}]},
+          {clause,L,
+           [{var,L,'NewMod'}],
+           [],
+           [{'case',L,
+             {call,L,{remote,L,{atom,L,erlang},{atom,L,function_exported}},
+              [{var,L,'NewMod'},{var,L,'Fun'},{var,L,'Arity'}]},
+             [{clause,L,[{atom,L,true}],[],
+               [{tuple,L,[{atom,L,true},{var,L,'NewMod'}]}]},
+              {clause,L,[{atom,L,false}],[],
+               [{atom,L,false}]}
+              ]}
+            ]}
+          ]}
+        ]}
+     ]}.
+
+%% Modified version of parse_trans:plain_transform/2
+%%
+plain_transform(Fun, Forms) when is_function(Fun, 1), is_list(Forms) ->
+    plain_transform1(Fun, Forms).
+
+plain_transform1(_, []) ->
+    [];
+plain_transform1(Fun, [F|Fs]) when element(1,F) == error ->
+    [F|plain_transform1(Fun, Fs)];
+plain_transform1(Fun, [F|Fs]) when is_atom(element(1,F)) ->
+    case Fun(F) of
+        skip ->
+            plain_transform1(Fun, Fs);
+        continue ->
+            [list_to_tuple(plain_transform1(Fun, tuple_to_list(F))) |
+             plain_transform1(Fun, Fs)];
+        {done, NewF} ->
+            [NewF | Fs];
+        NewF when is_tuple(NewF) ->
+            %% includes error tuples
+            [NewF | plain_transform1(Fun, Fs)];
+        NewFs when is_list(NewFs) ->
+            NewFs ++ plain_transform1(Fun, Fs)
+    end;
+plain_transform1(Fun, [L|Fs]) when is_list(L) ->
+    [plain_transform1(Fun, L) | plain_transform1(Fun, Fs)];
+plain_transform1(Fun, [F|Fs]) ->
+    [F | plain_transform1(Fun, Fs)];
+plain_transform1(_, F) ->
+    F.
+
+get_pos(F) when is_list(F) ->
+    parse_trans:get_pos(F);
+get_pos(Form) ->
+    element(2, Form).
+
+append_form(F, Forms) ->
+    [{eof,_}|RevForms] = lists:reverse(Forms),
+    NewLastPos = get_pos(F),
+    lists:reverse(RevForms) ++ [F,{eof,NewLastPos+1}].

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -14,6 +14,18 @@
 -define(GENESIS_VERSION, aec_block_genesis:version()).
 -define(GENESIS_TIME, aec_block_genesis:time_in_msecs()).
 
+%% If OTP 21 or later, a parse transform (aec_plugin_xform) will modify
+%% the code so that what would previously result in a function_clause exception,
+%% will instead become a case_clause. While this should not be seen as API-breaking
+%% it does break some tests in this EUnit suite.
+%%
+-ifdef(OTP_RELEASE).
+-define(EXCEPTION, {case_clause, _}).
+-else.
+-define(EXCEPTION, function_clause).
+-endif.
+
+
 network_key_serialization_test() ->
     Header = raw_key_header(),
     SerializedHeader = ?TEST_MODULE:serialize_to_binary(Header),
@@ -324,14 +336,14 @@ validate_test_() ->
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_nonce(Header0, -1),
-              ?assertError(case_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
+              ?assertError(?EXCEPTION, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, true),
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_nonce(Header0, 16#1ffffffffffffffff),
-              ?assertError(case_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
+              ?assertError(?EXCEPTION, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               Header = ?TEST_MODULE:set_version_and_height(

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -324,14 +324,14 @@ validate_test_() ->
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_nonce(Header0, -1),
-              ?assertError(function_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
+              ?assertError(case_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               meck:expect(aec_mining, verify, 4, true),
               Header0 = ?TEST_MODULE:set_version_and_height(
                            raw_key_header(), ?GENESIS_VERSION, ?GENESIS_HEIGHT),
               Header = ?TEST_MODULE:set_nonce(Header0, 16#1ffffffffffffffff),
-              ?assertError(function_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
+              ?assertError(case_clause, ?TEST_MODULE:validate_key_block_header(Header, ?GENESIS_VERSION))
       end,
       fun() ->
               Header = ?TEST_MODULE:set_version_and_height(

--- a/apps/aecore/test/aec_plugin_SUITE.erl
+++ b/apps/aecore/test/aec_plugin_SUITE.erl
@@ -1,0 +1,366 @@
+-module(aec_plugin_SUITE).
+
+-export([
+          all/0
+        , groups/0
+        , suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_group/2
+        , end_per_group/2
+        , init_per_testcase/2
+        , end_per_testcase/2
+        ]).
+
+%% test case exports
+
+-export([
+          registration/1
+        , compile_unpluggable/1
+        , compile_pluggable_export_all/1
+        , compile_pluggable_begin_end/1
+        , compile_pluggable_begin_no_end/1
+        , compile_pluggable_overlap/1
+        ]).
+
+-define(TMOD, plugin_test_module).
+
+-include_lib("common_test/include/ct.hrl").
+
+%%%===================================================================
+%%% Common test framework
+%%%===================================================================
+
+all() ->
+    [{group, all_tests}].
+
+groups() ->
+    [
+     {all_tests, [sequence], [{group, plugin}]},
+     {plugin,
+      [ registration
+      , compile_unpluggable
+      , compile_pluggable_export_all
+      , compile_pluggable_begin_end
+      , compile_pluggable_begin_no_end
+      , compile_pluggable_overlap
+      %% , pluggable_all
+      %% , pluggable_all_export_all
+      %% , pluggable_singles
+      %% , pluggable_blocks
+      ]}
+    ].
+
+suite() ->
+    [].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Grp, Config) ->
+    Config.
+
+end_per_group(_Grp, _Config) ->
+    ok.
+
+init_per_testcase(_TC, Config) ->
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    ok.
+
+%%%===================================================================
+
+
+registration(_Cfg) ->
+    case system_major_vsn() >= 21 of
+        true ->
+            real_registration();
+        false ->
+            legacy_registration()
+    end,
+    ok.
+
+real_registration() ->
+    undefined = aec_plugin:get_module(aec_headers),
+    ok = aec_plugin:register(#{aec_headers => ?MODULE}),
+    ?MODULE = aec_plugin:get_module(aec_headers),
+    ok.
+
+legacy_registration() ->
+    undefined = aec_plugin:get_module(aec_headers),
+    ok = aec_plugin:register(#{aec_headers => ?MODULE}),
+    ?MODULE = aec_plugin:get_module(aec_headers),
+    ok.
+
+compile_unpluggable(_Cfg) ->
+    compile_tmod(plain).
+
+compile_pluggable_export_all(_Cfg) ->
+    compile_tmod(pluggable_export_all).
+
+compile_pluggable_begin_end(_Cfg) ->
+    compile_tmod(pluggable_begin_end).
+
+compile_pluggable_begin_no_end(_Cfg) ->
+    compile_tmod(pluggable_begin_no_end, error).
+
+compile_pluggable_overlap(_Cfg) ->
+    compile_tmod(pluggable_overlap, error).
+
+compile_tmod(Tag) ->
+    compile_tmod(Tag, ok).
+
+compile_tmod(Tag, Expect) ->
+    {Fs, Forms} = forms(Tag),
+    case compile_tmod(Tag, Forms, Expect) of
+        {ok, Abst, _} ->
+            true = are_pluggable(Fs, Abst),
+            ok;
+        expected_error ->
+            ok
+    end.
+
+compile_tmod(Tag, Forms, Expect) ->
+    Src = [erl_pp:form(F) || F <- Forms],
+    case {compile:forms(Forms, [{parse_transform, aec_plugin_xform},
+                                return_errors, return_warnings, binary, debug_info]),
+          Expect} of
+        {{ok, ?TMOD, Bin, []}, ok} ->
+            {ok,{?TMOD,[{abstract_code,{raw_abstract_v1,Abst}}]}} =
+                beam_lib:chunks(Bin, [abstract_code]),
+            ct:log("Abst = ~p", [Abst]),
+            {ok, Abst, Bin};
+        {{error, Errors, Warnings}, _} ->
+            ct:log("Errors returned: ~p~n(Warnings = ~p)", [Errors, Warnings]),
+            list_errors(Errors),
+            case Expect of
+                ok ->
+                    error(errors);
+                error ->
+                    expected_error
+            end;
+        Other ->
+            ct:log("Other = ~p~n"
+                   "Tag   = ~p~n"
+                   "Forms = ~p~n"
+                   "Src:~n~s", [Other, Tag, Forms, Src]),
+            error(compile_error_or_warning)
+    end.
+
+system_major_vsn() ->
+    try list_to_integer(erlang:system_info(otp_release))
+    catch
+        error:_ ->
+            0
+    end.
+
+forms(pluggable_export_all = T) ->
+    Forms0 = plain_forms(T),
+    Pred = fun({attribute,_,export,_}) -> true end,
+    Forms = insert_forms(Forms0, Pred,
+                         [{attribute,1,pluggable,all_exported}], []),
+    ct:log("Forms0 = ~p~n"
+           "Forms  = ~p", [Forms0, Forms]),
+    {[{f1,0},{f2,1}], Forms};
+forms(pluggable_begin_end = T) ->
+    Forms0 = plain_forms(T),
+    Pred = fun({attribute,_,export,[{f1,0}]}) -> true end,
+    Forms = insert_forms(Forms0, Pred,
+                         [{attribute,1,pluggable_begin,f1}],
+                         [{attribute,1,pluggable_end  ,f1}]),
+    ct:log("Forms0 = ~p~n"
+           "Forms  = ~p", [Forms0, Forms]),
+    {[{f1,0}], Forms};
+forms(pluggable_begin_no_end = T) ->
+    Forms0 = plain_forms(T),
+    Pred = fun({attribute,_,export,[{f1,0}]}) -> true end,
+    Forms = insert_forms(Forms0, Pred,
+                         [{attribute,1,pluggable_begin, f1}],
+                         []),
+    {[], Forms};
+forms(pluggable_overlap = T) ->
+    Forms0 = plain_forms(T),
+    Pred = fun({attribute,_,export,[{f1,0}]}) -> true end,
+    Forms = insert_forms(Forms0, Pred,
+                         [{attribute,1,pluggable_begin, f1}],
+                         [{attribute,1,pluggable_begin, f2},
+                          {attribute,1,pluggable_end  , f1}]),
+    Pred1 = fun({attribute,_,export,[{f2,0}]}) -> true end,
+    Forms1 = insert_forms(Forms, Pred1,
+                          [],
+                          [{attribute,1,pluggable_end, f2}]),
+    {[], Forms1};
+forms(plain) ->
+    {[], plain_forms(plain)}.
+
+plain_forms(Tag) when is_atom(Tag) ->
+    [ {attribute,1,file,{erl_fname(?TMOD),1}}
+    , {attribute,2,module,?TMOD}
+    , {attribute,3,export,[{f1,0}]}
+    , {attribute,4,export,[{f2,1}]}
+    , {function,5,f1,0,
+       [{clause,5,[],[],[{tuple,5,[{atom,5,?TMOD},
+                                   {atom,5,Tag},
+                                   {atom,5,f1}]}]}]}
+    , {function,6,f2,1,
+       [{clause,6,[{var,6,'_'}],[],[{tuple,6,[{atom,6,?TMOD},
+                                              {atom,6,Tag},
+                                              {atom,6,f1}]}]}]}
+    , {eof,7}
+    ].
+
+erl_fname(Mod) ->
+    atom_to_list(Mod) ++ ".erl".
+
+insert_forms([F|Fs] = Forms, Pred, Bef, Aft) ->
+    case pred(Pred, F) of
+        True when True == true; element(1, True) == true ->
+            L = line(F),
+            N = get_n(True),
+            {Between, Tail} = lists:split(N, Forms),
+            {Bef1, L1} = renumber(Bef, L),
+            {Between1, L2} = renumber(Between, L1+1),
+            {Aft1, L3} = renumber(Aft, L2+1),
+            {Tail1 , _ } = renumber(Tail, L3+1),
+            Bef1 ++ Between1 ++ Aft1 ++ Tail1;
+        false ->
+            [F | insert_forms(Fs, Pred, Bef, Aft)]
+    end;
+insert_forms([], _, _, _) ->
+    [].
+
+pred(P, F) ->
+    try P(F)
+    catch
+        error:_ ->
+            false
+    end.
+
+line(F) when is_tuple(F) ->
+    element(2, F).
+
+get_n(true) ->
+    1;
+get_n({true, N}) when is_integer(N), N > 0 ->
+    N.
+
+renumber(Fs, L) when is_list(Fs) ->
+    lists:mapfoldl(fun set_line/2, L, Fs).
+
+set_line({attribute,_,file,{F,_}}, L) ->
+    {{attribute,L,file,{F,L}}, L+1};
+set_line({attribute,_,A,Fs}, L) ->
+    {{attribute,L,A,Fs}, L+1};
+set_line({function,_,F,A,Cs}, L) ->
+    {Cs1, L1} = renumber_exprs(Cs, L),
+    {{function,L,F,A,Cs1}, L1};
+set_line(F, L) when tuple_size(F) >= 2 ->
+    {setelement(2, F, L), L+1};
+set_line(F, L) ->
+    {F, L}.
+
+renumber_exprs(Es, L) ->
+    renumber_exprs(Es, L, []).
+
+renumber_exprs([E|Es], L, Acc) ->
+    {E1, L1, Le} =
+        if is_list(E) ->
+                {Ex, Lx} =
+                    lists:mapfoldl(fun renumber_expr_/2, L, E),
+                {Ex, Lx, next_l(E, L)};
+           is_tuple(E) ->
+                {E1x, L1x} = set_line(E, L),
+                {E2x, L2x} = renumber_expr_t(E1x, L1x),
+                {E2x, L2x, line(E)};
+           true ->
+                {E, L, L}
+        end,
+    NextL = case next_l(Es, Le) of
+                Le -> L1;
+                Ln -> L1+1 + (Ln-Le)
+            end,
+    renumber_exprs(Es, NextL, [E1|Acc]);
+renumber_exprs([], L, Acc) ->
+    {lists:reverse(Acc), L}.
+
+renumber_expr_(E, L) ->
+    if is_list(E) ->
+            renumber_exprs(E, L);
+       is_tuple(E) ->
+            {E1x, L1x} = set_line(E, L),
+            renumber_expr_t(E1x, L1x);
+       true ->
+            {E, L}
+    end.
+
+next_l([F|_], _) when is_tuple(F) ->
+    line(F);
+next_l([Fs|_], Def) when is_list(Fs) ->
+    next_l(Fs, Def);
+next_l(_, Def) ->
+    Def.
+
+renumber_expr_t(E, L) when is_tuple(E) ->
+    {E1, L1} =
+        renumber_exprs(tuple_to_list(E), L),
+    {list_to_tuple(E1), L1}.
+
+list_errors(Errs) ->
+    lists:foreach(
+      fun({F, Es}) ->
+              list_errors(F, Es)
+      end, Errs).
+
+%% Copied (modified) from compile.erl
+%% list_errors(File, ErrorDescriptors) -> ok
+
+list_errors(F, [{none,Mod,E}|Es]) ->
+    ct:log("~ts: ~ts\n", [F,Mod:format_error(E)]),
+    list_errors(F, Es);
+list_errors(F, [{{Line,Column},Mod,E}|Es]) ->
+    ct:log("~ts:~w:~w: ~ts\n", [F,Line,Column,Mod:format_error(E)]),
+    list_errors(F, Es);
+list_errors(F, [{Line,Mod,E}|Es]) ->
+    ct:log("~ts:~w: ~ts\n", [F,Line,Mod:format_error(E)]),
+    list_errors(F, Es);
+list_errors(F, [{Mod,E}|Es]) ->
+    %% Not documented and not expected to be used any more, but
+    %% keep a while just in case.
+    ct:log("~ts: ~ts\n", [F,Mod:format_error(E)]),
+    list_errors(F, Es);
+list_errors(_F, []) -> ok.
+
+are_pluggable(Fs, Forms) ->
+    lists:all(
+      fun({F,A}) ->
+              case get_function_clauses(F, A, Forms) of
+                  error ->
+                      ct:log("Cannot find ~p", [{F,A}]),
+                      false;
+                  Cs ->
+                      is_pluggable(Cs)
+              end
+      end, Fs).
+
+get_function_clauses(F,A, Forms) ->
+    case [Cs || {function,_,Fx,Ax,Cs} <- Forms,
+                Fx == F, Ax == A] of
+        [Found] ->
+            Found;
+        [] ->
+            error
+    end.
+
+is_pluggable({call,_,{atom,_,'--is_plugged--'},_}) ->
+    true;
+is_pluggable(Cs) when is_list(Cs) ->
+    lists:any(fun is_pluggable/1, Cs);
+is_pluggable(C) when is_tuple(C) ->
+    is_pluggable(tuple_to_list(C));
+is_pluggable(_) ->
+    false.
+                       


### PR DESCRIPTION
A PR against #3292 

As requested, a parse_transform acting on `-pluggable([f/1, g/2])` attributes instead. The core code then can remain untouched.