### PR TITLE
Improve block insertion time

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1169,10 +1169,6 @@ db_get_header(Hash) when is_binary(Hash) ->
     {value, Header} =  aec_db:find_header(Hash),
     Header.
 
-dirty_db_get_header(Hash) when is_binary(Hash) ->
-    {value, Header} =  aec_db:dirty_find_header(Hash),
-    Header.
-
 db_find_key_nodes_at_height(Height) when is_integer(Height) ->
     case aec_db:find_headers_and_hash_at_height(Height) of
         [_|_] = Headers ->

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -75,6 +75,9 @@
 
 -module(aec_chain_state).
 
+%% Let's not add another entry to the supervision tree
+-on_load(setup_etc_cache/0).
+
 -export([ calculate_state_for_new_keyblock/4
         , find_common_ancestor/2
         , get_key_block_hash_at_height/1
@@ -287,6 +290,45 @@ set_top_block_hash(H, State) when is_binary(H) -> State#{top_block_hash => H}.
               , type   :: block_type()
               }).
 
+%% Cache for block insertion
+%% For performance reasons an valid cache entry MUST be connected to genesis
+%% Ensuring this removes an additional read query to the db
+%% When the window reaches max capacity(as defined by the consensus engine)
+%% then the cache for the oldest block in the window gets evicted - this ensures that the
+%% amount of memory consumed by the ?RECENT_CACHE is bounded
+%% When the window size is N then we cache N^2 headers
+%% Orphaned key blocks will leak memory - fortunately leaking memory will require PoW
+%% TODO: periodically remove orphans from ram
+-define(RECENT_CACHE, aec_chain_state_cache).
+-record(recent_blocks, { key :: binary()
+                       %% window of last N keyheaders newest first
+                       , recent_key_headers :: [aec_headers:header()]
+                       %% current length of the header window
+                       , len :: non_neg_integer()
+                       }).
+
+recent_cache_n() ->
+    max(aec_governance:key_blocks_to_check_difficulty_count() + 1, aec_governance:median_timestamp_key_blocks()).
+
+%% Insertion context - cached data used during block insertion
+-record(insertion_ctx, {
+        %% window of last N keyheaders newest first
+        window_len = undefined :: non_neg_integer() | undefined,
+        recent_key_headers = undefined :: [aec_headers:header()] | undefined,
+        prev_node = undefined :: #node{} | undefined,
+        prev_key_node = undefined :: #node{} | undefined
+    }).
+
+%% Should hard crash when not enough headers are present
+ctx_get_n_key_headers(#insertion_ctx{window_len = L, recent_key_headers = Headers}, N) when L >= N ->
+    ctx_get_n_key_headers(Headers, N, []).
+
+ctx_get_n_key_headers(_, 0, Acc) -> Acc;
+ctx_get_n_key_headers([H|T], N, Acc) -> ctx_get_n_key_headers(T, N-1, [H|Acc]).
+
+ctx_prev(#insertion_ctx{prev_node = PrevNode}) -> PrevNode.
+ctx_prev_key(#insertion_ctx{prev_key_node = PrevKeyNode}) -> PrevKeyNode.
+
 hash(#node{hash = Hash}) -> Hash.
 
 prev_hash(#node{header = H}) -> aec_headers:prev_hash(H).
@@ -440,17 +482,27 @@ hash_is_in_main_chain(Hash, TopHash) ->
 %%%-------------------------------------------------------------------
 
 internal_insert(Node, Block, Origin) ->
-    case db_find_node(hash(Node)) of
+    case dirty_db_find_node(hash(Node)) of
         error ->
+            %% Build the insertion context using dirty reads to the DB and possibly
+            %% The ets cache, the insertion context depends on the type of block being inserted
+            InsertCtx = case ets:lookup(?RECENT_CACHE, prev_key_hash(Node)) of
+                            [C] -> build_insertion_ctx(Node, node_type(Node), C);
+                            [] -> build_insertion_ctx(Node, node_type(Node), undefined)
+                        end,
             %% To preserve the invariants of the chain,
             %% Only add the block if we can do the whole
             %% transitive operation (i.e., calculate all the state
             %% trees, and update the pointers)
             Fun = fun() ->
-                          internal_insert_transaction(Node, Block, Origin)
+                          internal_insert_transaction(Node, Block, Origin, InsertCtx)
                   end,
             try
-                aec_db:ensure_transaction(Fun)
+                case InsertCtx of
+                    {error, _} = Err -> Err;
+                    _ ->
+                        aec_db:ensure_transaction(Fun)
+                end
             catch
                 exit:{aborted, {throw, ?internal_error(What)}} ->
                     {error, What}
@@ -461,7 +513,69 @@ internal_insert(Node, Block, Origin) ->
             {error, {same_key_different_content, Node, Old}}
     end.
 
-internal_insert_transaction(Node, Block, Origin) ->
+%% Builds the insertion context from cached data and the node to insert
+%% Please note that this is called in dirty context
+build_insertion_ctx(Node, micro, undefined) ->
+    % Microblocks only require the prev node and prev_key_node for validation
+    {PrevNode, PrevKeyNode} = build_insertion_ctx_prev(Node, []),
+    #insertion_ctx{ prev_key_node = PrevKeyNode
+                  , prev_node = PrevNode };
+build_insertion_ctx(Node, micro, #recent_blocks{recent_key_headers = RecentKeyHeaders}) ->
+    {PrevNode, PrevKeyNode} = build_insertion_ctx_prev(Node, RecentKeyHeaders),
+    #insertion_ctx{ prev_key_node = PrevKeyNode
+                  , prev_node = PrevNode };
+build_insertion_ctx(Node, key, undefined) ->
+    Height        = node_height(Node),
+    GenesisHeight = aec_block_genesis:height(),
+    N = min(Height-GenesisHeight, recent_cache_n()),
+    case get_n_key_headers_from(Node, N+1) of
+        {ok, H} ->
+            [_|RecentKeyHeaders] = lists:reverse(H),
+            {PrevNode, PrevKeyNode} = build_insertion_ctx_prev(Node, RecentKeyHeaders),
+            #insertion_ctx{ prev_key_node = PrevKeyNode
+                          , prev_node = PrevNode
+                          , window_len = N
+                          , recent_key_headers = RecentKeyHeaders };
+        _ ->
+            %% This may only happen if this is an orphan block
+            {error, {illegal_orphan, hash(Node)}}
+    end;
+build_insertion_ctx(Node, key, #recent_blocks{recent_key_headers = RecentKeyHeaders, len = N}) ->
+    {PrevNode, PrevKeyNode} = build_insertion_ctx_prev(Node, RecentKeyHeaders),
+    #insertion_ctx{ prev_key_node = PrevKeyNode
+                  , prev_node = PrevNode
+                  , window_len = N
+                  , recent_key_headers = RecentKeyHeaders }.
+
+build_insertion_ctx_prev(Node, []) ->
+    PrevNode = ctx_db_get_node(prev_hash(Node)),
+    PrevKeyNode = case PrevNode of
+                       undefined -> ctx_db_get_node(prev_key_hash(Node));
+                       _ ->
+                           case node_type(PrevNode) of
+                               key -> PrevNode;
+                               _ -> ctx_db_get_node(prev_key_hash(Node))
+                           end
+                   end,
+    {PrevNode, PrevKeyNode};
+build_insertion_ctx_prev(Node, [PrevKeyHeader|_]) ->
+    PrevKeyHash = prev_key_hash(Node),
+    PrevKeyNode = #node{hash = PrevKeyHash, header = PrevKeyHeader, type = key},
+    PrevNode = case prev_hash(Node) of
+                   PrevKeyHash ->
+                       PrevKeyNode;
+                   H ->
+                       ctx_db_get_node(H)
+               end,
+    {PrevNode, PrevKeyNode}.
+
+ctx_db_get_node(H) ->
+    case dirty_db_find_node(H) of
+        error -> undefined;
+        {ok, R} -> R
+    end.
+
+internal_insert_transaction(Node, Block, Origin, Ctx) ->
     State1 = new_state_from_persistence(),
     assert_not_new_genesis(Node, State1),
     State2 = maybe_add_pof(maybe_add_genesis_hash(State1, Node), Block),
@@ -470,22 +584,21 @@ internal_insert_transaction(Node, Block, Origin) ->
             ok;
         false ->
             assert_not_illegal_fork_or_orphan(Node, Origin, State2),
-            PrevNode = db_get_node(prev_hash(Node)),
-            assert_previous_height(PrevNode, Node),
-            assert_previous_key_block_hash(PrevNode, Node),
+            assert_previous_height(Node, Ctx),
+            assert_previous_key_block_hash(Node, Ctx),
             case node_type(Node) of
                 key ->
-                    KeyHeaders = assert_key_block_time_return_headers(Node),
-                    assert_key_block_target(Node, KeyHeaders),
+                    assert_key_block_time(Node, Ctx),
+                    assert_key_block_target(Node, Ctx),
                     maybe_put_signal_count(Block, hash(Node), aeu_env:get_env(aecore, fork, undefined));
                 micro ->
-                    assert_micro_block_time(PrevNode, Node),
-                    assert_micro_signature(PrevNode, Node),
-                    assert_micro_pof(PrevNode, Node, Block)
+                    assert_micro_block_time(Node, Ctx),
+                    assert_micro_signature(Node, Ctx),
+                    assert_micro_pof(Block, Ctx)
             end
     end,
     ok = db_put_node(Block, hash(Node)),
-    {State3, Events} = update_state_tree(Node, State2),
+    {State3, Events} = update_state_tree(Node, State2, Ctx),
     persist_state(State3),
     case maps:get(found_pof, State3) of
         no_fraud  -> {ok, Events};
@@ -493,14 +606,10 @@ internal_insert_transaction(Node, Block, Origin) ->
     end.
 
 assert_not_illegal_fork_or_orphan(Node, Origin, State) ->
-    case node_is_genesis(Node, State) of
-        true -> ok;
-        false ->
-            assert_connection_to_chain(Node),
-            case Origin of
-                sync -> ok;
-                undefined -> assert_height_delta(Node, State)
-            end
+    assert_connection_to_chain(Node),
+    case Origin of
+        sync -> ok;
+        undefined -> assert_height_delta(Node, State)
     end.
 
 assert_connection_to_chain(Node) ->
@@ -519,7 +628,8 @@ assert_height_delta(Node, State) ->
     end.
 
 %% NG-INFO: micro blocks inherit the height from the last key block
-assert_previous_height(PrevNode, Node) ->
+assert_previous_height(Node, Ctx) ->
+    PrevNode = ctx_prev(Ctx),
     case is_key_block(Node) of
         true ->
             case node_height(PrevNode) =:= (node_height(Node) - 1) of
@@ -533,7 +643,8 @@ assert_previous_height(PrevNode, Node) ->
             end
     end.
 
-assert_previous_key_block_hash(PrevNode, Node) ->
+assert_previous_key_block_hash(Node, Ctx) ->
+    PrevNode = ctx_prev(Ctx),
     case is_key_block(PrevNode) of
         true ->
             case hash(PrevNode) =:= prev_key_hash(Node) of
@@ -549,50 +660,27 @@ assert_previous_key_block_hash(PrevNode, Node) ->
 
 %% To assert key block target calculation we need DeltaHeight headers counted
 %% backwards from the node we want to assert.
-assert_key_block_target(Node, Headers) ->
-    case db_find_node(prev_hash(Node)) of
-        error -> ok;
-        {ok, PrevNode} ->
-            Delta         = aec_governance:key_blocks_to_check_difficulty_count() + 1,
-            Height        = node_height(Node),
-            GenesisHeight = aec_block_genesis:height(),
-            case Delta >= Height - GenesisHeight of
-                true ->
-                    %% We only need to verify that the target is equal to its predecessor.
-                    assert_target_equal_to_prev(Node, PrevNode);
-                false ->
-                    assert_calculated_target(Node, PrevNode, Delta, Headers)
-            end
-    end.
+assert_key_block_target(Node, Ctx) ->
+        Delta         = aec_governance:key_blocks_to_check_difficulty_count() + 1,
+        Height        = node_height(Node),
+        GenesisHeight = aec_block_genesis:height(),
+        case Delta >= Height - GenesisHeight of
+            true ->
+                %% We only need to verify that the target is equal to its predecessor.
+                assert_target_equal_to_prev(Node, Ctx);
+            false ->
+                assert_calculated_target(Node, Delta, Ctx)
+        end.
 
-assert_target_equal_to_prev(Node, PrevNode) ->
-    PrevKeyNode = case is_key_block(PrevNode) of
-                      true  ->
-                          PrevNode;
-                      false ->
-                          KeyHash = prev_key_hash(PrevNode),
-                          {ok, KeyNode} = db_find_node(KeyHash),
-                          KeyNode
-                  end,
+assert_target_equal_to_prev(Node, Ctx) ->
+    PrevKeyNode = ctx_prev_key(Ctx),
     case {node_target(Node), node_target(PrevKeyNode)} of
         {X, X} -> ok;
         {X, Y} -> internal_error({target_not_equal_to_parent, Node, X, Y})
     end.
 
-assert_calculated_target(Node, PrevNode, Delta, HeadersIn) ->
-    {ok, Headers} =
-        case length(HeadersIn) of
-            0 ->
-                get_n_key_headers_from(PrevNode, Delta);
-            N when N == Delta ->
-                {ok, HeadersIn};
-            N when N > Delta ->
-                {ok, lists:nthtail(N - Delta, HeadersIn)};
-            N when N < Delta ->
-                NextHash = aec_headers:prev_key_hash(hd(HeadersIn)),
-                NextNode = db_get_node(NextHash),
-                get_n_key_headers_from({ok, NextNode}, Delta - N, HeadersIn)
-        end,
+assert_calculated_target(Node, Delta, Ctx) ->
+    Headers = ctx_get_n_key_headers(Ctx, Delta),
     case aec_target:verify(node_header(Node), Headers) of
         ok -> ok;
         {error, {wrong_target, Actual, Expected}} ->
@@ -604,7 +692,7 @@ get_n_key_headers_from(Node, N) ->
         key   ->
             get_n_key_headers_from({ok, Node}, N, []);
         micro ->
-            get_n_key_headers_from(db_find_node(prev_key_hash(Node)), N, [])
+            get_n_key_headers_from(dirty_db_find_node(prev_key_hash(Node)), N, [])
     end.
 
 get_n_key_headers_from(_, 0, Acc) ->
@@ -612,36 +700,32 @@ get_n_key_headers_from(_, 0, Acc) ->
 get_n_key_headers_from({ok, Node}, N, Acc) ->
     %% Assert
     key = node_type(Node),
-    MaybePrevKeyNode = db_find_node(prev_key_hash(Node)),
+    MaybePrevKeyNode = dirty_db_find_node(prev_key_hash(Node)),
     get_n_key_headers_from(MaybePrevKeyNode, N-1, [node_header(Node) | Acc]);
 get_n_key_headers_from(error, _N, _Acc) ->
     error.
 
-assert_key_block_time_return_headers(Node) ->
+assert_key_block_time(Node, Ctx) ->
     Time = node_time(Node),
-    case median_timestamp_and_headers(Node) of
-        {ok, Median, Headers} when Time > Median -> Headers;
-        {ok,_Median,_Headers} -> internal_error(key_block_from_the_past)
+    case median_timestamp(Node, Ctx) of
+        {ok, Median} when Time > Median -> ok;
+        {ok,_Median} -> internal_error(key_block_from_the_past)
     end.
 
 %% Compute the median timestamp for last aec_governance:median_timestamp_key_blocks()
-median_timestamp_and_headers(Node) ->
+median_timestamp(Node, Ctx) ->
     TimeStampKeyBlocks = aec_governance:median_timestamp_key_blocks(),
     case node_height(Node) =< TimeStampKeyBlocks of
         true ->
-            {ok, aec_block_genesis:time_in_msecs(), []};
+            {ok, aec_block_genesis:time_in_msecs()};
         false ->
-            PrevKeyNode = db_get_node(prev_key_hash(Node)),
-            case get_n_key_headers_from(PrevKeyNode, TimeStampKeyBlocks) of
-                {ok, Headers} ->
-                    Times = [aec_headers:time_in_msecs(H) || H <- Headers],
-                    {ok, median(Times), Headers};
-                error ->
-                    error
-            end
+            Headers = ctx_get_n_key_headers(Ctx, TimeStampKeyBlocks),
+            Times = [aec_headers:time_in_msecs(H) || H <- Headers],
+            {ok, median(Times)}
     end.
 
-assert_micro_block_time(PrevNode, Node) ->
+assert_micro_block_time(Node, Ctx) ->
+    PrevNode = ctx_prev(Ctx),
     case is_micro_block(Node) of
         true ->
             case is_micro_block(PrevNode) of
@@ -662,46 +746,31 @@ assert_micro_block_time(PrevNode, Node) ->
 time_diff_greater_than_minimal(Node, PrevNode) ->
     node_time(Node) >= node_time(PrevNode) + aec_governance:micro_block_cycle().
 
-assert_micro_signature(PrevNode, Node) ->
-    case is_micro_block(Node) of
-        true ->
-            {ok, KeyNode} =
-                case node_type(PrevNode) of
-                    key   -> {ok, PrevNode};
-                    micro -> db_find_node(prev_key_hash(Node))
-                end,
-            case aeu_sig:verify(node_header(Node), node_miner(KeyNode)) of
-                ok         -> ok;
-                {error, _} -> internal_error(signature_verification_failed)
-            end;
-        false ->
-            ok
+assert_micro_signature(Node, Ctx) ->
+    case aeu_sig:verify(node_header(Node), node_miner(ctx_prev_key(Ctx))) of
+        ok         -> ok;
+        {error, _} -> internal_error(signature_verification_failed)
     end.
 
-assert_micro_pof(PrevNode, Node, Block) ->
-    case is_micro_block(Node) of
-        false ->
+assert_micro_pof(Block, Ctx) ->
+    case aec_blocks:pof(Block) of
+        no_fraud ->
             ok;
-        true ->
-            case aec_blocks:pof(Block) of
-                no_fraud ->
+        Pof ->
+            FraudNode = get_fraud_node(Ctx),
+            case aec_pof:pubkey(Pof) =:= node_miner(FraudNode) of
+                true ->
                     ok;
-                Pof ->
-                    FraudNode = get_fraud_node(PrevNode, Node),
-                    case aec_pof:pubkey(Pof) =:= node_miner(FraudNode) of
-                        true ->
-                            ok;
-                        false ->
-                            internal_error(wrong_pubkey_in_pof)
-                    end
+                false ->
+                    internal_error(wrong_pubkey_in_pof)
             end
     end.
 
-get_fraud_node(PrevNode, Node) ->
+get_fraud_node(Ctx) ->
+    PrevNode = ctx_prev(Ctx),
     case node_type(PrevNode) of
         micro ->
-            PrevKey = db_get_node(prev_key_hash(Node)),
-            db_get_node(prev_key_hash(PrevKey));
+            ctx_prev_key(Ctx);
         key ->
             db_get_node(prev_key_hash(PrevNode))
     end.
@@ -712,10 +781,10 @@ get_fraud_node(PrevNode, Node) ->
                    , fraud
                    }).
 
-update_state_tree(Node, State) ->
+update_state_tree(Node, State, Ctx) ->
     {ok, Trees, ForkInfoIn} = get_state_trees_in(Node, State),
     {ForkInfo, MicSibHeaders} = maybe_set_new_fork_id(Node, ForkInfoIn, State),
-    State1 = update_found_pof(Node, MicSibHeaders, State),
+    State1 = update_found_pof(Node, MicSibHeaders, State, Ctx),
     {State2, NewTopDifficulty, Events} = update_state_tree(Node, Trees, ForkInfo, State1),
     OldTopHash = get_top_block_hash(State),
     handle_top_block_change(OldTopHash, NewTopDifficulty, Events, State2).
@@ -764,7 +833,7 @@ get_state_trees_in(Node, State) ->
                     %% For key blocks, reset:
                     %% 1. Fees, to accumulate new fees for generation
                     %% 2. Fraud, since a new generation starts fresh
-                    case node_type(db_get_node(PrevHash)) of
+                    case node_type(db_get_node(prev_hash(Node))) of
                         key   -> {ok, Trees, ForkInfo#fork_info{fees = 0,
                                                                 fraud = false}};
                         micro -> {ok, Trees, ForkInfo}
