### PR TITLE
Peer pool refactoring

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -108,7 +108,7 @@
         , find_block_state_and_data/1
         , find_block_state_and_data/2
         ]).
-
+%%
 %% for testing
 -export([backend_mode/0]).
 

--- a/apps/aecore/src/aec_db_error_store.erl
+++ b/apps/aecore/src/aec_db_error_store.erl
@@ -13,17 +13,17 @@
 
 %% API
 -export([ start_link/0
-	, stop/0
+        , stop/0
         , check/1
 	]).
 
 %% gen_server callbacks
 -export([ init/1
         , handle_call/3
-	, handle_cast/2
-	, handle_info/2
-	, terminate/2
-	, code_change/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
 	]).
 
 -define(DB_NAME, ?MODULE).

--- a/apps/aecore/src/aec_peer.erl
+++ b/apps/aecore/src/aec_peer.erl
@@ -18,6 +18,10 @@
         , format_address/1
         ]).
 
+-ifdef(TEST).
+-export([ set_trusted/2]).
+-endif.
+
 -record(peer, {
     pubkey            :: aec_keys:pubkey(),
     host              :: host(),
@@ -115,3 +119,8 @@ port(#{ port := Port }) -> Port.
 
 -spec is_trusted(peer()) -> boolean().
 is_trusted(#peer{ trusted = Trusted }) -> Trusted.
+
+-ifdef(TEST).
+set_trusted(Peer, Trusted) ->
+    Peer#peer{trusted = Trusted}.
+-endif.

--- a/apps/aecore/src/aec_peer.erl
+++ b/apps/aecore/src/aec_peer.erl
@@ -1,7 +1,7 @@
 -module(aec_peer).
 
 %% API
--export([new/3,
+-export([new/4,
          socket/2
         ]).
 
@@ -16,6 +16,8 @@
         , ppp/1
         , info/1
         , format_address/1
+        , source/1
+        , set_source/2
         ]).
 
 -ifdef(TEST).
@@ -26,6 +28,7 @@
     pubkey            :: aec_keys:pubkey(),
     host              :: host(),
     address           :: inet:ip_address(),
+    source            :: inet:ip_address(),
     port              :: inet:port_number(),
     % If it is a pre-configured peer.
     trusted = false   :: boolean()
@@ -54,13 +57,14 @@
               socket/0]).
 
 
--spec new(inet:ip_address(), aec_peer:info(), boolean()) -> peer().
-new(PeerAddr, PeerInfo, IsTrusted) ->
+-spec new(inet:ip_address(), inet:ip_address(), aec_peer:info(), boolean()) -> peer().
+new(PeerAddr, Source, PeerInfo, IsTrusted) ->
     #{ pubkey := PubKey, host := Host, port := Port } = PeerInfo,
     #peer{
         pubkey = PubKey,
         host = Host,
         address = PeerAddr,
+        source = Source,
         port = Port,
         trusted = IsTrusted
     }.
@@ -124,3 +128,12 @@ is_trusted(#peer{ trusted = Trusted }) -> Trusted.
 set_trusted(Peer, Trusted) ->
     Peer#peer{trusted = Trusted}.
 -endif.
+
+-spec source(peer()) -> inet:ip_address().
+source(#peer{source = Source}) ->
+    Source.
+
+-spec set_source(peer(), inet:ip_address()) -> peer().
+set_source(Peer, Source) ->
+    Peer#peer{source = Source}.
+

--- a/apps/aecore/src/aec_peer.erl
+++ b/apps/aecore/src/aec_peer.erl
@@ -1,0 +1,117 @@
+-module(aec_peer).
+
+%% API
+-export([new/3,
+         socket/2
+        ]).
+
+%% getters
+-export([ id/1
+        , pubkey/1
+        , host/1
+        , ip/1
+        , port/1
+        , socket/1
+        , is_trusted/1
+        , ppp/1
+        , info/1
+        , format_address/1
+        ]).
+
+-record(peer, {
+    pubkey            :: aec_keys:pubkey(),
+    host              :: host(),
+    address           :: inet:ip_address(),
+    port              :: inet:port_number(),
+    % If it is a pre-configured peer.
+    trusted = false   :: boolean()
+}).
+
+-record(socket, {
+    address           :: inet:ip_address(),
+    port              :: inet:port_number()
+}).
+
+%% The Peer is identified by its pubkey for now.
+-type info() :: #{
+    pubkey  := aec_keys:pubkey(),
+    host    => host(),
+    port    => inet:port_number()
+}.
+-type id() :: binary().
+-type peer() :: #peer{}.
+-type socket() :: #socket{}.
+-type host() :: string() | binary().
+
+
+-export_type([id/0,
+              peer/0,
+              info/0,
+              socket/0]).
+
+
+-spec new(inet:ip_address(), aec_peer:info(), boolean()) -> peer().
+new(PeerAddr, PeerInfo, IsTrusted) ->
+    #{ pubkey := PubKey, host := Host, port := Port } = PeerInfo,
+    #peer{
+        pubkey = PubKey,
+        host = Host,
+        address = PeerAddr,
+        port = Port,
+        trusted = IsTrusted
+    }.
+
+
+-spec id(peer() | info()) -> id().
+id(#peer{pubkey = Pubkey}) ->
+    Pubkey;
+id(#{ pubkey := PubKey }) ->
+    PubKey.
+
+-spec socket(peer()) -> socket().
+socket(#peer{address = Address,
+                  port    = Port}) ->
+    socket(Address, Port).
+
+socket(Address, Port) ->
+    #socket{address = Address, port = Port}.
+
+-spec ppp(id() | peer() | info()) -> string().
+ppp(PeerId) when is_binary(PeerId) ->
+    Str = lists:flatten(io_lib:format("~p", [aeser_api_encoder:encode(peer_pubkey, PeerId)])),
+    lists:sublist(Str, 4, 10) ++ "..." ++ lists:sublist(Str, length(Str) - 9, 7);
+ppp(#{ pubkey := PK }) -> ppp(PK);
+ppp(#peer{ pubkey = PK }) -> ppp(PK);
+ppp(X) -> X.
+
+%% Gets peer's info from given data.
+-spec info(peer()) -> info().
+info(#peer{ host = H, port = P, pubkey = PK }) ->
+    #{ host => H, port => P, pubkey => PK }.
+
+-spec format_address(peer() | inet:ip_address() | {inet:ip_address(), inet:port_number()})
+    -> binary().
+format_address({A, B, C, D}) ->
+    iolist_to_binary(io_lib:format("~b.~b.~b.~b", [A, B, C, D]));
+format_address({{A, B, C, D}, P}) ->
+    iolist_to_binary(io_lib:format("~b.~b.~b.~b:~b", [A, B, C, D, P]));
+format_address(#peer{ address = Addr, port = Port }) ->
+    format_address({Addr, Port}).
+
+-spec pubkey(peer() | info()) -> aec_keys:pubkey().
+pubkey(#peer{ pubkey = Pubkey }) -> Pubkey;
+pubkey(#{ pubkey := Pubkey }) -> Pubkey.
+
+-spec ip(peer() | info()) -> inet:ip_address().
+ip(#peer{ address = Address }) -> Address;
+ip(#{ address := Address }) -> Address.
+
+-spec host(peer()) -> host().
+host(#peer{ host = Host }) -> Host.
+
+-spec port(peer() | info()) -> inet:port_number().
+port(#peer{ port = Port }) -> Port;
+port(#{ port := Port }) -> Port.
+
+-spec is_trusted(peer()) -> boolean().
+is_trusted(#peer{ trusted = Trusted }) -> Trusted.

--- a/apps/aecore/src/aec_peer.erl
+++ b/apps/aecore/src/aec_peer.erl
@@ -21,7 +21,7 @@
         ]).
 
 -ifdef(TEST).
--export([ set_trusted/2]).
+-export([ set_trusted/2 ]).
 -endif.
 
 -record(peer, {
@@ -41,7 +41,7 @@
 
 %% The Peer is identified by its pubkey for now.
 -type info() :: #{
-    pubkey  := aec_keys:pubkey(),
+    pubkey  => aec_keys:pubkey(),
     host    => host(),
     port    => inet:port_number()
 }.
@@ -78,7 +78,7 @@ id(#{ pubkey := PubKey }) ->
 
 -spec socket(peer()) -> socket().
 socket(#peer{address = Address,
-                  port    = Port}) ->
+             port    = Port}) ->
     socket(Address, Port).
 
 socket(Address, Port) ->

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -763,7 +763,7 @@ ping_obj_rsp(S, RemotePingObj) ->
     #{ share := Share, peers := TheirPeers } = RemotePingObj,
     LocalPingObj = local_ping_obj(S),
     ping_obj(LocalPingObj#{ share => Share },
-             [PeerId | [aec_peers:peer_id(P) || P <- TheirPeers]]).
+             [PeerId | [aec_peer:id(P) || P <- TheirPeers]]).
 
 local_ping_obj(#{ kind := ConnKind, ext_sync_port := Port }) ->
     GHash = aec_chain:genesis_hash(),

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -56,10 +56,6 @@
 %% API only used in aec_sync.
 -export([log_ping/2]).
 
-%% Function that shouldn't really be used by other modules but are.
--export([peer_id/1]).
--export([ppp/1]).
-
 %% gen_server callbacks
 -export([start_link/0, init/1, handle_call/3, handle_cast/2,
          handle_info/2, terminate/2, code_change/3]).
@@ -90,17 +86,8 @@
 
 %=== TYPES =====================================================================
 
--record(peer, {
-    pubkey            :: aec_keys:pubkey(),
-    host              :: string() | binary(),
-    address           :: inet:ip_address(),
-    port              :: inet:port_number(),
-    % If it is a pre-configured peer.
-    trusted = false   :: boolean()
-}).
-
 -record(conn, {
-    peer              :: peer(),
+    peer              :: aec_peer:peer(),
     state             :: connecting | connected,
     type              :: inbound | outbound,
     tcp_probe = false :: boolean(),
@@ -109,17 +96,12 @@
     pid               :: pid()
 }).
 
--record(peer_socket, {
-    address           :: inet:ip_address(),
-    port              :: inet:port_number()
-}).
-
 -record(state, {
     pool              :: aec_peers_pool:state(),
     %$ The address groups we have an outbound connection for.
-    groups            :: #{binary() => #{peer_id() => true}},
+    groups            :: #{binary() => #{aec_peer:id() => true}},
     %% The peer connections.
-    conns             :: #{peer_id() => conn()},
+    conns             :: #{aec_peer:id() => conn()},
     %% The number of inbound connections.
     inbound = 0       :: non_neg_integer(),
     %% The number of outbound connections.
@@ -139,50 +121,38 @@
     %% The last time there was a TCP probe to an unverified peer.
     last_tcp_unverified_probe_time :: undefined | non_neg_integer(),
     %% The blocked peers.
-    blocked           :: gb_trees:tree(peer_id(), peer_info()),
+    blocked           :: gb_trees:tree(aec_peer:id(), aec_peer:info()),
     %% The set of known addresses and ports
-    known_sockets     :: gb_trees:tree(peer_socket(), peer_id()),
+    known_sockets     :: gb_trees:tree(aec_peer:socket(), aec_peer:id()),
     %% For universal handling of URIs.
-    local_peer        :: peer_info(),
+    local_peer        :: aec_peer:info(),
     %% The time of next unblock as an erlang timestamp in ms.
     next_unblock = 0  :: non_neg_integer(),
     %% The connection monitors.
-    monitors          :: #{pid() => {reference(), peer_id()}},
+    monitors          :: #{pid() => {reference(), aec_peer:id()}},
     %% The hostnames that failed to resolve and are pending for retries.
     hostnames         :: #{Host::string() =>
                                  %% Host data.
                                  {ResolverTimer :: reference(),
                                   RetryCount :: pos_integer(),
-                                  #{ peer_id() =>
+                                  #{ aec_peer:id() =>
                                          %% Peer data.
                                          {SourceAddress :: inet:ip_address()
                                                          | undefined,
-                                          peer_info(),
+                                          aec_peer:info(),
                                           Trusted :: boolean()}}}}
 }).
 
-%% The Peer is identified by its pubkey for now.
--type peer_id() :: binary().
--type peer_info() :: #{
-    pubkey  := aec_keys:pubkey(),
-    host    => string() | binary(),
-    port    => inet:port_number()
-}.
--type peer() :: #peer{}.
 -type peer_pool_name() :: verified | unverified.
 -type conn() :: #conn{}.
 -type state() :: #state{}.
--type peer_socket() :: #peer_socket{}.
-
--export_type([peer_id/0,
-              peer_info/0]).
 
 %=== API FUNCTIONS =============================================================
 
 %--- PEER MANAGMENT FUNCTIONS --------------------------------------------------
 
 %% @doc Adds a trusted peer or a list of trusted peers.
--spec add_trusted(peer_info() | [peer_info()]) -> ok.
+-spec add_trusted(aec_peer:info() | [aec_peer:info()]) -> ok.
 add_trusted(PeerInfos) when is_list(PeerInfos) ->
     lists:foreach(fun(I) -> add_trusted(I) end, PeerInfos);
 add_trusted(PeerInfo) ->
@@ -190,7 +160,7 @@ add_trusted(PeerInfo) ->
 
 %% @doc Adds a normal peer or a list of normal peers.
 %% The IP address of the node that gave us this peer must be specified.
--spec add_peers(inet:ip_address(), peer_info() | [peer_info()]) -> ok.
+-spec add_peers(inet:ip_address(), aec_peer:info() | [aec_peer:info()]) -> ok.
 add_peers(SourceAddr, PeerInfos) when is_list(PeerInfos) ->
     lists:foreach(fun(I) -> add_peers(SourceAddr, I) end, PeerInfos);
 add_peers(SourceAddr, PeerInfo) ->
@@ -198,18 +168,17 @@ add_peers(SourceAddr, PeerInfo) ->
 
 %% @doc Removes a peer; if connected, closes the connection.
 %% At the moment also removes peer from the blocked list.
--spec del_peer(peer_id() | peer_info()) -> ok.
-del_peer(PeerIdOrInfo) ->
-    PeerId = peer_id(PeerIdOrInfo),
+-spec del_peer(aec_peer:id() | aec_peer:info()) -> ok.
+del_peer(PeerId) ->
     gen_server:cast(?MODULE, {del_peer, PeerId}).
 
 %% @doc Blocks given peer.
--spec block_peer(peer_info()) -> ok | {error, term()}.
+-spec block_peer(aec_peer:info()) -> ok | {error, term()}.
 block_peer(PeerInfo) ->
     gen_server:call(?MODULE, {block_peer, PeerInfo}).
 
 %% @doc Unblocks given peer.
--spec unblock_peer(peer_id()) -> ok | {error, term()}.
+-spec unblock_peer(aec_peer:id()) -> ok | {error, term()}.
 unblock_peer(PeerId) ->
     gen_server:call(?MODULE, {unblock_peer, PeerId}).
 
@@ -217,7 +186,7 @@ unblock_peer(PeerId) ->
 
 %% @doc Checks if given peer is blocked.
 %% Erroneous Peers are by definition blocked.
--spec is_blocked(peer_id()) -> boolean().
+-spec is_blocked(aec_peer:id()) -> boolean().
 is_blocked(PeerId) ->
     gen_server:call(?MODULE, {is_blocked, PeerId}).
 
@@ -242,7 +211,7 @@ count(Tag)
 
 %% @doc Gets the list of peers available to connect to.
 %% The result could be very large; use only for debugging/testing.
--spec available_peers() -> [peer_info()].
+-spec available_peers() -> [aec_peer:info()].
 available_peers() ->
     gen_server:call(?MODULE, {available_peers, both}).
 
@@ -251,12 +220,12 @@ available_peers() ->
 %%  * `verified': only available verified peers.
 %%  * `unverified': only available unverified peers.
 %% The result could be very large; use only for debugging/testing.
--spec available_peers(both | verified | unverified) -> [peer_info()].
+-spec available_peers(both | verified | unverified) -> [aec_peer:info()].
 available_peers(Tag) when Tag =:= both; Tag =:= verified; Tag =:= unverified ->
     gen_server:call(?MODULE, {available_peers, Tag}).
 
 %% @doc Gets the list of all connected peers.
--spec connected_peers() -> [peer_info()].
+-spec connected_peers() -> [aec_peer:info()].
 connected_peers() ->
     connected_peers(all).
 
@@ -264,23 +233,23 @@ connected_peers() ->
 %%  * `all': All connected peers.
 %%  * `outbound': All peers with outbound connection to.
 %%  * `inbound': All peers with inbound connection from.
--spec connected_peers(all | inbound | outbound) -> [peer_info()].
+-spec connected_peers(all | inbound | outbound) -> [aec_peer:info()].
 connected_peers(Tag) when Tag =:= all; Tag =:= inbound; Tag =:= outbound ->
     gen_server:call(?MODULE, {connected_peers, Tag}).
 
 %% @doc Gets the list of blocked peers.
--spec blocked_peers() -> [peer_info()].
+-spec blocked_peers() -> [aec_peer:info()].
 blocked_peers() ->
     gen_server:call(?MODULE, blocked_peers).
 
 %% @doc Gets up to N random peers.
--spec get_random(all | non_neg_integer()) -> [peer_info()].
+-spec get_random(all | non_neg_integer()) -> [aec_peer:info()].
 get_random(NumberOfPeers) ->
     get_random(NumberOfPeers, undefined).
 
 %% @doc Gets up to N random peers, but none of the peers from the Exclude list.
--spec get_random(all | non_neg_integer(), [peer_id()] | undefined)
-    -> [peer_info()].
+-spec get_random(all | non_neg_integer(), [aec_peer:id()] | undefined)
+    -> [aec_peer:info()].
 get_random(N, Exclude)
   when (Exclude =:= undefined) orelse is_list(Exclude),
        (N =:= all) orelse (is_integer(N) andalso N >= 0) ->
@@ -288,12 +257,12 @@ get_random(N, Exclude)
 
 
 %% @doc Gets up to N random connected peers.
--spec get_random_connected(pos_integer()) -> [peer_info()].
+-spec get_random_connected(pos_integer()) -> [aec_peer:info()].
 get_random_connected(N) when (is_integer(N) andalso N > 0) ->
     gen_server:call(?MODULE, {get_random_connected, N}).
 
 %% @doc Gets a connection PID from a peer identifier.
--spec get_connection(peer_id()) -> {ok, pid()} | {error, term()}.
+-spec get_connection(aec_peer:id()) -> {ok, pid()} | {error, term()}.
 get_connection(PeerId) ->
     gen_server:call(?MODULE, {get_connection, PeerId}).
 
@@ -301,7 +270,7 @@ get_connection(PeerId) ->
 
 %% @doc Parses a peer URI to a peer info map.
 -spec parse_peer_address(binary() | string())
-    -> {ok, peer_info()} | {error, term()}.
+    -> {ok, aec_peer:info()} | {error, term()}.
 parse_peer_address(PeerAddress) ->
     case http_uri:parse(PeerAddress) of
         {ok, {aenode, EncPubKey, Host, Port, _Path, _Query}} ->
@@ -321,7 +290,7 @@ parse_peer_address(PeerAddress) ->
     end.
 
 %% @doc Encodes peer info map to a peer URI.
--spec encode_peer_address(peer_info()) -> binary().
+-spec encode_peer_address(aec_peer:info()) -> binary().
 encode_peer_address(#{ pubkey := PubKey, host := Host, port := Port }) ->
     list_to_binary(["aenode://", aeser_api_encoder:encode(peer_pubkey, PubKey), "@",
                     Host, ":", integer_to_list(Port)]).
@@ -329,73 +298,52 @@ encode_peer_address(#{ pubkey := PubKey, host := Host, port := Port }) ->
 %--- CONNECTION MANAGMENT FUNCTIONS FOR aec_peer_connection ONLY ---------------
 
 %% @doc Informs that an outbound connection successfully connected.
--spec peer_connected(peer_id(), pid()) -> ok | {error, term()}.
+-spec peer_connected(aec_peer:id(), pid()) -> ok | {error, term()}.
 peer_connected(PeerId, PeerCon) ->
     gen_server:call(?MODULE, {peer_connected, PeerId, PeerCon}).
 
 %% @doc Informs that an inbound connection has been accepted.
 %% If it returns `temporary' the connection should be closed as soon as
 %% the first ping has been responded.
--spec peer_accepted(peer_info(), inet:ip_address(), pid())
+-spec peer_accepted(aec_peer:info(), inet:ip_address(), pid())
     -> permanent | temporary | {error, term()}.
 peer_accepted(PeerInfo, Addr, PeerCon) ->
     gen_server:call(?MODULE, {peer_accepted, Addr, PeerInfo, PeerCon}).
 
--spec peer_alive(peer_id(), pid()) -> ok | {error, term()}.
+-spec peer_alive(aec_peer:id(), pid()) -> ok | {error, term()}.
 peer_alive(PeerId, PeerCon) ->
     gen_server:call(?MODULE, {peer_alive, PeerId, PeerCon}).
 
 %% @doc Informs that a connection failed unexpectedly; either when connecting
 %% or while already being connected.
--spec connection_failed(peer_id(), pid()) -> ok.
+-spec connection_failed(aec_peer:id(), pid()) -> ok.
 connection_failed(PeerId, PeerCon) ->
     gen_server:call(?MODULE, {connection_failed, PeerId, PeerCon}).
 
 %% @doc Informs that a connection got closed cleanly.
--spec connection_closed(peer_id(), pid()) -> ok.
+-spec connection_closed(aec_peer:id(), pid()) -> ok.
 connection_closed(PeerId, PeerCon) ->
     gen_server:call(?MODULE, {connection_closed, PeerId, PeerCon}).
 
--spec peer_dead(peer_id(), pid()) -> ok | {error, term()}.
+-spec peer_dead(aec_peer:id(), pid()) -> ok | {error, term()}.
 peer_dead(PeerId, PeerCon) ->
     gen_server:call(?MODULE, {peer_dead, PeerId, PeerCon}).
 
 %--- UTILITY FUNCTIONS FOR aec_sync ONLY ---------------------------------------
 
--spec log_ping(peer_id(), ok | error) -> ok | {error, any()}.
+-spec log_ping(aec_peer:id(), ok | error) -> ok | {error, any()}.
 log_ping(PeerId, Outcome) ->
     gen_server:cast(?MODULE, {log_ping, Outcome, PeerId, timestamp()}).
 
-%--- PUBLIC FUNCTIONS THAT SHOULDN'T BE PUBLIC ---------------------------------
+%--- Utility functions for extraction of peer id ------------------------------
 
-%% @doc Extracts a peer identifier from given parameter.
--spec peer_id(state() | conn() | peer_id() | peer() | peer_info()) -> peer_id().
-peer_id(#state{ local_peer = LocalPeerInfo }) ->
-    #{ pubkey := PubKey } = LocalPeerInfo,
-    PubKey;
+-spec local_peer_id(state()) -> aec_peer:id().
+local_peer_id(#state{ local_peer = LocalPeerInfo }) ->
+    aec_peer:id(LocalPeerInfo).
+
+-spec peer_id(conn()) -> aec_peer:id().
 peer_id(#conn{ peer = Peer }) ->
-    #peer{ pubkey = PubKey } = Peer,
-    PubKey;
-peer_id(PeerId) when is_binary(PeerId) ->
-    PeerId;
-peer_id(#{ pubkey := PubKey }) ->
-    PubKey;
-peer_id(#peer{ pubkey = PubKey }) ->
-    PubKey.
-
--spec peer_socket(#peer{}) -> peer_socket().
-peer_socket(#peer{address = Address,
-                  port    = Port}) ->
-    #peer_socket{address = Address, port = Port}.
-
-%% @doc Tries formating a peer for logging.
--spec ppp(peer_id() | peer_info() | peer()) -> string().
-ppp(PeerId) when is_binary(PeerId) ->
-    Str = lists:flatten(io_lib:format("~p", [aeser_api_encoder:encode(peer_pubkey, PeerId)])),
-    lists:sublist(Str, 4, 10) ++ "..." ++ lists:sublist(Str, length(Str) - 9, 7);
-ppp(#{ pubkey := PK }) -> ppp(PK);
-ppp(#peer{ pubkey = PK }) -> ppp(PK);
-ppp(X) -> X.
+    aec_peer:id(Peer).
 
 %--- TESTING FUNCTIONS ---------------------------------------------------------
 
@@ -416,7 +364,7 @@ init(ok) ->
     LocalPeer = #{ pubkey => PubKey },
     LogTimeout = log_peer_connection_count_interval(),
     erlang:send_after(LogTimeout, self(), log_peer_conn_count_timeout),
-    epoch_sync:info("aec_peers started for ~p", [ppp(LocalPeer)]),
+    epoch_sync:info("aec_peers started for ~p", [aec_peer:ppp(LocalPeer)]),
     {ok, #state{
         local_peer = LocalPeer,
         pool = aec_peers_pool:new(pool_config()),
@@ -454,7 +402,7 @@ handle_call({get_connection, PeerId}, _From, State) ->
     {reply, conn_pid(PeerId, State), State};
 handle_call({get_random, N, Exclude}, _From, State0) ->
     {Subset, State} = pool_random_subset(N, Exclude, State0),
-    Result = [ peer_info(P) || {_, P} <- Subset ],
+    Result = [ aec_peer:info(P) || {_, P} <- Subset ],
     {reply, Result, State};
 handle_call({get_random_connected, N}, _From, State) ->
     {reply, random_connected_peers(N, all, State), State};
@@ -504,10 +452,10 @@ handle_cast({resolved_hostname, Host, {ok, Addr}}, #state{hostnames = HostMap} =
             NewState =
                 maps:fold(fun
                               (_, {undefined, PeerInfo, IsTrusted}, S) ->
-                                  Peer = peer(Addr, PeerInfo, IsTrusted),
+                                  Peer = aec_peer:new(Addr, PeerInfo, IsTrusted),
                                   on_add_peer(Addr, Peer, S);
                               (_, {SourceAddr, PeerInfo, IsTrusted}, S) ->
-                                  Peer = peer(Addr, PeerInfo, IsTrusted),
+                                  Peer = aec_peer:new(Addr, PeerInfo, IsTrusted),
                                   on_add_peer(SourceAddr, Peer, S)
                           end, State2, PeerMap),
             {noreply, update_peer_metrics(schedule_connect(NewState))};
@@ -577,40 +525,15 @@ start_timer(Msg, Timeout) ->
     erlang:start_timer(Timeout, self(), Msg).
 
 %% Tells if a given peer is the local peer.
--spec is_local(peer_id(), state()) -> boolean().
+-spec is_local(aec_peer:id(), state()) -> boolean().
 is_local(PeerId, State) ->
-    PeerId =:= peer_id(State).
-
-%% Gets peer's info from given data.
--spec peer_info(peer()) -> peer_info().
-peer_info(#peer{ host = H, port = P, pubkey = PK }) ->
-    #{ host => H, port => P, pubkey => PK }.
-
-%% Creates a peer record from peer's information and resolved address.
--spec peer(inet:ip_address(), peer_info(), boolean()) -> peer().
-peer(PeerAddr, PeerInfo, IsTrusted) ->
-    #{ pubkey := PubKey, host := Host, port := Port } = PeerInfo,
-    #peer{
-        pubkey = PubKey,
-        host = Host,
-        address = PeerAddr,
-        port = Port,
-        trusted = IsTrusted
-    }.
+    PeerId =:= local_peer_id(State).
 
 %% Format the given address or the given peer or connection address.
 %% Only supports IPv4 for now.
--spec format_address(peer() | conn() | inet:ip_address()
-                     | {inet:ip_address(), inet:port_number()})
-    -> binary().
-format_address({A, B, C, D}) ->
-    iolist_to_binary(io_lib:format("~b.~b.~b.~b", [A, B, C, D]));
-format_address({{A, B, C, D}, P}) ->
-    iolist_to_binary(io_lib:format("~b.~b.~b.~b:~b", [A, B, C, D, P]));
-format_address(#peer{ address = Addr, port = Port}) ->
-    format_address({Addr, Port});
-format_address(#conn{ peer = Peer }) ->
-    format_address(Peer).
+-spec format_conn_address(conn()) -> binary().
+format_conn_address(#conn{ peer = Peer }) ->
+    aec_peer:format_address(Peer).
 
 to_binary(Bin) when is_binary(Bin) -> Bin;
 to_binary(List) when is_list(List) -> list_to_binary(List).
@@ -658,20 +581,20 @@ update_ping_metrics(Outcome) ->
 %% the background. If the process silently fails in the background, we
 %% will be able to detect that in the logs since we won't be able to
 %% connect.
--spec async_add_peer(inet:ip_address() | undefined, peer_info(), boolean()) -> ok.
+-spec async_add_peer(inet:ip_address() | undefined, aec_peer:info(), boolean()) -> ok.
 async_add_peer(SourceAddr0, #{ host := Host} = PeerInfo, IsTrusted) ->
     spawn(fun() ->
              case inet:getaddr(to_list(Host), inet) of
                  {error, nxdomain} ->
                      epoch_sync:debug("Peer ~p - failed to resolve hostname ~p; "
-                                     "retrying later", [ppp(PeerInfo), Host]),
+                                     "retrying later", [aec_peer:ppp(PeerInfo), Host]),
                      gen_server:cast(?MODULE, {resolve_peer, SourceAddr0,
                                                PeerInfo, IsTrusted});
                  {ok, Addr} when SourceAddr0 == undefined ->
-                     Peer = peer(Addr, PeerInfo, IsTrusted),
+                     Peer = aec_peer:new(Addr, PeerInfo, IsTrusted),
                      gen_server:cast(?MODULE, {add_peer, Addr, Peer});
                  {ok, Addr} when SourceAddr0 =/= undefined ->
-                     Peer = peer(Addr, PeerInfo, IsTrusted),
+                     Peer = aec_peer:new(Addr, PeerInfo, IsTrusted),
                      gen_server:cast(?MODULE, {add_peer, SourceAddr0, Peer})
              end
           end),
@@ -714,27 +637,27 @@ count(Tag, State) when Tag =:= verified; Tag =:= unverified ->
     #state{ pool = Pool } = State,
     aec_peers_pool:count(Pool, all, Tag).
 
--spec connected_peers(all | inbound | outbound, state()) -> [peer_info()].
+-spec connected_peers(all | inbound | outbound, state()) -> [aec_peer:info()].
 connected_peers(all, #state{ conns = Conns }) ->
-    [ peer_info(P) || #conn{ peer = P, state = connected }
+    [ aec_peer:info(P) || #conn{ peer = P, state = connected }
                       <- maps:values(Conns) ];
 connected_peers(inbound, #state{ conns = Conns }) ->
-    [ peer_info(P) || #conn{ peer = P, type = inbound, state = connected }
+    [ aec_peer:info(P) || #conn{ peer = P, type = inbound, state = connected }
                       <- maps:values(Conns) ];
 connected_peers(outbound, #state{ conns = Conns }) ->
-    [ peer_info(P) || #conn{ peer = P, type = outbound, state = connected }
+    [ aec_peer:info(P) || #conn{ peer = P, type = outbound, state = connected }
                       <- maps:values(Conns) ].
 
 -spec random_connected_peers(N :: pos_integer(), all | inbound | outbound, state())
-    -> [peer_info()].
+    -> [aec_peer:info()].
 random_connected_peers(N, Tag, State) ->
     Keyed = [{rand:uniform(), P} || P <- connected_peers(Tag, State)],
     Sorted = lists:keysort(1, Keyed),
     [P || {_, P} <- lists:sublist(Sorted, N)].
 
--spec available_peers(both | verified | unverified, state()) -> [peer_info()].
+-spec available_peers(both | verified | unverified, state()) -> [aec_peer:info()].
 available_peers(Tag, #state{ pool = Pool }) ->
-    [ peer_info(P) || {_, P} <- aec_peers_pool:available(Pool, Tag) ].
+    [ aec_peer:info(P) || {_, P} <- aec_peers_pool:available(Pool, Tag) ].
 
 %--- OUTBOUND CONNECTION HANDLING FUNCTIONS ------------------------------------
 
@@ -797,7 +720,7 @@ connect(PeerId, State0) ->
             case pool_find(PeerId, State) of
                 error ->
                     epoch_sync:debug("Peer ~p - requested to connect to "
-                                     "unknown peer", [ppp(PeerId)]),
+                                     "unknown peer", [aec_peer:ppp(PeerId)]),
                     State;
                 {ok, Peer} ->
                     State2 = pool_select(PeerId, State),
@@ -906,12 +829,14 @@ cancel_tcp_probe_timer(unverified, State) ->
     State#state{ tcp_unverified_probe_ref = undefined }.
 
 %% Starts a connection process for the given peer.
--spec start_connection(noise | {tcp, peer_pool_name()}, peer(), state()) -> state().
+-spec start_connection(noise | {tcp, peer_pool_name()}, aec_peer:peer(), state()) -> state().
 start_connection(ConnType0, Peer, State) ->
     #{ pubkey := NodePKey } = State#state.local_peer,
-    #peer{ pubkey = RemPKey, host = Host, port = Port } = Peer,
+    RemPKey = aec_peer:pubkey(Peer),
+    Host = aec_peer:host(Peer),
+    Port = aec_peer:port(Peer),
     epoch_sync:debug("Peer ~p - starting Noise connection to ~s",
-                     [ppp(Peer), format_address(Peer)]),
+                     [aec_peer:ppp(Peer), aec_peer:format_address(Peer)]),
     ConnType =
         case ConnType0 of
             noise -> noise;
@@ -950,7 +875,7 @@ start_connection(ConnType0, Peer, State) ->
             conn_add(Conn, conn_monitor(Conn, State2));
         {error, Reason} ->
             epoch_sync:info("Peer ~p - failed to start connection process: ~p",
-                            [ppp(Peer), Reason]),
+                            [aec_peer:ppp(Peer), Reason]),
             State
     end.
 
@@ -987,165 +912,171 @@ resolver_start_timer(Host, RetryCount) ->
 %--- EVENT HANDLING FUNCTIONS --------------------------------------------------
 
 %% Handles a connection failure.
--spec on_connection_failed(peer_id(), pid(), state()) -> state().
+-spec on_connection_failed(aec_peer:id(), pid(), state()) -> state().
 on_connection_failed(PeerId, Pid, State) ->
     case conn_take(PeerId, State) of
         {#conn{ pid = Pid } = Conn, State2} ->
             epoch_sync:debug("Peer ~p - connection to ~s failed by process ~p",
-                             [ppp(PeerId), format_address(Conn), Pid]),
+                             [aec_peer:ppp(PeerId), format_conn_address(Conn), Pid]),
             pool_release(PeerId, conn_cleanup(Conn, State2));
         {#conn{ pid = OtherPid }, _State2} ->
             epoch_sync:info("Peer ~p - got connection_failed from unexpected "
                             "process ~p; supposed to come from ~p",
-                            [ppp(PeerId), Pid, OtherPid]),
+                            [aec_peer:ppp(PeerId), Pid, OtherPid]),
             State;
         error ->
             epoch_sync:info("Peer ~p - got connection_failed for unknown "
-                            "connection from process ~p", [ppp(PeerId), Pid]),
+                            "connection from process ~p", [aec_peer:ppp(PeerId), Pid]),
             State
     end.
 
 %% Handles a connection clean disconnection.
--spec on_connection_closed(peer_id(), pid(), state()) -> state().
+-spec on_connection_closed(aec_peer:id(), pid(), state()) -> state().
 on_connection_closed(PeerId, Pid, State) ->
     case conn_take(PeerId, State) of
         {#conn{ pid = Pid, tcp_probe = false } = Conn, State2} ->
             epoch_sync:debug("Peer ~p - Connection ~s closed by ~p",
-                             [ppp(PeerId), format_address(Conn), Pid]),
+                             [aec_peer:ppp(PeerId), format_conn_address(Conn), Pid]),
             pool_release(PeerId, conn_cleanup(Conn, State2));
         {#conn{ pid = OtherPid }, _State2} ->
             epoch_sync:info("Peer ~p - got connection_closed from unexpected "
                             "process ~p; supposed to come from ~p",
-                            [ppp(PeerId), Pid, OtherPid]),
+                            [aec_peer:ppp(PeerId), Pid, OtherPid]),
             State;
         error ->
             epoch_sync:info("Peer ~p - got connection_closed for unknown "
-                            "connection from process ~p", [ppp(PeerId), Pid]),
+                            "connection from process ~p", [aec_peer:ppp(PeerId), Pid]),
             State
     end.
 
--spec on_peer_dead(peer_id(), pid(), state()) -> state().
+-spec on_peer_dead(aec_peer:id(), pid(), state()) -> state().
 on_peer_dead(PeerId, Pid, State) ->
     case conn_take(PeerId, State) of
         {#conn{ state = connecting, type = outbound, tcp_probe = true,
                 pid = Pid } = Conn, State2 } ->
             epoch_sync:debug("Peer ~p - TCP probe failed through process ~p",
-                             [ppp(PeerId), Pid]),
+                             [aec_peer:ppp(PeerId), Pid]),
             pool_reject(PeerId, conn_cleanup(Conn, State2));
         {#conn{ pid = OtherPid }, _State2} ->
             epoch_sync:info("Peer ~p - got peer_dead from unexpected "
                             "process ~p; supposed to come from ~p",
-                            [ppp(PeerId), Pid, OtherPid]),
+                            [aec_peer:ppp(PeerId), Pid, OtherPid]),
             State;
         error ->
             epoch_sync:info("Peer ~p - got peer_dead for unknown "
-                            "connection from process ~p", [ppp(PeerId), Pid]),
+                            "connection from process ~p", [aec_peer:ppp(PeerId), Pid]),
             State
     end.
 
 %% Handles outbound connection being successfully estabished.
--spec on_peer_connected(peer_id(), pid(), state())
+-spec on_peer_connected(aec_peer:id(), pid(), state())
     -> {ok, state()} | {{error, term()}, state()}.
 on_peer_connected(PeerId, Pid, State) ->
     case conn_find(PeerId, State) of
         error ->
             epoch_sync:info("Peer ~p - got peer_connected for unknown peer "
-                            "from process ~p", [ppp(PeerId), Pid]),
+                            "from process ~p", [aec_peer:ppp(PeerId), Pid]),
             {{error, invalid}, State};
         {ok, #conn{ state = connecting, type = outbound, tcp_probe = false,
                     pid = Pid } = Conn} ->
             epoch_sync:debug("Peer ~p - connected to ~s through process ~p",
-                             [ppp(PeerId), format_address(Conn), Pid]),
-            epoch_sync:debug("Peer ~p - schedule ping", [ppp(PeerId)]),
+                             [aec_peer:ppp(PeerId), format_conn_address(Conn), Pid]),
+            epoch_sync:debug("Peer ~p - schedule ping", [aec_peer:ppp(PeerId)]),
             aec_sync:schedule_ping(PeerId),
             State2 = pool_verify(PeerId, State),
             {ok, conn_set_connected(PeerId, State2)};
         {ok, #conn{ state = ConnState, type = Type, pid = Pid }} ->
             epoch_sync:info("Peer ~p - got unexpected peer_connected for ~p ~p "
                             "peer from process ~p; rejecting the connection",
-                            [ppp(PeerId), ConnState, Type, Pid]),
+                            [aec_peer:ppp(PeerId), ConnState, Type, Pid]),
             State2 = pool_reject(PeerId, conn_del(PeerId, State)),
             {{error, invalid}, State2};
         {ok, #conn{ pid = OtherPid }} ->
             epoch_sync:info("Peer ~p - got peer_connected from unexpected "
                             "process ~p; supposed to come from ~p; "
                             "rejecting the connection",
-                            [ppp(PeerId), Pid, OtherPid]),
+                            [aec_peer:ppp(PeerId), Pid, OtherPid]),
             {{error, already_connected}, State}
     end.
 
 %% Handles inbound connection being accepted.
 %% Validates it is not local or blocked.
 %% Supports not trusted peer address changing.
--spec on_peer_accepted(inet:ip_address(), peer_info(), pid(), state())
+-spec on_peer_accepted(inet:ip_address(), aec_peer:info(), pid(), state())
     -> {ok, state()} | {temporary, state()} | {{error, term()}, state()}.
 on_peer_accepted(PeerAddr, PeerInfo, Pid, State0) ->
     State = maybe_unblock(State0),
-    #{ pubkey := PubKey, port := Port } = PeerInfo,
-    PeerId  = peer_id(PeerInfo),
+    Port = aec_peer:port(PeerInfo),
+    PeerId  = aec_peer:id(PeerInfo),
     case is_local(PeerId, State) orelse is_blocked(PeerId, State) of
         true ->
             epoch_sync:debug("Peer ~p - will not be accepted; local or blocked",
-                             [ppp(PeerId)]),
+                             [aec_peer:ppp(PeerId)]),
             {{error, blocked}, State};
         false ->
             case pool_find(PeerId, State) of
                 error ->
                     % New unknown peer.
-                    Peer = peer(PeerAddr, PeerInfo, false),
+                    Peer = aec_peer:new(PeerAddr, PeerInfo, false),
                     new_inbound_resolve_conflicts(Peer, Pid, State);
-                {ok, #peer{ pubkey = PubKey, address = PeerAddr,
-                            port = Port } = Peer} ->
-                    % Known peer.
-                    new_inbound_resolve_conflicts(Peer, Pid, State);
-                {ok, #peer{ pubkey = PubKey, trusted = false } = OldPeer} ->
-                    % Peer's address changed and it is not trusted;
-                    % deleting the old peer and its connections.
-                    NewPeer = peer(PeerAddr, PeerInfo, false),
-                    epoch_sync:info("Peer ~p - peer address change from ~s "
-                                    "to ~s", [ppp(PeerId),
-                                     format_address(OldPeer),
-                                     format_address(NewPeer)]),
-                    State2 = conn_del(PeerId, State),
-                    State3 = pool_delete(PeerId, pool_release(PeerId, State2)),
-                    new_inbound_resolve_conflicts(NewPeer, Pid, State3);
-                {ok, #peer{ pubkey = PubKey, trusted = true } = OldPeer} ->
-                    % Trusted peers' address is not allowed to change.
-                    epoch_sync:info("Peer ~p - trusted peer address changed "
-                                    "from ~s to ~s; rejecting connection",
-                                    [ppp(PeerId), format_address(OldPeer),
-                                     format_address({PeerAddr, Port})]),
-                    {{error, trusted_address_changed}, State}
+                {ok, FoundPeer} ->
+                    ExpectedSocket = aec_peer:socket(PeerAddr, Port),
+                    FoundPSocket = aec_peer:socket(FoundPeer),
+                    Trusted = aec_peer:is_trusted(FoundPeer),
+                    case ExpectedSocket =:= FoundPSocket of
+                        true ->
+                            % Known peer.
+                            new_inbound_resolve_conflicts(FoundPeer, Pid, State);
+                        false when not Trusted ->
+                            % Peer's address changed and it is not trusted;
+                            % deleting the old peer and its connections.
+                            NewPeer = aec_peer:new(PeerAddr, PeerInfo, false),
+                            epoch_sync:info("Peer ~p - peer address change from ~s "
+                                            "to ~s", [aec_peer:ppp(PeerId),
+                                            aec_peer:format_address(FoundPeer),
+                                            aec_peer:format_address(NewPeer)]),
+                            State2 = conn_del(PeerId, State),
+                            State3 = pool_delete(PeerId, pool_release(PeerId, State2)),
+                            new_inbound_resolve_conflicts(NewPeer, Pid, State3);
+                        false ->
+                            % Trusted peers' address is not allowed to change.
+                            epoch_sync:info("Peer ~p - trusted peer address changed "
+                                            "from ~s to ~s; rejecting connection",
+                                            [aec_peer:ppp(PeerId),
+                                             aec_peer:format_address(FoundPeer),
+                                             aec_peer:format_address({PeerAddr, Port})]),
+                            {{error, trusted_address_changed}, State}
+                    end
             end
     end.
 
--spec on_peer_alive(peer_id(), pid(), state())
+-spec on_peer_alive(aec_peer:id(), pid(), state())
     -> {ok, state()} | {{error, term()}, state()}.
 on_peer_alive(PeerId, Pid, State) ->
     case conn_take(PeerId, State) of
         {#conn{ state = connecting, type = outbound, tcp_probe = true,
                 pid = Pid } = Conn, State2} ->
             epoch_sync:info("Peer ~p - TCP probe successful through process ~p",
-                            [ppp(PeerId), Pid]),
+                            [aec_peer:ppp(PeerId), Pid]),
             State3 = conn_cleanup(Conn, State2),
             {ok, pool_verify(PeerId, pool_release(PeerId, State3))};
         {#conn{ state = ConnState, type = Type, pid = Pid2 } = Conn, State2} ->
             epoch_sync:info("Peer ~p - got unexpected peer_alive for ~p ~p "
                             "peer from process ~p; rejecting the connection",
-                            [ppp(PeerId), ConnState, Type, Pid2]),
+                            [aec_peer:ppp(PeerId), ConnState, Type, Pid2]),
             {{error, invalid}, pool_reject(PeerId, conn_cleanup(Conn, State2))};
         error ->
             epoch_sync:info("Peer ~p - got peer_alive for unknown peer "
-                            "from process ~p", [ppp(PeerId), Pid]),
+                            "from process ~p", [aec_peer:ppp(PeerId), Pid]),
             {{error, invalid}, State}
     end.
 
 %% Adds a new inbound connection if not conflicting with an existing one.
--spec new_inbound_resolve_conflicts(peer(), pid(), state())
+-spec new_inbound_resolve_conflicts(aec_peer:peer(), pid(), state())
     -> {ok, state()} | {temporary, state()} | {{error, term()}, state()}.
 new_inbound_resolve_conflicts(Peer, Pid, State) ->
-    LocalId = peer_id(State),
-    PeerId  = peer_id(Peer),
+    LocalId = local_peer_id(State),
+    PeerId  = aec_peer:id(Peer),
     Conn = #conn{ peer = Peer, type = inbound, state = connected, pid = Pid },
     WouldBeTemporary = not is_inbound_allowed(State),
     case conn_find(PeerId, State) of
@@ -1159,21 +1090,21 @@ new_inbound_resolve_conflicts(Peer, Pid, State) ->
             epoch_sync:debug("Peer ~p - rejecting second connection from "
                              "process ~p because it would be temporary; keep "
                              "using the old one from process ~p",
-                             [ppp(PeerId), Pid, OldPid]),
+                             [aec_peer:ppp(PeerId), Pid, OldPid]),
             {{error, already_connected}, State};
         {ok, #conn{ state = connected, pid = OldPid }}
           when Pid =/= OldPid, LocalId > PeerId ->
             %% We slash the accepted connection and use the old one.
             epoch_sync:debug("Peer ~p - rejecting second connection from "
                              "process ~p due to LPK > PK; keep using the old "
-                             "one from process ~p", [ppp(PeerId), Pid, OldPid]),
+                             "one from process ~p", [aec_peer:ppp(PeerId), Pid, OldPid]),
             {{error, already_connected}, State};
         {ok, #conn{ state = ConnState, type = Type, pid = OldPid } = OldConn}
           when Pid =/= OldPid ->
             % We slash the old one and keep the new one.
             epoch_sync:debug("Peer ~p - closing ~p ~p connection ~s from "
-                             "process ~p", [ppp(PeerId), ConnState, Type,
-                             format_address(OldConn), OldPid]),
+                             "process ~p", [aec_peer:ppp(PeerId), ConnState, Type,
+                             format_conn_address(OldConn), OldPid]),
             State2 = conn_del(PeerId, pool_reject(PeerId, State)),
             new_inbound_accepted(Conn, State2)
     end.
@@ -1187,8 +1118,8 @@ new_inbound_accepted(Conn, State) ->
         {ok, State2} ->
             InboundKind = new_inbound_kind(State2),
             epoch_sync:debug("Peer ~p - ~p inbound connection ~s accepted from "
-                             "process ~p", [ppp(Peer), InboundKind,
-                             format_address(Conn), Pid]),
+                             "process ~p", [aec_peer:ppp(Peer), InboundKind,
+                             format_conn_address(Conn), Pid]),
             Conn2 = Conn#conn{ kind = InboundKind, tcp_probe = false },
             State3 = conn_add(Conn2, State2),
             {InboundKind, conn_monitor(Conn2, State3)};
@@ -1205,12 +1136,12 @@ new_inbound_kind(State) ->
     end.
 
 %% Handles ping logging event.
--spec on_log_ping(peer_id(), ok | error, state()) -> state().
+-spec on_log_ping(aec_peer:id(), ok | error, state()) -> state().
 on_log_ping(PeerId, Outcome, State) ->
     case conn_find(PeerId, State) of
         error ->
             epoch_sync:debug("Peer ~p - got ping event ~p for unknown "
-                             "peer connection", [ppp(PeerId), Outcome]),
+                             "peer connection", [aec_peer:ppp(PeerId), Outcome]),
             State;
         {ok, #conn{ state = connected }} ->
             %% TODO: if a ping keeps failing we should do something?!
@@ -1218,12 +1149,12 @@ on_log_ping(PeerId, Outcome, State) ->
         {ok, _Conn} ->
             epoch_sync:debug("Peer ~p - got ping event ~p for disconnected "
                              "peer; no more ping scheduled",
-                             [ppp(PeerId), Outcome]),
+                             [aec_peer:ppp(PeerId), Outcome]),
             State
     end.
 
 %% Handles peer hostname resolution event.
--spec on_resolve_peer(inet:ip_address() | undefined, peer_info(),
+-spec on_resolve_peer(inet:ip_address() | undefined, aec_peer:info(),
                       boolean(), state()) ->
     state().
 on_resolve_peer(SourceAddr, PeerInfo, IsTrusted, State) ->
@@ -1233,7 +1164,7 @@ on_resolve_peer(SourceAddr, PeerInfo, IsTrusted, State) ->
         true ->
             #{ host := BinHost } = PeerInfo,
             Host = to_list(BinHost),
-            PeerId = peer_id(PeerInfo),
+            PeerId = aec_peer:id(PeerInfo),
             PeerData = {SourceAddr, PeerInfo, IsTrusted},
             HostData = case maps:find(Host, HostMap) of
                 error ->
@@ -1247,92 +1178,101 @@ on_resolve_peer(SourceAddr, PeerInfo, IsTrusted, State) ->
 
 
 %% Handles event adding a new peer to the pool.
--spec on_add_peer(inet:ip_address(), peer(), state()) -> state().
+-spec on_add_peer(inet:ip_address(), aec_peer:peer(), state()) -> state().
 on_add_peer(SourceAddr, Peer, State0) ->
     State = maybe_unblock(State0),
-    PeerId = peer_id(Peer),
+    PeerId = aec_peer:id(Peer),
+    LogMismatch =
+        fun(OtherPeer) ->
+            epoch_sync:info("Peer ~p - ignoring peer address changed "
+                            "from ~s to ~s by ~s", [aec_peer:ppp(PeerId),
+                            aec_peer:format_address(OtherPeer),
+                            aec_peer:format_address(Peer),
+                            aec_peer:format_address(SourceAddr)])
+        end,
     case is_local(PeerId, State) orelse is_blocked(PeerId, State) of
         true ->
             epoch_sync:debug("Peer ~p - will not be added; local or blocked",
-                             [ppp(PeerId)]),
+                             [aec_peer:ppp(PeerId)]),
             State;
         false ->
-            PeerSocket = peer_socket(Peer),
+            PeerSocket = aec_peer:socket(Peer),
             case {pool_find_by_socket(PeerSocket, State),
                   pool_find(PeerId, State)} of
                 {error, error}  -> %% unknown peer and unknown address and port
                     %% The TCP probe timer is started with addition of the firts peer.
                     State2 = maybe_start_tcp_probe_timers(State),
                     add_peer(SourceAddr, Peer, State2);
-                {{ok, PeerId}, {ok, #peer{ pubkey = SamePeerId} = Peer2}}
-                    when SamePeerId =:= PeerId -> %% same peer id and same IP and port
-                    % Only update gossip time and source.
-                    {_, State2} = pool_update(SourceAddr, Peer2, State),
-                    State2;
-                {_, {ok, OtherPeer}} ->
-                    epoch_sync:info("Peer ~p - ignoring peer address changed "
-                                    "from ~s to ~s by ~s", [ppp(PeerId),
-                                    format_address(OtherPeer),
-                                    format_address(Peer),
-                                    format_address(SourceAddr)]),
+                {{ok, PeerId}, {ok, Peer2}} ->
+                    case aec_peer:id(Peer2) of
+                        PeerId -> %% same peer id and same IP and port
+                            % Only update gossip time and source.
+                            {_, State2} = pool_update(SourceAddr, Peer2, State),
+                            State2;
+                        _ ->
+                            LogMismatch(Peer2),
+                            State
+                    end;
+                {_, {ok, Peer2}} ->
+                    LogMismatch(Peer2),
                     State;
                 {{ok, OtherPeerPubkey}, error} ->
                     epoch_sync:info("Peer ~p with address ~p - ignoring peer pubkey changed "
-                                    "from ~s to ~s by ~s", [ppp(PeerId),
-                                    format_address(Peer),
-                                    ppp(PeerId),
-                                    ppp(OtherPeerPubkey),
-                                    format_address(SourceAddr)]),
+                                    "from ~s to ~s by ~s", [aec_peer:ppp(PeerId),
+                                    aec_peer:format_address(Peer),
+                                    aec_peer:ppp(PeerId),
+                                    aec_peer:ppp(OtherPeerPubkey),
+                                    aec_peer:format_address(SourceAddr)]),
                     State
             end
     end.
 
 %% Adds a NEW peer to the pool and connect to it if it is trusted.
--spec add_peer(inet:ip_address(), peer(), state()) -> state().
+-spec add_peer(inet:ip_address(), aec_peer:peer(), state()) -> state().
 add_peer(SourceAddr, Peer, State) ->
     case pool_update(SourceAddr, Peer, State) of
         {ignored, State2} -> State2;
         {_, State2} ->
-            #peer{ trusted = IsTrusted } = Peer,
+            IsTrusted = aec_peer:is_trusted(Peer),
             case IsTrusted of
                 true ->
-                    PeerId = peer_id(Peer),
+                    PeerId = aec_peer:id(Peer),
                     epoch_sync:debug("Peer ~p - adding trusted peer ~s",
-                                     [ppp(PeerId), format_address(Peer)]),
+                                     [aec_peer:ppp(PeerId), aec_peer:format_address(Peer)]),
                     connect(PeerId, State2);
                 false ->
                     epoch_sync:debug("Peer ~p - adding peer ~s given by ~s",
-                                     [ppp(Peer), format_address(Peer),
-                                      format_address(SourceAddr)]),
+                                     [aec_peer:ppp(Peer), aec_peer:format_address(Peer),
+                                      aec_peer:format_address(SourceAddr)]),
                     State2
             end
     end.
 
 %% Handles event removing a peer.
--spec on_del_peer(peer_id(), state()) -> state().
+-spec on_del_peer(aec_peer:id(), state()) -> state().
 on_del_peer(PeerId, State) ->
     case pool_find(PeerId, State) of
         error -> State;
         {ok, _Peer} ->
-            epoch_sync:debug("Peer ~p - deleting peer", [ppp(PeerId)]),
+            epoch_sync:debug("Peer ~p - deleting peer", [aec_peer:ppp(PeerId)]),
             pool_delete(PeerId, pool_release(PeerId, conn_del(PeerId, State)))
     end.
 
 %% Handles ping timeout event.
--spec on_ping_timeout(peer_id(), reference(), state()) -> state().
+-spec on_ping_timeout(aec_peer:id(), reference(), state()) -> state().
 on_ping_timeout(PeerId, TimeoutRef, State) ->
     case conn_find(PeerId, State) of
         error ->
             epoch_sync:info("Peer ~p - ping timeout for unknown connection",
-                            [ppp(PeerId)]),
+                            [aec_peer:ppp(PeerId)]),
             State;
         {ok, #conn{ ping = TimeoutRef }} ->
-            epoch_sync:debug("Peer ~p - schedule ping", [ppp(PeerId)]),
+            epoch_sync:debug("Peer ~p - schedule ping", [aec_peer:ppp(PeerId)]),
             aec_sync:schedule_ping(PeerId),
             conn_reset_ping(PeerId, State);
         {ok, _Conn} ->
             epoch_sync:info("Peer ~p - ping timeout with invalid reference",
-                             [ppp(PeerId)]),
+                             [aec_peer:ppp(PeerId)]),
             State
     end.
 
@@ -1362,14 +1302,14 @@ on_process_down(Pid, MonitorRef, State) ->
             case conn_take(PeerId, State2) of
                 error ->
                     epoch_sync:info("Peer ~p - process down for unknwon "
-                                    "connection", [ppp(PeerId)]),
+                                    "connection", [aec_peer:ppp(PeerId)]),
                     State2;
                 {Conn, State3} ->
                     pool_reject(PeerId, conn_cleanup(Conn, State3))
             end;
         {PeerId, _OtherMonitorRef, _State2} ->
             epoch_sync:info("Peer ~p - process down with invalid reference",
-                             [ppp(PeerId)]),
+                             [aec_peer:ppp(PeerId)]),
             State;
         error ->
             epoch_sync:info("Unknown process down message for process ~p",
@@ -1383,8 +1323,8 @@ on_process_down(Pid, MonitorRef, State) ->
 %% Only tracks outbound connection.
 group_add(#conn{ peer = Peer, type = outbound, tcp_probe = false }, State) ->
     #state{ groups = Groups } = State,
-    #peer{ address = Addr } = Peer,
-    PeerId = peer_id(Peer),
+    Addr = aec_peer:ip(Peer),
+    PeerId = aec_peer:id(Peer),
     Group = aec_peers_pool:address_group(Addr),
     Peers = maps:get(Group, Groups, #{}),
     State#state{ groups = Groups#{ Group => Peers#{ PeerId => true } } };
@@ -1395,8 +1335,8 @@ group_add(_Conn, State) ->
 %% Only tracks outbound connection.
 group_del(#conn{ peer = Peer, type = outbound, tcp_probe = false }, State) ->
     #state{ groups = Groups } = State,
-    #peer{ address = Addr } = Peer,
-    PeerId = peer_id(Peer),
+    Addr = aec_peer:ip(Peer),
+    PeerId = aec_peer:id(Peer),
     Group = aec_peers_pool:address_group(Addr),
     Peers = maps:get(Group, Groups, #{}),
     Peers2 = maps:remove(PeerId, Peers),
@@ -1410,41 +1350,44 @@ group_del(_Conn, State) ->
 %--- POOL MANAGMENT FUNCTIONS --------------------------------------------------
 
 %% Logs the pooling changes of a peer.
--spec pool_log_changes(peer_id(), undefined | unverified | verified,
+-spec pool_log_changes(aec_peer:id(), undefined | unverified | verified,
                       undefined | verified | unverified | ignored) -> ok.
 pool_log_changes(_Id, Same, Same) -> ok;
 pool_log_changes(Id, undefined, New)
   when New =:= undefined; New =:= ignored ->
-    epoch_sync:debug("Peer ~p - failed to add peer to the pool", [ppp(Id)]);
+    epoch_sync:debug("Peer ~p - failed to add peer to the pool", [aec_peer:ppp(Id)]);
 pool_log_changes(Id, Old, New)
   when New =:= undefined; New =:= ignored ->
-    epoch_sync:debug("Peer ~p - peer removed from ~p pool", [ppp(Id), Old]);
+    epoch_sync:debug("Peer ~p - peer removed from ~p pool", [aec_peer:ppp(Id), Old]);
 pool_log_changes(Id, undefined, New) ->
-    epoch_sync:debug("Peer ~p - peer added to ~p pool", [ppp(Id), New]);
+    epoch_sync:debug("Peer ~p - peer added to ~p pool", [aec_peer:ppp(Id), New]);
 pool_log_changes(Id, Old, New) ->
     epoch_sync:debug("Peer ~p - peer moved from ~p pool to ~p pool",
-                     [ppp(Id), Old, New]).
+                     [aec_peer:ppp(Id), Old, New]).
 
 %% Tries to add given peer to the pool.
--spec pool_update(inet:ip_address(), peer(), state())
+-spec pool_update(inet:ip_address(), aec_peer:peer(), state())
     -> {ignored | verified | unverified, state()}.
 pool_update(SourceAddr, Peer, State) ->
     #state{ pool = Pool
           , known_sockets = KnownSockets} = State,
-    #peer{ pubkey = PeerId, address = PeerAddr, trusted = IsTrusted } = Peer,
+    PeerId = aec_peer:id(Peer),
+    PeerAddr = aec_peer:ip(Peer),
+    IsTrusted = aec_peer:is_trusted(Peer),
     Now = timestamp(),
     {OldPoolName, _} = aec_peers_pool:peer_state(Pool, PeerId),
     {NewPoolName, Pool2} = aec_peers_pool:update(Pool, Now, PeerId, PeerAddr,
                                                  SourceAddr, IsTrusted, Peer),
     pool_log_changes(PeerId, OldPoolName, NewPoolName),
 
+    Socket = aec_peer:socket(Peer),
     {NewPoolName, State#state{ pool = Pool2
-                             , known_sockets = gb_trees:enter(peer_socket(Peer),
+                             , known_sockets = gb_trees:enter(Socket,
                                                               PeerId,
                                                               KnownSockets)}}.
 
 -spec pool_random_select(state())
-    -> {selected, peer(), state()}
+    -> {selected, aec_peer:peer(), state()}
      | {wait, non_neg_integer(), state()}
      | {unavailable, state()}.
 pool_random_select(State) ->
@@ -1453,7 +1396,7 @@ pool_random_select(State) ->
 %% Select a random peer optionally excluding the ones the node already have
 %% an outbound connection from the same address group.
 -spec pool_random_select(aec_peers_pool:select_target(), state())
-    -> {selected, peer(), state()}
+    -> {selected, aec_peer:peer(), state()}
      | {wait, non_neg_integer(), state()}
      | {unavailable, state()}.
 pool_random_select(Target, State) ->
@@ -1461,7 +1404,7 @@ pool_random_select(Target, State) ->
     Now = timestamp(),
     FilterFun = pool_select_filter_fun(State),
     case aec_peers_pool:random_select(Pool, Now, Target, FilterFun) of
-        {selected, {_, #peer{} = Peer}, Pool2} ->
+        {selected, {_, Peer}, Pool2} ->
             {selected, Peer, State#state{ pool = Pool2 }};
         {wait, Delay, Pool2} ->
             {wait, Delay, State#state{ pool = Pool2 }};
@@ -1470,7 +1413,7 @@ pool_random_select(Target, State) ->
     end.
 
 %% Select given peer so we will not try connecting to it.
--spec pool_select(peer_id(), state()) -> state().
+-spec pool_select(aec_peer:id(), state()) -> state().
 pool_select(PeerId, State) ->
     #state{ pool = Pool } = State,
     Now = timestamp(),
@@ -1478,7 +1421,7 @@ pool_select(PeerId, State) ->
     State#state{ pool = Pool2 }.
 
 %% Trys to move given peer to the verified pool.
--spec pool_verify(peer_id(), state()) -> state().
+-spec pool_verify(aec_peer:id(), state()) -> state().
 pool_verify(PeerId, State) ->
     #state{ pool = Pool } = State,
     Now = timestamp(),
@@ -1491,11 +1434,13 @@ pool_verify(PeerId, State) ->
 %% `update' to be sure the peer is pooled, `verify' to move it to the
 %% verified pool becuase it is connected, and `select' so we will not try
 %% to connect to it later on.
--spec pool_upversel(peer(), state())
+-spec pool_upversel(aec_peer:peer(), state())
     -> {ok, state()} | {{error, term()}, state()}.
 pool_upversel(Peer, State) ->
     #state{ pool = Pool } = State,
-    #peer{ pubkey = PeerId, address = PeerAddr, trusted = IsTrusted } = Peer,
+    PeerId = aec_peer:id(Peer),
+    PeerAddr = aec_peer:ip(Peer),
+    IsTrusted = aec_peer:is_trusted(Peer),
     Now = timestamp(),
     {OldPoolName, _} = aec_peers_pool:peer_state(Pool, PeerId),
     case aec_peers_pool:update(Pool, Now, PeerId, PeerAddr,
@@ -1515,7 +1460,7 @@ pool_upversel(Peer, State) ->
     end.
 
 %% Rejects a select peer.
--spec pool_reject(peer_id(), state()) -> state().
+-spec pool_reject(aec_peer:id(), state()) -> state().
 pool_reject(PeerId, State) ->
     #state{ pool = Pool } = State,
     Now = timestamp(),
@@ -1523,7 +1468,7 @@ pool_reject(PeerId, State) ->
     State#state{ pool = Pool2 }.
 
 %% Releases a selected peer.
--spec pool_release(peer_id(), state()) -> state().
+-spec pool_release(aec_peer:id(), state()) -> state().
 pool_release(PeerId, State) ->
     #state{ pool = Pool } = State,
     Now = timestamp(),
@@ -1531,7 +1476,7 @@ pool_release(PeerId, State) ->
     State#state{ pool = Pool2 }.
 
 %% Removes a peer from the pool and disconnect
--spec pool_delete(peer_id(), state()) -> state().
+-spec pool_delete(aec_peer:id(), state()) -> state().
 pool_delete(PeerId, State0) when is_binary(PeerId) ->
     #state{ pool = Pool
           , known_sockets = KnownSockets } = State0,
@@ -1542,18 +1487,19 @@ pool_delete(PeerId, State0) when is_binary(PeerId) ->
     case pool_find(PeerId, State0) of
         error -> State1;
         {ok, Peer} ->
-            State1#state{known_sockets = gb_trees:delete_any(peer_socket(Peer),
+            PeerSocket = aec_peer:socket(Peer),
+            State1#state{known_sockets = gb_trees:delete_any(PeerSocket,
                                                              KnownSockets)}
     end.
 
 %% Gets a peer record from the pool.
--spec pool_find(peer_id(), state()) -> error | {ok, peer()}.
+-spec pool_find(aec_peer:id(), state()) -> error | {ok, aec_peer:peer()}.
 pool_find(PeerId, State) when is_binary(PeerId) ->
     #state{ pool = Pool } = State,
     aec_peers_pool:find(Pool, PeerId).
 
 %% Gets a peer record from the pool by its socket
--spec pool_find_by_socket(peer_socket(), state()) -> error | {ok, peer_id()}.
+-spec pool_find_by_socket(aec_peer:socket(), state()) -> error | {ok, aec_peer:id()}.
 pool_find_by_socket(PeerSocket, State) ->
     #state{ known_sockets = KnownSockets} = State,
     case gb_trees:lookup(PeerSocket, KnownSockets) of
@@ -1562,8 +1508,8 @@ pool_find_by_socket(PeerSocket, State) ->
     end.
 
 %% Gets a random subset of pooled peers.
--spec pool_random_subset(non_neg_integer(), [peer_id()] | undefined, state())
-    -> {[{peer_id(), peer()}], state()}.
+-spec pool_random_subset(non_neg_integer(), [aec_peer:id()] | undefined, state())
+    -> {[{aec_peer:id(), aec_peer:peer()}], state()}.
 pool_random_subset(N, Exclude, State) ->
     #state{ pool = Pool } = State,
     FilterFun = pool_subset_filter_fun(Exclude),
@@ -1571,7 +1517,7 @@ pool_random_subset(N, Exclude, State) ->
     {Result, State#state{ pool = Pool2 }}.
 
 %% Returns the filter function to be used when getting a random subset.
--spec pool_subset_filter_fun(undefined | [peer_id()])
+-spec pool_subset_filter_fun(undefined | [aec_peer:id()])
     -> undefined | aec_peers_pool:filter_fun().
 pool_subset_filter_fun(undefined) -> undefined;
 pool_subset_filter_fun(Exclude) ->
@@ -1586,7 +1532,7 @@ pool_select_filter_fun(State) ->
         true ->
             #state{ groups = Groups } = State,
             fun(_PeerId, Peer) ->
-                #peer{ address = Addr } = Peer,
+                Addr = aec_peer:ip(Peer),
                 Group = aec_peers_pool:address_group(Addr),
                 not  maps:is_key(Group, Groups)
             end
@@ -1595,23 +1541,28 @@ pool_select_filter_fun(State) ->
 %--- PEER BLOCKING FUNCTIONS ---------------------------------------------------
 
 %% Tells if a peer is blocked.
--spec is_blocked(peer_id(), state()) -> boolean().
+-spec is_blocked(aec_peer:id(), state()) -> boolean().
 is_blocked(PeerId, State) ->
     #state{ blocked = Blocked } = State,
     gb_trees:is_defined(PeerId, Blocked).
 
 %% Blocks given peer.
--spec block_peer(peer_info(), state()) -> state().
+-spec block_peer(aec_peer:info(), state()) -> state().
 block_peer(PeerInfo, State) ->
     #state{ blocked = Blocked } = State,
-    PeerId = peer_id(PeerInfo),
+    PeerId = aec_peer:id(PeerInfo),
     case pool_find(PeerId, State) of
-        {ok, #peer{ trusted = true }} -> State;
         {ok, Peer} ->
-            aec_events:publish(peers, {blocked, PeerId}),
-            Blocked2 = add_blocked(PeerId, peer_info(Peer), Blocked),
-            State2 = State#state{ blocked = Blocked2 },
-            pool_delete(PeerId, pool_release(PeerId, conn_del(PeerId, State2)));
+            IsTrusted = aec_peer:is_trusted(Peer),
+            case IsTrusted of
+                true ->
+                    State;
+                false ->
+                    aec_events:publish(peers, {blocked, PeerId}),
+                    Blocked2 = add_blocked(PeerId, aec_peer:info(Peer), Blocked),
+                    State2 = State#state{ blocked = Blocked2 },
+                    pool_delete(PeerId, pool_release(PeerId, conn_del(PeerId, State2)))
+              end;
         error ->
             aec_events:publish(peers, {blocked, PeerId}),
             Blocked2 = add_blocked(PeerId, PeerInfo, Blocked),
@@ -1619,7 +1570,7 @@ block_peer(PeerInfo, State) ->
     end.
 
 %% Unblocks given peer.
--spec unblock_peer(peer_id(), state()) -> state().
+-spec unblock_peer(aec_peer:id(), state()) -> state().
 unblock_peer(PeerId, State) ->
     #state{ blocked = Blocked } = State,
     case is_blocked(PeerId, State) of
@@ -1699,7 +1650,7 @@ conn_count(outbound, State) ->
     Outbound.
 
 %% Gives the connection record for given peer identifier.
--spec conn_find(peer_id(), state()) -> {ok, conn()} | error.
+-spec conn_find(aec_peer:id(), state()) -> {ok, conn()} | error.
 conn_find(PeerId, State) ->
     #state{ conns = Conns } = State,
     maps:find(PeerId, Conns).
@@ -1707,7 +1658,7 @@ conn_find(PeerId, State) ->
 %% Takes the connection record for given peer identifier, removing it.
 %% Updates the connection counters but doesn't cancel timers and monitors;
 %% this is so the function has no side-effects.
--spec conn_take(peer_id(), state()) -> {conn(), state()} | error.
+-spec conn_take(aec_peer:id(), state()) -> {conn(), state()} | error.
 conn_take(PeerId, State) ->
     #state{ conns = Conns,
             inbound = Inbound,
@@ -1734,7 +1685,7 @@ conn_add(Conn, State0) ->
             outbound = Outbound,
             tcp_probes = TcpProbes } = State0,
     #conn{ peer = Peer } = Conn,
-    PeerId = peer_id(Peer),
+    PeerId = aec_peer:id(Peer),
     ?assertNot(maps:is_key(PeerId, Conns)),
     Conns2 = Conns#{ PeerId => Conn },
     case Conn of
@@ -1747,7 +1698,7 @@ conn_add(Conn, State0) ->
     end.
 
 %% Set connections state.
--spec conn_set_connected(peer_id(), state()) -> state().
+-spec conn_set_connected(aec_peer:id(), state()) -> state().
 conn_set_connected(PeerId, #state{ conns = Conns } = State) ->
     #{ PeerId := Conn } = Conns,
     Conn2 = Conn#conn{ state = connected },
@@ -1755,7 +1706,7 @@ conn_set_connected(PeerId, #state{ conns = Conns } = State) ->
 
 %% Deletes a connection.
 %% Cancels timers and monitors; Notify the connection process.
--spec conn_del(peer_id(), state()) -> state().
+-spec conn_del(aec_peer:id(), state()) -> state().
 conn_del(PeerId, State) ->
     case conn_take(PeerId, State) of
         error -> State;
@@ -1765,7 +1716,7 @@ conn_del(PeerId, State) ->
     end.
 
 %% Gives the connection process for given peer identifier.
--spec conn_pid(peer_id(), state()) -> {ok, pid()} | {error, term()}.
+-spec conn_pid(aec_peer:id(), state()) -> {ok, pid()} | {error, term()}.
 conn_pid(PeerId, State) ->
     case conn_find(PeerId, State) of
         {ok, #conn{ state = connected, pid = Pid }} -> {ok, Pid};
@@ -1773,18 +1724,18 @@ conn_pid(PeerId, State) ->
         error -> {error, no_connection}
     end.
 
--spec conn_schedule_ping(peer_id(), non_neg_integer(), state()) -> state().
+-spec conn_schedule_ping(aec_peer:id(), non_neg_integer(), state()) -> state().
 conn_schedule_ping(PeerId, Timeout, #state{ conns = Conns } = State) ->
     #{ PeerId := Conn } = Conns,
     #conn{ ping = OldRef } = Conn,
     PeerId = peer_id(Conn),
     cancel_timer(OldRef),
     epoch_sync:debug("Peer ~p - wait ~b ms for next ping",
-                     [ppp(PeerId), Timeout]),
+                     [aec_peer:ppp(PeerId), Timeout]),
     Conn2 = Conn#conn{ ping = start_timer({ping, PeerId}, Timeout) },
     State#state{ conns = Conns#{ PeerId := Conn2} }.
 
--spec conn_reset_ping(peer_id(), state()) -> state().
+-spec conn_reset_ping(aec_peer:id(), state()) -> state().
 conn_reset_ping(PeerId, #state{ conns = Conns } = State) ->
     #{ PeerId := Conn } = Conns,
     State#state{ conns = Conns#{ PeerId := Conn#conn{ ping = undefined } } }.
@@ -1804,7 +1755,7 @@ conn_cleanup(#conn{ ping = OldRef } = Conn, State) ->
 -spec conn_monitor(conn(), state()) -> state().
 conn_monitor(#conn{ peer = Peer, pid = Pid }, State) when is_pid(Pid) ->
     #state{ monitors = Monitors } = State,
-    PeerId = peer_id(Peer),
+    PeerId = aec_peer:id(Peer),
     case maps:find(Pid, Monitors) of
         {ok, {_, PeerId}} -> State;
         error ->
@@ -1817,7 +1768,7 @@ conn_monitor(#conn{ peer = Peer, pid = Pid }, State) when is_pid(Pid) ->
 -spec conn_demonitor(conn(), state()) -> state().
 conn_demonitor(#conn{ peer = Peer, pid = Pid }, State) when is_pid(Pid) ->
     #state{ monitors = Monitors } = State,
-    PeerId = peer_id(Peer),
+    PeerId = aec_peer:id(Peer),
     case maps:take(Pid, Monitors) of
         error -> State;
         {{Ref, PeerId}, Monitors2} ->
@@ -1828,7 +1779,7 @@ conn_demonitor(#conn{ peer = Peer, pid = Pid }, State) when is_pid(Pid) ->
 %% Remove given monitoring entries; assumes it is already demonitored
 %% or the monitore fired.
 -spec conn_take_monitor(pid(), state())
-    -> error | {peer_id(), reference(), state()}.
+    -> error | {aec_peer:id(), reference(), state()}.
 conn_take_monitor(Pid, State) ->
     #state{ monitors = Monitors } = State,
     case maps:take(Pid, Monitors) of
@@ -1885,3 +1836,4 @@ log_peer_connection_count_interval() ->
     aeu_env:user_config_or_env([<<"sync">>, <<"log_peer_connection_count_interval">>],
                                aecore, log_peer_connection_count_interval,
                                ?DEFAULT_LOG_PEER_CONNECTION_COUNT_INTERVAL).
+

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -1372,12 +1372,11 @@ pool_update(SourceAddr, Peer, State) ->
     #state{ pool = Pool
           , known_sockets = KnownSockets} = State,
     PeerId = aec_peer:id(Peer),
-    PeerAddr = aec_peer:ip(Peer),
     IsTrusted = aec_peer:is_trusted(Peer),
     Now = timestamp(),
     {OldPoolName, _} = aec_peers_pool:peer_state(Pool, PeerId),
-    {NewPoolName, Pool2} = aec_peers_pool:update(Pool, Now, PeerId, PeerAddr,
-                                                 SourceAddr, IsTrusted, Peer),
+    {NewPoolName, Pool2} = aec_peers_pool:update(Pool, Now, SourceAddr,
+                                                 IsTrusted, Peer),
     pool_log_changes(PeerId, OldPoolName, NewPoolName),
 
     Socket = aec_peer:socket(Peer),
@@ -1443,8 +1442,7 @@ pool_upversel(Peer, State) ->
     IsTrusted = aec_peer:is_trusted(Peer),
     Now = timestamp(),
     {OldPoolName, _} = aec_peers_pool:peer_state(Pool, PeerId),
-    case aec_peers_pool:update(Pool, Now, PeerId, PeerAddr,
-                               PeerAddr, IsTrusted, Peer) of
+    case aec_peers_pool:update(Pool, Now, PeerAddr, IsTrusted, Peer) of
         {unverified, Pool2} ->
             {NewPoolName, Pool3} = aec_peers_pool:verify(Pool2, Now, PeerId),
             Pool4 = aec_peers_pool:select(Pool3, Now, PeerId),

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -1372,11 +1372,10 @@ pool_update(SourceAddr, Peer, State) ->
     #state{ pool = Pool
           , known_sockets = KnownSockets} = State,
     PeerId = aec_peer:id(Peer),
-    IsTrusted = aec_peer:is_trusted(Peer),
     Now = timestamp(),
     {OldPoolName, _} = aec_peers_pool:peer_state(Pool, PeerId),
     {NewPoolName, Pool2} = aec_peers_pool:update(Pool, Now, SourceAddr,
-                                                 IsTrusted, Peer),
+                                                 Peer),
     pool_log_changes(PeerId, OldPoolName, NewPoolName),
 
     Socket = aec_peer:socket(Peer),
@@ -1439,10 +1438,9 @@ pool_upversel(Peer, State) ->
     #state{ pool = Pool } = State,
     PeerId = aec_peer:id(Peer),
     PeerAddr = aec_peer:ip(Peer),
-    IsTrusted = aec_peer:is_trusted(Peer),
     Now = timestamp(),
     {OldPoolName, _} = aec_peers_pool:peer_state(Pool, PeerId),
-    case aec_peers_pool:update(Pool, Now, PeerAddr, IsTrusted, Peer) of
+    case aec_peers_pool:update(Pool, Now, PeerAddr, Peer) of
         {unverified, Pool2} ->
             {NewPoolName, Pool3} = aec_peers_pool:verify(Pool2, Now, PeerId),
             Pool4 = aec_peers_pool:select(Pool3, Now, PeerId),

--- a/apps/aecore/src/aec_peers_pool.erl
+++ b/apps/aecore/src/aec_peers_pool.erl
@@ -519,7 +519,7 @@ is_available(St, PeerId) ->
 %% number of references, another reference may be added to the unverified pool;
 %% the peer last update time and source address fields are updated too.
 %%
-%% Some immutable peed data must be specified; this will be returned by
+%% Some immutable peer data must be specified; this will be returned by
 %% {@link random_select/4} alongside the peer identifier.
 %% This information will <b>not</b> be updated if the peer already
 %% exists and is considered immutable

--- a/apps/aecore/src/aec_peers_pool.erl
+++ b/apps/aecore/src/aec_peers_pool.erl
@@ -793,9 +793,7 @@ update_peer(St, Now, SourceAddr, PeerData) ->
                     {updated, set_peer(St, PeerId, Peer2)};
                 false ->
                     ignored
-            end;
-        _ ->
-            ignored
+            end
     end.
 
 %% Deletes a peer and all its references.

--- a/apps/aecore/src/aec_peers_pool.erl
+++ b/apps/aecore/src/aec_peers_pool.erl
@@ -163,8 +163,6 @@
 %=== TYPES =====================================================================
 
 -record(peer, {
-    % The peer unique identifier.
-    id                     :: binary(),
     % If the peer is trusted and should never be downgraded.
     trusted = false        :: boolean(),
     % The IP address of the source of the peer.
@@ -1138,7 +1136,8 @@ verified_maybe_add(St, Now, PeerId) ->
     -> {verified, state()} | {ignored, state()}.
 verified_add(St, Now, Peer) ->
     ?assertEqual(undefined, Peer#peer.vidx),
-    #peer{ id = PeerId, immutable = PeerData} = Peer,
+    #peer{immutable = PeerData} = Peer,
+    PeerId = aec_peer:id(PeerData),
     PeerAddr = aec_peer:ip(PeerData),
     BucketIdx = verified_bucket_index(St, PeerAddr),
     case verified_make_space_for(St, Now, BucketIdx, PeerId) of
@@ -1313,7 +1312,8 @@ unverified_maybe_add(St, Now, PeerId, KeepPeerId) ->
 -spec unverified_add(state(), millitimestamp(), peer(), peer_id() | undefined)
     -> {unverified, state()} | {ignored, state()}.
 unverified_add(St, Now, Peer, KeepPeerId) ->
-    #peer{id = PeerId, source = SourceAddr, immutable = PeerData} = Peer,
+    #peer{source = SourceAddr, immutable = PeerData} = Peer,
+    PeerId = aec_peer:id(PeerData),
     ?assertEqual([], Peer#peer.uidxs),
     PeerAddr = aec_peer:ip(PeerData),
     BucketIdx = unverified_bucket_index(St, SourceAddr, PeerAddr),
@@ -1343,11 +1343,11 @@ unverified_add(St, Now, Peer, KeepPeerId) ->
     -> state().
 unverified_add_reference(St, Now, Peer, KeepPeerId) ->
     #peer{
-        id = PeerId,
         source = SourceAddr,
         uidxs = Idxs,
         immutable = PeerData
     } = Peer,
+    PeerId = aec_peer:id(PeerData),
     PeerAddr = aec_peer:ip(PeerData),
     ?assertNotEqual([], Idxs),
     BucketIdx = unverified_bucket_index(St, SourceAddr, PeerAddr),
@@ -1453,9 +1453,7 @@ unverified_select(St, _Now, FilterFun) ->
 -spec peer_new(peer_addr(), boolean(), aec_peer:peer())
     -> peer().
 peer_new(SourceAddr, IsTrusted, PeerData) ->
-    PeerId = aec_peer:id(PeerData),
     #peer{
-        id = PeerId,
         trusted = IsTrusted,
         source = SourceAddr,
         immutable = PeerData

--- a/apps/aecore/src/aec_tx_pool_sync.erl
+++ b/apps/aecore/src/aec_tx_pool_sync.erl
@@ -25,7 +25,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--import(aec_peers, [ppp/1]).
+-import(aec_peer, [ppp/1]).
 -include("blocks.hrl").
 
 -record(sync,

--- a/apps/aecore/test/aec_peers_pool_tests.erl
+++ b/apps/aecore/test/aec_peers_pool_tests.erl
@@ -20,7 +20,7 @@
     is_verified/2,
     is_unverified/2,
     is_available/2,
-    update/7,
+    update/5,
     verify/3,
     random_subset/3,
     random_select/4,
@@ -78,15 +78,17 @@ reference_bug_test() ->
 
     % Create 50 peers
     Peers = lists:foldl(fun(_, Acc) ->
-        [{random_peer_id(), random_address()} | Acc]
+        [random_peer() | Acc]
     end, [], lists:seq(1, 50)),
 
     lists:foldl(fun(_, {S, N}) ->
         % Update 10 random peers
         {S2, N2} = lists:foldl(fun(_, {Sf, Nf}) ->
-            {I, A1} = X = rand_peek(Peers),
+            RandPeer  = X = rand_peek(Peers),
+            RandPeerId = aec_peer:id(RandPeer),
+            RandPeerAddress = aec_peer:ip(RandPeer),
             A2 = rand_peek(Sources),
-            {_, Sf2} = aec_peers_pool:update(Sf, Nf, I, A1, A2, false, X),
+            {_, Sf2} = aec_peers_pool:update(Sf, Nf, A2, false, X),
             {Sf2, Nf + 1}
         end, {S, N}, lists:seq(1, 10)),
 
@@ -145,12 +147,13 @@ empty_pool_test() ->
 %% Tests pool behaviour with a single normal peer.
 add_single_normal_test() ->
     P = new(?BASE_POOL_OPTS),
-    Id1 = random_peer_id(),
-    Addr1 = random_address(),
+    RandomPeer = random_peer(),
+    Id1 = aec_peer:id(RandomPeer),
+    Addr1 = aec_peer:ip(RandomPeer),
     Now = erlang:system_time(millisecond),
     NoFilterFun = make_ext_exclude_filter([]),
     FilterFun = make_ext_exclude_filter([Id1]),
-    {unverified, P2} = update(P, Now, Id1, Addr1, Addr1, false, bar),
+    {unverified, P2} = update(P, Now, Addr1, false, RandomPeer),
     ?assertEqual(1, count(P2, all, both)),
     ?assertEqual(0, count(P2, all, verified)),
     ?assertEqual(1, count(P2, all, unverified)),
@@ -160,10 +163,10 @@ add_single_normal_test() ->
     ?assertEqual(0, count(P2, standby, both)),
     ?assertEqual(0, count(P2, standby, verified)),
     ?assertEqual(0, count(P2, standby, unverified)),
-    ?assertEqual([{Id1, bar}], available(P2, both)),
+    ?assertEqual([{Id1, RandomPeer}], available(P2, both)),
     ?assertEqual([], available(P2, verified)),
-    ?assertEqual([{Id1, bar}], available(P2, unverified)),
-    ?assertEqual({ok, bar}, find(P2, Id1)),
+    ?assertEqual([{Id1, RandomPeer}], available(P2, unverified)),
+    ?assertEqual({ok, RandomPeer}, find(P2, Id1)),
     ?assertEqual(false, is_verified(P2, Id1)),
     ?assertEqual(true, is_unverified(P2, Id1)),
     ?assertMatch({[], _}, random_subset(P2, all, undefined)),
@@ -176,18 +179,18 @@ add_single_normal_test() ->
     ?assertMatch({[], _}, random_subset(P2, 10, NoFilterFun)),
     ?assertMatch({[], _}, random_subset(P2, 10, FilterFun)),
     {verified, P3} = verify(P2, Now, Id1),
-    ?assertMatch({[{Id1, bar}], _}, random_subset(P3, all, undefined)),
-    ?assertMatch({[{Id1, bar}], _}, random_subset(P3, all, NoFilterFun)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P3, all, undefined)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P3, all, NoFilterFun)),
     ?assertMatch({[], _}, random_subset(P3, all, FilterFun)),
-    ?assertMatch({[{Id1, bar}], _}, random_subset(P3, 1, undefined)),
-    ?assertMatch({[{Id1, bar}], _}, random_subset(P3, 1, NoFilterFun)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P3, 1, undefined)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P3, 1, NoFilterFun)),
     ?assertMatch({[], _}, random_subset(P3, 1, FilterFun)),
-    ?assertMatch({[{Id1, bar}], _}, random_subset(P3, 10, undefined)),
-    ?assertMatch({[{Id1, bar}], _}, random_subset(P3, 10, NoFilterFun)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P3, 10, undefined)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P3, 10, NoFilterFun)),
     ?assertMatch({[], _}, random_subset(P3, 10, FilterFun)),
-    ?assertMatch({selected, {Id1, bar}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P3, Now, both, undefined)),
-    ?assertMatch({selected, {Id1, bar}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P3, Now, both, NoFilterFun)),
     ?assertMatch({unavailable, _},
                random_select(P3, Now, both, FilterFun)),
@@ -197,9 +200,9 @@ add_single_normal_test() ->
                random_select(P3, Now, unverified, NoFilterFun)),
     ?assertMatch({unavailable, _},
                random_select(P3, Now, unverified, FilterFun)),
-    ?assertMatch({selected, {Id1, bar}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P3, Now, verified, undefined)),
-    ?assertMatch({selected, {Id1, bar}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P3, Now, verified, NoFilterFun)),
     ?assertMatch({unavailable, _},
                random_select(P3, Now, verified, FilterFun)),
@@ -208,12 +211,13 @@ add_single_normal_test() ->
 %% Tests pool behavior with a single trusted peer.
 add_single_trusted_test() ->
     P = new(?BASE_POOL_OPTS),
-    Id1 = random_peer_id(),
-    Addr1 = random_address(),
+    RandomPeer = random_peer(),
+    Id1 = aec_peer:id(RandomPeer),
+    Addr1 = aec_peer:ip(RandomPeer),
     Now = erlang:system_time(millisecond),
     NoFilterFun = make_ext_exclude_filter([]),
     FilterFun = make_ext_exclude_filter([Id1]),
-    {verified, P2} = update(P, Now, Id1, Addr1, Addr1, true, foo),
+    {verified, P2} = update(P, Now, Addr1, true, RandomPeer),
     ?assertEqual(1, count(P2, all, both)),
     ?assertEqual(1, count(P2, all, verified)),
     ?assertEqual(0, count(P2, all, unverified)),
@@ -223,29 +227,29 @@ add_single_trusted_test() ->
     ?assertEqual(0, count(P2, standby, both)),
     ?assertEqual(0, count(P2, standby, verified)),
     ?assertEqual(0, count(P2, standby, unverified)),
-    ?assertEqual([{Id1, foo}], available(P2, both)),
-    ?assertEqual([{Id1, foo}], available(P2, verified)),
+    ?assertEqual([{Id1, RandomPeer}], available(P2, both)),
+    ?assertEqual([{Id1, RandomPeer}], available(P2, verified)),
     ?assertEqual([], available(P2, unverified)),
     ?assertEqual(true, is_verified(P2, Id1)),
     ?assertEqual(false, is_unverified(P2, Id1)),
-    ?assertMatch({[{Id1, foo}], _}, random_subset(P2, all, undefined)),
-    ?assertMatch({[{Id1, foo}], _}, random_subset(P2, all, NoFilterFun)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P2, all, undefined)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P2, all, NoFilterFun)),
     ?assertMatch({[], _}, random_subset(P2, all, FilterFun)),
-    ?assertMatch({[{Id1, foo}], _}, random_subset(P2, 1, undefined)),
-    ?assertMatch({[{Id1, foo}], _}, random_subset(P2, 1, NoFilterFun)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P2, 1, undefined)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P2, 1, NoFilterFun)),
     ?assertMatch({[], _}, random_subset(P2, 1, FilterFun)),
-    ?assertMatch({[{Id1, foo}], _}, random_subset(P2, 10, undefined)),
-    ?assertMatch({[{Id1, foo}], _}, random_subset(P2, 10, NoFilterFun)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P2, 10, undefined)),
+    ?assertMatch({[{Id1, RandomPeer}], _}, random_subset(P2, 10, NoFilterFun)),
     ?assertMatch({[], _}, random_subset(P2, 10, FilterFun)),
-    ?assertMatch({selected, {Id1, foo}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P2, Now, both, undefined)),
-    ?assertMatch({selected, {Id1, foo}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P2, Now, both, NoFilterFun)),
     ?assertMatch({unavailable, _},
                random_select(P2, Now, both, FilterFun)),
-    ?assertMatch({selected, {Id1, foo}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P2, Now, verified, undefined)),
-    ?assertMatch({selected, {Id1, foo}, _},
+    ?assertMatch({selected, {Id1, RandomPeer}, _},
                random_select(P2, Now, verified, NoFilterFun)),
     ?assertMatch({unavailable, _},
                random_select(P2, Now, verified, FilterFun)),
@@ -267,16 +271,18 @@ multiple_peers_subset_test() ->
     Now = erlang:system_time(millisecond),
     Pool1 = new(?POOL_OPTS),
     Peers = make_peers(TotalCount, VerifCount),
-    ExcludedKeys = rand_int_list(1, VerifCount + 1, ExcludedCount),
-    ExcludedIds = [maps:get(id, maps:get(K, Peers)) || K <- ExcludedKeys],
+    ExcludedIdxs = rand_int_list(1, VerifCount + 1, ExcludedCount),
+    VerifiedIds = [I || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P)],
+    ExcludedIds = [lists:nth(Int, VerifiedIds) || Int <- ExcludedIdxs],
     FilterFun = make_ext_exclude_filter(ExcludedIds),
 
     UnverCount = TotalCount - VerifCount,
     UnexCount = VerifCount - ExcludedCount,
 
     Pool2 = maps:fold(fun(_, Peer, P) ->
-        #{id := I, addr := A, source := S, trusted := T} = Peer,
-        {_, P2} = update(P, Now, I, A, S, T, Peer),
+        T = aec_peer:is_trusted(Peer),
+        S = random_address(),
+        {_, P2} = update(P, Now, S, T, Peer),
         P2
     end, Pool1, Peers),
 
@@ -286,63 +292,58 @@ multiple_peers_subset_test() ->
     ?assertEqual(TotalCount, count(Pool2, available, both)),
     ?assertEqual(VerifCount, count(Pool2, available, verified)),
     ?assertEqual(UnverCount, count(Pool2, available, unverified)),
-    ?assertEqual(lists:sort([{maps:get(id, P), P} || P <- maps:values(Peers)]),
+    ?assertEqual(lists:sort([{aec_peer:id(P), P} || P <- maps:values(Peers)]),
                  lists:sort(available(Pool2, both))),
-    ?assertEqual(lists:sort([{maps:get(id, P), P}
-                             || #{trusted := true} = P <- maps:values(Peers)]),
+    ?assertEqual(lists:sort([{aec_peer:id(P), P}
+                             ||  P <- maps:values(Peers), aec_peer:is_trusted(P)]),
                  lists:sort(available(Pool2, verified))),
-    ?assertEqual(lists:sort([{maps:get(id, P), P}
-                             || #{trusted := false} = P <- maps:values(Peers)]),
+    ?assertEqual(lists:sort([{aec_peer:id(P), P}
+                             ||  P <- maps:values(Peers),
+                                 aec_peer:is_trusted(P) =:= false]),
                  lists:sort(available(Pool2, unverified))),
 
     {S2a, _} = random_subset(Pool2, all, undefined),
     ?assertEqual(VerifCount, length(S2a)),
     ?assertEqual(VerifCount, length(lists:usort([I || {I, _} <- S2a]))),
-    lists:foreach(fun({I, #{key := Key} = P}) ->
-        ?assertEqual(maps:get(Key, Peers), P),
-        ?assertMatch(#{id := I}, P)
+    lists:foreach(fun({I, P}) ->
+        ?assertEqual(maps:get(I, Peers), P) %% same peer
     end, S2a),
 
     {S2b, _} = random_subset(Pool2, all, FilterFun),
     ?assertEqual(UnexCount, length(S2b)),
     ?assertEqual(UnexCount, length(lists:usort([I || {I, _} <- S2b]))),
-    lists:foreach(fun({I, #{key := Key} = P}) ->
-        ?assertEqual(maps:get(Key, Peers), P),
-        ?assertMatch(#{id := I}, P),
+    lists:foreach(fun({I, P}) ->
+        ?assertEqual(maps:get(I, Peers), P),
         ?assertNot(lists:member(I, ExcludedIds))
     end, S2b),
 
     {S2c, _} = random_subset(Pool2, VerifCount * 2, undefined),
     ?assertEqual(VerifCount, length(S2c)),
     ?assertEqual(VerifCount, length(lists:usort([I || {I, _} <- S2c]))),
-    lists:foreach(fun({I, #{key := Key} = P}) ->
-        ?assertEqual(maps:get(Key, Peers), P),
-        ?assertMatch(#{id := I}, P)
+    lists:foreach(fun({I, P}) ->
+        ?assertEqual(maps:get(I, Peers), P)
     end, S2c),
 
     {S2d, _} = random_subset(Pool2, VerifCount * 2, FilterFun),
     ?assertEqual(UnexCount, length(S2d)),
     ?assertEqual(UnexCount, length(lists:usort([I || {I, _} <- S2d]))),
-    lists:foreach(fun({I, #{key := Key} = P}) ->
-        ?assertEqual(maps:get(Key, Peers), P),
-        ?assertMatch(#{id := I}, P),
+    lists:foreach(fun({I, P}) ->
+        ?assertEqual(maps:get(I, Peers), P),
         ?assertNot(lists:member(I, ExcludedIds))
     end, S2d),
 
     {S2e, _} = random_subset(Pool2, 30, undefined),
     ?assertEqual(30, length(S2e)),
     ?assertEqual(30, length(lists:usort([I || {I, _} <- S2e]))),
-    lists:foreach(fun({I, #{key := Key} = P}) ->
-        ?assertEqual(maps:get(Key, Peers), P),
-        ?assertMatch(#{id := I}, P)
+    lists:foreach(fun({I, P}) ->
+        ?assertEqual(maps:get(I, Peers), P)
     end, S2e),
 
     {S2f, _} = random_subset(Pool2, 30, FilterFun),
     ?assertEqual(30, length(S2f)),
     ?assertEqual(30, length(lists:usort([I || {I, _} <- S2f]))),
-    lists:foreach(fun({I, #{key := Key} = P}) ->
-        ?assertEqual(maps:get(Key, Peers), P),
-        ?assertMatch(#{id := I}, P),
+    lists:foreach(fun({I, P}) ->
+        ?assertEqual(maps:get(I, Peers), P),
         ?assertNot(lists:member(I, ExcludedIds))
     end, S2f),
     ok.
@@ -351,51 +352,59 @@ multiple_peers_subset_test() ->
 multiple_peers_select_test() ->
     TotalCount = 1000,
     VerifCount = 50,
-    ExcludedCount = 100,
+    ExcludedCount = 10,
 
     Now = erlang:system_time(millisecond),
     Pool1 = new(?BASE_POOL_OPTS),
     Peers = make_peers(TotalCount, VerifCount),
-    ExcludedKeys = rand_int_list(1, TotalCount + 1, ExcludedCount),
-    ExcludedIds = [maps:get(id, maps:get(K, Peers)) || K <- ExcludedKeys],
+    ExcludedIdxs = rand_int_list(1, VerifCount + 1, ExcludedCount),
+    VerifiedIds = [I || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P)],
+    ExcludedIds = [lists:nth(Int, VerifiedIds) || Int <- ExcludedIdxs],
     FilterFun = make_ext_exclude_filter(ExcludedIds),
 
-    AllIds = [I || {_, #{id := I}} <- maps:to_list(Peers)],
+    AllIds = [I || {I, _} <- maps:to_list(Peers)],
     UnexIds = [I || I <- AllIds, not lists:member(I, ExcludedIds)],
-    VerifIds = [I || {_, #{id := I, trusted := true}} <- maps:to_list(Peers)],
+    VerifIds = [I || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P)],
     UnexVerifIds = [I || I <- VerifIds, not lists:member(I, ExcludedIds)],
-    UnverIds = [I || {_, #{id := I, trusted := false}} <- maps:to_list(Peers)],
+    UnverIds = [I || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P) =:= false],
     UnexUnverIds = [I || I <- UnverIds, not lists:member(I, ExcludedIds)],
 
     Pool2 = maps:fold(fun(_, Peer, P) ->
-        #{id := Id, addr := Addr, source := Source, trusted := Trusted} = Peer,
-        {_, P2} = update(P, Now, Id, Addr, Source, Trusted, Peer),
+        Id = aec_peer:id(Peer),
+        Trusted = aec_peer:is_trusted(Peer),
+        Addr = aec_peer:ip(Peer),
+        Source = random_address(),
+        {_, P2} = update(P, Now, Source, Trusted, Peer),
         P2
     end, Pool1, Peers),
 
     {selected, {I2a, P2a}, _} =
         random_select(Pool2, Now, both, undefined),
-    ?assertMatch(#{id := I2a}, P2a),
+    ?assertMatch(I2a, aec_peer:id(P2a)),
     ?assert(lists:member(I2a, AllIds)),
     {selected, {I2b, P2b}, _} =
         random_select(Pool2, Now, both, FilterFun),
-    ?assertMatch(#{id := I2b}, P2b),
+    ?assertMatch(I2b, aec_peer:id(P2b)),
     ?assert(lists:member(I2b, UnexIds)),
     {selected, {I2c, P2c}, _} =
         random_select(Pool2, Now, verified, undefined),
-    ?assertMatch(#{id := I2c, trusted := true}, P2c),
+    ?assertMatch(I2c, aec_peer:id(P2c)),
+    ?assertMatch(true, aec_peer:is_trusted(P2c)),
     ?assert(lists:member(I2c, VerifIds)),
     {selected, {I2d, P2d}, _} =
         random_select(Pool2, Now, verified, FilterFun),
-    ?assertMatch(#{id := I2d, trusted := true}, P2d),
+    ?assertMatch(I2d, aec_peer:id(P2d)),
+    ?assertMatch(true, aec_peer:is_trusted(P2d)),
     ?assert(lists:member(I2d, UnexVerifIds)),
     {selected, {I2e, P2e}, _} =
         random_select(Pool2, Now, unverified, undefined),
-    ?assertMatch(#{id := I2e, trusted := false}, P2e),
+    ?assertMatch(I2e, aec_peer:id(P2e)),
+    ?assertMatch(false, aec_peer:is_trusted(P2e)),
     ?assert(lists:member(I2e, UnverIds)),
     {selected, {I2f, P2f}, _} =
         random_select(Pool2, Now, unverified, FilterFun),
-    ?assertMatch(#{id := I2f, trusted := false}, P2f),
+    ?assertMatch(I2f, aec_peer:id(P2f)),
+    ?assertMatch(false, aec_peer:is_trusted(P2f)),
     ?assert(lists:member(I2f, UnexUnverIds)),
     ok.
 
@@ -411,19 +420,24 @@ peer_selection_unavailability_test() ->
     Peers = make_peers(TotalCount, VerifCount),
 
     Pool2 = maps:fold(fun(_, Peer, P) ->
-        #{id := Id, addr := Addr, source := Source, trusted := Trusted} = Peer,
-        {_, P2} = update(P, Now, Id, Addr, Source, Trusted, Peer),
+        Id = aec_peer:id(Peer),
+        Addr = aec_peer:ip(Peer),
+        Source = Addr,
+        Trusted = aec_peer:is_trusted(Peer),
+        {_, P2} = update(P, Now, Source, Trusted, Peer),
         P2
     end, Pool1, Peers),
 
     {Pool3, _, _, _} = lists:foldl(fun(_, {P, A, V, U}) ->
-        {selected, {I, X}, P2} = random_select(P, Now, both, undefined),
-        ?assertNot(lists:member(I, A)),
-        ?assertEqual(true, is_available(P, I)),
-        ?assertEqual(false, is_available(P2, I)),
-        {A2, V2, U2} = case X of
-            #{id := I, trusted := true} -> {[I | A], [I | V], U};
-            #{id := I, trusted := false} -> {[I | A], V, [I | U]}
+        {selected, {Id, Peer}, P2} = random_select(P, Now, both, undefined),
+        ?assertNot(lists:member(Id, A)),
+        ?assertEqual(true, is_available(P, Id)),
+        ?assertEqual(false, is_available(P2, Id)),
+        IsTrusted = aec_peer:is_trusted(Peer),
+        ?assertEqual(Id, aec_peer:id(Peer)),
+        {A2, V2, U2} = case IsTrusted of
+            true -> {[Id | A], [Id | V], U};
+            false -> {[Id | A], V, [Id | U]}
         end,
         ?assertEqual(TotalCount, count(P2, all, both)),
         ?assertEqual(VerifCount, count(P2, all, verified)),
@@ -442,12 +456,13 @@ peer_selection_unavailability_test() ->
                  random_select(Pool3, Now, unverified, undefined)),
 
     {Pool4, _} = lists:foldl(fun(_, {P, V}) ->
-        {selected, {I, X}, P2} = random_select(P, Now, verified, undefined),
-        ?assertNot(lists:member(I, V)),
-        ?assertMatch(#{id := I, trusted := true}, X),
-        ?assertEqual(true, is_verified(P2, I)),
-        ?assertEqual(false, is_unverified(P2, I)),
-        V2 = [I | V],
+        {selected, {Id, Peer}, P2} = random_select(P, Now, verified, undefined),
+        ?assertNot(lists:member(Id, V)),
+        ?assertEqual(Id, aec_peer:id(Peer)),
+        ?assertEqual(true, aec_peer:is_trusted(Peer)),
+        ?assertEqual(true, is_verified(P2, Id)),
+        ?assertEqual(false, is_unverified(P2, Id)),
+        V2 = [Id | V],
         ?assertEqual(TotalCount, count(P2, all, both)),
         ?assertEqual(VerifCount, count(P2, all, verified)),
         ?assertEqual(UnverCount, count(P2, all, unverified)),
@@ -465,12 +480,12 @@ peer_selection_unavailability_test() ->
                  random_select(Pool4, Now, unverified, undefined)),
 
     {Pool5, _} = lists:foldl(fun(_, {P, U}) ->
-        {selected, {I, X}, P2} = random_select(P, Now, unverified, undefined),
-        ?assertNot(lists:member(I, U)),
-        ?assertMatch(#{id := I, trusted := false}, X),
-        ?assertEqual(false, is_verified(P2, I)),
-        ?assertEqual(true, is_unverified(P2, I)),
-        U2 = [I | U],
+        {selected, {Id, Peer}, P2} = random_select(P, Now, unverified, undefined),
+        ?assertNot(lists:member(Id, U)),
+        ?assertEqual(Id, aec_peer:id(Peer)),
+        ?assertEqual(false, aec_peer:is_trusted(Peer)),
+        ?assertEqual(true, is_unverified(P2, Id)),
+        U2 = [Id | U],
         ?assertEqual(TotalCount, count(P2, all, both)),
         ?assertEqual(VerifCount, count(P2, all, verified)),
         ?assertEqual(UnverCount, count(P2, all, unverified)),
@@ -489,16 +504,16 @@ peer_selection_unavailability_test() ->
 
     % Check explicit selection.
 
-    {Pool6, _, _, _} = lists:foldl(fun(K, {P, A, V, U}) ->
-        #{K := Peer} = Peers,
-        #{id := I} = Peer,
-        ?assertNot(lists:member(I, A)),
-        P2 = select(P, Now, I),
-        ?assertEqual(true, is_available(P, I)),
-        ?assertEqual(false, is_available(P2, I)),
-        {A2, V2, U2} = case Peer of
-            #{trusted := true} -> {[I | A], [I | V], U};
-            #{trusted := false} -> {[I | A], V, [I | U]}
+    {Pool6, _, _, _} = lists:foldl(fun(Id, {P, A, V, U}) ->
+        #{Id := Peer} = Peers,
+        ?assertNot(lists:member(Id, A)),
+        P2 = select(P, Now, Id),
+        ?assertEqual(true, is_available(P, Id)),
+        ?assertEqual(false, is_available(P2, Id)),
+        IsTrusted = aec_peer:is_trusted(Peer),
+        {A2, V2, U2} = case IsTrusted of
+            true -> {[Id | A], [Id | V], U};
+            false -> {[Id | A], V, [Id | U]}
         end,
         ?assertEqual(TotalCount, count(P2, all, both)),
         ?assertEqual(VerifCount, count(P2, all, verified)),
@@ -507,7 +522,7 @@ peer_selection_unavailability_test() ->
         ?assertEqual(VerifCount - length(V2), count(P2, available, verified)),
         ?assertEqual(UnverCount - length(U2), count(P2, available, unverified)),
         {P2, A2, V2, U2}
-    end, {Pool2, [], [], []}, lists:seq(1, TotalCount)),
+    end, {Pool2, [], [], []}, maps:keys(Peers)),
 
     ?assertMatch({unavailable, _},
                  random_select(Pool6, Now, both, undefined)),
@@ -525,8 +540,11 @@ peer_release_test() ->
     Peers = make_peers(6, 3),
 
     Pool2 = maps:fold(fun(_, Peer, P) ->
-        #{id := Id, addr := Addr, source := Source, trusted := Trusted} = Peer,
-        {_, P2} = update(P, Now, Id, Addr, Source, Trusted, Peer),
+        Id = aec_peer:id(Peer),
+        Addr = aec_peer:ip(Peer),
+        Source = Addr,
+        Trusted = aec_peer:is_trusted(Peer),
+        {_, P2} = update(P, Now, Source, Trusted, Peer),
         P2
     end, Pool1, Peers),
 
@@ -596,17 +614,17 @@ peer_release_test() ->
     % Check released peers can be selected again.
 
     {AllSelIds, _} = select_all(Pool8, Now, both, undefined),
-    ?assertEqual(lists:sort([I || {_, #{id := I}} <- maps:to_list(Peers)]),
+    ?assertEqual(lists:sort([I || {I, _} <- maps:to_list(Peers)]),
                  lists:sort(AllSelIds)),
 
     {VerifSelIds, _} = select_all(Pool8, Now, verified, undefined),
-    ?assertEqual(lists:sort([I || {_, #{id := I, trusted := true}}
-                                  <- maps:to_list(Peers)]),
+    ?assertEqual(lists:sort([I || {I, P} <- maps:to_list(Peers),
+                             aec_peer:is_trusted(P)]),
                  lists:sort(VerifSelIds)),
 
     {UnverSelIds, _} = select_all(Pool8, Now, unverified, undefined),
-    ?assertEqual(lists:sort([I || {_, #{id := I, trusted := false}}
-                                  <- maps:to_list(Peers)]),
+    ?assertEqual(lists:sort([I || {I, P} <- maps:to_list(Peers),
+                             aec_peer:is_trusted(P) =:= false]),
                  lists:sort(UnverSelIds)),
     ok.
 
@@ -619,8 +637,11 @@ peer_rejection_test() ->
     Peers = make_peers(3, 1),
 
     Pool2 = maps:fold(fun(_, Peer, P) ->
-        #{id := Id, addr := Addr, source := Source, trusted := Trusted} = Peer,
-        {_, P2} = update(P, Now1, Id, Addr, Source, Trusted, Peer),
+        Id = aec_peer:id(Peer),
+        Addr = aec_peer:ip(Peer),
+        Source = Addr,
+        Trusted = aec_peer:is_trusted(Peer),
+        {_, P2} = update(P, Now1, Source, Trusted, Peer),
         P2
     end, Pool1, Peers),
 
@@ -739,10 +760,12 @@ rejection_downgrade_test() ->
     Now1 = erlang:system_time(millisecond),
     Pool1 = new(?POOL_OPTS),
 
-    Id = random_peer_id(),
-    Addr = random_address(),
+    Peer = random_peer(),
+    Id = aec_peer:id(Peer),
+    Addr = aec_peer:ip(Peer),
 
-    {unverified, Pool2} = update(Pool1, Now1, Id, Addr, Addr, false, undefined),
+
+    {unverified, Pool2} = update(Pool1, Now1, Addr, false, Peer),
     {verified, Pool3} = verify(Pool2, Now1, Id),
     ?assertEqual({verified, true}, peer_state(Pool3, Id)),
 
@@ -796,10 +819,11 @@ basic_verification_test() ->
     Now = erlang:system_time(millisecond),
     Pool1 = new(?POOL_OPTS),
 
-    Id = random_peer_id(),
-    Addr = random_address(),
+    Peer = random_peer(),
+    Id = aec_peer:id(Peer),
+    Addr = aec_peer:ip(Peer),
 
-    {unverified, Pool2} = update(Pool1, Now, Id, Addr, Addr, false, undefined),
+    {unverified, Pool2} = update(Pool1, Now, Addr, false, Peer),
     ?assertEqual(true, is_available(Pool2, Id)),
     ?assertEqual(false, is_verified(Pool2, Id)),
     ?assertEqual(true, is_unverified(Pool2, Id)),
@@ -831,10 +855,11 @@ verification_of_selected_peer_test() ->
     Now = erlang:system_time(millisecond),
     Pool1 = new(?POOL_OPTS),
 
-    Id = random_peer_id(),
-    Addr = random_address(),
+    Peer = random_peer(),
+    Id = aec_peer:id(Peer),
+    Addr = aec_peer:ip(Peer),
 
-    {unverified, Pool2} = update(Pool1, Now, Id, Addr, Addr, false, undefined),
+    {unverified, Pool2} = update(Pool1, Now, Addr, false, Peer),
     {selected, {Id, _}, Pool3} =
         random_select(Pool2, Now, unverified, undefined),
     ?assertEqual(false, is_available(Pool3, Id)),
@@ -865,10 +890,12 @@ verification_of_standby_peer_test() ->
     Now = erlang:system_time(millisecond),
     Pool1 = new(?POOL_OPTS),
 
-    Id = random_peer_id(),
-    Addr = random_address(),
+    Peer = random_peer(),
+    Id = aec_peer:id(Peer),
+    Addr = aec_peer:ip(Peer),
 
-    {unverified, Pool2} = update(Pool1, Now, Id, Addr, Addr, false, undefined),
+
+    {unverified, Pool2} = update(Pool1, Now, Addr, false, Peer),
     {selected, {Id, _}, Pool3} =
         random_select(Pool2, Now, unverified, undefined),
     Pool4 = reject(Pool3, Now, Id),
@@ -897,15 +924,19 @@ verification_canceled_test() ->
     Pool1 = new(PoolOpts),
     Now = erlang:system_time(millisecond),
 
-    Id1 = random_peer_id(),
-    Addr1 = random_address(),
-    Id2 = random_peer_id(),
-    Addr2 = random_address(),
+    Peer1 = random_peer(),
+    Id1 = aec_peer:id(Peer1),
+    Addr1 = aec_peer:ip(Peer1),
+
+    Peer2 = random_peer(),
+    Id2 = aec_peer:id(Peer2),
+    Addr2 = aec_peer:ip(Peer2),
+
 
     {unverified, Pool2} =
-        update(Pool1, Now, Id1, Addr1, Addr1, false, undefined),
+        update(Pool1, Now, Addr1, false, Peer1),
     {unverified, Pool3} =
-        update(Pool2, Now, Id2, Addr2, Addr2, false, undefined),
+        update(Pool2, Now, Addr2, false, Peer2),
 
     {verified, Pool4} = verify(Pool3, Now, Id1),
     ?assertEqual({verified, true}, peer_state(Pool4, Id1)),
@@ -933,30 +964,34 @@ update_ignored_test() ->
     Pool1 = new(PoolOpts),
     Now = erlang:system_time(millisecond),
 
-    Id1 = random_peer_id(),
-    Addr1 = random_address(),
-    Id2 = random_peer_id(),
-    Addr2 = random_address(),
+    Peer1 = random_peer(),
+    Id1 = aec_peer:id(Peer1),
+    Addr1 = aec_peer:ip(Peer1),
+    Peer1DifferentAddress = random_peer(#{pubkey => Id1}),
+
+    Peer2 = random_peer(),
+    Id2 = aec_peer:id(Peer2),
+    Addr2 = aec_peer:ip(Peer2),
 
     {unverified, Pool2} =
-        update(Pool1, Now, Id1, Addr1, Addr1, false, undefined),
+        update(Pool1, Now, Addr1, false, Peer1),
     ?assertEqual({unverified, true}, peer_state(Pool2, Id1)),
     ?assertEqual({undefined, undefined}, peer_state(Pool2, Id2)),
 
     % Updating with a different address is ignored.
     {ignored, Pool3} =
-        update(Pool2, Now, Id1, Addr2, Addr2, false, undefined),
+        update(Pool2, Now, Addr2, false, Peer1DifferentAddress),
     ?assertEqual({unverified, true}, peer_state(Pool3, Id1)),
     ?assertEqual({undefined, undefined}, peer_state(Pool3, Id2)),
 
     % Updating with a different trust status is ignored.
-    {ignored, Pool4} = update(Pool3, Now, Id1, Addr1, Addr1, true, undefined),
+    {ignored, Pool4} = update(Pool3, Now, Addr1, true, Peer1),
     ?assertEqual({unverified, true}, peer_state(Pool4, Id1)),
     ?assertEqual({undefined, undefined}, peer_state(Pool4, Id2)),
 
     % Normal update evict the old peer.
     {unverified, Pool5} =
-        update(Pool4, Now, Id2, Addr2, Addr2, false, undefined),
+        update(Pool4, Now, Addr2, false, Peer2),
     ?assertEqual({undefined, undefined}, peer_state(Pool5, Id1)),
     ?assertEqual({unverified, true}, peer_state(Pool5, Id2)),
 
@@ -966,7 +1001,7 @@ update_ignored_test() ->
     ?assertEqual({unverified, false}, peer_state(Pool6, Id2)),
 
     % Update should be ignored due to not being able to evict any peer.
-    {ignored, Pool7} = update(Pool6, Now, Id1, Addr1, Addr1, false, undefined),
+    {ignored, Pool7} = update(Pool6, Now, Addr1, false, Peer1),
     ?assertEqual({undefined, undefined}, peer_state(Pool7, Id1)),
     ?assertEqual({unverified, false}, peer_state(Pool7, Id2)),
     ok.
@@ -983,16 +1018,19 @@ downgrade_to_bucket_with_no_eviction_possible_test() ->
     Pool1 = new(PoolOpts),
     Now = erlang:system_time(millisecond),
 
-    Id1 = random_peer_id(),
-    Addr1 = random_address(),
-    Id2 = random_peer_id(),
-    Addr2 = random_address(),
+    RandomPeer1 = random_peer(),
+    Id1 = aec_peer:id(RandomPeer1),
+    Addr1 = aec_peer:ip(RandomPeer1),
+
+    RandomPeer2 = random_peer(),
+    Id2 = aec_peer:id(RandomPeer2),
+    Addr2 = aec_peer:ip(RandomPeer2),
 
     {unverified, Pool2} =
-        update(Pool1, Now, Id1, Addr1, Addr1, false, undefined),
+        update(Pool1, Now, Addr1, false, RandomPeer1),
     {verified, Pool3} = verify(Pool2, Now, Id1),
     {unverified, Pool4} =
-        update(Pool3, Now, Id2, Addr2, Addr2, false, undefined),
+        update(Pool3, Now, Addr2, false, RandomPeer2),
     ?assertEqual({verified, true}, peer_state(Pool4, Id1)),
     ?assertEqual({unverified, true}, peer_state(Pool4, Id2)),
 
@@ -1022,10 +1060,12 @@ manual_selection_of_standby_peer_test() ->
     Now = erlang:system_time(millisecond),
     Pool1 = new(?POOL_OPTS),
 
-    Id = random_peer_id(),
-    Addr = random_address(),
+    RandomPeer = random_peer(),
+    Id = aec_peer:id(RandomPeer),
+    Addr = aec_peer:ip(RandomPeer),
+    false = Trusted = aec_peer:is_trusted(RandomPeer),
 
-    {unverified, Pool2} = update(Pool1, Now, Id, Addr, Addr, false, undefined),
+    {unverified, Pool2} = update(Pool1, Now, Addr, Trusted, RandomPeer),
     {selected, {Id, _}, Pool3} =
         random_select(Pool2, Now, unverified, undefined),
     Pool4 = reject(Pool3, Now, Id),
@@ -1050,13 +1090,17 @@ unverified_selected_are_not_evicted_test() ->
 
     Now1 = erlang:system_time(millisecond),
     Peers = make_peers(200, 0),
+    PeersList = [P || {_, P} <- maps:to_list(Peers)],
 
-    {Pool2, Now2} = lists:foldl(fun(K, {P, N}) ->
-        #{K := Peer} = Peers,
-        #{id := Id, addr := Addr, source := Source} = Peer,
-        {unverified, P2} = update(P, N, Id, Addr, Source, false, undefined),
-        {P2, N + 1000}
-    end, {Pool1, Now1}, lists:seq(1, 10)),
+    {Pool2, Now2} =
+        lists:foldl(
+            fun(Peer, {P, N}) ->
+                Source = random_address(),
+                {unverified, P2} = update(P, N, Source, false, Peer),
+                {P2, N + 1000}
+            end,
+            {Pool1, Now1},
+            lists:sublist(PeersList, 10)),
 
     % Select some of the peer to ensure they never get evicted.
     {selected, {SelId1, _}, Pool3} =
@@ -1073,12 +1117,15 @@ unverified_selected_are_not_evicted_test() ->
     ?assertEqual( 0, count(Pool5, available, verified)),
     ?assertEqual( 7, count(Pool5, available, unverified)),
 
-    Pool6 = lists:foldl(fun(K, P) ->
-        #{K := Peer} = Peers,
-        #{id := Id, addr := Addr, source := Source} = Peer,
-        {unverified, P2} = update(P, Now2, Id, Addr, Source, false, undefined),
-        P2
-    end, Pool5, lists:seq(11, 100)),
+    Pool6 =
+        lists:foldl(
+            fun(Peer, P) ->
+                Source = random_address(),
+                {unverified, P2} = update(P, Now2, Source, false, Peer),
+                P2
+            end,
+            Pool5,
+            lists:sublist(PeersList, 11, 100)),
 
     ?assertEqual(true, is_unverified(Pool6, SelId1)),
     ?assertEqual(true, is_unverified(Pool6, SelId2)),
@@ -1106,13 +1153,17 @@ unverified_old_peers_are_removed_test() ->
 
     Now1 = erlang:system_time(millisecond),
     Peers = make_peers(20, 0),
+    PeersList = [P || {_, P} <- maps:to_list(Peers)],
 
-    {Pool2, Now2} = lists:foldl(fun(K, {P, N}) ->
-        #{K := Peer} = Peers,
-        #{id := Id, addr := Addr, source := Source} = Peer,
-        {unverified, P2} = update(P, N, Id, Addr, Source, false, undefined),
-        {P2, N + 1000}
-    end, {Pool1, Now1}, lists:seq(1, 10)),
+    {Pool2, Now2} =
+        lists:foldl(
+            fun(Peer, {P, N}) ->
+                Source = random_address(),
+                {unverified, P2} = update(P, N, Source, false, Peer),
+                {P2, N + 1000}
+            end,
+            {Pool1, Now1},
+            lists:sublist(PeersList, 10)),
 
     % Select some of the peer to ensure they never get evicted.
     {selected, {SelId1, _}, Pool3} =
@@ -1131,10 +1182,10 @@ unverified_old_peers_are_removed_test() ->
 
     Now3 = Now2 + 30000,
 
-    #{11 := Peer11} = Peers,
-    #{id := Id, addr := Addr, source := Source} = Peer11,
+    Peer11 = lists:nth(11, PeersList),
+    Source = random_address(),
     {unverified, Pool6} =
-        update(Pool5, Now3, Id, Addr, Source, false, undefined),
+        update(Pool5, Now3, Source, false, Peer11),
 
     % Selected peers should NOT be removed
     ?assertEqual(true, is_unverified(Pool6, SelId1)),
@@ -1159,10 +1210,9 @@ unverified_multiple_references_test() ->
     Pool1 = new(PoolOpts),
 
     Now = erlang:system_time(millisecond),
-    PeerId = random_peer_id(),
-    PeerAddr = random_address(),
-
-    Pool2 = unver_add_refs(Pool1, Now, PeerId, PeerAddr, MaxRefs, 10000),
+    Peer = random_peer(),
+    PeerId = aec_peer:id(Peer),
+    Pool2 = unver_add_refs(Pool1, Now, Peer, MaxRefs, 10000),
 
     ?assertEqual(MaxRefs, aec_peers_pool:reference_count(Pool2, PeerId)),
     ?assertEqual(1, count(Pool2, all, both)),
@@ -1173,7 +1223,7 @@ unverified_multiple_references_test() ->
     ?assertEqual(1, count(Pool2, available, unverified)),
 
     % Checks than 1000 more updates do not add anymore references.
-    Pool3 = unver_add_refs(Pool2, Now, PeerId, PeerAddr, MaxRefs + 1, 1000),
+    Pool3 = unver_add_refs(Pool2, Now, Peer, MaxRefs + 1, 1000),
 
     ?assertEqual(MaxRefs, aec_peers_pool:reference_count(Pool3, PeerId)),
     ?assertEqual(1, count(Pool3, all, both)),
@@ -1192,8 +1242,9 @@ unverified_reference_eviction_test() ->
     Pool1 = new(PoolOpts),
     Now = erlang:system_time(millisecond),
 
-    Id1 = random_peer_id(),
-    Addr1 = random_address(),
+    Peer1 = random_peer(),
+    Id1 = aec_peer:id(Peer1),
+    Addr1 = aec_peer:ip(Peer1),
     Src1a = random_address(),
     BIdx1a = aec_peers_pool:unverified_bucket_index(Pool1, Src1a, Addr1),
     % Find a source address that match to the other bucket...
@@ -1201,24 +1252,24 @@ unverified_reference_eviction_test() ->
     Src1b = find_unverified_source(Pool1, Addr1, BIdx1b),
 
     {unverified, Pool2} =
-        update(Pool1, Now, Id1, Addr1, Src1a, false, undefined),
+        update(Pool1, Now, Src1a, false, Peer1),
     ?assertEqual(true, is_unverified(Pool2, Id1)),
     ?assertEqual(1, aec_peers_pool:reference_count(Pool2, Id1)),
     ?assertEqual(1, count(Pool2, all, both)),
     ?assertEqual(1, count(Pool2, available, both)),
 
-    Pool3 = unver_add_refs(Pool2, Now, Id1, Addr1, Src1b, 2, 1000),
+    Pool3 = unver_add_refs(Pool2, Now, Peer1, Src1b, 2, 1000),
     ?assertEqual(true, is_unverified(Pool2, Id1)),
     ?assertEqual(2, aec_peers_pool:reference_count(Pool3, Id1)),
     ?assertEqual(1, count(Pool3, all, both)),
     ?assertEqual(1, count(Pool3, available, both)),
 
-    Id2 = random_peer_id(),
-    Addr2 = random_address(),
+    Peer2 = random_peer(),
+    Id2 = aec_peer:id(Peer2),
     Src2 = random_address(),
 
     {unverified, Pool4} =
-        update(Pool3, Now, Id2, Addr2, Src2, false, undefined),
+        update(Pool3, Now, Src2, false, Peer2),
     ?assertEqual(true, is_unverified(Pool4, Id1)),
     ?assertEqual(true, is_unverified(Pool4, Id2)),
     ?assertEqual(1, aec_peers_pool:reference_count(Pool4, Id1)),
@@ -1237,16 +1288,46 @@ verified_selected_and_trusted_peers_are_not_evicted_test() ->
     Pool1 = new(PoolOpts),
 
     Now = erlang:system_time(millisecond),
-    Peers = make_peers(500, 2), % First 2 peers are trusted
-    TrustedId1 = maps:get(id, maps:get(1, Peers)),
-    TrustedId2 = maps:get(id, maps:get(2, Peers)),
+    Peers = make_peers(500, 2), % 2 peers are trusted
+    TrustedPeers = [TrustedPeer1, TrustedPeer2] =
+        [P || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P)],
+    TrustedId1 = aec_peer:id(TrustedPeer1),
+    TrustedId2 = aec_peer:id(TrustedPeer2),
+    UntrustedPeers = 
+        [P || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P) =:= false],
+    PeersToPost = TrustedPeers ++ lists:sublist(UntrustedPeers, 8),
 
-    Pool2 = lists:foldl(fun(K, P) ->
-        #{K := Peer} = Peers,
-        #{id := Id, addr := Addr, source := Source, trusted := Trusted} = Peer,
-        {_, P2} = update(P, Now, Id, Addr, Source, Trusted, undefined),
-        P2
-    end, Pool1, lists:seq(1, 10)),
+    UpdatePeers =
+        fun(Pool, PList, Verify) ->
+            lists:foldl(
+                fun(Peer, P) ->
+                    IsTrusted = aec_peer:is_trusted(Peer),
+                    Source = random_address(),
+                    {_, P1} = update(P, Now, Source, IsTrusted, Peer),
+                    case Verify of
+                        true ->
+                            Id = aec_peer:id(Peer),
+                            {verified, P2} = verify(P1, Now, Id),
+                            P2;
+                        false -> P1
+                    end
+                end,
+                Pool,
+                PList)
+        end,
+    VerifyPeers =
+        fun(Pool, PList) ->
+            lists:foldl(
+                fun(Peer, P) ->
+                    Id = aec_peer:id(Peer),
+                    {verified, P1} = verify(P, Now, Id),
+                    P1
+                end,
+                Pool,
+                PList)
+        end,
+
+    Pool2 = UpdatePeers(Pool1, PeersToPost, false),
 
     % Select some of the peer to ensure they never get evicted.
     {selected, {SelId1, _}, Pool4} =
@@ -1257,12 +1338,7 @@ verified_selected_and_trusted_peers_are_not_evicted_test() ->
         random_select(Pool5, Now, unverified, undefined),
 
     % Verify all the peers to fill the single verified bucket
-    Pool7 = lists:foldl(fun(K, P) ->
-        #{K := Peer} = Peers,
-        #{id := Id} = Peer,
-        {verified, P2} = verify(P, Now, Id),
-        P2
-    end, Pool6, lists:seq(1, 10)),
+    Pool7 = VerifyPeers(Pool6, PeersToPost),
 
     ?assertEqual(10, count(Pool7, all, both)),
     ?assertEqual(10, count(Pool7, all, verified)),
@@ -1272,13 +1348,8 @@ verified_selected_and_trusted_peers_are_not_evicted_test() ->
     ?assertEqual( 0, count(Pool7, available, unverified)),
 
     % Update and verify all the other peers.
-    Pool8 = lists:foldl(fun(K, P) ->
-        #{K := Peer} = Peers,
-        #{id := Id, addr := Addr, source := Source} = Peer,
-        {unverified, P2} = update(P, Now, Id, Addr, Source, false, undefined),
-        {verified, P3} = verify(P2, Now, Id),
-        P3
-    end, Pool7, lists:seq(11, 100)),
+    SecondBatchOfPeers = lists:sublist(UntrustedPeers, 9, 100),
+    Pool8 = UpdatePeers(Pool7, SecondBatchOfPeers, true),
 
     % Selected peers didn't get evicted.
     ?assertEqual(true, is_verified(Pool8, SelId1)),
@@ -1309,16 +1380,25 @@ verified_old_peers_are_removed_test() ->
     Pool1 = new(PoolOpts),
 
     Now1 = erlang:system_time(millisecond),
-    Peers = make_peers(20, 2),
-    TrustedId1 = maps:get(id, maps:get(1, Peers)),
-    TrustedId2 = maps:get(id, maps:get(2, Peers)),
+    TrustedCnt = 2,
+    Peers = make_peers(20, TrustedCnt),
+    TrustedPeers = [TrustedPeer1, TrustedPeer2] =
+        [P || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P)],
+    TrustedId1 = aec_peer:id(TrustedPeer1),
+    TrustedId2 = aec_peer:id(TrustedPeer2),
+    UntrustedPeers = 
+        [P || {I, P} <- maps:to_list(Peers), aec_peer:is_trusted(P) =:= false],
 
-    {Pool2, Now2} = lists:foldl(fun(K, {P, N}) ->
-        #{K := Peer} = Peers,
-        #{id := Id, addr := Addr, source := Source, trusted := Trusted} = Peer,
-        {_, P2} = update(P, N, Id, Addr, Source, Trusted, undefined),
+    
+    PeersToPost = TrustedPeers ++ lists:sublist(UntrustedPeers, 8),
+    {Pool2, Now2} = lists:foldl(fun(Peer, {P, N}) ->
+        Id = aec_peer:id(Peer),
+        Addr = aec_peer:ip(Peer),
+        Trusted = aec_peer:is_trusted(Peer),
+        Source = random_address(),
+        {_, P2} = update(P, N, Source, Trusted, Peer),
         {P2, N + 1000}
-    end, {Pool1, Now1}, lists:seq(1, 10)),
+    end, {Pool1, Now1}, PeersToPost),
 
     % Select some of the peer to ensure they never get evicted.
     {selected, {SelId1, _}, Pool3} =
@@ -1329,12 +1409,11 @@ verified_old_peers_are_removed_test() ->
         random_select(Pool4, Now2, unverified, undefined),
 
     % Verify all the peers to fill the single verified bucket
-    Pool6 = lists:foldl(fun(K, P) ->
-        #{K := Peer} = Peers,
-        #{id := Id} = Peer,
+    Pool6 = lists:foldl(fun(Peer, P) ->
+        Id = aec_peer:id(Peer),
         {verified, P2} = verify(P, Now2, Id),
         P2
-    end, Pool5, lists:seq(1, 10)),
+    end, Pool5, PeersToPost),
 
     ?assertEqual(10, count(Pool6, all, both)),
     ?assertEqual(10, count(Pool6, all, verified)),
@@ -1345,9 +1424,11 @@ verified_old_peers_are_removed_test() ->
 
     Now3 = Now2 + 30000,
 
-    #{11 := Peer11} = Peers,
-    #{id := Id, addr := Addr, source := Source} = Peer11,
-    {verified, Pool7} = update(Pool6, Now3, Id, Addr, Source, true, undefined),
+    [Peer11 | _] = maps:values(Peers) -- PeersToPost,
+    Id = aec_peer:id(Peer11),
+    Addr = aec_peer:ip(Peer11),
+    Source = random_address(),
+    {verified, Pool7} = update(Pool6, Now3, Source, true, Peer11),
 
     % Selected peers should NOT be removed
     ?assertEqual(true, is_verified(Pool7, SelId1)),
@@ -1419,16 +1500,18 @@ validate_counters() ->
                     case peer_state(P, Id) of
                         {undefined, _} -> {P, N + 500, A2, S};
                         _ ->
+                            RandomPeer = random_peer(#{pubkey => Id,
+                                                       address => Addr}),
                             Source = random_address(),
-                            {_, P2} = update(P, N, Id, Addr, Source,
-                                             false, undefined),
+                            {_, P2} = update(P, N, Source, false, RandomPeer),
                             {P2, N + 500, A, S}
                     end;
                 _ ->
-                    Id = random_peer_id(),
-                    Addr = random_address(),
+                    RandomPeer = random_peer(),
+                    Id = aec_peer:id(RandomPeer),
+                    Addr = aec_peer:ip(RandomPeer),
                     Source = random_address(),
-                    {_, P2} = update(P, N, Id, Addr, Source, false, undefined),
+                    {_, P2} = update(P, N, Source, false, RandomPeer),
                     {P2, N + 500, [{Id, Addr} | A], S}
             end
     end, {Pool1, Now1, [], []}, lists:seq(1, 100000)),
@@ -1926,18 +2009,13 @@ random_address(A, B) ->
 
 make_peers(TotalCount, TrustedCount) ->
     ?assert(TotalCount >= TrustedCount),
-    make_peers(TotalCount, TrustedCount, 1, #{}).
+    make_peers(TotalCount, TrustedCount, #{}).
 
-make_peers(0, _, _, Acc) -> Acc;
-make_peers(TotalCount, TrustedCount, Key, Acc) ->
-    Peer = #{
-        key => Key,
-        id => random_peer_id(),
-        addr => random_address(),
-        source => random_address(),
-        trusted => TrustedCount > 0
-    },
-    make_peers(TotalCount - 1, TrustedCount - 1, Key + 1, Acc#{Key => Peer}).
+make_peers(0, _, Acc) -> Acc;
+make_peers(TotalCount, TrustedCount,  Acc) ->
+    Peer = random_peer(#{trusted => TrustedCount > 0}), 
+    make_peers(TotalCount - 1, TrustedCount - 1,
+               Acc#{aec_peer:id(Peer) => Peer}).
 
 make_ext_exclude_filter(ExcludePeerIds) ->
     fun(PeerId, _) -> not lists:member(PeerId, ExcludePeerIds) end.
@@ -1984,22 +2062,32 @@ select_all(Pool, Now, Target, FilterFun, Acc) ->
             select_all(Pool2, Now, Target, FilterFun, [I | Acc])
     end.
 
-unver_add_refs(Pool, Now, PeerId, PeerAddr, Count, Max) ->
-    unver_add_refs(Pool, Now, PeerId, PeerAddr, undefined, Count, Max).
+unver_add_refs(Pool, Now, Peer, Count, Max) ->
+    unver_add_refs(Pool, Now, Peer, undefined, Count, Max).
 
-unver_add_refs(Pool, _Now, _PeerId, _PeerAddr, _SourceAddr, _Count, 0) -> Pool;
-unver_add_refs(Pool, Now, PeerId, PeerAddr, SourceAddr0, Count, Max) ->
+unver_add_refs(Pool, _Now, _Peer, _SourceAddr, _Count, 0) -> Pool;
+unver_add_refs(Pool, Now, Peer, SourceAddr0, Count, Max) ->
     SourceAddr = case SourceAddr0 of
         undefined -> random_address();
         Addr -> Addr
     end,
-    {unverified, Pool2} = update(Pool, Now, PeerId, PeerAddr,
-                                 SourceAddr, false, undefined),
+    {unverified, Pool2} = update(Pool, Now, SourceAddr, false, Peer),
+    PeerId = aec_peer:id(Peer),
     case aec_peers_pool:reference_count(Pool2, PeerId) =:= Count of
         true -> Pool2;
         false ->
-            unver_add_refs(Pool2, Now, PeerId, PeerAddr,
+            unver_add_refs(Pool2, Now, Peer,
                            SourceAddr0, Count, Max - 1)
     end.
+
+random_peer() ->
+    random_peer(#{}).
+
+random_peer(Opts) ->
+    PeerInfo =
+        maps:merge(#{ pubkey => random_peer_id(), host => <<>>, port => 4000 },
+                   Opts),
+    aec_peer:new(maps:get(address, Opts, random_address()), PeerInfo, maps:get(trusted, Opts, false)).
+
 
 -endif.

--- a/apps/aecore/test/aec_peers_tests.erl
+++ b/apps/aecore/test/aec_peers_tests.erl
@@ -161,7 +161,7 @@ test_single_trusted_peer() ->
     test_mgr_set_recipient(self()),
 
     PubKey = <<"ef42d46eace742cd0000000000000000">>,
-    Id = aec_peers:peer_id(PubKey),
+    Id = peer_id(PubKey),
 
     ?assertMatch(false, aec_peers:is_blocked(Id)),
     ?assertMatch([], aec_peers:blocked_peers()),
@@ -217,7 +217,7 @@ test_single_normal_peer() ->
 
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd0000000000000000">>,
-    Id = aec_peers:peer_id(PubKey),
+    Id = peer_id(PubKey),
     Peer = peer(PubKey, <<"10.1.0.1">>, 4000),
 
     aec_peers:add_peers(Source, Peer),
@@ -259,7 +259,7 @@ test_duplicating_peer() ->
     TrustedPeerAddress = "10.1.0.1",
     TrustedPeerPort = 4000,
     TrustedPeer = peer(TrustedPubKey, TrustedPeerAddress, TrustedPeerPort),
-    TrustedId = aec_peers:peer_id(TrustedPubKey),
+    TrustedId = peer_id(TrustedPubKey),
 
     ?assertMatch(false, aec_peers:is_blocked(TrustedId)),
     ?assertMatch([], aec_peers:blocked_peers()),
@@ -334,7 +334,7 @@ test_duplicating_peer() ->
     %% create a different peer with the same address and a different port
     ?assertEqual(true, TrustedPeerPort =/= TrustedPeerPort2),
     Peer2 = peer(PubKey2, TrustedPeerAddress, TrustedPeerPort2),
-    PeerId2 = aec_peers:peer_id(PubKey2),
+    PeerId2 = peer_id(PubKey2),
     aec_peers:add_peers(Source, Peer2),
 
     {ok, Conn1} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey2 }], {ok, _}, 3500),
@@ -357,11 +357,11 @@ test_multiple_trusted_peers() ->
     test_mgr_set_recipient(self()),
 
     PubKey1 = <<"ef42d46eace742cd0000000000000000">>,
-    Id1 = aec_peers:peer_id(PubKey1),
+    Id1 = peer_id(PubKey1),
     PubKey2 = <<"854a8e1f93f94b950000000000000000">>,
-    Id2 = aec_peers:peer_id(PubKey2),
+    Id2 = peer_id(PubKey2),
     PubKey3 = <<"eb56e9292dda481c0000000000000000">>,
-    Id3 = aec_peers:peer_id(PubKey3),
+    Id3 = peer_id(PubKey3),
 
     Peers = [
         peer(PubKey1, <<"10.1.0.1">>, 4000),
@@ -411,11 +411,11 @@ test_multiple_normal_peers() ->
 
     Source = {192, 168, 0, 1},
     PubKey1 = <<"ef42d46eace742cd0000000000000000">>,
-    Id1 = aec_peers:peer_id(PubKey1),
+    Id1 = peer_id(PubKey1),
     PubKey2 = <<"854a8e1f93f94b950000000000000000">>,
-    Id2 = aec_peers:peer_id(PubKey2),
+    Id2 = peer_id(PubKey2),
     PubKey3 = <<"eb56e9292dda481c0000000000000000">>,
-    Id3 = aec_peers:peer_id(PubKey3),
+    Id3 = peer_id(PubKey3),
 
     Peers = [
         peer(PubKey1, <<"10.1.0.1">>, 4000),
@@ -459,11 +459,11 @@ test_tcp_probe() ->
 
     Source = {192, 168, 0, 1},
     PubKey1 = <<"ef42d46eace742cd0000000000000000">>,
-    Id1 = aec_peers:peer_id(PubKey1),
+    Id1 = peer_id(PubKey1),
     PubKey2 = <<"854a8e1f93f94b950000000000000000">>,
-    _Id2 = aec_peers:peer_id(PubKey2),
+    _Id2 = peer_id(PubKey2),
     PubKey3 = <<"eb56e9292dda481c0000000000000000">>,
-    _Id3 = aec_peers:peer_id(PubKey3),
+    _Id3 = peer_id(PubKey3),
 
     Peer1 = peer(PubKey1, <<"10.1.0.1">>, 4000),
     Peer2 = peer(PubKey2, <<"10.2.0.1">>, 4000),
@@ -526,7 +526,7 @@ test_invalid_hostname() ->
     Source = {192, 168, 0, 1},
     PubKey1 = <<"ef42d46eace742cd0000000000000000">>,
     Peer1 = peer(PubKey1, <<"aeternity.com">>, 4000),
-    Id1 = aec_peers:peer_id(Peer1),
+    Id1 = peer_id(Peer1),
 
     PubKey2 = <<"ff92adcbcc684dda0000000000000000">>,
     Peer2 = peer(PubKey2, <<"aeternity.com">>, 5000),
@@ -587,7 +587,7 @@ test_invalid_hostname() ->
     mock_getaddr({error, nxdomain}),
 
     % Delete peer2 and add back both.
-    aec_peers:del_peer(Peer2),
+    aec_peers:del_peer(peer_id(Peer2)),
     ?assertCalled(disconnect, [Conn1], ok, 100),
     aec_peers:add_peers(Source, Peer1),
     ?assertMessage({getaddr, "aeternity.com"}, 100),
@@ -661,19 +661,19 @@ test_address_group_selection() ->
 
     Source = {192, 168, 0, 1},
     PubKey1 = <<"ef42d46eace742cd0000000000000000">>,
-    Id1 = aec_peers:peer_id(PubKey1),
+    Id1 = peer_id(PubKey1),
     Peer1 = peer(PubKey1, "10.1.0.1", 4000),
     PubKey2 = <<"854a8e1f93f94b950000000000000000">>,
-    Id2 = aec_peers:peer_id(PubKey2),
+    Id2 = peer_id(PubKey2),
     Peer2 = peer(PubKey2, "10.1.0.2", 4000),
     PubKey3 = <<"eb56e9292dda481c0000000000000000">>,
-    Id3 = aec_peers:peer_id(PubKey3),
+    Id3 = peer_id(PubKey3),
     Peer3 = peer(PubKey3, "10.2.0.1", 4000),
     PubKey4 = <<"9d9e1c43de304d810000000000000000">>,
-    Id4 = aec_peers:peer_id(PubKey4),
+    Id4 = peer_id(PubKey4),
     Peer4 = peer(PubKey4, "10.2.0.2", 4000),
     PubKey5 = <<"75640b5ffaac40480000000000000000">>,
-    Id5 = aec_peers:peer_id(PubKey5),
+    Id5 = peer_id(PubKey5),
     Peer5 = peer(PubKey5, "10.3.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer1),
@@ -740,13 +740,13 @@ test_selection_without_address_group() ->
 
     Source = {192, 168, 0, 1},
     PubKey1 = <<"ef42d46eace742cd0000000000000000">>,
-    Id1 = aec_peers:peer_id(PubKey1),
+    Id1 = peer_id(PubKey1),
     Peer1 = peer(PubKey1, "10.1.0.1", 4000),
     PubKey2 = <<"854a8e1f93f94b950000000000000000">>,
-    Id2 = aec_peers:peer_id(PubKey2),
+    Id2 = peer_id(PubKey2),
     Peer2 = peer(PubKey2, "10.1.0.2", 4000),
     PubKey3 = <<"eb56e9292dda481c0000000000000000">>,
-    Id3 = aec_peers:peer_id(PubKey3),
+    Id3 = peer_id(PubKey3),
     Peer3 = peer(PubKey3, "10.1.0.3", 4000),
 
     aec_peers:add_peers(Source, Peer1),
@@ -775,7 +775,7 @@ test_connection_closed() ->
 
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd0000000000000000">>,
-    Id = aec_peers:peer_id(PubKey),
+    Id = peer_id(PubKey),
     Peer = peer(PubKey, "10.1.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer),
@@ -819,7 +819,7 @@ test_connection_failure() ->
 
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd0000000000000000">>,
-    Id = aec_peers:peer_id(PubKey),
+    Id = peer_id(PubKey),
     Peer = peer(PubKey, "10.1.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer),
@@ -872,7 +872,7 @@ test_connection_down() ->
 
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd0000000000000000">>,
-    Id = aec_peers:peer_id(PubKey),
+    Id = peer_id(PubKey),
     Peer = peer(PubKey, "10.1.0.1", 4000),
 
     aec_peers:add_peers(Source, Peer),
@@ -950,7 +950,7 @@ test_inbound_connections() ->
     lists:foldl(fun(Peer, Acc) ->
         {ok, Conn} = test_mgr_start_inbound(Peer),
         ?assertEqual(permanent, conn_peer_accepted(Conn, maps:get(host, Peer))),
-        PeerId = aec_peers:peer_id(Peer),
+        PeerId = peer_id(Peer),
         Acc#{ PeerId => Conn }
     end, #{}, Peers),
 
@@ -1043,7 +1043,7 @@ test_ping() ->
 
     Source = {192, 168, 0, 1},
     PubKey = <<"ef42d46eace742cd0000000000000000">>,
-    Id = aec_peers:peer_id(PubKey),
+    Id = peer_id(PubKey),
     Peer = peer(PubKey, "10.1.0.1", 4000),
 
     ok = aec_peers:add_peers(Source, Peer),
@@ -1070,10 +1070,10 @@ test_connection_conflict() ->
     Source = {192, 168, 0, 1},
     Peer1 = peer(1, "10.1.0.1", 4000),
     #{ pubkey := PubKey1 } = Peer1,
-    Id1 = aec_peers:peer_id(PubKey1),
+    Id1 = peer_id(PubKey1),
     Peer2 = peer(9, "10.1.0.2", 4000),
     #{ pubkey := PubKey2 } = Peer2,
-    Id2 = aec_peers:peer_id(PubKey2),
+    Id2 = peer_id(PubKey2),
 
     ok = aec_peers:add_peers(Source, Peer1),
     {ok, Conn1} = ?assertCalled(connect, [#{ conn_type := noise, r_pubkey := PubKey1 }], {ok, _}, 200),
@@ -1141,16 +1141,16 @@ test_blocking() ->
 
     Source = {192, 168, 0, 1},
     Peer1 = peer(1, "10.1.0.1", 1),
-    Id1 = aec_peers:peer_id(Peer1),
+    Id1 = peer_id(Peer1),
     #{ pubkey := PubKey1 } = Peer1,
     Peer2 = peer(2, "10.1.0.2", 2),
     #{ pubkey := PubKey2 } = Peer2,
-    Id2 = aec_peers:peer_id(Peer2),
+    Id2 = peer_id(Peer2),
     Peer3 = peer(3, "10.1.0.3", 3),
     #{ pubkey := PubKey3 } = Peer3,
-    Id3 = aec_peers:peer_id(Peer3),
+    Id3 = peer_id(Peer3),
     Peer4 = peer(4, "10.1.0.4", 4),
-    Id4 = aec_peers:peer_id(Peer4),
+    Id4 = peer_id(Peer4),
 
     A = erlang:system_time(millisecond),
 
@@ -1504,7 +1504,7 @@ proc_conn_init(Parent, Recipient, {outbound, Opts}) ->
         id => PeerId
     });
 proc_conn_init(Parent, Recipient, {inbound, PeerInfo}) ->
-    PeerId = aec_peers:peer_id(PeerInfo),
+    PeerId = peer_id(PeerInfo),
     proc_conn_loop(#{
         connected => false,
         parent => Parent,
@@ -1586,4 +1586,6 @@ proc_conn_loop(S) ->
             reply(From, ok)
     end.
 
+    peer_id(Bin) when is_binary(Bin) -> Bin;
+    peer_id(InfoOrPeer) -> aec_peer:id(InfoOrPeer).
 -endif.

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -479,7 +479,7 @@ crash_syncing_worker(Config) ->
 
     %% Ensure compatible notation of uri:
     {ok, PeerInfo} = aec_peers:parse_peer_address(aecore_suite_utils:peer_info(Dev1)),
-    PeerId = aec_peers:peer_id(PeerInfo),
+    PeerId = aec_peer:id(PeerInfo),
     ct:log("PeerId of Dev1 ~p", [PeerId]),
 
     spawn_link(fun() -> kill_sync_worker(N2, PeerId) end),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3375,7 +3375,7 @@ peers(_Config) ->
 
     %% ensure no peers
     lists:foreach(
-        fun(Peer) -> rpc(aec_peers, del_peer, [Peer]) end,
+        fun(Peer) -> rpc(aec_peers, del_peer, [aec_peer:id(Peer)]) end,
         rpc(aec_peers, get_random, [all])),
 
     {ok, 200, #{<<"blocked">> := [], <<"peers">> := []}} = get_peers(),


### PR DESCRIPTION
There had been quite a lot of entanglement between the different modules. This PR does some refactoring in that direction with the strongest aim of removing data duplication.

This is a prerequisite to #3356

Still TODO:
- [x]  move the `source` to `aec_peer:peer()`

The work on this PR is supported by AEternity Foundation.