### PR TITLE
Fix problem with enacl after init:restart() on MacOS

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -82,9 +82,8 @@
 
         %% forks
 
-        % waiting for https://github.com/jlouis/enacl/pull/40 to be merged
         {enacl, {git, "https://github.com/aeternity/enacl.git",
-                {ref, "26180f4"}}},
+                {ref, "a45b433"}}},
 
 
         {jesse, {git, "https://github.com/for-GET/jesse.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -58,7 +58,7 @@
   0},
  {<<"enacl">>,
   {git,"https://github.com/aeternity/enacl.git",
-      {ref,"26180f42c0b3a450905d2efd8bc7fd5fd9cece75"}},
+      {ref,"a45b433f88cdea0f282ca5c027fbb4c7c76beba4"}},
   0},
  {<<"enoise">>,
   {git,"https://github.com/aeternity/enoise.git",


### PR DESCRIPTION
Fixes #3247

Note that this bug makes it impossible to run a node with GC switched on on MacOS...

This PR is supported by the Æternity Crypto Foundation