### PR TITLE
Allow Chain.block_hash for current generation in FATE VM 2

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -263,6 +263,12 @@
         false -> ?assertMatch(__Exp, __Res)
     end).
 
+-define(assertMatchFATE(__ExpVm1, __ExpVm2, __Res),
+    case vm_version() of
+        ?VM_FATE_SOPHIA_1 -> ?assertMatch(__ExpVm1, __Res);
+        ?VM_FATE_SOPHIA_2 -> ?assertMatch(__ExpVm2, __Res)
+    end).
+
 -define(assertMatchVM(AEVM, FATE, Res),
     case ?IS_AEVM_SOPHIA(vm_version()) of
         true  -> ?assertMatch(AEVM, Res);
@@ -6725,8 +6731,9 @@ fate_environment(_Cfg) ->
     %% Block hash is mocked to return the height if it gets a valid height
     %% since we don't have a chain.
     BHHeight = 1000,
-    ?assertEqual(none, ?call(call_contract, Acc, Contract, block_hash, {option, word}, {BHHeight},
-                          #{height => BHHeight})),
+    %% Behavior at current height changed in FATE_VM2.
+    ?assertMatchFATE(none, {some, {bytes, <<BBHeight:256>>}},
+        ?call(call_contract, Acc, Contract, block_hash, {option, word}, {BHHeight}, #{height => BHHeight})),
     ?assertEqual(none, ?call(call_contract, Acc, Contract, block_hash, {option, word}, {BHHeight + 1},
                           #{height => BHHeight})),
     ?assertEqual(none, ?call(call_contract, Acc, Contract, block_hash, {option, word}, {BHHeight - 256},

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -1123,9 +1123,12 @@ blockhash(Arg0, Arg1, ES) ->
         {?FATE_INTEGER_VALUE(N), ES1} when ?IS_FATE_INTEGER(N) ->
             GenesisHeight = aec_block_genesis:height(),
             API = aefa_engine_state:chain_api(ES1),
+            VMVsn = aefa_engine_state:vm_version(ES1),
             CurrentHeight = aefa_chain_api:generation(API),
             case (N < GenesisHeight orelse
-                  N >= CurrentHeight orelse
+                  %% BlockHash at current height available from FATE VM version 2
+                  (N == CurrentHeight andalso VMVsn < ?VM_FATE_SOPHIA_2) orelse
+                  N > CurrentHeight orelse
                   N =< CurrentHeight - 256) of
                 true ->
                     write(Arg0, aeb_fate_data:make_variant([0, 1], 0, {}), ES1);

--- a/docs/release-notes/next-iris/AENS_sophia.md
+++ b/docs/release-notes/next-iris/AENS_sophia.md
@@ -4,3 +4,7 @@
   set to 0, from `VM_FATE_SOPHIA_2` it has the correct value.
 * Fixed bug in `AENS.resolve` in FATE VM - for invalid names `VM_FATE_SOPHIA_1`
   will crash. From `VM_FATE_SOPHIA_2` it will not crash, rather return `None`.
+* Changed `Chain.block_hash` - in `VM_FATE_SOPHIA_2` it will return
+  `Some(<blockhash>)` for `Chain.block_height` (i.e. current generation)
+  previously it returned `None`. With Bitcoin-NG we do have the block hash of
+  the current generation, so no reason not to allow this.


### PR DESCRIPTION
This solves #3002 

This PR is supported by the Æternity Crypto Foundation 