### PR TITLE
Fix SC chain watcher

### DIFF
--- a/apps/aechannel/src/aesc_chain_watcher.erl
+++ b/apps/aechannel/src/aesc_chain_watcher.erl
@@ -523,7 +523,7 @@ clear_locked_until(#req{info = I} = R) when is_map(I) ->
 handle_info({gproc_ps_event, top_changed, #{info := Info}}, #st{} = St) ->
     case ets:info(?T_REQUESTS, size) of
         0 ->
-            {noreply, St};
+            {noreply, St#st{ last_top = undefined }};
         _ ->
             {noreply, check_status(Info, St)}
     end;


### PR DESCRIPTION
#3377 got really big and I'm not even close finishing this :(
I've started to separate some parts into more manageable PR's which can be merged independently of #3377.

After I've introduced true instant mining in #3377 I've discovered a bug in the chain watcher.
When a fork switch to a block with a channel_create_tx occurs while a watch request is in place channel_changed_on_chain never gets sent to the clients.
Normally forks happen on keyblocks so this is not an issue but currently the chain watcher forgets to update his top_hash when no requests are present - this means that after a period of inactivity a fork switch might be triggered on a microblock and channel_changed_on_chain isn't sent out. I've included a minimal example of this issue. 