@@ -817,7 +886,7 @@ handle_top_block_change(OldTopHash, NewTopDifficulty, Events, State) ->
                     {ok, OldTopDifficulty} = db_find_difficulty(OldTopHash),
                     case OldTopDifficulty >= NewTopDifficulty of
                         true ->
-                            State1 =set_top_block_hash(OldTopHash, State), %% Reset
+                            State1 = set_top_block_hash(OldTopHash, State), %% Reset
                             {State1, Events};
                         false ->
                             State1 = update_main_chain(OldTopHash, NewTopHash,
@@ -1070,12 +1139,22 @@ db_find_node(Hash) when is_binary(Hash) ->
         none -> error
     end.
 
+dirty_db_find_node(Hash) when is_binary(Hash) ->
+    case aec_db:dirty_find_header(Hash) of
+        {value, Header} -> {ok, wrap_header(Header, Hash)};
+        none -> error
+    end.
+
 db_get_node(Hash) when is_binary(Hash) ->
     {ok, Node} = db_find_node(Hash),
     Node.
 
 db_get_header(Hash) when is_binary(Hash) ->
     {value, Header} =  aec_db:find_header(Hash),
+    Header.
+
+dirty_db_get_header(Hash) when is_binary(Hash) ->
+    {value, Header} =  aec_db:dirty_find_header(Hash),
     Header.
 
 db_find_key_nodes_at_height(Height) when is_integer(Height) ->
@@ -1186,17 +1265,16 @@ match_prev_at_height(Height, PrevHash, Hash) ->
                H =/= Hash,
                aec_headers:prev_hash(Header) =:= PrevHash].
 
