### PR TITLE
Speedup node stopping time in tests

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -361,6 +361,7 @@ end_per_suite(Config) ->
     [ok = application:stop(A) || A <- lists:reverse(StartedApps)],
     TableOwner = ?config(table_owner, Config),
     TableOwner ! die,
+    aecore_suite_utils:stop_node(dev1, Config),
     ok.
 
 init_per_group(signatures, Config0) ->


### PR DESCRIPTION
#3377 got really big and I'm not even close finishing this :(
I've started to separate some parts into more manageable PR's which can be merged independently of #3377.

Stopping a node using the CLI takes 4 seconds - doing it via RPC takes 2 seconds. Some CT tests restart nodes really often - this yields a decrease in testing time.
