### PR TITLE
Optional dirty tree backend

### DIFF
--- a/apps/aechannel/src/aesc_state_tree.erl
+++ b/apps/aechannel/src/aesc_state_tree.erl
@@ -16,6 +16,7 @@
          lookup/2,
          mtree_iterator/1,
          new_with_backend/1,
+         new_with_dirty_backend/1,
          root_hash/1]).
 
 -export([ from_binary_without_backend/1
@@ -59,6 +60,9 @@ empty_with_backend() ->
 -spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_backend(Hash) ->
     aeu_mtrees:new_with_backend(Hash, aec_db_backends:channels_backend()).
+
+new_with_dirty_backend(Hash) ->
+    aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_channels_backend()).
 
 -spec enter(channel(), tree()) -> tree().
 enter(Channel, Tree) ->

--- a/apps/aechannel/src/aesc_state_tree.erl
+++ b/apps/aechannel/src/aesc_state_tree.erl
@@ -61,6 +61,7 @@ empty_with_backend() ->
 new_with_backend(Hash) ->
     aeu_mtrees:new_with_backend(Hash, aec_db_backends:channels_backend()).
 
+-spec new_with_dirty_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_dirty_backend(Hash) ->
     aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_channels_backend()).
 

--- a/apps/aecontract/src/aect_call_state_tree.erl
+++ b/apps/aecontract/src/aect_call_state_tree.erl
@@ -74,6 +74,7 @@ new_with_backend(Hash) ->
     CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:calls_backend()),
     #call_tree{calls = CtTree}.
 
+-spec new_with_dirty_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_dirty_backend(Hash) ->
     CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_calls_backend()),
     #call_tree{calls = CtTree}.

--- a/apps/aecontract/src/aect_call_state_tree.erl
+++ b/apps/aecontract/src/aect_call_state_tree.erl
@@ -16,6 +16,7 @@
         , insert_call/2
         , lookup_call/3
         , new_with_backend/1
+        , new_with_dirty_backend/1
         , iterator/1
         , prune/2
         , prune_without_backend/1
@@ -71,6 +72,10 @@ empty_with_backend() ->
 -spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_backend(Hash) ->
     CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:calls_backend()),
+    #call_tree{calls = CtTree}.
+
+new_with_dirty_backend(Hash) ->
+    CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_calls_backend()),
     #call_tree{calls = CtTree}.
 
 %% A new block always starts with an empty calls tree.

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -81,6 +81,7 @@ new_with_backend(Hash) ->
     CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:contracts_backend()),
     #contract_tree{contracts = CtTree}.
 
+-spec new_with_dirty_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_dirty_backend(Hash) ->
     CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_contracts_backend()),
     #contract_tree{contracts = CtTree}.

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -21,6 +21,7 @@
         , lookup_contract/2
         , lookup_contract/3
         , new_with_backend/1
+        , new_with_dirty_backend/1
         , gc_cache/1
         , root_hash/1]).
 
@@ -78,6 +79,10 @@ empty_with_backend() ->
 -spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_backend(Hash) ->
     CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:contracts_backend()),
+    #contract_tree{contracts = CtTree}.
+
+new_with_dirty_backend(Hash) ->
+    CtTree = aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_contracts_backend()),
     #contract_tree{contracts = CtTree}.
 
 -spec gc_cache(tree()) -> tree().

--- a/apps/aecore/src/aec_accounts_trees.erl
+++ b/apps/aecore/src/aec_accounts_trees.erl
@@ -63,6 +63,7 @@ empty_with_backend() ->
 new_with_backend(Hash) ->
     aeu_mtrees:new_with_backend(Hash, aec_db_backends:accounts_backend()).
 
+-spec new_with_dirty_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_dirty_backend(Hash) ->
     aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_accounts_backend()).
 

--- a/apps/aecore/src/aec_accounts_trees.erl
+++ b/apps/aecore/src/aec_accounts_trees.erl
@@ -11,6 +11,7 @@
          get/2,
          lookup/2,
          new_with_backend/1,
+         new_with_dirty_backend/1,
          gc_cache/1,
          enter/2]).
 
