### PR TITLE
Fix CI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,22 +132,22 @@ references:
     restore_cache:
       key: *rebar_cache_key
 
-  build_otp21_cache_key: &build_otp21_cache_key build-otp21-cache-v5-{{ .Revision }}
+  build_otp21_cache_key: &build_otp21_cache_key build-otp21-cache-v6-{{ .Revision }}
   restore_build_otp21_cache: &restore_build_otp21_cache
     restore_cache:
       key: *build_otp21_cache_key
 
-  build_otp22_cache_key: &build_otp22_cache_key build-otp22-cache-v2-{{ .Revision }}
+  build_otp22_cache_key: &build_otp22_cache_key build-otp22-cache-v3-{{ .Revision }}
   restore_build_otp22_cache: &restore_build_otp22_cache
     restore_cache:
       key: *build_otp22_cache_key
 
-  build_otp23_cache_key: &build_otp23_cache_key build-otp23-cache-v1-{{ .Revision }}
+  build_otp23_cache_key: &build_otp23_cache_key build-otp23-cache-v2-{{ .Revision }}
   restore_build_otp23_cache: &restore_build_otp23_cache
     restore_cache:
       key: *build_otp23_cache_key
 
-  build_nix_cache_key: &build_nix_cache_key build-nix-cache-v1-{{ .Revision }}
+  build_nix_cache_key: &build_nix_cache_key build-nix-cache-v2-{{ .Revision }}
   restore_build_nix_cache: &restore_build_nix_cache
     restore_cache:
       key: *build_nix_cache_key
@@ -365,7 +365,7 @@ references:
         dmesg > ${SYSTEM_TEST_HOST_LOGS_DIR:?}/dmesg.log
       when: always
 
-  test_steps: &test_steps
+  test_steps_otp21: &test_steps_otp21
     - checkout
     - *restore_rebar_cache
     - *restore_build_otp21_cache
@@ -388,10 +388,68 @@ references:
     - *store_rebar3_crashdump
     - *fail_notification
 
-  eunit_steps: &eunit_steps
+  test_steps_otp22: &test_steps_otp22
+    - checkout
+    - *restore_rebar_cache
+    - *restore_build_otp22_cache
+    - run:
+        name: Test
+        command: |
+          epmd -daemon
+          make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
+    # Isolates the junit.xml report because additional files in _build/test/logs
+    # are somehow causing issue with xunit report upload, parsing and merging
+    - run:
+        name: move test report
+        command: |
+          mkdir _build/test/reports
+          mv _build/test/logs/junit.xml _build/test/reports/
+    - store_test_results:
+        path: _build/test/reports
+    - store_artifacts:
+        path: _build/test/logs
+    - *store_rebar3_crashdump
+    - *fail_notification
+
+  test_steps_otp23: &test_steps_otp23
+    - checkout
+    - *restore_rebar_cache
+    - *restore_build_otp23_cache
+    - run:
+        name: Test
+        command: |
+          epmd -daemon
+          make ${MAKE_TARGET:?} CT_TEST_FLAGS="--suite=$(.circleci/split_suites.sh)"
+    # Isolates the junit.xml report because additional files in _build/test/logs
+    # are somehow causing issue with xunit report upload, parsing and merging
+    - run:
+        name: move test report
+        command: |
+          mkdir _build/test/reports
+          mv _build/test/logs/junit.xml _build/test/reports/
+    - store_test_results:
+        path: _build/test/reports
+    - store_artifacts:
+        path: _build/test/logs
+    - *store_rebar3_crashdump
+    - *fail_notification
+
+  eunit_steps_otp21: &eunit_steps_otp21
     - checkout
     - *restore_rebar_cache
     - *restore_build_otp21_cache
+    - run:
+        name: Test
+        command: |
+          epmd -daemon
+          make ${MAKE_TARGET:?}
+    - *store_rebar3_crashdump
+    - *fail_notification
+
+  eunit_steps_otp22: &eunit_steps_otp22
+    - checkout
+    - *restore_rebar_cache
+    - *restore_build_otp22_cache
     - run:
         name: Test
         command: |
