### PR TITLE
Remove integration sync triggers from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1151,16 +1151,6 @@ jobs:
           path: docs/state-channels
       - *fail_notification
 
-  integration_sync:
-    executor: infrastructure_container_unstable
-    steps:
-      - checkout
-      - run:
-          name: Integration sync
-          command: |
-            cd /infrastructure && DEPLOY_ENV=integration_sync make mnesia-reset-once
-      - *fail_notification
-
   # Windows jobs
   windows_package:
     <<: *windows_container
@@ -1781,16 +1771,3 @@ workflows:
                 - *master_branch
     jobs:
       - docker_system_tests
-
-  integration_sync:
-    triggers:
-      - schedule:
-          # run at midnight and noon UTC
-          cron: "0 0,12 * * *"
-          filters:
-            branches:
-              only:
-                - *master_branch
-    jobs:
-      - integration_sync:
-          context: ae-node-builds


### PR DESCRIPTION
Because the context does not work with a schedule as we expected.