### PR TITLE
Conductor benchmarks

### DIFF
--- a/apps/aecore/src/aec_plugin.erl
+++ b/apps/aecore/src/aec_plugin.erl
@@ -77,4 +77,3 @@ get_registry() ->
     persistent_term:get({?MODULE, registry}, undefined).
 
 -endif.
-


### PR DESCRIPTION
#3377 got really big and I'm not even close finishing this :(
I've started to separate some parts into more manageable PR's which can be merged independently of #3377.

This PR introduces benchmarks for aec_conductor:add_synced_block - it turned out that the overhead of postprocesing blocks was absurdly large(#3377 has the fix for it).