### PR TITLE
Block insertion performance optimisations

### DIFF
--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -21,6 +21,7 @@
         , get_generation_by_hash/2
         , get_generation_by_height/2
         , get_header/1
+        , dirty_get_header/1
         , get_key_header_by_height/1
         , get_n_generation_headers_backwards_from_hash/2
         , get_at_most_n_generation_headers_forward_from_hash/2
@@ -666,6 +667,13 @@ get_generation_by_height(Height, forward) ->
 -spec get_header(binary()) -> {'ok', aec_headers:header()} | 'error'.
 get_header(Hash) when is_binary(Hash) ->
     case aec_db:find_header(Hash) of
+        none -> error;
+        {value, Header} -> {ok, Header}
+    end.
+
+-spec dirty_get_header(binary()) -> {'ok', aec_headers:header()} | 'error'.
+dirty_get_header(Hash) when is_binary(Hash) ->
+    case aec_db:dirty_find_header(Hash) of
         none -> error;
         {value, Header} -> {ok, Header}
     end.

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -719,15 +719,9 @@ internal_insert_transaction(Node, Block, Origin, Ctx) ->
     ok = db_put_node(Block, hash(Node)),
     {State3, Events} = update_state_tree(Node, State2, Ctx),
     TopChanged = persist_state(State1, State3) =:= top_changed,
-    PrevKeyHeader = case ctx_prev_key(Ctx) of
-                  #node{header = H} ->
-                      H;
-                  undefined ->
-                      undefined
-              end,
     case maps:get(found_pof, State3) of
-        no_fraud  -> {ok, TopChanged, PrevKeyHeader, Events};
-        PoF       -> {pof, TopChanged, PrevKeyHeader, PoF, Events}
+        no_fraud  -> {ok, TopChanged, Events};
+        PoF       -> {pof, TopChanged, PoF, Events}
     end.
 
 assert_not_illegal_fork_or_orphan(Node, Origin, State) ->
@@ -1214,7 +1208,7 @@ find_fork_point(_MaybeNode1, _Hash1, _Res1, _MaybeNode2, _Hash2, _Res2) ->
     error.
 
 find_fork_point_maybe_node(undefined, Hash) -> db_get_node(Hash);
-find_fork_point_maybe_node(Node, _Hash) -> Node.
+find_fork_point_maybe_node(Node, Hash) -> Node.
 
 find_micro_fork_point(Hash1, Hash2) ->
     case do_find_micro_fork_point(Hash1, Hash2) of

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1267,7 +1267,7 @@ db_get_header(Hash) when is_binary(Hash) ->
 db_find_key_nodes_at_height(Height) when is_integer(Height) ->
     case aec_db:find_headers_and_hash_at_height(Height) of
         [_|_] = Headers ->
-            case [wrap_header(H, Hash) || {H, Hash} <- Headers, aec_headers:type(H) =:= key] of
+            case [wrap_header(H, Hash) || {Hash, H} <- Headers, aec_headers:type(H) =:= key] of
                 [] -> error;
                 List -> {ok, List}
             end;
@@ -1368,7 +1368,7 @@ db_put_signal_count(Hash, Count) ->
     aec_db:write_signal_count(Hash, Count).
 
 match_prev_at_height(Height, PrevHash, Hash) ->
