### PR TITLE
Aesophia rebar plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -108,7 +108,10 @@
 
        ]}.
 
-{plugins, [{swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "d5a9f07"}}}]}.
+{plugins, [
+        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "d5a9f07"}}},
+        {aesophia_rebar_plugin, {git, "https://github.com/aeternity/aesophia_rebar_plugin", {ref, "df113cc"}}}
+    ]}.
 
 {swagger_endpoints, [{src, "apps/aehttp/priv/swagger.yaml"}, {dst, "apps/aeutils/src/endpoints.erl"}]}.
 


### PR DESCRIPTION
This PR adds a rebar plugin for interacting with the sophia compiler when building the node.
This will be used in the build system of hyperchains.

The plugin introduces 2 neat operations:
- Compile and generate the ACI:
```
./rebar3 aesophia -c contract.aes -o result.json
```
- Verify the contract bytecode:
```
./rebar3 aesophia -c contract.aes -o result.json -v
```