### PR TITLE
Fix timestamp check in contract tests

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -6759,7 +6759,7 @@ fate_environment(_Cfg) ->
     Time1 = aeu_time:now_in_msecs(),
     Timestamp = ?call(call_contract, Acc, Contract, timestamp, word, {}),
     Time2 = aeu_time:now_in_msecs(),
-    ?assert(Time1 < Timestamp andalso Timestamp < Time2),
+    ?assert(Time1 =< Timestamp andalso Timestamp =< Time2),
 
     SentValue = 12340,
     Value1 = ?call(call_contract, Acc, Contract, call_value, word, {}, #{amount => SentValue}),


### PR DESCRIPTION
#3377 got really big and I'm not even close finishing this :(
I've started to separate some parts into more manageable PR's which can be merged independently of #3377.

#3377 and #3386 improve performance so much that this check fails as most of the time Time1 == Timestamp :) 
