### PR TITLE
Allow picking the trusted peers

### DIFF
--- a/apps/aecore/src/aec_peer.erl
+++ b/apps/aecore/src/aec_peer.erl
@@ -21,7 +21,8 @@
         ]).
 
 -ifdef(TEST).
--export([ set_trusted/2 ]).
+-export([ set_trusted/2,
+          peer_config_info/1 ]).
 -endif.
 
 -record(peer, {
@@ -127,6 +128,12 @@ is_trusted(#peer{ trusted = Trusted }) -> Trusted.
 -ifdef(TEST).
 set_trusted(Peer, Trusted) ->
     Peer#peer{trusted = Trusted}.
+
+peer_config_info(#peer{ pubkey = PK } = Peer) ->
+    EncodedPK = aeser_api_encoder:encode(peer_pubkey, PK),
+    FormattedAddr = format_address(Peer),
+    <<"aenode://", EncodedPK/binary, "@", FormattedAddr/binary>>.
+
 -endif.
 
 -spec source(peer()) -> inet:ip_address().

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -150,7 +150,7 @@ init([]) ->
     aec_events:subscribe(tx_created),
     aec_events:subscribe(tx_received),
 
-    Peers0       = parse_peers(aeu_env:user_config(<<"peers">>, []) ++ default_peers()),
+    Peers0       = parse_peers(aeu_env:user_config(<<"peers">>, default_peers())),
     BlockedPeers = parse_peers(aeu_env:user_map_or_env(<<"blocked_peers">>, aecore, blocked_peers, [])),
     Peers        = Peers0 -- BlockedPeers,
 

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -151,7 +151,7 @@ init([]) ->
     aec_events:subscribe(tx_received),
 
     DefaultPeers = 
-        case aeu_env:find_config(<<"include_default_peers">>, [user_config, schema_default, {value, true}]) of
+        case aeu_env:find_config([<<"include_default_peers">>], [user_config, schema_default, {value, true}]) of
             {ok, true} -> default_peers();
             {ok, false} -> [];
             undefined -> []

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -152,8 +152,9 @@ init([]) ->
 
     DefaultPeers = 
         case aeu_env:find_config(<<"include_default_peers">>, [user_config, schema_default, {value, true}]) of
-            true -> default_peers();
-            false -> []
+            {ok, true} -> default_peers();
+            {ok, false} -> [];
+            undefined -> []
         end,
     Peers0       = parse_peers(aeu_env:user_config(<<"peers">>, []) ++ DefaultPeers),
 

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -151,7 +151,7 @@ init([]) ->
     aec_events:subscribe(tx_received),
 
     DefaultPeers = 
-        case aeu_env:user_config(<<"include_default_peers">>, true) of
+        case aeu_env:find_config(<<"include_default_peers">>, [user_config, schema_default, {value, true}]) of
             true -> default_peers();
             false -> []
         end,

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -150,7 +150,13 @@ init([]) ->
     aec_events:subscribe(tx_created),
     aec_events:subscribe(tx_received),
 
-    Peers0       = parse_peers(aeu_env:user_config(<<"peers">>, default_peers())),
+    DefaultPeers = 
+        case aeu_env:user_config(<<"include_default_peers">>, true) of
+            true -> default_peers();
+            false -> []
+        end,
+    Peers0       = parse_peers(aeu_env:user_config(<<"peers">>, []) ++ DefaultPeers),
+
     BlockedPeers = parse_peers(aeu_env:user_map_or_env(<<"blocked_peers">>, aecore, blocked_peers, [])),
     Peers        = Peers0 -- BlockedPeers,
 

--- a/apps/aecore/test/aec_peers_pool_tests.erl
+++ b/apps/aecore/test/aec_peers_pool_tests.erl
@@ -31,6 +31,10 @@
     available/2
 ]).
 
+-export([random_peer/0,
+         random_peer/1
+        ]).
+
 %=== MACROS ====================================================================
 
 -define(BASE_POOL_OPTS, []).
@@ -1949,8 +1953,7 @@ rand_take(Col) when is_list(Col)->
 
 random_peer_id() ->
     A = rand_int(1, 1 bsl 64),
-    B = rand_int(1, 1 bsl 64),
-    <<A:64, B:64>>.
+    <<A:32/unit:8>>.
 
 random_address() ->
     {rand_byte(), rand_byte(), rand_byte(), rand_byte()}.

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -41,7 +41,12 @@ suite() ->
     [].
 
 init_per_suite(Config) ->
-    aecore_suite_utils:init_per_suite([dev1, dev2], [{symlink_name, "latest.fork"}, {test_module, ?MODULE}] ++ Config).
+    aecore_suite_utils:init_per_suite([dev1, dev2],
+                                      #{},
+                                      [{add_peers, true}],
+                                      [{symlink_name, "latest.fork"},
+                                       {test_module, ?MODULE}]
+                                      ++ Config).
 
 end_per_suite(Config) ->
     aecore_suite_utils:stop_node(dev1, Config),

--- a/apps/aecore/test/aecore_pof_SUITE.erl
+++ b/apps/aecore/test/aecore_pof_SUITE.erl
@@ -41,7 +41,11 @@ init_per_suite(Config) ->
             <<"beneficiary_reward_delay">> => 2
         }
     },