@@ -61,6 +62,9 @@ empty_with_backend() ->
 -spec new_with_backend(aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_backend(Hash) ->
     aeu_mtrees:new_with_backend(Hash, aec_db_backends:accounts_backend()).
+
+new_with_dirty_backend(Hash) ->
+    aeu_mtrees:new_with_backend(Hash, aec_db_backends:dirty_accounts_backend()).
 
 -spec gc_cache(tree()) -> tree().
 gc_cache(Tree) ->

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1222,7 +1222,7 @@ db_put_found_pof(Node, PoF) ->
     end.
 
 db_find_state(Hash) ->
-    case aec_db:find_block_state_and_data(Hash) of
+    case aec_db:find_block_state_and_data(Hash, true) of
         {value, Trees, Difficulty, ForkId, Fees, Fraud} ->
             {ok, Trees,
              #fork_info{ difficulty = Difficulty

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -49,7 +49,8 @@
          get_signed_tx/1,
          get_top_block_hash/0,
          get_top_block_height/0,
-         get_block_state/1
+         get_block_state/1,
+         get_block_state/2
         ]).
 
 %% Location of chain transactions
@@ -78,6 +79,14 @@
         , find_ns_cache_node/1
         , find_oracles_node/1
         , find_oracles_cache_node/1
+        , dirty_find_accounts_node/1
+        , dirty_find_calls_node/1
+        , dirty_find_channels_node/1
+        , dirty_find_contracts_node/1
+        , dirty_find_ns_node/1
+        , dirty_find_ns_cache_node/1
+        , dirty_find_oracles_node/1
+        , dirty_find_oracles_cache_node/1
         , write_accounts_node/2
         , write_accounts_node/3
         , write_calls_node/2
@@ -90,11 +99,13 @@
         ]).
 
 -export([ find_block_state/1
+        , find_block_state/2
         , find_block_difficulty/1
         , find_block_fees/1
         , find_block_fork_id/1
         , find_block_fraud_status/1
         , find_block_state_and_data/1
+        , find_block_state_and_data/2
         ]).
 
 %% for testing
@@ -516,16 +527,22 @@ get_top_block_height() ->
     get_chain_state_value(top_block_height).
 
 get_block_state(Hash) ->
