### PR TITLE
External endpoint: /peers/connected

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -74,7 +74,8 @@
          httpc_request/4,
          process_http_return/1,
          internal_address/0,
-         external_address/0
+         external_address/0,
+         external_address/1
         ]).
 
 -export([generate_key_pair/0]).
@@ -866,7 +867,7 @@ config_apply_options(Node, Cfg, [OptNodesCfg | T]) when is_map(OptNodesCfg) ->
                #{Node := OptNodeCfg} -> maps_merge(Cfg, OptNodeCfg);
                #{} -> Cfg
            end,
-    config_apply_options(Node, Cfg, T).
+    config_apply_options(Node, Cfg1, T).
 
 
 write_keys(Node, Config) ->
@@ -1194,9 +1195,12 @@ internal_address() ->
     "http://127.0.0.1:" ++ integer_to_list(Port).
 
 external_address() ->
-    Port = rpc(aeu_env, user_config_or_env,
-              [ [<<"http">>, <<"external">>, <<"port">>],
-                aehttp, [external, port], 8043]),
+    external_address(?DEFAULT_NODE).
+
+external_address(Node) ->
+    Port = rpc(Node, aeu_env, user_config_or_env,
+               [ [<<"http">>, <<"external">>, <<"port">>],
+                 aehttp, [external, port], 8043]),
     "http://127.0.0.1:" ++ integer_to_list(Port).     % good enough for requests
 
 rpc(Mod, Fun, Args) ->

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -932,6 +932,31 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/PeerPubKey'
+  /peers/connected:
+    get:
+      tags:
+        - external
+        - node_info
+      operationId: GetConnectedPeers
+      description: 'Get a list of connected peers'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: type
+          description: 'Connection type: inbound, outbound or all'
+          required: false
+          type: string
+          enum: [inbound, outbound, all]
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/ConnectedPeers'
+        '400':
+          description: 'Invalid connection type'
+          schema:
+            $ref: '#/definitions/Error'
   /status:
     get:
       tags:
@@ -2542,6 +2567,28 @@ definitions:
         $ref: '#/definitions/EncodedPubkey'
     required:
       - pub_key
+  ConnectedPeers:
+    type: object
+    properties:
+      connected_peers:
+        type: array
+        items:
+          $ref: '#/definitions/ConnectedPeer'
+    required:
+      - connected_peers
+  ConnectedPeer:
+    type: object
+    properties:
+      pubkey:
+        $ref: '#/definitions/EncodedPubkey'
+      host:
+        type: string
+      port:
+        $ref: '#/definitions/UInt32'
+      required:
+        - pub_key
+        - host
+        - port
   Status:
     type: object
     properties:


### PR DESCRIPTION
See issue #3357 

There _is_ an internal endpoint, `/debug/peers`, which basically returns the same thing (at least the pubkeys of connected peers).
I added an external endpoint which returns an array of objects, currently containing `pub_key`, `host` and `port` of the relevant peers.

Example, from the new test `aehttp_integration_SUITE:get_connected_peers/1`:
```erlang
connected_peers (dev1) = [{default,
                              {ok,200,
                                  #{<<"connected_peers">> =>
                                        [#{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3025,
                                           <<"pub_key">> =>
                                               <<"pp_23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5">>},
                                         #{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3035,
                                           <<"pub_key">> =>
                                               <<"pp_2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R">>}]}}},
                          {all,
                              {ok,200,
                                  #{<<"connected_peers">> =>
                                        [#{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3025,
                                           <<"pub_key">> =>
                                               <<"pp_23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5">>},
                                         #{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3035,
                                           <<"pub_key">> =>
                                               <<"pp_2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R">>}]}}},
                          {inbound,
                              {ok,200,
                                  #{<<"connected_peers">> =>
                                        [#{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3025,
                                           <<"pub_key">> =>
                                               <<"pp_23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5">>},
                                         #{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3035,
                                           <<"pub_key">> =>
                                               <<"pp_2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R">>}]}}},
                          {outbound,
                              {ok,200,
                                  #{<<"connected_peers">> =>
                                        [#{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3025,
                                           <<"pub_key">> =>
                                               <<"pp_23YdvfRPQ1b1AMWmkKZUGk2cQLqygQp55FzDWZSEUicPjhxtp5">>},
                                         #{<<"host">> => <<"localhost">>,
                                           <<"port">> => 3035,
                                           <<"pub_key">> =>
                                               <<"pp_2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R">>}]}}}]
```

I added a three-node configuration for the `peer_endpoints` test group, in preparation for further tests. Also, the peer pool persistence issue (#3356) may warrant other parameters for each peer, which could be added to the result.