### PR TITLE
Instant block mining

### DIFF
--- a/apps/aechannel/bench/aesc_bench_SUITE.erl
+++ b/apps/aechannel/bench/aesc_bench_SUITE.erl
@@ -128,7 +128,7 @@ init_per_group(_Group, Config) ->
 
 init_per_group_(Config) ->
     aecore_suite_utils:start_node(dev1, Config),
-    aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1), [block_pow]),
+    aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1), [block_pow, instant_tx_confirm]),
     ?LOG("dev1 connected", []),
     try begin
             Node = dev1,

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -117,7 +117,7 @@
 -include_lib("aecontract/include/hard_forks.hrl").
 -include_lib("aeutils/include/aeu_stacktrace.hrl").
 
--define(TIMEOUT, 10000).
+-define(TIMEOUT, 500).
 -define(LONG_TIMEOUT, 60000).
 -define(PORT, 9325).
 
@@ -430,7 +430,7 @@ init_per_group_(Config) ->
             Config;
         false ->
             aecore_suite_utils:start_node(dev1, Config),
-            aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1), [block_pow]),
+            aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1), [block_pow, instant_tx_confirm]),
             ?LOG("dev1 connected", []),
             try begin
                     Node = dev1,
@@ -1773,6 +1773,9 @@ check_mutual_close_after_close_solo(Cfg) ->
     %% cannot shutdown the channel after it was closed but before the TTL runs out
     case aect_test_utils:latest_protocol_version() < ?LIMA_PROTOCOL_VSN of
         true ->