-    [Header || {Header, H} <- aec_db:find_headers_and_hash_at_height(Height),
+    [Header || {H, Header} <- aec_db:find_headers_and_hash_at_height(Height),
                H =/= Hash,
                aec_headers:prev_hash(Header) =:= PrevHash].
 

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -707,46 +707,40 @@ deregister_miner_instance(Pid, #state{miner_instances = MinerInstances0} = State
 %%%===================================================================
 %%% Preemption of workers if the top of the chain changes.
 
-preempt_if_new_top(#state{ top_block_hash = OldHash,
-                           top_key_block_hash = OldKeyHash } = State, Origin) ->
-    case aec_chain:top_block_hash() of
-        OldHash -> no_change;
-        NewHash ->
-            {ok, NewBlock} = aec_chain:get_block(NewHash),
-            BlockType = aec_blocks:type(NewBlock),
-            PrevNewHash = aec_blocks:prev_hash(NewBlock),
-            {T, ok} = timer:tc(fun() -> aec_tx_pool:top_change(BlockType, OldHash, NewHash, PrevNewHash) end),
-            io:format(user, "Tx pool top change took: ~p\n", [T]),
-            Hdr = aec_blocks:to_header(NewBlock),
-            Height = aec_headers:height(Hdr),
-            aec_events:publish(top_changed, #{ block_hash => NewHash
-                                             , block_type => BlockType
-                                             , prev_hash  => aec_headers:prev_hash(Hdr)
-                                             , height     => Height }),
-            maybe_publish_top(Origin, NewBlock),
-            aec_metrics:try_update([ae,epoch,aecore,chain,height], Height),
-            State1 = State#state{top_block_hash = NewHash},
-            KeyHash = aec_blocks:prev_key_hash(NewBlock),
-            %% A new micro block from the same generation should
-            %% not cause a pre-emption or full re-generation of key-block.
-            case BlockType of
-                micro when OldKeyHash =:= KeyHash ->
-                    {micro_changed, State1};
-                KeyOrNewForkMicro ->
-                    State2 = kill_all_workers_with_tag(mining, State1),
-                    State3 = kill_all_workers_with_tag(create_key_block_candidate, State2),
-                    State4 = kill_all_workers_with_tag(micro_sleep, State3), %% in case we are the leader
-                    NewTopKey = case KeyOrNewForkMicro of
-                                    micro -> KeyHash;
-                                    key   -> NewHash
-                                end,
-                    State5 = State4#state{ top_key_block_hash = NewTopKey,
-                                           key_block_candidates = undefined },
+preempt_on_new_top(#state{ top_block_hash = OldHash,
+                           top_key_block_hash = OldKeyHash } = State, NewBlock, NewHash, Origin) ->
+    BlockType = aec_blocks:type(NewBlock),
+    PrevNewHash = aec_blocks:prev_hash(NewBlock),
+    aec_tx_pool:top_change(BlockType, OldHash, NewHash, PrevNewHash),
+    Hdr = aec_blocks:to_header(NewBlock),
+    Height = aec_headers:height(Hdr),
+    aec_events:publish(top_changed, #{ block_hash => NewHash
+                                     , block_type => BlockType
+                                     , prev_hash  => aec_headers:prev_hash(Hdr)
+                                     , height     => Height }),
+    maybe_publish_top(Origin, NewBlock),
+    aec_metrics:try_update([ae,epoch,aecore,chain,height], Height),
+    State1 = State#state{top_block_hash = NewHash},
+    KeyHash = aec_blocks:prev_key_hash(NewBlock),
+    %% A new micro block from the same generation should
+    %% not cause a pre-emption or full re-generation of key-block.
+    case BlockType of
+        micro when OldKeyHash =:= KeyHash ->
+            {micro_changed, State1};
+        KeyOrNewForkMicro ->
+            State2 = kill_all_workers_with_tag(mining, State1),
+            State3 = kill_all_workers_with_tag(create_key_block_candidate, State2),
+            State4 = kill_all_workers_with_tag(micro_sleep, State3), %% in case we are the leader
+            NewTopKey = case KeyOrNewForkMicro of
+                            micro -> KeyHash;
+                            key   -> NewHash
+                        end,
+            State5 = State4#state{ top_key_block_hash = NewTopKey,
+                                   key_block_candidates = undefined },
 
-                    [ aec_keys:promote_candidate(aec_blocks:miner(NewBlock)) || KeyOrNewForkMicro == key ],
+            [ aec_keys:promote_candidate(aec_blocks:miner(NewBlock)) || KeyOrNewForkMicro == key ],
 
-                    {changed, KeyOrNewForkMicro, NewBlock, create_key_block_candidate(State5)}
-            end
+            {changed, KeyOrNewForkMicro, NewBlock, create_key_block_candidate(State5)}
     end.
 
 %% GH3283: If we start storing more kinds of tx_events - we have to expand this
