### PR TITLE
Make inner tx of PayingForTx non-valid

### DIFF
--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -66,7 +66,7 @@
         , substitute_innermost_tx/2
         , sign_tx/3
         , sign_tx_hash/2
-        , sign_tx_with_specific_network_id_prefix/3
+        , sign_pay_for_inner_tx/2
         , signed_spend_tx/1
         , wait_for_pubkey/0
         , min_gas_price/0
@@ -632,17 +632,17 @@ sign_tx(Tx, PrivKey) ->
 sign_tx_hash(Tx, PrivKey) ->
     sign_tx(Tx, PrivKey, true).
 
-sign_tx_with_specific_network_id_prefix(Tx, PrivKey, PubKeyPrefix) ->
-    sign_tx(Tx, PrivKey, true, PubKeyPrefix).
+sign_pay_for_inner_tx(Tx, PrivKey) ->
+    sign_tx(Tx, PrivKey, true, <<"inner_tx">>).
 
 -define(VALID_PRIVK(K), byte_size(K) =:= 64).
 
 sign_tx(Tx, PrivKey, SignHash) ->
     sign_tx(Tx, PrivKey, SignHash, undefined).
 
-sign_tx(Tx, PrivKey, SignHash, PubKeyPrefix) when is_binary(PrivKey) ->
-    sign_tx(Tx, [PrivKey], SignHash, PubKeyPrefix);
-sign_tx(Tx, PrivKeys, SignHash, PubKeyPrefix) when is_list(PrivKeys) ->
+sign_tx(Tx, PrivKey, SignHash, AdditionalPrefix) when is_binary(PrivKey) ->
+    sign_tx(Tx, [PrivKey], SignHash, AdditionalPrefix);
+sign_tx(Tx, PrivKeys, SignHash, AdditionalPrefix) when is_list(PrivKeys) ->
     Bin0 = aetx:serialize_to_binary(Tx),
     Bin1 =
         case SignHash of
@@ -650,11 +650,10 @@ sign_tx(Tx, PrivKeys, SignHash, PubKeyPrefix) when is_list(PrivKeys) ->
             false -> Bin0
         end,
     Bin =
-        case PubKeyPrefix of
+        case AdditionalPrefix of
             undefined -> Bin1;
             _ ->
-              PEnc = aeser_api_encoder:encode(account_pubkey, PubKeyPrefix),
-              <<"-", PEnc/binary, Bin1/binary>>
+              <<"-", AdditionalPrefix/binary, Bin1/binary>>
         end,
     BinForNetwork = aec_governance:add_network_id(Bin),
     case lists:filter(fun(PrivKey) -> not (?VALID_PRIVK(PrivKey)) end, PrivKeys) of

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -1033,7 +1033,9 @@ paying_for_outer(_Cfg) ->
                   nonce        => aect_test_utils:next_nonce(Acc2, State)}),
 
     PrivKey  = aect_test_utils:priv_key(Acc2, State),
-    SignedTx = aec_test_utils:sign_tx(SpendTx, PrivKey),
+    SignedTx = aec_test_utils:sign_tx_with_specific_network_id_prefix(SpendTx,
+                                                                      PrivKey,
+                                                                      Acc1),
 
     PreBalance  = ?call(account_balance, Acc2),
     {ok, #{tx_res := ok}} =

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -1033,9 +1033,7 @@ paying_for_outer(_Cfg) ->
                   nonce        => aect_test_utils:next_nonce(Acc2, State)}),
 
     PrivKey  = aect_test_utils:priv_key(Acc2, State),
-    SignedTx = aec_test_utils:sign_tx_with_specific_network_id_prefix(SpendTx,
-                                                                      PrivKey,
-                                                                      Acc1),
+    SignedTx = aec_test_utils:sign_pay_for_inner_tx(SpendTx, PrivKey),
 
     PreBalance  = ?call(account_balance, Acc2),
     {ok, #{tx_res := ok}} =

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1288,7 +1288,10 @@ paying_for_contract(Config) ->
     SpendTx = aega_test_utils:spend_tx(#{ sender_id => aeser_id:create(account, BPub)
                                         , recipient_id => aeser_id:create(account, BrokePub1)
                                         , nonce => get_online_nonce(BPub) }),