+    get_block_state(Hash, false).
+
+get_block_state(Hash, DirtyBackend) ->
     ?t(begin
            [#aec_block_state{value = Trees}] =
                mnesia:read(aec_block_state, Hash),
-           aec_trees:deserialize_from_db(Trees)
+           aec_trees:deserialize_from_db(Trees, DirtyBackend)
        end).
 
 find_block_state(Hash) ->
+    find_block_state(Hash, false).
+
+find_block_state(Hash, DirtyBackend) ->
     case ?t(mnesia:read(aec_block_state, Hash)) of
         [#aec_block_state{value = Trees}] ->
-            {value, aec_trees:deserialize_from_db(Trees)};
+            {value, aec_trees:deserialize_from_db(Trees, DirtyBackend)};
         [] -> none
     end.
 
@@ -554,57 +571,108 @@ find_block_fraud_status(Hash) ->
     end.
 
 find_block_state_and_data(Hash) ->
+    find_block_state_and_data(Hash, false).
+
+find_block_state_and_data(Hash, DirtyBackend) ->
     case ?t(mnesia:read(aec_block_state, Hash)) of
         [#aec_block_state{value = Trees, difficulty = D,
                           fork_id = FId, fees = Fees,
                           fraud = Fraud}] ->
-            {value, aec_trees:deserialize_from_db(Trees), D, FId, Fees, Fraud};
+            {value, aec_trees:deserialize_from_db(Trees, DirtyBackend), D, FId, Fees, Fraud};
         [] -> none
     end.
 
 find_oracles_node(Hash) ->
+    case ?t(mnesia:read(aec_oracle_state, Hash)) of
+        [#aec_oracle_state{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_oracles_node(Hash) ->
     case mnesia:dirty_read(aec_oracle_state, Hash) of
         [#aec_oracle_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_oracles_cache_node(Hash) ->
+    case ?t(mnesia:read(aec_oracle_cache, Hash)) of
+        [#aec_oracle_cache{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_oracles_cache_node(Hash) ->
     case mnesia:dirty_read(aec_oracle_cache, Hash) of
         [#aec_oracle_cache{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_calls_node(Hash) ->
+    case ?t(mnesia:read(aec_call_state, Hash)) of
+        [#aec_call_state{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_calls_node(Hash) ->
     case mnesia:dirty_read(aec_call_state, Hash) of
         [#aec_call_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_channels_node(Hash) ->
+    case ?t(mnesia:read(aec_channel_state, Hash)) of
+        [#aec_channel_state{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_channels_node(Hash) ->
     case mnesia:dirty_read(aec_channel_state, Hash) of
         [#aec_channel_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_contracts_node(Hash) ->
+    case ?t(mnesia:read(aec_contract_state, Hash)) of
+        [#aec_contract_state{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_contracts_node(Hash) ->
     case mnesia:dirty_read(aec_contract_state, Hash) of
         [#aec_contract_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_ns_node(Hash) ->
+    case ?t(mnesia:read(aec_name_service_state, Hash)) of
+        [#aec_name_service_state{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_ns_node(Hash) ->
     case mnesia:dirty_read(aec_name_service_state, Hash) of
         [#aec_name_service_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_ns_cache_node(Hash) ->
+    case ?t(mnesia:read(aec_name_service_cache, Hash)) of
+        [#aec_name_service_cache{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_ns_cache_node(Hash) ->
     case mnesia:dirty_read(aec_name_service_cache, Hash) of
         [#aec_name_service_cache{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 find_accounts_node(Hash) ->
+    case ?t(mnesia:read(aec_account_state, Hash)) of
+        [#aec_account_state{value = Node}] -> {value, Node};
+        [] -> none
+    end.
+
+dirty_find_accounts_node(Hash) ->
     case mnesia:dirty_read(aec_account_state, Hash) of
         [#aec_account_state{value = Node}] -> {value, Node};
         [] -> none

--- a/apps/aecore/src/aec_db_backends.erl
+++ b/apps/aecore/src/aec_db_backends.erl
@@ -15,6 +15,14 @@
         , ns_cache_backend/0
         , oracles_backend/0
         , oracles_cache_backend/0
+        , dirty_accounts_backend/0
+        , dirty_calls_backend/0
+        , dirty_channels_backend/0
+        , dirty_contracts_backend/0
+        , dirty_ns_backend/0
+        , dirty_ns_cache_backend/0
+        , dirty_oracles_backend/0
+        , dirty_oracles_cache_backend/0
         ]).
 
 %% Callbacks for aeu_mp_trees_db
@@ -31,34 +39,65 @@
 accounts_backend() ->
     aeu_mp_trees_db:new(db_spec(accounts)).
 
+-spec dirty_accounts_backend() -> aeu_mp_trees_db:db().
+dirty_accounts_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_accounts)).
+
 -spec calls_backend() -> aeu_mp_trees_db:db().
 calls_backend() ->
     aeu_mp_trees_db:new(db_spec(calls)).
+
+-spec dirty_calls_backend() -> aeu_mp_trees_db:db().
+dirty_calls_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_calls)).
 
 -spec channels_backend() -> aeu_mp_trees_db:db().
 channels_backend() ->
     aeu_mp_trees_db:new(db_spec(channels)).
 
+-spec dirty_channels_backend() -> aeu_mp_trees_db:db().
+dirty_channels_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_channels)).
+
 -spec contracts_backend() -> aeu_mp_trees_db:db().
 contracts_backend() ->
     aeu_mp_trees_db:new(db_spec(contracts)).
+
+-spec dirty_contracts_backend() -> aeu_mp_trees_db:db().
+dirty_contracts_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_contracts)).
 
 -spec ns_backend() -> aeu_mp_trees_db:db().
 ns_backend() ->
     aeu_mp_trees_db:new(db_spec(ns)).
 
+-spec dirty_ns_backend() -> aeu_mp_trees_db:db().
+dirty_ns_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_ns)).
+
 -spec ns_cache_backend() -> aeu_mp_trees_db:db().
 ns_cache_backend() ->
     aeu_mp_trees_db:new(db_spec(ns_cache)).
+
+-spec dirty_ns_cache_backend() -> aeu_mp_trees_db:db().
+dirty_ns_cache_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_ns_cache)).
 
 -spec oracles_backend() -> aeu_mp_trees_db:db().
 oracles_backend() ->
     aeu_mp_trees_db:new(db_spec(oracles)).
 
+-spec dirty_oracles_backend() -> aeu_mp_trees_db:db().
+dirty_oracles_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_oracles)).
+
 -spec oracles_cache_backend() -> aeu_mp_trees_db:db().
 oracles_cache_backend() ->
     aeu_mp_trees_db:new(db_spec(oracles_cache)).
 
+-spec dirty_oracles_cache_backend() -> aeu_mp_trees_db:db().
+dirty_oracles_cache_backend() ->
+    aeu_mp_trees_db:new(db_spec(dirty_oracles_cache)).
 
 %%%===================================================================
 %%% Internal functions
@@ -76,45 +115,61 @@ db_get(Key, {gb_trees, Tree}) ->
     gb_trees:lookup(Key, Tree);
 db_get(Key, accounts) ->
     aec_db:find_accounts_node(Key);
+db_get(Key, dirty_accounts) ->
+    aec_db:dirty_find_accounts_node(Key);
 db_get(Key, calls) ->
     aec_db:find_calls_node(Key);
+db_get(Key, dirty_calls) ->
+    aec_db:dirty_find_calls_node(Key);
 db_get(Key, channels) ->
     aec_db:find_channels_node(Key);
+db_get(Key, dirty_channels) ->
+    aec_db:dirty_find_channels_node(Key);
 db_get(Key, contracts) ->
     aec_db:find_contracts_node(Key);
+db_get(Key, dirty_contracts) ->
+    aec_db:dirty_find_contracts_node(Key);
 db_get(Key, ns) ->
     aec_db:find_ns_node(Key);
+db_get(Key, dirty_ns) ->
+    aec_db:dirty_find_ns_node(Key);
 db_get(Key, ns_cache) ->
     aec_db:find_ns_cache_node(Key);
+db_get(Key, dirty_ns_cache) ->
+    aec_db:dirty_find_ns_cache_node(Key);
 db_get(Key, oracles) ->
     aec_db:find_oracles_node(Key);
+db_get(Key, dirty_oracles) ->
+    aec_db:dirty_find_oracles_node(Key);
 db_get(Key, oracles_cache) ->
-    aec_db:find_oracles_cache_node(Key).
+    aec_db:find_oracles_cache_node(Key);
+db_get(Key, dirty_oracles_cache) ->
+    aec_db:dirty_find_oracles_cache_node(Key).
 
 db_put(Key, Val, {gb_trees, Tree}) ->
     {gb_trees, gb_trees:enter(Key, Val, Tree)};
-db_put(Key, Val, accounts = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= accounts; Handle =:= dirty_accounts ->
     ok = aec_db:write_accounts_node(Key, Val),
     Handle;
-db_put(Key, Val, channels = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= channels; Handle =:= dirty_channels ->
     ok = aec_db:write_channels_node(Key, Val),
     Handle;
-db_put(Key, Val, ns = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= ns; Handle =:= dirty_ns ->
     ok = aec_db:write_ns_node(Key, Val),
     Handle;
-db_put(Key, Val, ns_cache = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= ns_cache; Handle =:= dirty_ns_cache ->
     ok = aec_db:write_ns_cache_node(Key, Val),
     Handle;
-db_put(Key, Val, calls = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= calls; Handle =:= dirty_calls ->
     ok = aec_db:write_calls_node(Key, Val),
     Handle;
-db_put(Key, Val, contracts = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= contracts; Handle =:= dirty_contracts ->
     ok = aec_db:write_contracts_node(Key, Val),
     Handle;
-db_put(Key, Val, oracles = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= oracles; Handle =:= dirty_oracles ->
     ok = aec_db:write_oracles_node(Key, Val),
     Handle;
-db_put(Key, Val, oracles_cache = Handle) ->
+db_put(Key, Val, Handle) when Handle =:= oracles_cache; Handle =:= dirty_oracles_cache ->
     ok = aec_db:write_oracles_cache_node(Key, Val),
     Handle.
 

--- a/apps/aens/src/aens_state_tree.erl
+++ b/apps/aens/src/aens_state_tree.erl
@@ -24,6 +24,7 @@
          lookup_name_auction/2,
          lookup_name/2,
          new_with_backend/2,
+         new_with_dirty_backend/2,
          root_hash/1,
          auction_iterator/1,
          auction_iterator_next/1]).
@@ -106,6 +107,11 @@ empty_with_backend() ->
 new_with_backend(RootHash, CacheRootHash) ->
     MTree = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:ns_backend()),
     Cache = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:ns_cache_backend()),
+    #ns_tree{mtree = MTree, cache = Cache}.
+
+new_with_dirty_backend(RootHash, CacheRootHash) ->
+    MTree = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:dirty_ns_backend()),
+    Cache = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:dirty_ns_cache_backend()),
     #ns_tree{mtree = MTree, cache = Cache}.
 
 -spec prune(block_height(), aec_trees:trees()) -> aec_trees:trees().

--- a/apps/aens/src/aens_state_tree.erl
+++ b/apps/aens/src/aens_state_tree.erl
@@ -109,6 +109,8 @@ new_with_backend(RootHash, CacheRootHash) ->
     Cache = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:ns_cache_backend()),
     #ns_tree{mtree = MTree, cache = Cache}.
 
+-spec new_with_dirty_backend(aeu_mtrees:root_hash() | 'empty',
+                             aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_dirty_backend(RootHash, CacheRootHash) ->
     MTree = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:dirty_ns_backend()),
     Cache = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:dirty_ns_cache_backend()),

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -111,6 +111,8 @@ new_with_backend(RootHash, CacheRootHash) ->
                 , cache  = Cache
                 }.
 