@@ -696,6 +754,7 @@ jobs:
     steps:
       - checkout
       - *restore_rebar_cache
+      - *restore_build_nix_cache
       - run:
           name: Build
           command: nix-shell -j auto --run "make KIND=test"
@@ -715,35 +774,35 @@ jobs:
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-roma
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   test_minerva:
     executor: builder_container_otp22
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-minerva
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   test_fortuna:
     executor: builder_container_otp22
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-fortuna
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   test_lima:
     executor: builder_container_otp22
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-lima
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   test_latest:
     executor: builder_container_otp22
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-latest
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   # Sanity check whether the latest aesophia compiler works
   test_latest_with_aesophia_compiler:
@@ -751,65 +810,65 @@ jobs:
     parallelism: 1
     environment:
       - MAKE_TARGET: ct-latest-no-aci
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   test_latest_otp21:
     executor: builder_container_otp21
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-latest
-    steps: *test_steps
+    steps: *test_steps_otp21
 
   test_latest_otp23:
     executor: builder_container_otp23
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-latest
-    steps: *test_steps
+    steps: *test_steps_otp23
 
   test_mnesia_leveled:
     executor: builder_container_otp22
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-mnesia-leveled
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   test_mnesia_rocksdb:
     executor: builder_container_otp22
     parallelism: 3
     environment:
       - MAKE_TARGET: ct-mnesia-rocksdb
-    steps: *test_steps
+    steps: *test_steps_otp22
 
   eunit_roma:
     executor: builder_container_otp22
     environment:
       - MAKE_TARGET: eunit-roma
-    steps: *eunit_steps
+    steps: *eunit_steps_otp22
 
   eunit_minerva:
     executor: builder_container_otp22
     environment:
       - MAKE_TARGET: eunit-minerva
-    steps: *eunit_steps
+    steps: *eunit_steps_otp22
 
   eunit_fortuna:
     executor: builder_container_otp22
     environment:
       - MAKE_TARGET: eunit-fortuna
-    steps: *eunit_steps
+    steps: *eunit_steps_otp22
 
   eunit_lima:
     executor: builder_container_otp22
     environment:
       - MAKE_TARGET: eunit-lima
-    steps: *eunit_steps
+    steps: *eunit_steps_otp22
 
   eunit_latest:
     executor: builder_container_otp22
     environment:
       - MAKE_TARGET: eunit-latest
-    steps: *eunit_steps
+    steps: *eunit_steps_otp22
 
   aevm_tests:
     executor: builder_container_otp22
@@ -1046,6 +1105,7 @@ jobs:
       - *install_os_deps
       - *install_otp
       - *install_libsodium
+      - *restore_rebar_cache
       - *restore_machine_build_cache
       - *prepare_ubuntu_user
       - *install_system_test_deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -718,7 +718,7 @@ jobs:
       - *restore_rebar_cache
       - run:
           name: Build
-          command: make KIND=test
+          command: make test-build
       - save_cache:
           key: *build_otp21_cache_key
           paths:
@@ -737,7 +737,7 @@ jobs:
       - *restore_rebar_cache
       - run:
           name: Build
-          command: make KIND=test
+          command: make test-build
       - save_cache:
           key: *build_otp23_cache_key
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,16 @@ references:
         dmesg > ${SYSTEM_TEST_HOST_LOGS_DIR:?}/dmesg.log
       when: always
 
+  trim_test_artifacts: &trim_test_artifacts
+      run:
+        name: trim down artifacts
+        command: |
+          find _build/test/logs -iname bin | xargs rm -rf
+          find _build/test/logs -iname data | xargs rm -rf
+          find _build/test/logs -iname releases | xargs rm -rf
+          find _build/test/logs -iname extensions | xargs rm -rf
+          find _build/test/logs -iname hooks | xargs rm -rf
+
   test_steps_otp21: &test_steps_otp21
     - checkout
     - *restore_rebar_cache
