### PR TITLE
Ensure rocksdb compiled with snappy & lz4

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -13,6 +13,20 @@ FilterRelxRocksDb = fun(Apps) ->
                         end
                     end,
 
+case FilterRocksDbCheck of
+    false ->
+        case os:getenv("ERLANG_ROCKSDB_OPTS") of
+            false ->
+                RocksDbOpts = "-DWITH_SNAPPY=ON -DWITH_LZ4=ON",
+                true = os:putenv("ERLANG_ROCKSDB_OPTS", RocksDbOpts);
+            _ ->
+                %% If manually set, we assume it's thought through
+                skip
+        end;
+    true ->
+        skip
+end.
+
 FilterDepsRocksDb = fun(Deps) ->
                         case FilterRocksDbCheck of
                             false ->


### PR DESCRIPTION
Closes #3413 

Whereas release packages and docker images had rocksdb compiled with snappy compression (and LZ4), the default settings for compiling from source didn't. This change has been tested on the [10/9/2020 mainnet backup](https://downloads.aeternity.io/).