-update_found_pof(Node, MicroSibHeaders, State) ->
-    State#{found_pof => maybe_pof(Node, MicroSibHeaders)}.
+update_found_pof(Node, MicroSibHeaders, State, Ctx) ->
+    State#{found_pof => maybe_pof(Node, MicroSibHeaders, Ctx)}.
 
-maybe_pof(_Node, []) ->
+maybe_pof(_Node, [], _Ctx) ->
     no_fraud;
-maybe_pof(Node, MicroSibHeaders) ->
+maybe_pof(Node, MicroSibHeaders, Ctx) ->
     case node_type(Node) of
         key -> no_fraud;
         micro ->
-            PrevKeyHash = prev_key_hash(Node),
-            Miner = node_miner(db_get_node(PrevKeyHash)),
+            Miner = node_miner(ctx_prev_key(Ctx)),
             [Header| _] = MicroSibHeaders,
             aec_pof:new(node_header(Node), Header, Miner)
     end.
@@ -1310,3 +1388,27 @@ fork_result(Count, #{signalling_block_count := SigCount}) when Count >= SigCount
     true;
 fork_result(_Count, _Fork) ->
     false.
+
+setup_etc_cache() ->
+    %% Lager might not be up so don't bother with logging
+    Self = self(),
+    Tab = ?RECENT_CACHE,
+    Keypos = #recent_blocks.key,
+    case ets:info(Tab, name) of
+        undefined ->
+            spawn(fun() ->
+                ets:new(Tab, [set, public, named_table, {keypos, Keypos}]),
+                Self ! cache_ready,
+                timer:sleep(infinity)
+            end),
+            receive
+                cache_ready ->
+                    ok
+            after
+                3000 ->
+                    exit(timeout)
+            end;
+        _ ->
+            ok
+    end,
+    ok.

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -306,7 +306,7 @@ set_top_block_hash(H, State) when is_binary(H) -> State#{top_block_hash => H}.
                        %% window of last N keyheaders newest first
                        %% All but the first header in this list is stripped
                        %% Invariant: {ok, key} = calulate_hash(hd(recent_key_headers))
-                       , recent_key_headers :: [aec_headers:header() | any()]
+                       , recent_key_headers :: [aec_headers:header() | term()]
                        %% current length of the header window
                        , len :: non_neg_integer()
                        }).
