### PR TITLE
Fix status endpoint inconsistency

### DIFF
--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -582,8 +582,7 @@ handle_request_('GetStatus', _Params, _Context) ->
     GenesisBlockHash = aec_consensus:get_genesis_hash(),
     Solutions = 0, %% TODO
     Difficulty = aec_blocks:difficulty(TopKeyBlock),
-    Syncing = aec_sync:is_syncing(),
-    SyncProgress = aec_sync:sync_progress(),
+    {Syncing, SyncProgress} = aec_sync:sync_progress(),
     Listening = true, %% TODO
     Protocols =
         maps:fold(fun(Vsn, Height, Acc) ->

--- a/docs/release-notes/next/GH-2083_out_of_sync_status_endpoint.md
+++ b/docs/release-notes/next/GH-2083_out_of_sync_status_endpoint.md
@@ -1,0 +1,1 @@
+* Fixes inconsistency of the `/status` endpoint


### PR DESCRIPTION
Fixes #3083

There is an inconsistency of the `/status` endpoint: showing both that the
node is still syncin but also it is synced to 100%.

I tried reproducing this in a test to expose the bug but it was not reliable.
The problem is a race condition, actually two of them. Both are fixed.

1. The sync status is being fetched independently from the percentage. In case
   the node was synking while the status was fetched (being correctly `true`)
   and then the sync was completed - it _could_ show 100% while also syncing.
   This is fixed by encorporating both in a single call.
2. If there is a sync job while the top is not yet updated, the actual height
   is a bit higher and then it could result in more than 100%, which had been
   handled in the code to return 100%. In that case it would now return 99.9%

The work on this PR is supported by Aeternity Crypto Foundation.
