### PR TITLE
Fine tune aec_condutor_sup spec

### DIFF
--- a/apps/aecore/src/aec_conductor_sup.erl
+++ b/apps/aecore/src/aec_conductor_sup.erl
@@ -41,6 +41,6 @@ start_link() ->
 %%====================================================================
 
 init([]) ->
-    {ok, {{rest_for_one, 5, 10}, [?CHILD(aec_block_generator, 5000, worker),
-                                  ?CHILD(aec_conductor, 5000, worker)]}}.
+    {ok, {{one_for_all, 5, 50}, [?CHILD(aec_block_generator, 5000, worker),
+                                 ?CHILD(aec_conductor, 5000, worker)]}}.
 

--- a/docs/release-notes/next/GH-3061_fine_tune_aec_conductor_supervisor.md
+++ b/docs/release-notes/next/GH-3061_fine_tune_aec_conductor_supervisor.md
@@ -1,0 +1,2 @@
+* Provides some fine tuning to the supervision tree of the conductor. This
+  will prevent the node making too many recovery attempts after a crash.


### PR DESCRIPTION
Fixes #3061

The error reported was that the `aec_conductor` kept crashing over and over
again without bringing down the whole node with it. Since the spec allowed 5
crashes for 50 seconds, my assumption is that booting the process takes more
than 2 seconds, especially on AWS instances. I modified this to allow 5
crashes for a window of 50 seconds.

Since it makes little sense keeping the `aec_block_generator` while there is
no `aec_conductor` alive, I've also revisited the strategy there. This is open
for a discussion.
