### PR TITLE
Verified peer downgrade on first down

### DIFF
--- a/apps/aecore/src/aec_peers_pool.erl
+++ b/apps/aecore/src/aec_peers_pool.erl
@@ -644,9 +644,9 @@ select(St, Now, PeerId) ->
 %% again before some time has passed. The time the peer will stay on standby
 %% depends on the number of time it got rejected.
 %%
-%% If the peer reached the maximum number of rejections, it is downgraded to
-%% the unverified pool if verified, or removed completely if unverified; the
-%% rejection counter is reset when downgrading.
+%% If the peer is verified, it is downgraded to the unverified pool; if it is
+%% unverified - the rejection counter is increased; if an unverified peer
+%% reaches the maximum counter of rejections, one is removed completely
 -spec reject(state(), millitimestamp(), peer_id()) -> state().
 reject(St, Now, PeerId) ->
     reject_peer(St, Now, PeerId).

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -766,41 +766,8 @@ test_connection_down() ->
     ?assertEqual(1, aec_peers:count(unverified)),
     ?assertEqual(1, aec_peers:count(standby)),
 
-    % Check first retry.
-    {ok, Conn2} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 400),
-    ok = conn_peer_connected(Conn2),
-    conn_kill(Conn2),
-
-    ?assertMatch([], aec_peers:connected_peers()),
-    ?assertMatch([Peer], aec_peers:get_random(all)),
-    ?assertMatch({error, _}, aec_peers:get_connection(Id)),
-
-    ?assertEqual(0, aec_peers:count(connections)),
-    ?assertEqual(1, aec_peers:count(verified)),
-    ?assertEqual(0, aec_peers:count(unverified)),
-    ?assertEqual(1, aec_peers:count(standby)),
-
-    % Check second retry.
-    {ok, Conn3} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 500),
-    ok = conn_peer_connected(Conn3),
-    conn_kill(Conn3),
-
-    ?assertMatch([], aec_peers:connected_peers()),
-    ?assertMatch([Peer], aec_peers:get_random(all)),
-    ?assertMatch({error, _}, aec_peers:get_connection(Id)),
-
-    ?assertEqual(0, aec_peers:count(connections)),
-    ?assertEqual(1, aec_peers:count(verified)),
-    ?assertEqual(0, aec_peers:count(unverified)),
-    ?assertEqual(1, aec_peers:count(standby)),
-
-    % Check last retry.
-    {ok, Conn4} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 500),
-    ok = conn_peer_connected(Conn4),
-    conn_kill(Conn4),
-
     % Peer is downgraded to the unverified pool, and retried.
-    {ok, Conn5} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 200),
+    {ok, Conn2} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 200),
 
     ?assertMatch([], aec_peers:connected_peers()),
     ?assertMatch([], aec_peers:get_random(all)),
@@ -814,13 +781,7 @@ test_connection_down() ->
     % Killing the connection before calling peer_connected
     % so the peer stay unverified.
 
-    conn_kill(Conn5),
-
-    {ok, Conn6} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 400),
-    conn_kill(Conn6),
-
-    {ok, Conn7} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 500),
-    conn_kill(Conn7),
+    conn_kill(Conn2),
 
     ?assertMatch([], aec_peers:connected_peers()),
     ?assertMatch([], aec_peers:get_random(all)),
@@ -831,10 +792,22 @@ test_connection_down() ->
     ?assertEqual(1, aec_peers:count(unverified)),
     ?assertEqual(1, aec_peers:count(standby)),
 
-    % Last retry of unverified peer, should be removed.
 
-    {ok, Conn8} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 500),
-    conn_kill(Conn8),
+    {ok, Conn3} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 400),
+    conn_kill(Conn3),
+    ?assertMatch([], aec_peers:connected_peers()),
+    ?assertMatch([], aec_peers:get_random(all)),
+    ?assertMatch({error, _}, aec_peers:get_connection(Id)),
+
+    ?assertEqual(0, aec_peers:count(connections)),
+    ?assertEqual(0, aec_peers:count(verified)),
+    ?assertEqual(1, aec_peers:count(unverified)),
+    ?assertEqual(1, aec_peers:count(standby)),
+
+
+    % Last retry of unverified peer, should be removed.
+    {ok, Conn4} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 500),
+    conn_kill(Conn4),
 
     ?assertMatch([], aec_peers:connected_peers()),
     ?assertMatch([], aec_peers:get_random(all)),

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -806,6 +806,7 @@ test_connection_down() ->
 
 
     % Last retry of unverified peer, should be removed.
+    % This depends on max_rejections = 3 in the setup
     {ok, Conn4} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey }], {ok, _}, 500),
     conn_kill(Conn4),
 

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -300,11 +300,12 @@ start_blocked_second(Config) ->
 
     %% Check that there is only one non-blocked peer (dev3) and no connected peers
     NonBlocked = rpc:call(N1, aec_peers, get_random, [all], 5000),
+    Standby = rpc:call(N1, aec_peers, count, [standby], 5000),
     Connected  = rpc:call(N1, aec_peers, connected_peers, [], 5000),
     ct:log("Non-blocked peers on dev1: ~p", [NonBlocked]),
     ct:log("Connected peers on dev1: ~p", [Connected]),
     [] = Connected,
-    [_] = NonBlocked,
+    1 = Standby,
 
     %% Also check that they have different top blocks
     B1 = rpc:call(N1, aec_chain, top_block, [], 5000),

--- a/docs/release-notes/next/verified_peer_downgrade.md
+++ b/docs/release-notes/next/verified_peer_downgrade.md
@@ -1,0 +1,9 @@
+* Improves sync's peer propagation: peers are split into verified and
+  unverified. We had allowed a grace period for peers to be down while the
+  node still considers them as verified and broadcasts them as such. Once a
+  verified peer is being detected as down, it enters a standby state that
+  allows them to stay verified.
+  This PR tightens the process - once a peer is being detected to be
+  unreachable - it is being downgraded from verified to unverified
+  immedeately. The processing of unverified being deleted is left unchanged -
+  they still enter the standby mode for a few times before being removed.

--- a/docs/release-notes/next/verified_peer_downgrade.md
+++ b/docs/release-notes/next/verified_peer_downgrade.md
@@ -5,5 +5,5 @@
   allows them to stay verified.
   This PR tightens the process - once a peer is being detected to be
   unreachable - it is being downgraded from verified to unverified
-  immedeately. The processing of unverified being deleted is left unchanged -
+  immediately. The processing of unverified being deleted is left unchanged -
   they still enter the standby mode for a few times before being removed.


### PR DESCRIPTION
Part of #3290 

Peers are either `verified` or `unverified`. Nodes broadcast only `verified` peers to other nodes.

Once a peer is `verified` it is sort of hard to downgrade to `unverified` - even if the node detects it is down, it enters a `standby` state which gracefully allows it to return online. By default a peer stays `verified` for 7 consecutive failures to respond, only then it is being marked as `unverified`. Then it stays for 7 more rejects before it is deleted. That's how a node is still broadcasting missing peers even it had detected they were down.

This PR implements a more radical approach - if we receive a rejection to a TCP probe or the connection to the peer drops - the node downgrades the peer to unverified immediately. The `trusted` peers are not downgraded ever and the processing of `unverified` peers is left unchanged.

The parallelisation of checks would be addressed in a different PR.

This PR had been supported by AE Foundation