@@ -326,7 +326,7 @@ recent_cache_trim_header(Header) ->
         %% window of last N keyheaders newest first
         window_len = undefined :: non_neg_integer() | undefined,
         %% Recent key headers -> ALWAYS stripped
-        recent_key_headers = undefined :: [aec_headers:header()] | undefined,
+        recent_key_headers = undefined :: [term()] | undefined,
         prev_node = undefined :: #node{} | undefined,
         prev_key_node = undefined :: #node{} | undefined
     }).

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -238,9 +238,34 @@ reinit_chain_state() ->
     exit(whereis(aec_tx_pool), kill),
     aec_tx_pool:await_tx_pool(),
     ok.
+
+reinit_chain_impl(State1 = #state{ consensus = Cons }) ->
+    %% NOTE: ONLY FOR TEST
+    ok = reinit_chain_state(),
+    TopBlockHash = aec_chain:top_block_hash(),
+    TopKeyBlockHash = aec_chain:top_key_block_hash(),
+    State2 = State1#state{top_block_hash = TopBlockHash,
+                          top_key_block_hash = TopKeyBlockHash},
+    State =
+        case State2#state.mining_state of
+            stopped  ->
+                State2;
+            running ->
+                epoch_mining:info("Mining stopped"),
+                State3 = kill_all_workers(State2),
+                hard_reset_block_generator(),
+                epoch_mining:info("Mining started" ++ print_opts(State3)),
+                start_mining_(State3#state{mining_state = running,
+                                           micro_block_candidate = undefined,
+                                           key_block_candidates = undefined,
+                                           consensus = Cons#consensus{leader = false}})
+        end,
+    {reply, ok, State}.
 -else.
-reinit_chain_state() ->
-    error("DISABLED outside testing env").
+reinit_chain_impl(State) ->
+    epoch_mining:error("Received unknown request: ~p", [reinit_chain]),
+    Reply = ok,
+    {reply, Reply, State}.
 -endif.
 
 handle_call({add_synced_block, Block},_From, State) ->
@@ -292,28 +317,8 @@ handle_call(get_mining_workers, _From, State) ->
     {reply, worker_pids_by_tag(mining, State), State};
 handle_call(is_leader, _From, State = #state{ consensus = Cons }) ->
     {reply, Cons#consensus.leader, State};
-handle_call(reinit_chain, _From, State1 = #state{ consensus = Cons }) ->
-    %% NOTE: ONLY FOR TEST
-    ok = reinit_chain_state(),
-    TopBlockHash = aec_chain:top_block_hash(),
-    TopKeyBlockHash = aec_chain:top_key_block_hash(),
-    State2 = State1#state{top_block_hash = TopBlockHash,
-                          top_key_block_hash = TopKeyBlockHash},
-    State =
-        case State2#state.mining_state of
-            stopped  ->
-                State2;
-            running ->
-                epoch_mining:info("Mining stopped"),
-                State3 = kill_all_workers(State2),
-                hard_reset_block_generator(),
-                epoch_mining:info("Mining started" ++ print_opts(State3)),
-                start_mining_(State3#state{mining_state = running,
-                                           micro_block_candidate = undefined,
-                                           key_block_candidates = undefined,
-                                           consensus = Cons#consensus{leader = false}})
-        end,
-    {reply, ok, State};
+handle_call(reinit_chain, _From, State) ->
+    reinit_chain_impl(State);
 handle_call(Request, _From, State) ->
     epoch_mining:error("Received unknown request: ~p", [Request]),
     Reply = ok,
@@ -1157,6 +1162,7 @@ is_leader(NewTopBlock) ->
         {error, _}     -> false
     end.
 
+-ifdef(TEST).
 hard_reset_block_generator() ->
     %% Hard reset of aec_block_generator
     exit(whereis(aec_block_generator), kill),
@@ -1169,6 +1175,7 @@ flush_candidate() ->
     after 10 ->
             ok
     end.
+-endif.
 
 setup_loop(State = #state{ consensus = Cons }, RestartMining, IsLeader, Origin) ->
     State1 = State#state{ consensus = Cons#consensus{ leader = IsLeader } },

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -563,49 +563,49 @@ find_block_state_and_data(Hash) ->
     end.
 
 find_oracles_node(Hash) ->
-    case ?t(mnesia:read(aec_oracle_state, Hash)) of
+    case mnesia:dirty_read(aec_oracle_state, Hash) of
         [#aec_oracle_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_oracles_cache_node(Hash) ->
-    case ?t(mnesia:read(aec_oracle_cache, Hash)) of
+    case mnesia:dirty_read(aec_oracle_cache, Hash) of
         [#aec_oracle_cache{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_calls_node(Hash) ->
-    case ?t(mnesia:read(aec_call_state, Hash)) of
+    case mnesia:dirty_read(aec_call_state, Hash) of
         [#aec_call_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_channels_node(Hash) ->
-    case ?t(mnesia:read(aec_channel_state, Hash)) of
+    case mnesia:dirty_read(aec_channel_state, Hash) of
         [#aec_channel_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_contracts_node(Hash) ->
-    case ?t(mnesia:read(aec_contract_state, Hash)) of
+    case mnesia:dirty_read(aec_contract_state, Hash) of
         [#aec_contract_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_ns_node(Hash) ->
-    case ?t(mnesia:read(aec_name_service_state, Hash)) of
+    case mnesia:dirty_read(aec_name_service_state, Hash) of
         [#aec_name_service_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_ns_cache_node(Hash) ->
-    case ?t(mnesia:read(aec_name_service_cache, Hash)) of
+    case mnesia:dirty_read(aec_name_service_cache, Hash) of
         [#aec_name_service_cache{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_accounts_node(Hash) ->
-    case ?t(mnesia:read(aec_account_state, Hash)) of
+    case mnesia:dirty_read(aec_account_state, Hash) of
         [#aec_account_state{value = Node}] -> {value, Node};
         [] -> none
     end.

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -37,6 +37,7 @@
          find_block_tx_hashes/1,
          find_discovered_pof/1,
          find_header/1,
+         dirty_find_header/1,
          find_headers_at_height/1,
          find_headers_and_hash_at_height/1,
          find_key_block/1,
@@ -408,6 +409,13 @@ find_key_block(Hash) ->
 -spec find_header(binary()) -> 'none' | {'value', aec_headers:header()}.
 find_header(Hash) ->
     case ?t(mnesia:read(aec_headers, Hash)) of
+        [#aec_headers{value = DBHeader}] -> {value, aec_headers:from_db_header(DBHeader)};
+        [] -> none
+    end.
+
+-spec dirty_find_header(binary()) -> 'none' | {'value', aec_headers:header()}.
+dirty_find_header(Hash) ->
+    case mnesia:dirty_read(aec_headers, Hash) of
         [#aec_headers{value = DBHeader}] -> {value, aec_headers:from_db_header(DBHeader)};
         [] -> none
     end.

--- a/apps/aecore/src/aec_target.erl
+++ b/apps/aecore/src/aec_target.erl
@@ -79,11 +79,23 @@ recalculate(PrevHeaders0) ->
     NewTargetInt             = TemperedTST * K div (DesiredTimeBetweenBlocks * SumKDivTargets),
     min(?HIGHEST_TARGET_SCI, aeminer_pow:integer_to_scientific(NewTargetInt)).
 
--spec verify(aec_headers:header(), nonempty_list(aec_headers:header())) ->
+recalculate_from_stripped(TimesAndTargets) ->
+    N                        = aec_governance:key_blocks_to_check_difficulty_count(),
+    N                        = length(TimesAndTargets) - 1, %% Sanity check.
+    K                        = aeminer_pow:scientific_to_integer(?HIGHEST_TARGET_SCI) * (1 bsl 32),
+    SumKDivTargets           = lists:sum([ K div aeminer_pow:scientific_to_integer(Target)
+                                           || {_, Target, _} <- tl(TimesAndTargets) ]),
+    DesiredTimeBetweenBlocks = aec_governance:expected_block_mine_rate(),
+    TotalSolveTime           = total_solve_time_from_stripped(TimesAndTargets),
+    TemperedTST              = (3 * N * DesiredTimeBetweenBlocks) div 4 + (2523 * TotalSolveTime) div 10000,
+    NewTargetInt             = TemperedTST * K div (DesiredTimeBetweenBlocks * SumKDivTargets),
+    min(?HIGHEST_TARGET_SCI, aeminer_pow:integer_to_scientific(NewTargetInt)).
+
+-spec verify(aec_headers:header(), nonempty_list({binary(), non_neg_integer(), non_neg_integer()})) ->
           ok | {error, {wrong_target, non_neg_integer(), non_neg_integer()}}.
-verify(Top, PrevHeaders) ->
+verify(Top, TimesAndTargets) ->
     HeaderTarget = aec_headers:target(Top),
-    ExpectedTarget = recalculate(PrevHeaders),
+    ExpectedTarget = recalculate_from_stripped(TimesAndTargets),
     case HeaderTarget == ExpectedTarget of
         true ->
             ok;
@@ -109,3 +121,18 @@ total_solve_time([Hdr2 | [Hdr1 | _] = Hdrs], MinMax = {Min, Max}, Acc) ->
         end,
     total_solve_time(Hdrs, MinMax, Acc + SolveTime).
 
+-spec total_solve_time_from_stripped([aec_headers:header()]) -> integer().
+total_solve_time_from_stripped(TimesAndTargets) ->
+    Min = -aec_governance:accepted_future_block_time_shift(),
+    Max = 6 * aec_governance:expected_block_mine_rate(),
+    total_solve_time_from_stripped(TimesAndTargets, {Min, Max}, 0).
+
+total_solve_time_from_stripped([_], _MinMax, Acc) -> Acc;
+total_solve_time_from_stripped([{_, _, T2} | [{_, _, T1} | _] = TimesAndTargets], MinMax = {Min, Max}, Acc) ->
+    SolveTime0 = T1 - T2,
+    SolveTime =
+        if SolveTime0 < Min -> Min;
+           SolveTime0 > Max -> Max;
+           true             -> SolveTime0
+        end,
+    total_solve_time_from_stripped(TimesAndTargets, MinMax, Acc + SolveTime).

--- a/apps/aecore/src/aec_target.erl
+++ b/apps/aecore/src/aec_target.erl
@@ -91,7 +91,7 @@ recalculate_from_stripped(TimesAndTargets) ->
     NewTargetInt             = TemperedTST * K div (DesiredTimeBetweenBlocks * SumKDivTargets),
     min(?HIGHEST_TARGET_SCI, aeminer_pow:integer_to_scientific(NewTargetInt)).
 
--spec verify(aec_headers:header(), nonempty_list({binary(), non_neg_integer(), non_neg_integer()})) ->
+-spec verify(aec_headers:header(), nonempty_list(term())) ->
           ok | {error, {wrong_target, non_neg_integer(), non_neg_integer()}}.
 verify(Top, TimesAndTargets) ->
     HeaderTarget = aec_headers:target(Top),

--- a/apps/aecore/test/aec_db_tests.erl
+++ b/apps/aecore/test/aec_db_tests.erl
@@ -277,57 +277,5 @@ persisted_database_write_error_test_() ->
                aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
 
                ok
-       end},
-       {"Throughput test inserting a chain with 50 blocks on ram and testing the state transitions",
-       fun() ->
-               %% Setup
-               TotalBlockCount = 50, %% To ensure overlap...
-               InsertTestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
-               ReadTestFun = fun(B) ->
-                   {ok, H} = aec_blocks:hash_internal_representation(B),
-                   aec_db:get_header(H)
-                 end,
-               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
-                Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block},
-                        block_type => key},
-               GenesisHash = aec_db:get_genesis_hash(),
-               try
-                    %% I know it looks bad
-                    aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, undefined}) end),
-                    aec_test_utils:run_throughput_test(InsertTestFun, Blocks, Opts),
-                    aec_test_utils:run_throughput_test(ReadTestFun, Blocks, Opts#{test_fun => {aec_db, get_header}})
-               after
-                   aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, GenesisHash}) end)
-               end,
-               ok
-       end},
-       {"Throughput test inserting a chain with 50 blocks on disc and testing the state transitions",
-       fun() ->
-               %% Setup
-               TotalBlockCount = 50, %% To ensure overlap...
-               InsertTestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
-               ReadTestFun = fun(B) ->
-                   {ok, H} = aec_blocks:hash_internal_representation(B),
-                   aec_db:get_header(H)
-                 end,
-               ForkIdTestFun = fun(B) ->
-                   {ok, H} = aec_blocks:hash_internal_representation(B),
-                   aec_db:find_block_fork_id(H)
-                               end,
-               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
-                Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block},
-                        block_type => key},
-               GenesisHash = aec_db:get_genesis_hash(),
-               try
-                    %% I know it looks bad
-                    aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, undefined}) end),
-                    aec_test_utils:run_throughput_test(InsertTestFun, Blocks, Opts),
-                    aec_test_utils:run_throughput_test(ReadTestFun, Blocks, Opts#{test_fun => {aec_db, get_header}}),
-                    aec_test_utils:run_throughput_test(ForkIdTestFun, Blocks, Opts#{test_fun => {aec_db, find_block_fork_id}})
-               after
-                   aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, GenesisHash}) end)
-               end,
-
-               ok
        end}
      ]}.

