### PR TITLE
GH-3282 AENS pointers cleanup

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -663,7 +663,6 @@ init_per_testcase(TC, Config) when TC == sophia_auth_tx;
 init_per_testcase(TC = bad_aens_pointer_handling_lima_to_iris, Config) ->
     case aect_test_utils:latest_protocol_version() of
         ?IRIS_PROTOCOL_VSN ->
-            LHeight = 20,
             IHeight = 25,
             Fun = fun(H) when H <  IHeight -> ?LIMA_PROTOCOL_VSN;
                      (H) when H >= IHeight -> ?IRIS_PROTOCOL_VSN
@@ -672,9 +671,7 @@ init_per_testcase(TC = bad_aens_pointer_handling_lima_to_iris, Config) ->
             meck:expect(aec_governance, name_claim_bid_timeout, fun(_, _) -> 0 end),
             Config1 =
                 [{sophia_version, ?SOPHIA_IRIS_FATE}, {vm_version, ?VM_FATE_SOPHIA_2},
-                 {fork_heights, #{ lima    => LHeight,
-                                   iris    => IHeight
-                                 }},
+                 {fork_heights, #{ iris    => IHeight }},
                  {protocol, iris} | Config],
             init_per_testcase_common(TC, Config1);
         _ ->
@@ -6293,7 +6290,6 @@ sophia_aens_update_transaction(_Cfg) ->
     ok.
 
 bad_aens_pointer_handling_lima_to_iris(Cfg) ->
-    _LimaHeight = maps:get(lima, ?config(fork_heights, Cfg)),
     IrisHeight = maps:get(iris, ?config(fork_heights, Cfg)),
 
     state(aect_test_utils:new_state()),

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -187,6 +187,7 @@
         , store_onetype_random_ops/1
         , fate_vm_cross_protocol_store_big/1
         , fate_vm_cross_protocol_store_multi_small/1
+        , bad_aens_pointer_handling_lima_to_iris/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -330,6 +331,7 @@ all() ->
                        , sophia_auth_tx
                        , sophia_strings
                        , {group, store_map_ops}
+                       , bad_aens_pointer_handling_lima_to_iris
                        ]).
 
 -define(FATE_TODO, [
@@ -451,6 +453,7 @@ groups() ->
                                  sophia_use_memory_gas,
                                  sophia_compiler_version,
                                  sophia_protected_call,
+                                 bad_aens_pointer_handling_lima_to_iris,
                                  lima_migration
                                ]}
     , {sophia_oracles_ttl, [],
@@ -657,6 +660,26 @@ init_per_testcase(TC, Config) when TC == sophia_auth_tx;
         true  -> init_per_testcase_common(TC, Config);
         false -> {skip, {requires_protocol, iris, TC}}
     end;
+init_per_testcase(TC = bad_aens_pointer_handling_lima_to_iris, Config) ->
+    case aect_test_utils:latest_protocol_version() of
+        ?IRIS_PROTOCOL_VSN ->
+            LHeight = 20,
+            IHeight = 25,
+            Fun = fun(H) when H <  IHeight -> ?LIMA_PROTOCOL_VSN;
+                     (H) when H >= IHeight -> ?IRIS_PROTOCOL_VSN
+                  end,
+            meck:expect(aec_hard_forks, protocol_effective_at_height, Fun),
+            meck:expect(aec_governance, name_claim_bid_timeout, fun(_, _) -> 0 end),
+            Config1 =
+                [{sophia_version, ?SOPHIA_IRIS_FATE}, {vm_version, ?VM_FATE_SOPHIA_2},
+                 {fork_heights, #{ lima    => LHeight,
+                                   iris    => IHeight
+                                 }},
+                 {protocol, iris} | Config],
+            init_per_testcase_common(TC, Config1);
+        _ ->
+            {skip, only_test_bad_aens_poiner_handling_in_iris}
+    end;
 
 init_per_testcase(TC, Config) ->
     init_per_testcase_common(TC, Config).
@@ -704,6 +727,10 @@ end_per_testcase(TC, _Config) when TC == sophia_aens_resolve;
                                    TC == sophia_aens_transactions;
                                    TC == sophia_aens_update_transaction ->
     meck:unload(aec_governance),
+    ok;
+end_per_testcase(bad_aens_pointer_handling_lima_to_iris, _Config) ->
+    meck:unload(aec_governance),
+    meck:unload(aec_hard_forks),
     ok;
 end_per_testcase(_TC, _Config) ->
     ok.
@@ -6039,7 +6066,7 @@ sophia_aens_resolve(Cfg) ->
     APubkey  = 1,
     OPubkey  = 2,
     CPubkey  = 3,