+-spec new_with_dirty_backend(aeu_mtrees:root_hash() | 'empty',
+                             aeu_mtrees:root_hash() | 'empty') -> tree().
 new_with_dirty_backend(RootHash, CacheRootHash) ->
     OTree  = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:dirty_oracles_backend()),
     Cache  = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:dirty_oracles_cache_backend()),

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -25,6 +25,7 @@
         , lookup_query/3
         , lookup_oracle/2
         , new_with_backend/2
+        , new_with_dirty_backend/2
         , prune/2
         , root_hash/1
         ]).
@@ -106,6 +107,13 @@ empty_with_backend() ->
 new_with_backend(RootHash, CacheRootHash) ->
     OTree  = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:oracles_backend()),
     Cache  = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:oracles_cache_backend()),
+    #oracle_tree{ otree  = OTree
+                , cache  = Cache
+                }.
+
+new_with_dirty_backend(RootHash, CacheRootHash) ->
+    OTree  = aeu_mtrees:new_with_backend(RootHash, aec_db_backends:dirty_oracles_backend()),
+    Cache  = aeu_mtrees:new_with_backend(CacheRootHash, aec_db_backends:dirty_oracles_cache_backend()),
     #oracle_tree{ otree  = OTree
                 , cache  = Cache
                 }.


### PR DESCRIPTION
Using dirty reads for our merkle trees is fine, as the in ram cache we got in place is enough to ensure that we don't mutate outdated/unavailable data(which might be returned by a dirty read). By enabling dirty reads, it turned out that one test case in CI randomly failed - aehttp_sc_SUITE ==> plain.sc_ws_min_depth_is_modifiable
Some components in our node, like the state channel chain watcher might try to read the channel state instantly after the new block got inserted to the DB - as the tree cache is not globally shared between processes we cannot rely on dirty reads in this case.

This PR changes the DB to return a "safe" tree db backend unless the caller explicitly asks for a dirty version.