@@ -1113,15 +1107,13 @@ handle_add_block(Block, Hash, Prev, #state{top_block_hash = TopBlockHash} = Stat
     %% Block validation is performed in the caller's context for
     %% external (gossip/sync) blocks and we trust the ones we
     %% produce ourselves.
-    case aec_chain_state:insert_block(Block, Origin) of
-        {ok, Events}  ->
-            {T, V} = timer:tc(fun() -> handle_successfully_added_block(Block, Hash, Events, State, Origin) end),
-            io:format(user, "Postprocessing took: ~p\n", [T]),
-            V;
-        {pof,_PoF,Events} ->
+    case aec_chain_state:insert_block_conductor(Block, Origin) of
+        {ok, TopChanged, PrevKeyHeader, Events}  ->
+            handle_successfully_added_block(Block, Hash, TopChanged, PrevKeyHeader, Events, State, Origin);
+        {pof, TopChanged, PrevKeyHeader, _PoF, Events} ->
             %% TODO: should we really publish tx_events in this case?
             lager:info("PoF found in ~p", [Hash]),
-            handle_successfully_added_block(Block, Hash, Events, State, Origin);
+            handle_successfully_added_block(Block, Hash, TopChanged, PrevKeyHeader, Events, State, Origin);
         {error, already_in_db} ->
             epoch_mining:debug("Block (~p) already in chain when top is (~p) [conductor]",
                                [Hash, TopBlockHash]),
@@ -1137,16 +1129,18 @@ handle_add_block(Block, Hash, Prev, #state{top_block_hash = TopBlockHash} = Stat
             {{error, Reason}, State}
     end.
 
-handle_successfully_added_block(Block, Hash, Events, State, Origin) ->
+handle_successfully_added_block(Block, Hash, false, _, Events, State, Origin) ->
     maybe_publish_tx_events(Events, Hash, Origin),
     maybe_publish_block(Origin, Block),
-    case preempt_if_new_top(State, Origin) of
-        no_change ->
-            {ok, State};
+    {ok, State};
+handle_successfully_added_block(Block, Hash, true, PrevKeyHeader, Events, State, Origin) ->
+    maybe_publish_tx_events(Events, Hash, Origin),
+    maybe_publish_block(Origin, Block),
+    case preempt_on_new_top(State, Block, Hash, Origin) of
         {micro_changed, State2 = #state{ consensus = Cons }} ->
             {ok, setup_loop(State2, false, Cons#consensus.leader, Origin)};
         {changed, BlockType, NewTopBlock, State2} ->
-            IsLeader = is_leader(NewTopBlock),
+            IsLeader = is_leader(NewTopBlock, PrevKeyHeader),
             case IsLeader of
                 true ->
                     ok; %% Don't spend time when we are the leader.
@@ -1157,17 +1151,13 @@ handle_successfully_added_block(Block, Hash, Events, State, Origin) ->
             {ok, setup_loop(State2, true, IsLeader, Origin)}
     end.
 
-
-%% NG-TODO: This is pretty inefficient and can be helped with some info
-%%          in the state.
-is_leader(NewTopBlock) ->
+is_leader(NewTopBlock, PrevKeyHeader) ->
     LeaderKey =
         case aec_blocks:type(NewTopBlock) of
-            key   -> aec_blocks:miner(NewTopBlock);
+            key   ->
+                aec_blocks:miner(NewTopBlock);
             micro ->
-                KeyHash = aec_blocks:prev_key_hash(NewTopBlock),
-                {ok, Block} = aec_chain:get_block(KeyHash),
-                aec_blocks:miner(Block)
+                aec_headers:miner(PrevKeyHeader)
         end,
     case aec_keys:pubkey() of
         {ok, MinerKey} -> LeaderKey =:= MinerKey;

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -50,7 +50,8 @@
          get_top_block_hash/0,
          get_top_block_height/0,
          get_block_state/1,
-         get_block_state/2
+         get_block_state/2,
+         get_block_from_micro_header/2
         ]).
 
 %% Location of chain transactions
@@ -405,6 +406,19 @@ find_block(Hash) ->
            [] -> none
        end).
 
+-spec get_block_from_micro_header(binary(), aec_headers:micro_header()) -> aec_blocks:micro_block().
+get_block_from_micro_header(Hash, MicroHeader) ->
+    aec_headers:assert_micro_header(MicroHeader),
+    ?t(begin
+        [#aec_blocks{txs = TxHashes, pof = PoF}] = mnesia:read(aec_blocks, Hash),
+        Txs = [begin
+                  [#aec_signed_tx{value = DBSTx}] =
+                      mnesia:read(aec_signed_tx, TxHash),
+                  aetx_sign:from_db_format(DBSTx)
+              end || TxHash <- TxHashes],
+        aec_blocks:new_micro_from_header(MicroHeader, Txs, PoF)
+       end).
+
 -spec find_key_block(binary()) -> 'none' | {'value', aec_blocks:key_block()}.
 find_key_block(Hash) ->
     ?t(case mnesia:read(aec_headers, Hash) of
@@ -437,9 +451,9 @@ find_headers_at_height(Height) when is_integer(Height), Height >= 0 ->
                  <- mnesia:index_read(aec_headers, Height, height)]).
 
 -spec find_headers_and_hash_at_height(pos_integer()) ->
-                                             [{aec_headers:header(), binary()}].
+                                             [{binary(), aec_headers:header()}].
 find_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
-    ?t([{aec_headers:from_db_header(H), K} || #aec_headers{key = K, value = H}
+    ?t([{K, aec_headers:from_db_header(H)} || #aec_headers{key = K, value = H}
                  <- mnesia:index_read(aec_headers, Height, #aec_headers.height)]).
 
 find_discovered_pof(Hash) ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -440,7 +440,7 @@ find_headers_at_height(Height) when is_integer(Height), Height >= 0 ->
                                              [{aec_headers:header(), binary()}].
 find_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
     ?t([{aec_headers:from_db_header(H), K} || #aec_headers{key = K, value = H}
-                 <- mnesia:index_read(aec_headers, Height, height)]).
+                 <- mnesia:index_read(aec_headers, Height, #aec_headers.height)]).
 
 find_discovered_pof(Hash) ->
     case ?t(read(aec_discovered_pof, Hash)) of

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -785,7 +785,7 @@ validate_pow(#key_header{nonce        = Nonce,
 validate_micro_block_cycle_time(Header, _Protocol) ->
     Time = time_in_msecs(Header),
     PrevHash = prev_hash(Header),
-    case aec_chain:get_header(PrevHash) of
+    case aec_chain:dirty_get_header(PrevHash) of
         {ok, PrevHeader} ->
             PrevTime = time_in_msecs(PrevHeader),
             MinAccepted =

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -838,7 +838,8 @@ handle_get_header_by_height(S, ?GET_HEADER_BY_HEIGHT_VSN,
 %% -- Get N Successors -------------------------------------------------------
 
 do_get_n_successors(Hash, N) ->
-    case aec_chain:get_at_most_n_generation_headers_forward_from_hash(Hash, N+1) of
+    F = fun() -> aec_chain:get_at_most_n_generation_headers_forward_from_hash(Hash, N+1) end,
+    case aec_db:ensure_activity(async_dirty, F) of
         {ok, [_ | Headers]} ->
             HHashes = [ begin
                             {ok, HHash} = aec_headers:hash_header(H),
@@ -894,7 +895,7 @@ handle_get_generation(S, Msg) ->
     S.
 
 do_get_generation(Hash, Forward) ->
-    aec_db:ensure_transaction(fun() ->
+    aec_db:ensure_activity(async_dirty, fun() ->
         do_get_generation_(Hash, Forward) end).
 
 do_get_generation_(Hash, true) ->

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -893,9 +893,13 @@ handle_get_generation(S, Msg) ->
     send_response(S, generation, Response),
     S.
 
-do_get_generation(Hash, true) ->
+do_get_generation(Hash, Forward) ->
+    aec_db:ensure_transaction(fun() ->
+        do_get_generation_(Hash, Forward) end).
+
+do_get_generation_(Hash, true) ->
     aec_chain:get_generation_by_hash(Hash, forward);
-do_get_generation(Hash, false) ->
+do_get_generation_(Hash, false) ->
     aec_chain:get_generation_by_hash(Hash, backward).
 
 handle_get_generation_rsp(S, {get_generation, From, _TRef}, Msg) ->

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -980,12 +980,12 @@ gen_is_consecutive(backward, KB, MBs = [MB1, MB2 | _]) ->
 %%%=============================================================================
 
 has_generation(KeyBlockHash) ->
-    %% We are looking for the generation backwards from this Hash
-    %% Possibly optimize by implementing aec_chain:has_generation operating on
-    %% headers only
-    case aec_chain:get_generation_by_hash(KeyBlockHash, backward) of
-        {ok, _Generation} -> true;
-        error             -> false
+    case aec_chain:get_header(KeyBlockHash) of
+        error ->
+            false;
+        {ok, Header} ->
+            aec_headers:assert_key_header(Header),
+            true
     end.
 
 header_hash(Block) ->

--- a/apps/aecore/test/aec_blocks_tests.erl
+++ b/apps/aecore/test/aec_blocks_tests.erl
@@ -24,7 +24,7 @@ validate_test_() ->
              meck:new(enacl, [passthrough]),
              meck:expect(enacl, sign_verify_detached, 3, {ok, <<>>}),
              meck:new(aec_chain, [passthrough]),
-             meck:expect(aec_chain, get_header, 1, error),
+             meck:expect(aec_chain, dirty_get_header, 1, error),
              TmpKeysDir
      end,
      fun(TmpKeysDir) ->

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -235,7 +235,7 @@ validate_test_() ->
              meck:new(aec_hard_forks, [passthrough]),
              meck:new(aec_mining, [passthrough]),
              meck:new(aec_chain, [passthrough]),
-             meck:expect(aec_chain, get_header, 1, error),
+             meck:expect(aec_chain, dirty_get_header, 1, error),
              meck:new(aeu_time, [passthrough])
      end,
      fun(_) ->


### PR DESCRIPTION
#3377 got really big and I'm not even close finishing this :(
I've started to separate some parts into more manageable PR's which can be merged independently of #3377.

Merge after #3387 and #3385. 
This PR optimizes block insertion times and the time to post-processes inserted blocks in the conductor. The main contributor to the block postprocesing time was changing the top in the tx_pool. Currently with those changes postprocesing an inserted block takes ~300-500us - this might be further reduced by changing the architecture slightly - Currently I don't think it's worth doing.
I've tried to reduce disk IO as much as possible.
