### PR TITLE
Improve sync_SUITE stability

### DIFF
--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -936,6 +936,7 @@ add_and_delete_untrusted_peers_and_restart(Config) ->
     Add(Peer2),
     Add(Peer3),
     Add(Peer4),
+    timer:sleep(100),
     0 = rpc:call(N1, aec_peers, count, [verified], 5000),
     4 = rpc:call(N1, aec_peers, count, [unverified], 5000),
 


### PR DESCRIPTION
Fixes yet another  intermittent failure:
```
%%% aecore_sync_SUITE ==> {{badmatch,3},
 [{aecore_sync_SUITE,add_and_delete_untrusted_peers_and_restart,1,
                     [{file,"/home/builder/aeternity/apps/aecore/test/aecore_sync_SUITE.erl"},
                      {line,940}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1754}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1263}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1195}]}]}

```
Samilar issue to #3439
