### PR TITLE
Refactor MPT to use behaviours for the db backend

### DIFF
--- a/apps/aecore/src/aec_db_backends.erl
+++ b/apps/aecore/src/aec_db_backends.erl
@@ -25,10 +25,12 @@
         , dirty_oracles_cache_backend/0
         ]).
 
+-behavior(aeu_mp_trees_db).
+
 %% Callbacks for aeu_mp_trees_db
--export([ db_drop_cache/1
-        , db_get/2
-        , db_put/3
+-export([ mpt_db_drop_cache/1
+        , mpt_db_get/2
+        , mpt_db_put/3
         ]).
 
 %%%===================================================================
@@ -106,72 +108,70 @@ dirty_oracles_cache_backend() ->
 db_spec(Type) ->
     #{ handle => Type
      , cache  => {gb_trees, gb_trees:empty()}
-     , get    => {?MODULE, db_get}
-     , put    => {?MODULE, db_put}
-     , drop_cache => {?MODULE, db_drop_cache}
+     , module => ?MODULE
      }.
 
-db_get(Key, {gb_trees, Tree}) ->
+mpt_db_get(Key, {gb_trees, Tree}) ->
     gb_trees:lookup(Key, Tree);
-db_get(Key, accounts) ->
+mpt_db_get(Key, accounts) ->
     aec_db:find_accounts_node(Key);
-db_get(Key, dirty_accounts) ->
+mpt_db_get(Key, dirty_accounts) ->
     aec_db:dirty_find_accounts_node(Key);
-db_get(Key, calls) ->
+mpt_db_get(Key, calls) ->
     aec_db:find_calls_node(Key);
-db_get(Key, dirty_calls) ->
+mpt_db_get(Key, dirty_calls) ->
     aec_db:dirty_find_calls_node(Key);
-db_get(Key, channels) ->
+mpt_db_get(Key, channels) ->
     aec_db:find_channels_node(Key);
-db_get(Key, dirty_channels) ->
+mpt_db_get(Key, dirty_channels) ->
     aec_db:dirty_find_channels_node(Key);
-db_get(Key, contracts) ->
+mpt_db_get(Key, contracts) ->
     aec_db:find_contracts_node(Key);
-db_get(Key, dirty_contracts) ->
+mpt_db_get(Key, dirty_contracts) ->
     aec_db:dirty_find_contracts_node(Key);
-db_get(Key, ns) ->
+mpt_db_get(Key, ns) ->
     aec_db:find_ns_node(Key);
-db_get(Key, dirty_ns) ->
+mpt_db_get(Key, dirty_ns) ->
     aec_db:dirty_find_ns_node(Key);
-db_get(Key, ns_cache) ->
+mpt_db_get(Key, ns_cache) ->
     aec_db:find_ns_cache_node(Key);
-db_get(Key, dirty_ns_cache) ->
+mpt_db_get(Key, dirty_ns_cache) ->
     aec_db:dirty_find_ns_cache_node(Key);
-db_get(Key, oracles) ->
+mpt_db_get(Key, oracles) ->
     aec_db:find_oracles_node(Key);
-db_get(Key, dirty_oracles) ->
+mpt_db_get(Key, dirty_oracles) ->
     aec_db:dirty_find_oracles_node(Key);
-db_get(Key, oracles_cache) ->
+mpt_db_get(Key, oracles_cache) ->
     aec_db:find_oracles_cache_node(Key);
-db_get(Key, dirty_oracles_cache) ->
+mpt_db_get(Key, dirty_oracles_cache) ->
     aec_db:dirty_find_oracles_cache_node(Key).
 
-db_put(Key, Val, {gb_trees, Tree}) ->
+mpt_db_put(Key, Val, {gb_trees, Tree}) ->
     {gb_trees, gb_trees:enter(Key, Val, Tree)};
-db_put(Key, Val, Handle) when Handle =:= accounts; Handle =:= dirty_accounts ->
+mpt_db_put(Key, Val, Handle) when Handle =:= accounts; Handle =:= dirty_accounts ->
     ok = aec_db:write_accounts_node(Key, Val),
     Handle;
-db_put(Key, Val, Handle) when Handle =:= channels; Handle =:= dirty_channels ->
+mpt_db_put(Key, Val, Handle) when Handle =:= channels; Handle =:= dirty_channels ->
     ok = aec_db:write_channels_node(Key, Val),
     Handle;
-db_put(Key, Val, Handle) when Handle =:= ns; Handle =:= dirty_ns ->
+mpt_db_put(Key, Val, Handle) when Handle =:= ns; Handle =:= dirty_ns ->
     ok = aec_db:write_ns_node(Key, Val),
     Handle;
-db_put(Key, Val, Handle) when Handle =:= ns_cache; Handle =:= dirty_ns_cache ->
+mpt_db_put(Key, Val, Handle) when Handle =:= ns_cache; Handle =:= dirty_ns_cache ->
     ok = aec_db:write_ns_cache_node(Key, Val),
     Handle;
-db_put(Key, Val, Handle) when Handle =:= calls; Handle =:= dirty_calls ->
+mpt_db_put(Key, Val, Handle) when Handle =:= calls; Handle =:= dirty_calls ->
     ok = aec_db:write_calls_node(Key, Val),
     Handle;
-db_put(Key, Val, Handle) when Handle =:= contracts; Handle =:= dirty_contracts ->
+mpt_db_put(Key, Val, Handle) when Handle =:= contracts; Handle =:= dirty_contracts ->
     ok = aec_db:write_contracts_node(Key, Val),
     Handle;
-db_put(Key, Val, Handle) when Handle =:= oracles; Handle =:= dirty_oracles ->
+mpt_db_put(Key, Val, Handle) when Handle =:= oracles; Handle =:= dirty_oracles ->
     ok = aec_db:write_oracles_node(Key, Val),
     Handle;
-db_put(Key, Val, Handle) when Handle =:= oracles_cache; Handle =:= dirty_oracles_cache ->
+mpt_db_put(Key, Val, Handle) when Handle =:= oracles_cache; Handle =:= dirty_oracles_cache ->
     ok = aec_db:write_oracles_cache_node(Key, Val),
     Handle.
 
-db_drop_cache({gb_trees, _}) ->
+mpt_db_drop_cache({gb_trees, _}) ->
     gb_trees:empty().

--- a/apps/aecore/src/aec_poi.erl
+++ b/apps/aecore/src/aec_poi.erl
@@ -22,9 +22,10 @@
         , serialization_format_template/0
         ]).
 
