### PR TITLE
First stab at sync_allowed_height_from_top

### DIFF
--- a/apps/aecore/src/aec_resilience.erl
+++ b/apps/aecore/src/aec_resilience.erl
@@ -1,0 +1,76 @@
+-module(aec_resilience).
+-behaviour(gen_server).
+
+-export([ start_link/0 ]).
+
+-export([ fork_resistance_active/0
+        ]).
+
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
+
+-record(st, {}).
+
+
+fork_resistance_active() ->
+    {Res, _} = get_fork_resistance(),
+    Res.
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    aec_events:subscribe(chain_sync),
+    aec_events:subscribe(update_config),
+    {ok, #st{}}.
+
+
+handle_call(_Req, _From, St) ->
+    {reply, {error, unknown_call}, St}.
+
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+handle_info({gproc_ps_event, chain_sync, #{info := {chain_sync_done, _}}}, St) ->
+    maybe_enable_fork_resistance(),
+    {noreply, St};
+handle_info({gproc_ps_event, update_config,
+             #{<<"sync">> := #{<<"sync_allowed_height_from_top">> := _}}}, St) ->
+    maybe_enable_fork_resistance(),
+    {noreply, St};
+handle_info(_Msg, St) ->
+    {noreply, St}.
+
+terminate(_Reason, _St) ->
+    ok.
+
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
+
+
+maybe_enable_fork_resistance() ->
+    case get_fork_resistance() of
+        {_, manual} -> ok;
+        _ ->
+            Res = case aeu_env:find_config([<<"sync">>, <<"sync_allowed_height_from_top">>],
+                                           [ user_config, schema_default ]) of
+                      {ok, Height} when Height > 0 ->
+                          lager:debug("Activating fork resistance for Height = ~p", [Height]),
+                          {yes, Height};
+                      _ ->
+                          lager:debug("No fork resistance", []),
+                          no
+                  end,
+            set_fork_resistance({Res, auto})
+    end.
+
+get_fork_resistance() ->
+    persistent_term:get({?MODULE, fork_resistance}, {no, auto}).
+
+set_fork_resistance({_, _} = Value) ->
+    persistent_term:put({?MODULE, fork_resistance}, Value).

--- a/apps/aecore/src/aecore_sup.erl
+++ b/apps/aecore/src/aecore_sup.erl
@@ -68,6 +68,7 @@ init([]) ->
             ?CHILD(aec_tx_pool, 5000, worker),
             ?CHILD(aec_tx_pool_gc, 5000, worker),
             ?CHILD(aec_db_error_store, 5000, worker),
+            ?CHILD(aec_resilience, 5000, worker),
             ?CHILD(aec_db_gc, 5000, worker),
             ?CHILD(aec_conductor_sup, 5000, supervisor),
             ?CHILD(aec_connection_sup, 5000, supervisor)

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -16,7 +16,10 @@
    [
     create_dev1_chain/1,
     create_dev2_chain/1,
-    sync_fork_in_wrong_order/1
+    sync_fork_in_wrong_order/1,
+    add_dev3_node/1,
+    dev3_failed_attack/1,
+    dev3_syncs_to_community/1
    ]).
 
 
@@ -30,32 +33,41 @@ all() ->
 
 groups() ->
     [
-     {all_nodes, [sequence], [{group, two_nodes}]},
+     {all_nodes, [sequence], [{group, two_nodes}, {group, three_nodes}]},
      {two_nodes, [sequence],
       [create_dev1_chain,
        create_dev2_chain,
-       sync_fork_in_wrong_order]}
+       sync_fork_in_wrong_order]},
+     {three_nodes, [sequence],
+      [add_dev3_node,
+       dev3_failed_attack,
+       dev3_syncs_to_community]}
     ].
 
 suite() ->
     [].
 
 init_per_suite(Config) ->
-    aecore_suite_utils:init_per_suite([dev1, dev2],
+    ct:pal("init_per_suite: ~p", [time()]),
+    aecore_suite_utils:init_per_suite([dev1, dev2, dev3],
                                       #{},
                                       [{add_peers, true}],
                                       [{symlink_name, "latest.fork"},
+                                       {instant_mining, true},
                                        {test_module, ?MODULE}]
                                       ++ Config).
 
 end_per_suite(Config) ->
-    aecore_suite_utils:stop_node(dev1, Config),
-    aecore_suite_utils:stop_node(dev2, Config),
+    [aecore_suite_utils:stop_node(D, Config) || D <- [dev1, dev2, dev3]],
+    ct:pal("end_per_suite: ~p", [time()]),
     ok.
 
 init_per_group(two_nodes, Config) ->
     [{nodes, [aecore_suite_utils:node_tuple(dev1),
               aecore_suite_utils:node_tuple(dev2)]} | Config];
+init_per_group(three_nodes, Config) ->
+    [{nodes, [aecore_suite_utils:node_tuple(D) ||
+                 D <- [dev1, dev2, dev3]]} | Config];
 init_per_group(_Group, Config) ->
     Config.
 
@@ -85,8 +97,7 @@ create_dev1_chain(Config) ->
     N1Top = rpc:call(N1, aec_chain, top_block, [], 5000),
     ct:log("top of chain dev1: ~p (mined ~p)", [N1Top, lists:last(Blocks)]),
     N1Top = lists:last(Blocks),
-    aecore_suite_utils:stop_node(dev1, Config),   %% make sure we do not sync with dev2.
-    ok = aecore_suite_utils:check_for_logs([dev1], Config),
+    ok = stop_and_check([dev1], Config),    %% make sure we do not sync with dev2.
     ok.
 
 create_dev2_chain(Config) ->
@@ -96,8 +107,7 @@ create_dev2_chain(Config) ->
     aecore_suite_utils:mine_key_blocks(N2, 1),
     ForkTop = rpc:call(N2, aec_chain, top_block, [], 5000),
     ct:log("top of fork dev2: ~p", [ ForkTop ]),
-    aecore_suite_utils:stop_node(dev2, Config),
-    ok = aecore_suite_utils:check_for_logs([dev2], Config),
+    ok = stop_and_check([dev2], Config),
     ok.
 
 sync_fork_in_wrong_order(Config) ->
@@ -128,6 +138,65 @@ sync_fork_in_wrong_order(Config) ->
     aec_test_utils:wait_for_it(
       fun() -> rpc:call(N2, aec_chain, top_block, [], 5000) end,
       N1Top),
+    ok = stop_and_check([dev1, dev2], Config).
+
+add_dev3_node(Config) ->
+    %% dev1 and dev2 are in sync
+    T0 = os:timestamp(),
+    aecore_suite_utils:start_node(dev1, Config),
+    aecore_suite_utils:start_node(dev2, Config),
+    [N1, N2, N3] = [aecore_suite_utils:node_name(D) || D <- [dev1, dev2, dev3]],
+    aecore_suite_utils:connect(N1),
+    aecore_suite_utils:connect(N2),
+    aecore_suite_utils:await_sync_complete(T0, [N1, N2]),
+    Top = rpc:call(N1, aec_chain, top_block, [], 5000),
+    Top = rpc:call(N2, aec_chain, top_block, [], 5000),
+    T1 = os:timestamp(),
+    aecore_suite_utils:start_node(dev3, Config),
+    aecore_suite_utils:connect(N3),
+    aecore_suite_utils:await_sync_complete(T1, [N3]),
+    Top = rpc:call(N3, aec_chain, top_block, [], 5000),
+    %% Nodes are all in sync
+    ok = stop_and_check([dev1, dev2, dev3], Config),
     ok.
 
+dev3_failed_attack(Config) ->
+    [N1, N2, N3] = [aecore_suite_utils:node_name(D) || D <- [dev1, dev2, dev3]],
+    aecore_suite_utils:start_node(dev3, Config),
+    aecore_suite_utils:connect(N3),
+    %% Mine a fork on dev3
+    {ok, BlocksN3} = aecore_suite_utils:mine_key_blocks(N3, 20),
+    N3Top = lists:last(BlocksN3),
+    ok = stop_and_check([dev3], Config),
+    %% restart dev1, dev2, sync, mine some and set fork resilience
+    T2 = os:timestamp(),
+    aecore_suite_utils:start_node(dev1, Config),
+    aecore_suite_utils:connect(N1),
+    aecore_suite_utils:start_node(dev2, Config),
+    aecore_suite_utils:connect(N2),
+    aecore_suite_utils:await_sync_complete(T2, [N1, N2]),
+    {ok, BlocksN1N2} = aecore_suite_utils:mine_key_blocks(N1, 10),  %% fewer than N3
+    NewTop = rpc:call(N1, aec_chain, top_block, [], 5000),
+    aec_test_utils:wait_for_it(
+      fun() -> rpc:call(N2, aec_chain, top_block, [], 5000) end,
+      NewTop),
+    SetCfg = #{<<"sync">> => #{<<"sync_allowed_height_from_top">> => 5}},
+    NewTop = lists:last(BlocksN1N2),
+    [ok = rpc:call(N, aeu_env, update_config, [SetCfg]) || N <- [N1, N2]],
+    aecore_suite_utils:start_node(dev3, Config),
+    timer:sleep(10000),   %% FIXME! What to do here, exactly?
+    %% Ensure that dev1 and dev2 still have the same top.
+    NewTop = rpc:call(N1, aec_chain, top_block, [], 5000),
+    NewTop = rpc:call(N2, aec_chain, top_block, [], 5000),
+    false = (N3Top == NewTop),
+    ok = stop_and_check([dev1, dev2, dev3], Config).
 
+dev3_syncs_to_community(_Config) ->
+    ok.
+
+stop_and_check(Ns, Config) ->
+    lists:foreach(
+      fun(N) ->
+              aecore_suite_utils:stop_node(N, Config)
+      end, Ns),
+    ok = aecore_suite_utils:check_for_logs(Ns, Config).

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -163,6 +163,26 @@
                     "description": "Allowed height difference from current top for incoming blocks (via gossip)",
                     "type" : "integer"
                 },
+                "sync_allowed_height_from_top" : {
+                    "description": "Once own node is synced, reject sync blocks at least this far from the current top; 0 means disabled",
+                    "type" : "integer",
+                    "default" : 0
+                },
+                "block_whitelist" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "set" : {
+                            "$ref" : "#/definitions/whitelist_objects"
+                        },
+                        "add" : {
+                            "$ref" : "#/definitions/whitelist_objects"
+                        },
+                        "del" : {
+                            "$ref" : "#/definitions/whitelist_objects"
+                        }
+                    }
+                },
                 "log_peer_connection_count_interval" : {
                     "description": "Time (milliseconds) between logging info about connected peers",
                     "type" : "integer",
@@ -1219,6 +1239,15 @@
     "definitions" : {
         "key_value_pattern": {
             "pattern" : "^[a-zA-Z0-9\\-_\\.]+\\h*:\\h*[0-9]+(\\h*,\\h*[a-zA-Z_]+\\h*:\\h*[0-9]+)*"
+        },
+        "whitelist_objects" : {
+            "type" : "array",
+            "items" : {
+                "type" : "string",
+                "description" : "Array of Height:KeyBlockHash strings",
+                "pattern" : "^[0-9]+:kh_[1-9A-HJ-NP-Za-km-z]+$",
+                "example" : "365349:kh_pgnGHhUWtK8ae4GGQrnswVdbMnyAFxvP6HUHQT2Utpmgr9mss"
+            }
         }
     }
 }

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -26,9 +26,7 @@
 -export([data_dir/1]).
 -export([check_config/1, check_config/2]).
 
--ifdef(TEST).
 -export([update_config/1]).
--endif.
 
 -type basic_type() :: number() | binary() | boolean().
 -type basic_or_list()  :: basic_type() | [basic_type()].
@@ -548,6 +546,7 @@ update_config(Map) when is_map(Map) ->
     ConfigTree1 = to_tree(ConfigMap1),
     set_env(aeutils, '$user_map', ConfigMap1),
     set_env(aeutils, '$user_config', ConfigTree1),
+    aec_events:publish(update_config, Map),
     ok.
 
 update_map(With, Map) when is_map(With), is_map(Map) ->


### PR DESCRIPTION
WIP prototype of fork resistance.

Modeled after the check of `gossip_allowed_height_from_top`, which rejects block insertions that are at least a given distance from the top, the introduction of `sync:sync_allowed_height_from_top` (default: `0` for now, which means disabled), makes it possible to resist a node connecting with a longer fork.