+            %% TODO: Instant TX confirm is too fast and the tests
+            %% fail without this sleep
+            timer:sleep(100),
             {error, unknown_request} = rpc(dev1, aesc_fsm, shutdown, [FsmI, #{}]),
             {error, unknown_request} = rpc(dev1, aesc_fsm, shutdown, [FsmR, #{}]),
 

--- a/apps/aecore/src/aec_instant_mining_plugin.erl
+++ b/apps/aecore/src/aec_instant_mining_plugin.erl
@@ -1,0 +1,31 @@
+%%%
+%%% Utility module for instantly mining blocks in tests and when dev mode is enabled
+%%%
+
+-module(aec_instant_mining_plugin).
+-export([ emit_mb/0
+        , emit_kb/0
+        , instant_tx_confirm_hook/1
+        , instant_tx_confirm_enabled/0 ]).
+
+emit_mb() ->
+    TopHash = aec_chain:top_block_hash(),
+    {ok, MicroBlock, _} = aec_block_micro_candidate:create(TopHash),
+    {ok, MicroBlockS} = aec_keys:sign_micro_block(MicroBlock),
+    ok = aec_conductor:post_block(MicroBlockS),
+    MicroBlockS.
+
+emit_kb() ->
+    TopHash = aec_chain:top_block_hash(),
+    {ok, Beneficiary} = aec_conductor:get_beneficiary(),
+    {ok, Block} = aec_block_key_candidate:create(TopHash, Beneficiary),
+    ok = aec_conductor:add_synced_block(Block),
+    Block.
+
+%% Executed after a transaction was successfully inserted to the tx pool
+%% This is a placeholder for dev mode
+instant_tx_confirm_hook(_) ->
+    ok.
+
+instant_tx_confirm_enabled() ->
+    true.

--- a/apps/aecore/src/aec_plugin.erl
+++ b/apps/aecore/src/aec_plugin.erl
@@ -22,7 +22,7 @@ get_module(_Tag, _Default) ->
 -else.
 
 tags() ->
-    [aec_headers].
+    [aec_tx_pool].
 
 register(Map) when is_map(Map) ->
     case valid_registry(Map) of

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -63,11 +63,15 @@
         , raw_delete/2
         ]).
 
--export([await_tx_pool/0]).
+-export([ await_tx_pool/0
+        , instant_tx_confirm_enabled/0 ]).
 
 -include("aec_tx_pool.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
 -include_lib("aeutils/include/aeu_stacktrace.hrl").
+-include("aec_plugin.hrl").
+
+-pluggable[instant_tx_confirm_hook/1, instant_tx_confirm_enabled/0].
 
 -ifdef(TEST).
 -export([sync_garbage_collect/1]). %% Only for (Unit-)test
@@ -75,6 +79,8 @@
 -export([peek_db/0]).
 -export([peek_visited/0]).
 -export([peek_nonces/0]).
+-export([instant_tx_confirm_init/0]).
+-export([instant_tx_confirm_end/0]).
 -endif.
 
 %% gen_server callbacks
@@ -191,8 +197,13 @@ push_(Tx, TxHash, Event, Timeout) ->
             E;
         ok ->
             incr([push]),
-            gen_server:call(?SERVER, {push, Tx, TxHash, Event}, Timeout)
+            Res = gen_server:call(?SERVER, {push, Tx, TxHash, Event}, Timeout),
+            instant_tx_confirm_hook(TxHash),
+            Res
     end.
+
+instant_tx_confirm_hook(_) -> ok.
+instant_tx_confirm_enabled() -> false.
 
 incr(Metric) ->
     aec_metrics:try_update([ae,epoch,aecore,tx_pool | Metric], 1).
@@ -964,3 +975,16 @@ minimum_miner_gas_price() ->
 maximum_auth_fun_gas() ->
     aeu_env:user_config_or_env([<<"mining">>, <<"max_auth_fun_gas">>],
                                aecore, mining_max_auth_fun_gas, ?DEFAULT_MAX_AUTH_FUN_GAS).
+
+-ifdef(TEST).
+instant_tx_confirm_init() ->
+    %% This should avoid spawning a separate process and consuming CPU resources which could be used to parallelize tests
+    lager:debug("Enabling instant TX confirmation"),
+    aec_plugin:register(#{aec_tx_pool => aec_instant_mining_plugin}),
+    ok.
+
+instant_tx_confirm_end() ->
+    lager:debug("Disabling instant TX confirmation"),
+    aec_plugin:register(#{}),
+    ok.
+-endif.

--- a/apps/aecore/test/aec_plugin_SUITE.erl
+++ b/apps/aecore/test/aec_plugin_SUITE.erl
@@ -91,20 +91,20 @@ registration(_Cfg) ->
     ok.
 
 real_registration() ->
-    undefined = aec_plugin:get_module(aec_headers),
-    ok = aec_plugin:register(#{aec_headers => ?MODULE}),
-    ?MODULE = aec_plugin:get_module(aec_headers),
+    undefined = aec_plugin:get_module(aec_tx_pool),
+    ok = aec_plugin:register(#{aec_tx_pool => ?MODULE}),
+    ?MODULE = aec_plugin:get_module(aec_tx_pool),
     ok.
 
 legacy_registration() ->
-    undefined = aec_plugin:get_module(aec_headers),
+    undefined = aec_plugin:get_module(aec_tx_pool),
     try begin
-            aec_plugin:register(#{aec_headers => ?MODULE}),
+            aec_plugin:register(#{aec_tx_pool => ?MODULE}),
             error(should_fail)
         end
     catch
         error:requires_OTP21 ->
-            undefined = aec_plugin:get_module(aec_headers),
+            undefined = aec_plugin:get_module(aec_tx_pool),
             ok
     end.
 

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -629,7 +629,7 @@ large_msgs(Config) ->
     N2 = aecore_suite_utils:node_name(Dev2),
 
     aecore_suite_utils:start_node(Dev1, Config),
-    aecore_suite_utils:connect(aecore_suite_utils:node_name(Dev1)),
+    aecore_suite_utils:connect(aecore_suite_utils:node_name(Dev1), [block_pow, instant_tx_confirm]),
 
     ok = rpc:call(N1, application, set_env, [aecore, block_gas_limit, 100000000]),
 
@@ -658,7 +658,7 @@ large_msgs(Config) ->
 
     T0 = os:timestamp(),
     aecore_suite_utils:start_node(Dev2, Config),
-    aecore_suite_utils:connect(N2),
+    aecore_suite_utils:connect(N2, [block_pow, instant_tx_confirm]),
 
     %% Set the same mining_rate to validate target
     %% Only needed when chain more than 18 blocks

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -117,7 +117,7 @@ init_per_group(VM, Config) when VM == aevm; VM == fate ->
 init_per_vm(Config) ->
     NodeName = aecore_suite_utils:node_name(?NODE),
     aecore_suite_utils:start_node(?NODE, Config),
-    aecore_suite_utils:connect(NodeName, [block_pow]),
+    aecore_suite_utils:connect(NodeName, [block_pow, instant_tx_confirm]),
 
     ToMine = max(0, aecore_suite_utils:latest_fork_height()),
     ct:pal("ToMine ~p\n", [ToMine]),

--- a/apps/aehttp/test/aehttp_dryrun_SUITE.erl
+++ b/apps/aehttp/test/aehttp_dryrun_SUITE.erl
@@ -67,7 +67,7 @@ init_per_group(VM, Config) when VM == aevm; VM == fate ->
 init_per_group(dry_run, Config) ->
     NodeName = aecore_suite_utils:node_name(?NODE),
     aecore_suite_utils:start_node(?NODE, Config),
-    aecore_suite_utils:connect(NodeName),
+    aecore_suite_utils:connect(NodeName, [block_pow, instant_tx_confirm]),
 
     ToMine = max(0, aecore_suite_utils:latest_fork_height()),
     ct:pal("ToMine ~p\n", [ToMine]),

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -125,7 +125,7 @@ init_per_group(VMGroup, Config) when VMGroup == aevm; VMGroup == fate ->
 init_per_group(_GAGroup, Config) ->
     NodeName = aecore_suite_utils:node_name(?NODE),
     aecore_suite_utils:start_node(?NODE, Config),
-    aecore_suite_utils:connect(NodeName, [block_pow]),
+    aecore_suite_utils:connect(NodeName, [block_pow, instant_tx_confirm]),
 
     ToMine = max(0, aecore_suite_utils:latest_fork_height()),
     ct:pal("ToMine ~p\n", [ToMine]),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -798,26 +798,26 @@ start_node(Group, Config) ->
     start_node(proplists:is_defined(node, Config), Group, Config).
 
 start_node(true, _Group, Config) ->
-    aecore_suite_utils:start_mock(aecore_suite_utils:node_name(?NODE), block_pow),
+    aecore_suite_utils:start_mocks(aecore_suite_utils:node_name(?NODE), [block_pow, instant_tx_confirm]),
     Config;
 start_node(false, Group, Config) ->
     %% TODO: consider reinint_chain to speed up tests
     aecore_suite_utils:start_node(?NODE, Config),
     Node = aecore_suite_utils:node_name(?NODE),
-    aecore_suite_utils:connect(Node, [block_pow]),
+    aecore_suite_utils:connect(Node, [block_pow, instant_tx_confirm]),
     [{node, Node}, {node_start_group, Group} | Config].
 
 start_node_no_mock(Group, Config) ->
     start_node_no_mock(proplists:is_defined(node, Config), Group, Config).
 
 start_node_no_mock(true, _Group, Config) ->
-    aecore_suite_utils:end_mock(aecore_suite_utils:node_name(?NODE), block_pow),
+    aecore_suite_utils:end_mocks(aecore_suite_utils:node_name(?NODE), [block_pow, instant_tx_confirm]),
     Config;
 start_node_no_mock(false, Group, Config) ->
     %% TODO: consider reinint_chain to speed up tests
     aecore_suite_utils:start_node(?NODE, Config),
     Node = aecore_suite_utils:node_name(?NODE),
-    aecore_suite_utils:connect(Node, [block_pow]),
+    aecore_suite_utils:connect(Node, [block_pow, instant_tx_confirm]),
     [{node, Node}, {node_start_group, Group} | Config].
 
 stop_node(Group, Config) ->

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -550,7 +550,7 @@ end_per_testcase(_Case, Config) ->
 start_node(Config) ->
     aecore_suite_utils:start_node(?NODE, Config),
     Node = aecore_suite_utils:node_name(?NODE),
-    aecore_suite_utils:connect(Node, [block_pow]),
+    aecore_suite_utils:connect(Node, [block_pow, instant_tx_confirm]),
 
     {ok, 404, _} = get_balance_at_top(),
     aecore_suite_utils:mine_key_blocks(Node, 10),

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -1492,7 +1492,7 @@ settle_(Config, Closer, Params) when Closer =:= initiator;
 
     ok = wait_for_signed_transaction_in_block(SettleTx),
     ?PEEK_MSGQ,
-    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE), 15),
+    aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE), 15),
     ?CHECK_INFO(20),
     {ok, SettleTx}.
 
@@ -1650,7 +1650,7 @@ sc_ws_deposit_(Config, Origin, XOpts) when Origin =:= initiator
     Fee = aetx:fee(aetx_sign:tx(SignedDepositTx)),
     {SStartB1, _, _} = {SStartB - 2 - Fee, SStartB1, SStartB},
 
-    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
+    aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                    ?DEFAULT_MIN_DEPTH),
     {ok, _, #{<<"event">> := <<"own_deposit_locked">>}} = wait_for_channel_event(SenderConnPid, info, Config),
     {ok, _, #{<<"event">> := <<"own_deposit_locked">>}} = wait_for_channel_event(AckConnPid, info, Config),
@@ -1726,7 +1726,7 @@ sc_ws_withdraw_(Config, Origin, XOpts) when Origin =:= initiator
     Fee = aetx:fee(aetx_sign:tx(SignedWTx)),
     {SStartB1, _, _} = {SStartB + 2 - Fee, SStartB1, SStartB},
 
-    aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
+    aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                    ?DEFAULT_MIN_DEPTH, #{strictly_follow_top => true}),
     {ok, _, #{<<"event">> := <<"own_withdraw_locked">>}} = wait_for_channel_event(SenderConnPid, info, Config),
     {ok, _, #{<<"event">> := <<"own_withdraw_locked">>}} = wait_for_channel_event(AckConnPid, info, Config),
@@ -5077,7 +5077,7 @@ sc_ws_optional_params_fail_slash(Cfg0) ->
             %% post the malicious tx and wait it to be included
             post_transactions_sut(EncRound2CloseTx),
             ok = wait_for_tx_hash_on_chain(Round2CloseTxHash),
-            aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
+            aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                            ?DEFAULT_MIN_DEPTH),
 
             ok
@@ -5102,7 +5102,7 @@ sc_ws_optional_params_fail_slash(Cfg0) ->
               fun() ->
                       ok = wait_for_tx_hash_on_chain(SlashTxHash)
               end, CleanCfg),
-            aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
+            aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                            ?DEFAULT_MIN_DEPTH),
             settle_(CleanCfg, initiator)
         end,
@@ -5117,7 +5117,7 @@ sc_ws_optional_params_fail_settle(Cfg0) ->
             %% make an update so we are not at channel_create_tx
             _Round1 = sc_ws_update_basic_round_(Round0, Cfg),
             {ok, _SignedTx} = sc_ws_close_solo_(Cfg, initiator, #{}),
-            aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
+            aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                            ?DEFAULT_MIN_DEPTH),
 
             ok
@@ -5138,7 +5138,7 @@ sc_ws_optional_params_fail_force_progress(Cfg0) ->
         fun(_ConnPid, Cfg) ->
             %% create and call some contracts
             sc_ws_contract_(Cfg, ContractName, initiator),
-            aecore_suite_utils:mine_blocks(aecore_suite_utils:node_name(?NODE),
+            aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE),
                                            ?DEFAULT_MIN_DEPTH),
 
             ok

--- a/apps/aehttp/test/aehttp_whitepaper_SUITE.erl
+++ b/apps/aehttp/test/aehttp_whitepaper_SUITE.erl
@@ -393,7 +393,8 @@ insurer_can_withdraw_after_insurance_expires(Cfg0) ->
                                     [integer_to_list(Reward + Generations * PricePerGeneration)],
                                     0, Cfg),
           ok
-      end).
+      end),
+    aehttp_sc_SUITE:sc_ws_close_(Cfg).
 
 insurer_can_deposit_multiple_times(Cfg0) ->
     City = "Sofia, Bulgaria",
@@ -507,7 +508,8 @@ insurer_can_withdraw_exess_tokens(Cfg0) ->
                                     [integer_to_list(Bonus + Generations * PricePerGeneration)],
                                     0, Cfg),
           ok
-      end).
+      end),
+    aehttp_sc_SUITE:sc_ws_close_(Cfg).
 
 insurer_can_withdraw_if_no_insurance(Cfg0) ->
     City = "Sofia, Bulgaria",
@@ -550,7 +552,8 @@ insurer_can_withdraw_if_no_insurance(Cfg0) ->
                                     ContractName, "withdraw",
                                     [integer_to_list(Compensation)], 0, Cfg),
           ok
-      end).
+      end),
+    aehttp_sc_SUITE:sc_ws_close_(Cfg).
 
 can_not_insure_if_not_enough_compensation(Cfg0) ->
     City = "Sofia, Bulgaria",


### PR DESCRIPTION
This is hopefully the last PR split out from #3377
#3377 will move instant mining and the old block pow mocks under the new consensus engine - I don't see a reason to wait for #3377 before merging this PR(besides using the old hacky mocks interface) - additionally this will allow me to keep the size of #3377 under control.