--export([ proof_db_get/2
-        , proof_db_put/3
-        , proof_db_drop_cache/1
+-behavior(aeu_mp_trees_db).
+-export([ mpt_db_get/2
+        , mpt_db_put/3
+        , mpt_db_drop_cache/1
         ]).
 
 -export_type([ poi/0
@@ -158,18 +159,16 @@ new_proof_db() ->
 proof_db_spec() ->
     #{ handle => gb_trees
      , cache  => gb_trees:empty()
-     , get    => {?MODULE, proof_db_get}
-     , put    => {?MODULE, proof_db_put}
-     , drop_cache => {?MODULE, proof_db_drop_cache}
+     , module => ?MODULE
      }.
 
-proof_db_get(Key, Proof) ->
+mpt_db_get(Key, Proof) ->
     gb_trees:lookup(Key, Proof).
 
-proof_db_put(Key, Val, Proof) ->
+mpt_db_put(Key, Val, Proof) ->
     gb_trees:enter(Key, Val, Proof).
 
-proof_db_drop_cache(_Cache) ->
+mpt_db_drop_cache(_Cache) ->
     error(no_drop_cache_in_proof).
 
 proof_serialize_to_list(Proof) ->

--- a/apps/aeutils/src/aeu_mp_trees.erl
+++ b/apps/aeutils/src/aeu_mp_trees.erl
@@ -34,9 +34,10 @@
         ]).
 
 %% For internal functional db
--export([ dict_db_drop_cache/1
-        , dict_db_get/2
-        , dict_db_put/3
+-behavior(aeu_mp_trees_db).
+-export([ mpt_db_drop_cache/1
+        , mpt_db_get/2
+        , mpt_db_put/3
         ]).
 
 -export([record_fields/1]).
@@ -1130,21 +1131,19 @@ new_dict_db() ->
 dict_db_spec() ->
     #{ handle => dict:new()
      , cache  => dict:new()
-     , get    => {?MODULE, dict_db_get}
-     , put    => {?MODULE, dict_db_put}
-     , drop_cache => {?MODULE, dict_db_drop_cache}
+     , module => ?MODULE
      }.
 
-dict_db_get(Key, Dict) ->
+mpt_db_get(Key, Dict) ->
     case dict:find(Key, Dict) of
         {ok, Val} -> {value, Val};
         error -> none
     end.
 
-dict_db_put(Key, Val, Dict) ->
+mpt_db_put(Key, Val, Dict) ->
     dict:store(Key, Val, Dict).
 
-dict_db_drop_cache(_Cache) ->
+mpt_db_drop_cache(_Cache) ->
     dict:new().
 
 %%%===================================================================

--- a/apps/aeutils/src/aeu_mtrees.erl
+++ b/apps/aeutils/src/aeu_mtrees.erl
@@ -44,9 +44,10 @@
         ]).
 
 %% For internal functional db
