### PR TITLE
Attempt to fix an IF

### DIFF
--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -1026,6 +1026,7 @@ trusted_peer_is_untrusted_after_a_restart(Config) ->
     ok = rpc:call(N1, aec_peers, add_peers, [aec_peer:source(Peer2),
                                             [aec_peer:info(Peer2)
                                             ]]),
+    timer:sleep(100),
     0 = rpc:call(N1, aec_peers, count, [verified], 5000),
     2 = rpc:call(N1, aec_peers, count, [unverified], 5000),
     assert_all_peers(N1, verified, []),


### PR DESCRIPTION
Fixes #3436 

Since the adding of a new peers is an async operation, there is room for a race...

The work on this PR is supported by Aeternity Crypto Foundation.