### PR TITLE
Swagger validator URL has changed #3324

### DIFF
--- a/apps/aehttp/test/aehttp_spec_SUITE.erl
+++ b/apps/aehttp/test/aehttp_spec_SUITE.erl
@@ -79,7 +79,7 @@ get_api(Config) ->
 validate_api(Config) ->
     Spec = json_from_yaml(Config),
 
-    Url = "http://validator.swagger.io/validator/",
+    Url = "https://validator.swagger.io/validator/",
     case httpc:request(post, {Url, [],  "application/json", Spec}, [], []) of
         {ok, {{_, 200, _}, _Headers, Body}} ->
             %% For manual verification visit https://github.com/swagger-api/validator-badge


### PR DESCRIPTION
The location of validator needs to be passed as https://validator.swagger.io/validator/ (instead of http). So that is the largest PR I ever made :).
P.S. I suggest to relocate this public endpoint to the appropriate config (it's should be visible to understand our behaviour from the external world perspective).