### PR TITLE
Remove support for MacOS High Sierra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1036,7 +1036,7 @@ jobs:
 
   osx_package:
     macos:
-      xcode: "10.1.0" # 10.1.0 is macOS 10.13.6
+      xcode: "11.1.0" # 11.1.0 is macOS 10.14.4
     working_directory: ~/aeternity
     steps:
       - checkout

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,6 @@ The release binaries are published on [GitHub][releases] and are tested on the f
 
 * Ubuntu 16.04.3 LTS (x86-64);
 * Ubuntu 18.04 LTS (x86-64);
-* macOS High Sierra 10.13 (x86-64);
 * macOS Mojave 10.14 (x86-64).
 * Windows 10 (x86-64)
 

--- a/docs/release-notes/next/GH-3442-deprecate-macos-high-sierra.md
+++ b/docs/release-notes/next/GH-3442-deprecate-macos-high-sierra.md
@@ -1,0 +1,1 @@
+* Due to MacOS High Sierra reaching EOL status we no longer build and provide release binaries for MacOS High Sierra. MacOS Mojave and above is supported.


### PR DESCRIPTION
High Sierra reached EOL status this month and homebrew removed some packages from their repository. This pr bumps the version of the executor to a supported version. 
Passing CI build:
https://app.circleci.com/pipelines/github/aeternity/aeternity/7419/workflows/14b55658-7558-4c9b-8579-6df950fdf646/jobs/133602/steps