@@ -383,6 +393,7 @@ references:
           mv _build/test/logs/junit.xml _build/test/reports/
     - store_test_results:
         path: _build/test/reports
+    - *trim_test_artifacts
     - store_artifacts:
         path: _build/test/logs
     - *store_rebar3_crashdump
@@ -406,6 +417,7 @@ references:
           mv _build/test/logs/junit.xml _build/test/reports/
     - store_test_results:
         path: _build/test/reports
+    - *trim_test_artifacts
     - store_artifacts:
         path: _build/test/logs
     - *store_rebar3_crashdump
@@ -429,6 +441,7 @@ references:
           mv _build/test/logs/junit.xml _build/test/reports/
     - store_test_results:
         path: _build/test/reports
+    - *trim_test_artifacts
     - store_artifacts:
         path: _build/test/logs
     - *store_rebar3_crashdump

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ aestratum_client_build:
 	if ! cmp .git/HEAD .build_lock; then \
 	  	mkdir -p _build/default; \
 	  	rm -rf _build/default; \
-  		cp -r ../../../default _build/default; \
 		../../../../$(REBAR) as test release; \
 		cp .git/HEAD .build_lock; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,19 @@ console: $(SWAGGER_ENDPOINTS_SPEC)
 	@$(REBAR) as local shell --config config/dev.config --sname aeternity@localhost
 
 test-build: KIND=test
-test-build: internal-build
-	cd _build/$(KIND)/lib/aestratum_client && ../../../../$(REBAR) as test release
+test-build: internal-build aestratum_client_build
+
+AESTRATUM_CLIENT_DIR = _build/$(KIND)/lib/aestratum_client
+aestratum_client_build:
+	touch $(AESTRATUM_CLIENT_DIR)/.build_lock
+	cd $(AESTRATUM_CLIENT_DIR); \
+	if ! cmp .git/HEAD .build_lock; then \
+	  	mkdir -p _build/default; \
+	  	rm -rf _build/default; \
+  		cp -r ../../../default _build/default; \
+		../../../../$(REBAR) as test release; \
+		cp .git/HEAD .build_lock; \
+	fi
 
 local-build: KIND=local
 local-build: internal-build

--- a/rebar.config
+++ b/rebar.config
@@ -73,7 +73,7 @@
                           {ref,"80ff8a4"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
-                         {ref, "96ffd9a"}}},
+                         {ref, "a043272"}}},
 
         {ecrecover, {git, "https://github.com/aeternity/ecrecover.git",
                      {ref, "b3b6421"}}},
@@ -258,8 +258,8 @@
   % We need to explicitely add lager as a compile-time dependency for
   % exometer_core, since we configure its logging to use lager.
   {add, exometer_core, [
-    {deps, [{lager, ".*", {git, "https://github.com/erlang-lager/lager.git",
-                          {ref, "69b4ada"}}} % tag: 3.6.7
+    {deps, [{lager, ".*", {git, "https://github.com/aeternity/lager.git",
+                {ref, "9d97ae3"}}}
            ]}]},
   {override, exometer_core, [
     {erl_opts, [{d,'HUT_LAGER'},

--- a/rebar.lock
+++ b/rebar.lock
@@ -26,7 +26,7 @@
   0},
  {<<"aestratum_lib">>,
   {git,"https://github.com/aeternity/aestratum_lib.git",
-      {ref,"96ffd9a36fab0d65640e87000e8466458276b8f3"}},
+      {ref,"a0432722a990da2b9d8bbf3cb29a345d97f18d16"}},
   0},
  {<<"base58">>,
   {git,"https://github.com/aeternity/erl-base58.git",


### PR DESCRIPTION
- Shares deps between the node and aestratum_client
- Does not invoke rebar on aestratum_client when it was built before
- Fixes CI caching - previously the wrong caches were used for tests (I hate that YAML does not support merging sequences together...)