--export([ proof_db_drop_cache/1
-        , proof_db_get/2
-        , proof_db_put/3
+-behavior(aeu_mp_trees_db).
+-export([ mpt_db_drop_cache/1
+        , mpt_db_get/2
+        , mpt_db_put/3
         ]).
 
 -export([ serialize/1
@@ -262,18 +263,16 @@ new_proof_db() ->
 proof_db_spec() ->
     #{ handle => dict:new()
      , cache  => dict:new()
-     , get    => {?MODULE, proof_db_get}
-     , put    => {?MODULE, proof_db_put}
-     , drop_cache => {?MODULE, proof_db_drop_cache}
+     , module => ?MODULE
      }.
 
-proof_db_get(Key, Proof) ->
+mpt_db_get(Key, Proof) ->
     {value, dict:fetch(Key, Proof)}.
 
-proof_db_put(Key, Val, Proof) ->
+mpt_db_put(Key, Val, Proof) ->
     dict:store(Key, Val, Proof).
 
-proof_db_drop_cache(_Cache) ->
+mpt_db_drop_cache(_Cache) ->
     dict:new().
 
 %%%===================================================================

--- a/apps/aeutils/test/aeu_mp_trees_tests.erl
+++ b/apps/aeutils/test/aeu_mp_trees_tests.erl
@@ -9,9 +9,10 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% For internal functional db
--export([ dict_db_drop_cache/1
-        , dict_db_get/2
-        , dict_db_put/3
+-behavior(aeu_mp_trees_db).
+-export([ mpt_db_drop_cache/1
+        , mpt_db_get/2
+        , mpt_db_put/3
         ]).
 
 
@@ -585,19 +586,17 @@ new_dict_db() ->
 dict_db_spec() ->
     #{ handle => dict:new()
      , cache  => dict:new()
-     , get    => {?MODULE, dict_db_get}
-     , put    => {?MODULE, dict_db_put}
-     , drop_cache => {?MODULE, dict_db_drop_cache}
+     , module => ?MODULE
      }.
 
-dict_db_get(Key, Dict) ->
+mpt_db_get(Key, Dict) ->
     case dict:find(Key, Dict) of
         {ok, Val} -> {value, Val};
         error -> none
     end.
 
-dict_db_put(Key, Val, Dict) ->
+mpt_db_put(Key, Val, Dict) ->
     dict:store(Key, Val, Dict).
 
-dict_db_drop_cache(_Dict) ->
+mpt_db_drop_cache(_Dict) ->
     dict:new().


### PR DESCRIPTION
#3377 got really big and I'm not even close finishing this :(
I've started to separate some parts into more manageable PR's which can be merged independently of #3377.

This PR refactors the DB backend of MPT trees to use behaviors instead of tuple funs - this surprisingly increased the sync performance dramatically as calls to validate_exported were performed unbelievably often and were expensive.
Before(This includes DB and conductor optimisations not present in this PR):
![image](https://user-images.githubusercontent.com/1352848/97748231-6f313800-1aed-11eb-8636-e53e06dc81a9.png)
After(the previous optimisations + this PR):
![image](https://user-images.githubusercontent.com/1352848/97748286-86702580-1aed-11eb-970e-5eef56e16e14.png)

Merge after #3387 #3385 #3388