-    Config1 = aecore_suite_utils:init_per_suite([dev1, dev2], DefCfg, [{symlink_name, "latest.pof"}, {test_module, ?MODULE}] ++ Config),
+    Config1 = aecore_suite_utils:init_per_suite([dev1, dev2], DefCfg,
+                                                [{add_peers, true}],
+                                                [{symlink_name, "latest.pof"},
+                                                 {test_module, ?MODULE}] ++
+                                                Config),
     [{nodes, [aecore_suite_utils:node_tuple(dev1),
               aecore_suite_utils:node_tuple(dev2)]} | Config1].
 

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -944,6 +944,9 @@ config_apply_options(Node, Cfg, [{add_peers, true}| T]) ->
     Cfg1 = Cfg#{<<"peers">> =>
               [peer_info(N1) || N1 <- [dev1, dev2, dev3] -- [Node]]},
     config_apply_options(Node, Cfg1, T);
+config_apply_options(Node, Cfg, [no_peers| T]) ->
+    Cfg1 = maps:remove(<<"peers">>, Cfg),
+    config_apply_options(Node, Cfg1, T);
 config_apply_options(Node, Cfg, [OptNodesCfg | T]) when is_map(OptNodesCfg) ->
     Cfg1 = case OptNodesCfg of
                #{Node := OptNodeCfg} -> maps_merge(Cfg, OptNodeCfg);

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -992,7 +992,8 @@ default_config(N, Config) ->
       <<"chain">> =>
           #{<<"persist">> => true},
       <<"fork_management">> =>
-          #{<<"network_id">> => NetworkId}
+          #{<<"network_id">> => NetworkId},
+      <<"include_default_peers">> => false
      }.
 
 epoch_config_dir(N, Config) ->

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -185,8 +185,10 @@ init_per_group(TwoNodes, Config) when
     [{initial_apps, InitialApps} | Config1];
 init_per_group(config_overwrites_defaults, Config) ->
     Dev1 = dev1,
+    aecore_suite_utils:stop_node(Dev1, Config),
     Config1 = config({devs, [Dev1]}, Config),
-    EpochCfg = aecore_suite_utils:epoch_config(Dev1, Config),
+    EpochCfg0 = aecore_suite_utils:epoch_config(Dev1, Config),
+    EpochCfg = EpochCfg0#{<<"include_default_peers">> => true},
     aecore_suite_utils:create_config(Dev1, Config1, EpochCfg,
                                             [no_peers
                                             ]),
@@ -272,7 +274,8 @@ end_per_group(Benchmark, _Config) when
     ok;
 end_per_group(config_overwrites_defaults, Config) ->
     Dev1 = dev1,
-    EpochCfg = aecore_suite_utils:epoch_config(Dev1, Config),
+    EpochCfg0 = aecore_suite_utils:epoch_config(Dev1, Config),
+    EpochCfg = EpochCfg0#{<<"include_default_peers">> => false},
     aecore_suite_utils:create_config(Dev1, Config, EpochCfg,
                                             [{add_peers, true}]),
     ok;
@@ -927,7 +930,8 @@ restart_with_different_defaults(Config) ->
     aecore_suite_utils:stop_node(Dev1, Config),
     Peer = aec_peers_pool_tests:random_peer(),
     EpochCfg0 = aecore_suite_utils:epoch_config(Dev1, Config),
-    EpochCfg = EpochCfg0#{<<"peers">> => [aec_peer:peer_config_info(Peer)]},
+    EpochCfg = EpochCfg0#{<<"peers">> => [aec_peer:peer_config_info(Peer)],
+                          <<"include_default_peers">> => false},
     aecore_suite_utils:create_config(Dev1, Config, EpochCfg,
                                             [
                                             ]),

--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -45,7 +45,13 @@ init_per_suite(Config) ->
         },
         <<"mempool">> => #{ <<"invalid_tx_ttl">> => 2 }
     },