--- a/apps/aecore/test/aec_db_tests.erl
+++ b/apps/aecore/test/aec_db_tests.erl
@@ -277,5 +277,57 @@ persisted_database_write_error_test_() ->
                aec_test_utils:run_throughput_test(TestFun, Blocks, Opts),
 
                ok
+       end},
+       {"Throughput test inserting a chain with 50 blocks on ram and testing the state transitions",
+       fun() ->
+               %% Setup
+               TotalBlockCount = 50, %% To ensure overlap...
+               InsertTestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
+               ReadTestFun = fun(B) ->
+                   {ok, H} = aec_blocks:hash_internal_representation(B),
+                   aec_db:get_header(H)
+                 end,
+               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
+                Opts = #{db_mode => ram, test_fun => {aec_chain_state, insert_block},
+                        block_type => key},
+               GenesisHash = aec_db:get_genesis_hash(),
+               try
+                    %% I know it looks bad
+                    aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, undefined}) end),
+                    aec_test_utils:run_throughput_test(InsertTestFun, Blocks, Opts),
+                    aec_test_utils:run_throughput_test(ReadTestFun, Blocks, Opts#{test_fun => {aec_db, get_header}})
+               after
+                   aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, GenesisHash}) end)
+               end,
+               ok
+       end},
+       {"Throughput test inserting a chain with 50 blocks on disc and testing the state transitions",
+       fun() ->
+               %% Setup
+               TotalBlockCount = 50, %% To ensure overlap...
+               InsertTestFun = fun(B) -> {ok, _} = aec_chain_state:insert_block(B) end,
+               ReadTestFun = fun(B) ->
+                   {ok, H} = aec_blocks:hash_internal_representation(B),
+                   aec_db:get_header(H)
+                 end,
+               ForkIdTestFun = fun(B) ->
+                   {ok, H} = aec_blocks:hash_internal_representation(B),
+                   aec_db:find_block_fork_id(H)
+                               end,
+               Blocks = aec_test_utils:gen_blocks_only_chain(TotalBlockCount),
+                Opts = #{db_mode => disc, test_fun => {aec_chain_state, insert_block},
+                        block_type => key},
+               GenesisHash = aec_db:get_genesis_hash(),
+               try
+                    %% I know it looks bad
+                    aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, undefined}) end),
+                    aec_test_utils:run_throughput_test(InsertTestFun, Blocks, Opts),
+                    aec_test_utils:run_throughput_test(ReadTestFun, Blocks, Opts#{test_fun => {aec_db, get_header}}),
+                    aec_test_utils:run_throughput_test(ForkIdTestFun, Blocks, Opts#{test_fun => {aec_db, find_block_fork_id}})
+               after
+                   aec_db:ensure_transaction(fun() -> mnesia:write({aec_chain_state, genesis_hash, GenesisHash}) end)
+               end,
+
+               ok
        end}
      ]}.


### PR DESCRIPTION
Preliminary refactoring of block validation to prepare for a customizable consensus engine.
1. Reduce the consumed IO resources by caching blocks required for target calculation in ram
2. Fail when the block is clearly invalid before starting the DB transaction 
3. Don't write the genesis hash to the db on every single block
4. Remove some unnecessary reads for the previous block/keyblock
5. Better benchmarks

My next PR will move the rest of the header validation logic outside the DB transaction - the validation of keyblocks will be made in the customizable consensus engine.