### PR TITLE
Fix issue in aec_chain_state

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -987,7 +987,7 @@ update_fraud_info(ForkInfoIn, Node, State) ->
 
 handle_top_block_change(OldTopHash, NewTopDifficulty, Node, Events, State) ->
     case get_top_block_hash(State) of
-        OldTopHash -> {State, []};
+        OldTopHash -> {State, no_events()};
         NewTopHash when OldTopHash =:= undefined ->
             NewTopHash = get_genesis_hash(State), %% Internal inconsistency check
             State1 = update_main_chain(NewTopHash, NewTopHash, NewTopHash, State),

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -103,7 +103,11 @@
         ]).
 
 -ifdef(TEST).
--export([calc_rewards/6]).
+-export([calc_rewards/6,
+         wrap_block/1,
+         internal_insert_transaction/4,
+         build_insertion_ctx/3
+        ]).
 -endif.
 
 -include_lib("aeminer/include/aeminer.hrl").
@@ -885,10 +889,21 @@ update_state_tree(Node, State, Ctx) ->
 
 update_state_tree(Node, TreesIn, ForkInfo, State) ->
     case db_find_state(hash(Node), true) of
-        {ok,_Trees,_ForkInfo} ->
-            %% NOTE: This is an internal inconsistency check,
-            %% so don't use internal_error
-            error({found_already_calculated_state, hash(Node)});
+        {ok, FoundTrees, FoundForkInfo} ->
+            {Trees, _Fees, Events} = apply_node_transactions(Node, TreesIn,
+                                                             ForkInfo, State),
+            case aec_trees:hash(Trees) =:= aec_trees:hash(FoundTrees) of
+                true -> %% race condition, we've already inserted this block
+                    %% in case of fork, set the correct top:
+                    State1 = set_top_block_hash(hash(Node), State),
+                    {State1,
+                     FoundForkInfo#fork_info.difficulty, %% keep correct difficulty
+                     Events};
+                false ->
+                    %% NOTE: This is an internal inconsistency check,
+                    %% so don't use internal_error
+                    error({found_already_calculated_state, hash(Node)})
+            end;
         error ->
             {DifficultyOut, Events} = apply_and_store_state_trees(Node, TreesIn,
                                                         ForkInfo, State),
@@ -972,7 +987,7 @@ update_fraud_info(ForkInfoIn, Node, State) ->
 
 handle_top_block_change(OldTopHash, NewTopDifficulty, Node, Events, State) ->
     case get_top_block_hash(State) of
-        OldTopHash -> State;
+        OldTopHash -> {State, []};
         NewTopHash when OldTopHash =:= undefined ->
             NewTopHash = get_genesis_hash(State), %% Internal inconsistency check
             State1 = update_main_chain(NewTopHash, NewTopHash, NewTopHash, State),

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -734,7 +734,7 @@ find_signal_count(Hash) ->
 add_tx_location(STxHash, BlockHash) when is_binary(STxHash),
                                          is_binary(BlockHash) ->
     ?t(mnesia:write(#aec_tx_location{key = STxHash, value = BlockHash}),
-       [aec_tx_location, STxHash]).
+       [{aec_tx_location, STxHash}]).
 
 remove_tx_location(TxHash) when is_binary(TxHash) ->
     ?t(mnesia:delete({aec_tx_location, TxHash}),


### PR DESCRIPTION
The service download.aeternity.io is fed some database snapshots. Those are
produced by simply grabbing mnesia files and publishing them. If at the moment
of moving the data a block was in the process of being consumed by the node
itself, there is a risk of a race condition: the block (wrapped as a MPT node)
is being included in the DB while it is not yet set to be the top block. This
PR identifies if a node's hash is already known and if so - checks if it
produces the same expected result. If so - it is accepted. In the case of a DB
node being found with the same hash but different state trees - the node is
still crashing, no change there.

While working on the PR, 2 small bugs were identified and fixed, please
consult the comments below.

Fixes #3311

The work on this PR is supported by the Aeternity Crypto Foundation.