-    Config1 = aecore_suite_utils:init_per_suite([dev1, dev2], DefCfg, [{symlink_name, "latest.txs"}, {test_module, ?MODULE}, {micro_block_cycle, MicroBlockCycle}] ++ Config),
+    Config1 = aecore_suite_utils:init_per_suite([dev1, dev2], DefCfg,
+                                                [{add_peers, true}],
+                                                [{symlink_name, "latest.txs"},
+                                                 {test_module, ?MODULE},
+                                                 {micro_block_cycle,
+                                                  MicroBlockCycle}] ++
+                                                Config),
     [{nodes, [aecore_suite_utils:node_tuple(dev1),
               aecore_suite_utils:node_tuple(dev2)]} | Config1].
 

--- a/apps/aestratum/test/aestratum_integration_SUITE.erl
+++ b/apps/aestratum/test/aestratum_integration_SUITE.erl
@@ -11,10 +11,7 @@
          groups/0,
          suite/0,
          init_per_suite/1,
-         end_per_suite/1,
-         init_per_group/2,
-         end_per_group/2,
-         init_per_testcase/2,
+         end_per_suite/1, init_per_group/2, end_per_group/2, init_per_testcase/2,
          end_per_testcase/2]).
 
 -export([session_in_authorized_phase/1,
@@ -68,8 +65,10 @@ init_per_suite_(Cfg) ->
     ct:log("Environment = ~p", [[{args, init:get_arguments()},
                                  {node, node()},
                                  {cookie, erlang:get_cookie()}]]),
-    aecore_suite_utils:create_config(?STRATUM_SERVER_NODE, Cfg1, stratum_server_node_config(false), []),
-    aecore_suite_utils:create_config(?MINING_NODE, Cfg1, mining_node_config(maps:get(pubkey, new_keypair())), []),
+    aecore_suite_utils:create_config(?STRATUM_SERVER_NODE, Cfg1, stratum_server_node_config(false),
+                                     [{add_peers, true}]),
+    aecore_suite_utils:create_config(?MINING_NODE, Cfg1, mining_node_config(maps:get(pubkey, new_keypair())),
+                                     [{add_peers, true}]),
     aecore_suite_utils:make_multi(Cfg1, [?STRATUM_SERVER_NODE, ?MINING_NODE]),
     Cfg2 = write_stratum_keys("stratum_test_keys", [{stratum_keypair, new_keypair()} | Cfg1]),
 

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -14,6 +14,11 @@
                 "pattern": "^aenode://pp_[a-zA-Z0-9]+@[^:\\.\"!#$%^&*()',/]+(\\.[^:\\.\"!#$%^&*()',/]+)*:[0-9]+/*$"
             }
         },
+        "include_default_peers": {
+            "description" : "If the default peers shall be added as trusted peers. Note: setting this to false means that the default seed nodes would not be used and a proper set of peers had been added instead.",
+            "type" : "boolean",
+            "default": true
+            },
         "blocked_peers" : {
             "description" :
             "Pre-configured addresses of nodes NOT to contact",
@@ -39,7 +44,7 @@
                 },
                 "sync_interval" : {
                     "description" : "Interval between mempool (re-)synchronization (in ms)",
-                    "type" : "integer"
+                   "type" : "integer"
                 },
                 "nonce_offset" : {
                     "description" : "Maximum nonce offset accepted",

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -10,6 +10,7 @@ peers:
 # Pre-configured addresses of epoch nodes NOT to contact
 blocked_peers:
     - aenode://pp_2M9oPohzsWgJrBBCFeYi3PVT4YF7F2botBtq6J1EGcVkiutx3R@some-really-bad-peer-address:3015
+include_default_peers: true
 
 sync:
     # If the UPnP / NAT-PMP service should be started

--- a/docs/release-notes/next/fix_obligatory_trusted_peers.md
+++ b/docs/release-notes/next/fix_obligatory_trusted_peers.md
@@ -1,0 +1,6 @@
+* Fixes a bug: there are special trusted peers that are never deleted nor
+  downgraded. Those are quite unique as the node consideres them to be
+  available. One can pick their own set of trusted peers but this was not
+  really effective: the default peers were always included as a bonus.
+  This PR fixes it: if there are user provided peers, the defaults are
+  omited.

--- a/docs/release-notes/next/fix_obligatory_trusted_peers.md
+++ b/docs/release-notes/next/fix_obligatory_trusted_peers.md
@@ -2,5 +2,6 @@
   downgraded. Those are quite unique as the node consideres them to be
   available. One can pick their own set of trusted peers but this was not
   really effective: the default peers were always included as a bonus.
-  This PR fixes it: if there are user provided peers, the defaults are
-  omited.
+  This PR fixes it: if the new config flag is set to `false` - the defaults
+  are omited. The flag is called `include_default_peers` and by default it
+  is true.


### PR DESCRIPTION
There had been a bug: the default trusted peers were always considered
trusted, disregarding the config file. This PR allows a user to pick their own
trusted peers: if so, the defaults are disregarded.
