### PR TITLE
Fix OSX build failures because of Python2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -916,7 +916,7 @@ jobs:
 
   osx_package:
     macos:
-      xcode: "10.1.0" # 10.0.0 is macOS 10.13.6
+      xcode: "10.1.0" # 10.1.0 is macOS 10.13.6
     working_directory: ~/aeternity
     steps:
       - checkout
@@ -1488,7 +1488,12 @@ workflows:
                 - env/dev2
                 - system-tests
 
-      - osx_package: {}
+      - osx_package:
+          filters:
+            branches:
+              only:
+                - /releases\/.*/
+                - *master_branch
 
       - deploy_integration:
           context: ae-node-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1487,12 +1487,7 @@ workflows:
                 - env/dev2
                 - system-tests
 
-      - osx_package:
-          filters:
-            branches:
-              only:
-                - /releases\/.*/
-                - *master_branch
+      - osx_package: {}
 
       - deploy_integration:
           context: ae-node-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -916,7 +916,7 @@ jobs:
 
   osx_package:
     macos:
-      xcode: "10.0.0" # 10.0.0 is macOS 10.13.6
+      xcode: "10.1.0" # 10.0.0 is macOS 10.13.6
     working_directory: ~/aeternity
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,6 +926,7 @@ jobs:
           # libsodium headers cannot be found without explicit brew link
           command: |
             brew update
+            brew rm python@2
             brew install gmp libsodium erlang@21
             brew link gmp
             brew link libsodium


### PR DESCRIPTION
Apparently OTP21 results in cascading upgrades of Python and then - upgrade of Python 2, the latter of which - failing. This PR removes Python2 altogether. No Python2 - no problem.

You can see Circle CI being happy about it here:

https://app.circleci.com/pipelines/github/aeternity/aeternity/6802/workflows/22c17042-471b-4696-9ab1-3df4489e9eff/jobs/122653

I've also updated Xcode to 10.1 so there are less warnings in the console