-    SignSpendTx = aec_test_utils:sign_tx(SpendTx, BPriv),
+    SignSpendTx =
+        aec_test_utils:sign_tx_with_specific_network_id_prefix(SpendTx,
+                                                               BPriv,
+                                                               APub),
     {ok, PayingForTx1} = aec_paying_for_tx:new(#{payer_id => aeser_id:create(account, APub),
                                                  nonce    => get_online_nonce(APub),
                                                  fee      => 10000 * aec_test_utils:min_gas_price(),
@@ -1322,7 +1325,10 @@ paying_for_contract(Config) ->
                   nonce => get_online_nonce(BrokePub1) },
     Call1Tx = aect_test_utils:call_tx(BrokePub1, DecP, CallSpec1, #{}),
 
-    SignCall1Tx = aec_test_utils:sign_tx(Call1Tx, BrokePriv1),
+    SignCall1Tx =
+        aec_test_utils:sign_tx_with_specific_network_id_prefix(Call1Tx,
+                                                               BrokePriv1,
+                                                               APub),
     {ok, PayingForTx2} = aec_paying_for_tx:new(#{payer_id => aeser_id:create(account, APub),
                                                  nonce    => get_online_nonce(APub),
                                                  fee      => 10000 * aec_test_utils:min_gas_price(),

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1288,10 +1288,7 @@ paying_for_contract(Config) ->
     SpendTx = aega_test_utils:spend_tx(#{ sender_id => aeser_id:create(account, BPub)
                                         , recipient_id => aeser_id:create(account, BrokePub1)
                                         , nonce => get_online_nonce(BPub) }),
-    SignSpendTx =
-        aec_test_utils:sign_tx_with_specific_network_id_prefix(SpendTx,
-                                                               BPriv,
-                                                               APub),
+    SignSpendTx = aec_test_utils:sign_pay_for_inner_tx(SpendTx, BPriv),
     {ok, PayingForTx1} = aec_paying_for_tx:new(#{payer_id => aeser_id:create(account, APub),
                                                  nonce    => get_online_nonce(APub),
                                                  fee      => 10000 * aec_test_utils:min_gas_price(),
@@ -1325,10 +1322,7 @@ paying_for_contract(Config) ->
                   nonce => get_online_nonce(BrokePub1) },
     Call1Tx = aect_test_utils:call_tx(BrokePub1, DecP, CallSpec1, #{}),
 
-    SignCall1Tx =
-        aec_test_utils:sign_tx_with_specific_network_id_prefix(Call1Tx,
-                                                               BrokePriv1,
-                                                               APub),
+    SignCall1Tx = aec_test_utils:sign_pay_for_inner_tx(Call1Tx, BrokePriv1),
     {ok, PayingForTx2} = aec_paying_for_tx:new(#{payer_id => aeser_id:create(account, APub),
                                                  nonce    => get_online_nonce(APub),
                                                  fee      => 10000 * aec_test_utils:min_gas_price(),

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -110,10 +110,17 @@ signatures(#signed_tx{signatures = Sigs}) ->
 verify_w_env(#signed_tx{tx = Tx, signatures = Sigs}, Trees, TxEnv) ->
     Bin      = aetx:serialize_to_binary(Tx),
     Protocol = aetx_env:consensus_version(TxEnv),
+    Payer = 
+        case aetx_env:payer(TxEnv) of
+            undefined -> undefined;
+            P ->
+              PEnc = aeser_api_encoder:encode(account_pubkey, P),
+              <<"-", PEnc/binary>>
+        end,
     case aetx:signers(Tx, Trees) of
         {ok, Signers} ->
             RemainingSigners = Signers -- aetx_env:ga_auth_ids(TxEnv),
-            verify_signatures(RemainingSigners, Bin, Sigs, Protocol);
+            verify_signatures(RemainingSigners, Bin, Sigs, Protocol, Payer);
         {error, _Reason} ->
             {error, signature_verification_failed}
     end.
@@ -150,39 +157,55 @@ verify_half_signed(Signer, SignedTx, Protocol) when is_binary(Signer) ->
 verify_half_signed(Signers, #signed_tx{tx = Tx, signatures = Sigs}, Protocol) ->
     verify_signatures(Signers, aetx:serialize_to_binary(Tx), Sigs, Protocol).
 
-verify_signatures([], _Bin, [], _Protocol) ->
+verify_signatures(PubKeys,_Bin, Sigs, _Protocol) ->
+    verify_signatures(PubKeys,_Bin, Sigs, _Protocol, undefined).
+
+verify_signatures([], _Bin, [], _Protocol, _SignPrefix) ->
     ok;
-verify_signatures([PubKey|Left], Bin, Sigs, Protocol) ->
-    case verify_one_pubkey(Sigs, PubKey, Bin, Protocol) of
-        {ok, SigsLeft} -> verify_signatures(Left, Bin, SigsLeft, Protocol);
+verify_signatures([PubKey|Left], Bin, Sigs, Protocol, SignPrefix) ->
+    case verify_one_pubkey(Sigs, PubKey, Bin, Protocol, SignPrefix) of
+        {ok, SigsLeft} -> verify_signatures(Left, Bin, SigsLeft, Protocol,
+                                            SignPrefix);
         error          -> {error, signature_check_failed}
     end;
-verify_signatures(PubKeys,_Bin, Sigs, _Protocol) ->
+verify_signatures(PubKeys,_Bin, Sigs, _Protocol, _SignPrefix) ->
     lager:debug("Signature check failed: ~p ~p", [PubKeys, Sigs]),
     {error, signature_check_failed}.
 
-verify_one_pubkey(Sigs, PubKey, Bin, Protocol) when ?VALID_PUBK(PubKey) ->
+verify_one_pubkey(Sigs, PubKey, Bin, Protocol) ->
+    verify_one_pubkey(Sigs, PubKey, Bin, Protocol, undefined).
+
+verify_one_pubkey(Sigs, PubKey, Bin, Protocol, SignPrefix) when ?VALID_PUBK(PubKey) ->
     HashSign = Protocol >= ?LIMA_PROTOCOL_VSN,
-    verify_one_pubkey(Sigs, PubKey, Bin, HashSign, []);
-verify_one_pubkey(_Sigs, _PubKey, _Bin, _Protocol) ->
+    verify_one_pubkey(Sigs, PubKey, Bin, HashSign, [], SignPrefix);
+verify_one_pubkey(_Sigs, _PubKey, _Bin, _Protocol, _SignPrefix) ->
     error. %% invalid pubkey
 
-verify_one_pubkey([Sig|Left], PubKey, Bin, HashSign, Acc)  ->
-    BinForNetwork = aec_governance:add_network_id(Bin),
+%% HERE
+maybe_add_predix(undefined, Bin) ->
+    Bin;
+maybe_add_predix(SignPrefix, Bin) ->
+    <<SignPrefix/binary,Bin/binary>>.
+
+verify_one_pubkey([Sig|Left], PubKey, Bin, HashSign, Acc, SignPrefix)  ->
+    BinForNetwork = aec_governance:add_network_id(maybe_add_predix(SignPrefix, Bin)),
     case enacl:sign_verify_detached(Sig, BinForNetwork, PubKey) of
         {ok, _} ->
             {ok, Acc ++ Left};
         {error, _} when HashSign ->
             TxHash = aec_hash:hash(signed_tx, Bin),
-            BinForNetwork2 = aec_governance:add_network_id(TxHash),
+            BinForNetwork2 =
+            aec_governance:add_network_id(maybe_add_predix(SignPrefix, TxHash)),
             case enacl:sign_verify_detached(Sig, BinForNetwork2, PubKey) of
                 {ok, _}    -> {ok, Acc ++ Left};
-                {error, _} -> verify_one_pubkey(Left, PubKey, Bin, HashSign, [Sig | Acc])
+                {error, _} -> verify_one_pubkey(Left, PubKey, Bin, HashSign,
+                                                [Sig | Acc], SignPrefix)
             end;
         {error, _} ->
-            verify_one_pubkey(Left, PubKey, Bin, HashSign, [Sig|Acc])
+            verify_one_pubkey(Left, PubKey, Bin, HashSign, [Sig|Acc],
+                              SignPrefix)
     end;
-verify_one_pubkey([], _PubKey, _Bin, _HashSign, _Acc) -> % no more signatures
+verify_one_pubkey([], _PubKey, _Bin, _HashSign, _Acc, _SignPrefix) -> % no more signatures
     error.
 
 -define(SIG_TX_TYPE, signed_tx).


### PR DESCRIPTION
Fixes #3054

There is a suggested approach in the issue: use empty `network_id` for signing the inner transaction. This has one big flaw: the inner transaction is repayable on a different network with a different `network_id`. Instead I took a slightly different approach: the inner transaction uses `<netwok_id>-<encoded payer_id>`, so for example it would be used `ae_mainnet-ak_123...`. Note that the payer account's ID is Base58c encoded.

The work on this PR is supported by the Aeternity Crypto Foundation.