-    %% TODO: Improve checks in aens_unpdate_tx
+    %% TODO: Improve checks in aens_update_tx
     Pointers = [aens_pointer:new(<<"account_pubkey">>, aeser_id:create(account, <<APubkey:256>>)),
                 aens_pointer:new(<<"oracle_pubkey">>, aeser_id:create(oracle, <<OPubkey:256>>)),
                 aens_pointer:new(<<"contract_pubkey">>, aeser_id:create(contract, <<CPubkey:256>>))
@@ -6262,6 +6289,70 @@ sophia_aens_update_transaction(_Cfg) ->
         ?call(call_contract, Acc, Ct, update, {tuple, []},
               {Ct, Name1, None, None, Some([1, 2, 3])},
               #{ height => 18 }),
+
+    ok.
+
+bad_aens_pointer_handling_lima_to_iris(Cfg) ->
+    _LimaHeight = maps:get(lima, ?config(fork_heights, Cfg)),
+    IrisHeight = maps:get(iris, ?config(fork_heights, Cfg)),
+
+    state(aect_test_utils:new_state()),
+    Acc      = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
+
+    Name1    = aens_test_utils:fullname(<<"foo">>),
+    Name2    = aens_test_utils:fullname(<<"bar">>),
+    Name3    = aens_test_utils:fullname(<<"baz">>),
+
+    NameFee  = aec_governance:name_claim_fee(Name1, ?config(protocol, Cfg)),
+    Salt1    = ?call(aens_preclaim, Acc, Name1),
+    Salt2    = ?call(aens_preclaim, Acc, Name2),
+    Salt3    = ?call(aens_preclaim, Acc, Name3),
+
+    Hash1    = ?call(aens_claim, Acc, Name1, Salt1, NameFee),
+    Hash2    = ?call(aens_claim, Acc, Name2, Salt2, NameFee),
+    Hash3    = ?call(aens_claim, Acc, Name3, Salt3, NameFee),
+
+    BadPts1  = [aens_pointer:new(<<1:(8*257)>>, aeser_id:create(account, <<1:256>>))],
+    BadPts2  = [aens_pointer:new(<<N:128>>, aeser_id:create(account, <<1:256>>)) || N <- lists:seq(1, 33) ],
+    BadPts3  = [aens_pointer:new(<<1:128>>, aeser_id:create(account, <<N:256>>)) || N <- lists:seq(1, 2) ],
+
+    ok       = ?call(aens_update, Acc, Hash1, BadPts1),
+    ok       = ?call(aens_update, Acc, Hash2, BadPts2),
+    ok       = ?call(aens_update, Acc, Hash3, BadPts3),
+
+    %% Now contract!
+    Ct       = ?call(create_contract, Acc, aens, {},
+                     #{ height => IrisHeight, amount => 20000000000000 * aec_test_utils:min_gas_price() }),
+
+    NameSig1 = sign(<<Acc/binary, Hash1/binary, Ct/binary>>, Acc),
+    NameSig2 = sign(<<Acc/binary, Hash2/binary, Ct/binary>>, Acc),
+    NameSig3 = sign(<<Acc/binary, Hash3/binary, Ct/binary>>, Acc),
+
+    GetNameRecord   = fun (NH) ->
+                              NSTree = aec_trees:ns(aect_test_utils:trees(state())),
+                              {value, Rec} = aens_state_tree:lookup_name(NH, NSTree),
+                              Rec
+                      end,
+
+    %% First check that we can still resolve the bad keys!
+    {some, {address, 1}} = ?call(call_contract, Acc, Ct, resolve_account, {option, word}, {Name1, <<1:(8*257)>>}, #{height => IrisHeight}),
+    {some, {address, 1}} = ?call(call_contract, Acc, Ct, resolve_account, {option, word}, {Name2, <<33:128>>}, #{height => IrisHeight}),
+    {some, {address, 1}} = ?call(call_contract, Acc, Ct, resolve_account, {option, word}, {Name3, <<1:128>>}, #{height => IrisHeight}),
+
+    %% Now try to update the pointers, just re-setting them (none) should be good enough...
+    {} = ?call(call_contract, Acc, Ct, signedUpdate, {tuple, []}, {Acc, Name1, none, none, none, NameSig1}, #{height => IrisHeight}),
+    {} = ?call(call_contract, Acc, Ct, signedUpdate, {tuple, []}, {Acc, Name2, none, none, none, NameSig2}, #{height => IrisHeight}),
+    {} = ?call(call_contract, Acc, Ct, signedUpdate, {tuple, []}, {Acc, Name3, none, none, none, NameSig3}, #{height => IrisHeight}),
+
+    %% Now check that we can't resolve the bad keys!
+    none = ?call(call_contract, Acc, Ct, resolve_account, {option, word}, {Name1, <<1:(8*257)>>}, #{height => IrisHeight}),
+    none = ?call(call_contract, Acc, Ct, resolve_account, {option, word}, {Name2, <<33:128>>}, #{height => IrisHeight}),
+    %% So the duplicate wasn't bad... It is still there :-)
+    {some, {address, 1}} = ?call(call_contract, Acc, Ct, resolve_account, {option, word}, {Name3, <<1:128>>}, #{height => IrisHeight}),
+
+    %% Double check the duplicate key is no longer there...
+    Rec3 = GetNameRecord(Hash3),
+    ?assertEqual(length(aens_names:pointers(Rec3)), 1),
 
     ok.
 

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -23,6 +23,8 @@
          name_claim_preclaim_delta/0,
          name_registrars/1,
          name_max_length_starting_auction/0,
+         name_pointers_max_count/1,
+         name_pointer_max_key_size/1,
          non_test_registrars/0,
          possible_name_registrars/0,
          micro_block_cycle/0,
@@ -259,6 +261,18 @@ name_claim_max_expiration(Protocol) when Protocol < ?IRIS_PROTOCOL_VSN ->
     50000;
 name_claim_max_expiration(_Protocol) ->
     180000. %% At 480 generations per day this is 375 days, i.e. ~1 year.
+
+-spec name_pointers_max_count(aec_hard_forks:protocol_vsn()) -> non_neg_integer() | inifinity.
+name_pointers_max_count(Protocol) when Protocol < ?IRIS_PROTOCOL_VSN ->
+    infinity;
+name_pointers_max_count(_Protocol) ->
+    32.
+
+-spec name_pointer_max_key_size(aec_hard_forks:protocol_vsn()) -> non_neg_integer() | inifinity.
+name_pointer_max_key_size(Protocol) when Protocol < ?IRIS_PROTOCOL_VSN ->
+    infinity;
+name_pointer_max_key_size(_Protocol) ->
+    256.
 
 name_protection_period() ->
     2016.

--- a/apps/aens/src/aens_pointer.erl
+++ b/apps/aens/src/aens_pointer.erl
@@ -3,6 +3,7 @@
 -export([new/2,
          key/1,
          id/1,
+         sanitize_pointers/1,
          serialize_for_client/1
         ]).
 
@@ -20,6 +21,8 @@
               id/0,
               pointer/0
              ]).
+
+-include_lib("aecontract/include/hard_forks.hrl").
 
 -spec new(key(), id()) -> pointer().
 new(Key, Id) ->
@@ -52,3 +55,26 @@ assert_id_type(channel)  -> ok;
 assert_id_type(contract) -> ok;
 assert_id_type(oracle)   -> ok.
 
+
+%% From IRIS pointers should be:
+%%  - unique (no overlapping keys)
+%%  - not more than 32
+%%  - keys should be no bigger than 256 bytes.
+-spec sanitize_pointers(list(pointer())) -> list(pointer()).
+sanitize_pointers(Pts) ->
+    MaxCount   = aec_governance:name_pointers_max_count(?IRIS_PROTOCOL_VSN),
+    MaxKeySize = aec_governance:name_pointer_max_key_size(?IRIS_PROTOCOL_VSN),
+    sanitize_pointers(Pts, #{}, 0, MaxCount, MaxKeySize).
+
+sanitize_pointers([], _, _, _, _) -> [];
+sanitize_pointers(_, _, N, N, _) -> [];
+sanitize_pointers([Pt | Pts], Seen, N, MaxCount, MaxKeySize) ->
+    Key = key(Pt),
+    case maps:is_key(Key, Seen) of
+        true -> sanitize_pointers(Pts, Seen, N, MaxCount, MaxKeySize);
+        false ->
+            case byte_size(Key) > MaxKeySize of
+                true -> sanitize_pointers(Pts, Seen, N, MaxCount, MaxKeySize);
+                false -> [Pt | sanitize_pointers(Pts, Seen#{Key => ok}, N + 1, MaxCount, MaxKeySize)]
+            end
+    end.

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -959,7 +959,7 @@ name_update({OwnerPubkey, NameHash, TTL, ClientTTL, Pointers}, S) ->
     assert_name_owner(Rec, OwnerPubkey),
     assert_name_claimed(Rec),
     %% 'undefined' means we got here from FATE - thus we don't expect to
-    %% fail on legcy invalid pointers - so explicitly sanitize them.
+    %% fail on legacy invalid pointers - so explicitly sanitize them.
     Pointers1  = if Pointers == undefined ->
                         aens_pointer:sanitize_pointers(aens_names:pointers(Rec));
                     is_list(Pointers) ->

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -955,12 +955,17 @@ name_update({OwnerPubkey, NameHash, TTL, ClientTTL, Pointers}, S) ->
     ClientTTL1 = if ClientTTL == undefined -> aens_names:client_ttl(Rec);
                     true -> ClientTTL
                  end,
-    Pointers1  = if Pointers == undefined -> aens_names:pointers(Rec);
-                    is_list(Pointers) -> Pointers
-                 end,
     assert_ttl(TTL1, S1),
     assert_name_owner(Rec, OwnerPubkey),
     assert_name_claimed(Rec),
+    %% 'undefined' means we got here from FATE - thus we don't expect to
+    %% fail on legcy invalid pointers - so explicitly sanitize them.
+    Pointers1  = if Pointers == undefined ->
+                        aens_pointer:sanitize_pointers(aens_names:pointers(Rec));
+                    is_list(Pointers) ->
+                        assert_name_pointers(Pointers, S#state.protocol),
+                        Pointers
+                 end,
     Rec1 = aens_names:update(Rec, TTL1, ClientTTL1, Pointers1),
     put_name(Rec1, S1).
 
@@ -1958,8 +1963,6 @@ assert_valid_overbid(NewNameFee, OldNameFee) ->
             runtime_error(name_fee_increment_too_low)
     end.
 
-
-
 assert_name_registrar(Registrar, Protocol) ->
     case lists:member(Registrar, aec_governance:name_registrars(Protocol)) of
         true  -> ok;
@@ -1982,6 +1985,14 @@ assert_name_claimed(Name) ->
     case aens_names:status(Name) of
         claimed -> ok;
         revoked -> runtime_error(name_revoked)
+    end.
+
+assert_name_pointers(_, Protocol) when Protocol < ?IRIS_PROTOCOL_VSN ->
+    ok;
+assert_name_pointers(Pointers, _) ->
+    case Pointers == aens_pointer:sanitize_pointers(Pointers) of
+        true  -> ok;
+        false -> runtime_error(invalid_pointers)
     end.
 
 %% Note: returns deserialized Code to avoid extra work

--- a/docs/release-notes/next-iris/GH-3282-aens_pointers_cleanup.md
+++ b/docs/release-notes/next-iris/GH-3282-aens_pointers_cleanup.md
@@ -1,0 +1,6 @@
+* AENS pointers are now limited, this is enforced when updating a name:
+  - No duplicate pointer keys.
+  - Pointer keys are not longer than 256 bytes.
+  - A name can not have more than 32 pointers.
+  When a name is updated, or looked up, inside a Sophia contract keys
+  that are no longer valid are automatically removed.

--- a/test/name_resolution_SUITE.erl
+++ b/test/name_resolution_SUITE.erl
@@ -204,7 +204,12 @@ spend_to_name(_Cfg) ->
     spend_to_name_(fun pointers/2).
 
 spend_to_name_when_multiple_pointer_entries(_Cfg) ->
-    spend_to_name_(fun pointers_with_duplicated_key_at_end/2).
+    Protocol = aec_hard_forks:protocol_effective_at_height(1),
+    case Protocol >= ?IRIS_PROTOCOL_VSN of
+        true -> ok;
+        false ->
+            spend_to_name_(fun pointers_with_duplicated_key_at_end/2)
+    end.
 
 spend_to_name_(PointersFun) ->
     {[Pubkey1, Pubkey2], S1} = init_state(2),
@@ -235,7 +240,12 @@ transfer_name_to_named_account(_Cfg) ->
     transfer_name_to_named_account_(fun pointers/2).
 
 transfer_name_to_named_account_when_multiple_pointer_entries(_Cfg) ->
-    transfer_name_to_named_account_(fun pointers_with_duplicated_key_at_end/2).
+    Protocol = aec_hard_forks:protocol_effective_at_height(1),
+    case Protocol >= ?IRIS_PROTOCOL_VSN of
+        true -> ok;
+        false ->
+            transfer_name_to_named_account_(fun pointers_with_duplicated_key_at_end/2)
+    end.
 
 transfer_name_to_named_account_(PointersFun) ->
     {[Pubkey1, Pubkey2, Pubkey3], S1} = init_state(3),


### PR DESCRIPTION
Limit AENS pointers from IRIS onward:
- no duplicate keys on chain
- not more than 32 pointers per name
- pointer key shouldn't be more than 256 bytes.

This is enforced in AENSUpdateTx. The main complication is when handling legacy (bad) pointers in Sophia, we take the approach of simply discarding bad pointers if/when encountered in Sophia.

Protocol: https://github.com/aeternity/protocol/pull/477
Sophia: https://github.com/aeternity/aesophia/pull/291

This PR is supported by the Æternity Crypto Foundation