### PR TITLE
Monitoring mode

### DIFF
--- a/apps/aecore/src/aec_peer_analytics.erl
+++ b/apps/aecore/src/aec_peer_analytics.erl
@@ -22,6 +22,7 @@
 -export([ log_peer_status/4
         , log_temporary_peer_status/4
         , get_stats/0
+        , enabled/0
         ]).
 
 -type peer_stat() :: #{ host => string() | binary()
@@ -49,13 +50,14 @@ log_peer_info(Pub, NetID, Ver, Os, Rev, Vendor) ->
 log_peer_info_unknown(Pub) ->
     gen_server:call(?MODULE, {log_peer_info_unknown, Pub}).
 get_stats() -> gen_server:call(?MODULE, get_stats).
+enabled() -> aeu_env:user_config([<<"sync">>, <<"peer_analytics">>], false).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 -spec init(any()) -> {ok, state()}.
 init(_) ->
-    Enabled = aeu_env:user_config([<<"sync">>, <<"peer_analytics">>], false),
+    Enabled = enabled(),
     case Enabled of
         true ->
             lager:info("Enabling detailed peer statistics"),

--- a/apps/aecore/src/aec_peer_analytics.erl
+++ b/apps/aecore/src/aec_peer_analytics.erl
@@ -26,6 +26,7 @@
         , get_stats/0
         , get_stats_for_client/0
         , enabled/0
+        , pending_requests/0
         ]).
 
 -type peer_stat() :: #{ host => string() | binary()
@@ -97,6 +98,8 @@ encode_peer_info_for_client(#{ network_id := NetID
      , <<"node_os">> => Os
      }.
 
+pending_requests() -> gen_server:call(?MODULE, pending_requests).
+
 enabled() ->
     {ok, Enabled} =
         aeu_env:find_config( [<<"sync">>, <<"peer_analytics">>]
@@ -139,6 +142,7 @@ handle_call({log_peer_info, Pub, NetID, Ver, Os, Rev, Vendor}, _From, #{ stats :
 handle_call({log_peer_info_unknown, Pub}, _From, #{ stats := Stats } = St) ->
     {reply, ok, St#{stats => update_peer_info(Stats, Pub, unknown)}};
 handle_call(get_stats, _From, #{stats := Stats } = St) -> {reply, Stats, St};
+handle_call(pending_requests, _From, #{probes_pids := PPids} = St) -> {reply, maps:size(PPids) /= 0, St};
 handle_call(Msg, _From, #{} = St) ->
     lager:debug("Unhandled call in peer analytics ~p", [Msg]),
     {noreply, St}.

--- a/apps/aecore/src/aec_peer_analytics.erl
+++ b/apps/aecore/src/aec_peer_analytics.erl
@@ -1,0 +1,139 @@
+%%% -*- erlang-indent-level:4; indent-tabs-mode: nil -*-
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2021, Aeternity Anstalt
+%%% @doc
+%%% Aggregator for statistics about remote peers
+%%% It tries to connect to as much peers as possible and tracks stats about peers
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aec_peer_analytics).
+
+-behaviour(gen_server).
+
+%% Genserver
+-export([ start_link/0
+        , init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        ]).
+
+%% Peer stats
+-export([ log_peer_status/4
+        , log_temporary_peer_status/4
+        , get_stats/0
+        ]).
+
+-type peer_stat() :: #{ host => string() | binary()
+                      , port => aec_peer:peer()
+                      , first_seen => non_neg_integer()
+                      , last_seen => non_neg_integer()
+                      , genesis_hash => binary()
+                      , top_hash => binary()
+                      , difficulty => non_neg_integer()
+                      , info => any()
+                      }.
+-type peer_pub() :: binary().
+-type state() :: #{ enabled => boolean()
+                  , stats => #{ aec_keys:pubkey() => peer_stat() }
+                  , probes_pids => #{ peer_pub() => pid() }
+                  , probes_mref => #{ reference() => peer_pub() }
+                  }.
+
+log_temporary_peer_status(S, GHash, THash, Diff) ->
+    gen_server:cast(?MODULE, {log_temporary_peer_status, S, GHash, THash, Diff}).
+log_peer_status(S, GHash, THash, Diff) ->
+    gen_server:cast(?MODULE, {log_peer_status, S, GHash, THash, Diff}).
+log_peer_info(Pub, NetID, Ver, Os, Rev, Vendor) ->
+    gen_server:call(?MODULE, {log_peer_info, Pub, NetID, Ver, Os, Rev, Vendor}).
+log_peer_info_unknown(Pub) ->
+    gen_server:call(?MODULE, {log_peer_info_unknown, Pub}).
+get_stats() -> gen_server:call(?MODULE, get_stats).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec init(any()) -> {ok, state()}.
+init(_) ->
+    Enabled = aeu_env:user_config([<<"sync">>, <<"peer_analytics">>], false),
+    case Enabled of
+        true ->
+            lager:info("Enabling detailed peer statistics"),
+            application:set_env(aecore, sync_max_outbound, 1000000),
+            application:set_env(aecore, sync_max_inbound, 1000000);
+        false -> lager:info("Detailed peer statistics are disabled")
+    end,
+    {ok, #{enabled => Enabled, stats => #{}, probes_pids => #{}, probes_mref => #{}}}.
+
+handle_call({log_peer_info, Pub, NetID, Ver, Os, Rev, Vendor}, _From, #{ stats := Stats } = St) ->
+    Info = #{ network_id => NetID
+            , version => Ver
+            , os => Os
+            , revision => Rev
+            , vendor => Vendor
+            },
+    {reply, ok, St#{stats => update_peer_info(Stats, Pub, Info)}};
+handle_call({log_peer_info_unknown, Pub}, _From, #{ stats := Stats } = St) ->
+    {reply, ok, St#{stats => update_peer_info(Stats, Pub, unknown)}};
+handle_call(get_stats, _From, #{stats := Stats } = St) -> {reply, Stats, St};
+handle_call(Msg, _From, #{} = St) ->
+    lager:debug("Unhandled call in peer analytics ~p", [Msg]),
+    {noreply, St}.
+
+handle_info({'DOWN', MRef, process, _, _}, #{probes_pids := PPids, probes_mref := PRefs} = St) ->
+    Pub = maps:get(MRef, PRefs),
+    {noreply, St#{probes_pids := maps:remove(Pub, PPids), probes_mref := maps:remove(MRef, PRefs)}}.
+
+handle_cast(_Msg, #{enabled := false} = St) -> {noreply, St};
+handle_cast({log_temporary_peer_status, #{r_pubkey := Pub, host := Host, port := Port}, GHash, THash, Diff}, St) ->
+    St1 = log_ping(St, Pub, Host, Port, GHash, THash, Diff),
+    {noreply, St1};
+handle_cast({log_peer_status, #{r_pubkey := Pub, host := Host, port := Port}, GHash, THash, Diff}, St) ->
+    St1 = log_ping(St, Pub, Host, Port, GHash, THash, Diff),
+    St2 = maybe_schedule_version_probe(St1, Pub),
+    {noreply, St2};
+handle_cast(Msg, #{} = St) ->
+    lager:debug("Unhandled cast in peer analytics ~p", [Msg]),
+    {noreply, St}.
+
+log_ping(#{stats := Stats} = St, Pub, Host, Port, GHash, THash, Diff) ->
+    PS0 = maps:get(Pub, Stats, #{ info => unresolved, first_seen => unix_time() }),
+    PS = PS0#{ host => Host
+             , port => Port
+             , last_seen => unix_time()
+             , genesis_hash => GHash
+             , top_hash => THash
+             , difficulty => Diff
+             },
+    St#{stats => Stats#{ Pub => PS }}.
+
+unix_time() ->
+    {MegaSecs, Secs, _MicroSecs} = now(),
+    MegaSecs * 1000000 + Secs.
+
+%% Ask the nodes for their version every hour
+time_between_version_probes() -> 60 * 60.
+
+maybe_schedule_version_probe(#{stats := Stats, probes_pids := PPids, probes_mref := MRefs} = St, Pub) ->
+    #{first_seen := First, last_seen := Last, info := Info} = maps:get(Pub, Stats),
+    case Last - First > time_between_version_probes() orelse Info =:= unresolved of
+        false -> St;
+        true ->
+            case maps:find(Pub, PPids) of
+                {ok, _} -> St; %% Already scheduled
+                error ->
+                    {Pid, MRef} = spawn_monitor(fun() ->
+                        lager:debug("Scheduling peer version probe"),
+                        case aec_peer_connection:get_node_info(Pub, 10000) of
+                            {ok, #{network_id := NetID, node_version := Ver, os := Os, revision := Rev, vendor := Vendor}} ->
+                                log_peer_info(Pub, NetID, Ver, Os, Rev, Vendor);
+                            {error, no_connection} -> ok;
+                            {error, _} ->
+                                log_peer_info_unknown(Pub)
+                        end end),
+                    St#{probes_pids := maps:put(Pub, Pid, PPids), probes_mref := maps:put(MRef, Pub, MRefs)}
+            end
+    end.
+
+update_peer_info(Stats, Pub, Key) ->
+    maps:update_with(Pub, fun(V) -> V#{info => Key} end, Stats).

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -44,6 +44,10 @@
 -export([gossip_serialize_block/1,
          gossip_serialize_tx/1]).
 
+-ifdef(TEST).
+-export([is_node_info_sharing_enabled/0]).
+-endif.
+
 -include("aec_peer_messages.hrl").
 -include("blocks.hrl").
 

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -725,7 +725,7 @@ handle_ping_msg(S, RemotePingObj) ->
     case DecodedPingObj of
         {ok, true, RGHash0, RTHash0, RDiff0, _} ->
             aec_peer_analytics:log_peer_status(S, RGHash0, RTHash0, RDiff0);
-        {ok, true, RGHash0, RTHash0, RDiff0, _} ->
+        {ok, false, RGHash0, RTHash0, RDiff0, _} ->
             aec_peer_analytics:log_temporary_peer_status(S, RGHash0, RTHash0, RDiff0);
         {error, _} -> ok
     end,

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -721,7 +721,15 @@ handle_ping_msg(S, RemotePingObj) ->
        difficulty   := LDiff } = local_ping_obj(S),
     #{ address := SourceAddr } = S,
     PeerId = peer_id(S),
-    case decode_remote_ping(RemotePingObj) of
+    DecodedPingObj = decode_remote_ping(RemotePingObj),
+    case DecodedPingObj of
+        {ok, true, RGHash0, RTHash0, RDiff0, _} ->
+            aec_peer_analytics:log_peer_status(S, RGHash0, RTHash0, RDiff0);
+        {ok, true, RGHash0, RTHash0, RDiff0, _} ->
+            aec_peer_analytics:log_temporary_peer_status(S, RGHash0, RTHash0, RDiff0);
+        {error, _} -> ok
+    end,
+    case DecodedPingObj of
         {ok, true, RGHash, RTHash, RDiff, RPeers}
           when RGHash == LGHash, LSyncAllowed =:= true ->
             case {{LTHash, LDiff}, {RTHash, RDiff}} of

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -787,7 +787,7 @@ next_connect_delay(State) ->
     case is_outbound_allowed(State) of
         false  -> infinity;
         true ->
-            case aeu_env:user_config([<<"sync">>, <<"peer_analytics">>], false) of
+            case aec_peer_analytics:enabled() of
                 false ->
                     #state{ last_connect_time = LastTime, outbound = Outbound } = State,
                     ExpDelay = floor(math:pow(2, Outbound - 1)) * 1000,

--- a/apps/aecore/src/aecore_sup.erl
+++ b/apps/aecore/src/aecore_sup.erl
@@ -66,6 +66,7 @@ init([]) ->
         ++ [?CHILD(aec_metrics_rpt_dest, 5000, worker),
             ?CHILD(aec_keys, 5000, worker),
             ?CHILD(aec_tx_pool, 5000, worker),
+            ?CHILD(aec_peer_analytics, 5000, worker),
             ?CHILD(aec_tx_pool_gc, 5000, worker),
             ?CHILD(aec_db_error_store, 5000, worker),
             ?CHILD(aec_db_gc, 5000, worker),

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -13,6 +13,7 @@
 -export(
    [
     start_first_node/1,
+    start_first_node_with_analytics/1,
     start_second_node/1,
     start_third_node/1,
     start_blocked_second/1,
@@ -48,11 +49,12 @@
     first_fetch_node_infos_2_successes/1,
     first_fetch_node_infos_1_success_1_failure/1,
     first_fetch_node_infos_2_failures/1,
+    first_fetch_analytics/1,
     stop_three_nodes/1,
-    start_second_with_enabled_node_info/1,
-    start_second_with_disabled_node_info/1,
-    start_third_with_enabled_node_info/1,
-    start_third_with_disabled_node_info/1
+    start_second_with_enabled_node_info_no_analytics/1,
+    start_second_with_disabled_node_info_no_analytics/1,
+    start_third_with_enabled_node_info_no_analytics/1,
+    start_third_with_disabled_node_info_no_analytics/1
    ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -178,23 +180,46 @@ groups() ->
        %% one out 2 nodes reponds:
        start_first_node,
        mine_on_first,
-       start_second_with_disabled_node_info,
+       start_second_with_disabled_node_info_no_analytics,
        start_third_node,
        first_fetch_node_infos_1_success_1_failure,
        stop_three_nodes,
        %% noone responded 
        start_first_node,
        mine_on_first,
-       start_second_with_disabled_node_info,
-       start_third_with_disabled_node_info,
+       start_second_with_disabled_node_info_no_analytics,
+       start_third_with_disabled_node_info_no_analytics,
        first_fetch_node_infos_2_failures,
        stop_three_nodes,
        %% setting to true works
        start_first_node,
        mine_on_first,
-       start_second_with_enabled_node_info,
-       start_third_with_enabled_node_info,
-       first_fetch_node_infos_2_successes
+       start_second_with_enabled_node_info_no_analytics,
+       start_third_with_enabled_node_info_no_analytics,
+       first_fetch_node_infos_2_successes,
+       stop_three_nodes
+      ]},
+     {peer_analytics, [sequence],
+      [%% Node info disabled for everyone
+       start_first_node_with_analytics,
+       mine_on_first,
+       start_second_with_disabled_node_info_no_analytics,
+       start_third_with_disabled_node_info_no_analytics,
+       first_fetch_analytics,
+       stop_three_nodes,
+       %% Node info enabled for one
+       start_first_node_with_analytics,
+       mine_on_first,
+       start_second_with_enabled_node_info_no_analytics,
+       start_third_with_disabled_node_info_no_analytics,
+       first_fetch_analytics,
+       stop_three_nodes,
+       %% Node info enabled for both
+       start_first_node_with_analytics,
+       mine_on_first,
+       start_second_with_enabled_node_info_no_analytics,
+       start_third_with_enabled_node_info_no_analytics,
+       first_fetch_analytics
       ]}
     ].
 
@@ -265,8 +290,9 @@ init_per_group(persistence, Config) ->
     aec_peers_pool_tests:seed_process_random(), %% required for the random_peer()
     Config1 = config({devs, [dev1, dev2]}, Config),
     Config1;
-init_per_group(ThreeNodes, Config) when ThreeNodes =:= three_nodes
-                                 orelse ThreeNodes =:= node_info ->
+init_per_group(ThreeNodes, Config) when ThreeNodes =:= three_nodes;
+                                        ThreeNodes =:= node_info;
+                                        ThreeNodes =:= peer_analytics ->
     Config1 = config({devs, [dev1, dev2, dev3]}, Config),
     InitialApps = {running_apps(), loaded_apps()},
     {ok, _} = application:ensure_all_started(exometer_core),
@@ -322,6 +348,7 @@ end_per_group(mempool_sync, Config) ->
 end_per_group(Group, Config) when Group =:= two_nodes;
                                   Group =:= three_nodes;
                                   Group =:= node_info;
+                                  Group =:= peer_analytics;
                                   Group =:= semantically_invalid_tx;
                                   Group =:= run_benchmark ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
@@ -383,6 +410,9 @@ start_first_node(Config) ->
     aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1)),
     ok = aecore_suite_utils:check_for_logs([dev1], Config),
     ok.
+
+start_first_node_with_analytics(Config) ->
+    start_a_node_with_node_info_and_analytics(Config, dev1, true, true).
 
 start_second_node(Config) ->
     [Dev1, Dev2] = [dev1, dev2],
@@ -1126,26 +1156,33 @@ get_pool({_, Name}) ->
     rpc:call(Name, aec_tx_pool, peek, [infinity], 5000).
 
 new_tx(#{node1 := {PK1, {_,N1} = T1}, node2 := {PK2, _}, amount := Am, fee := Fee} = _M) ->
-    ExtPort = rpc:call(N1, aeu_env, user_config_or_env,
-                       [ [<<"http">>, <<"external">>, <<"port">>],
-                         aehttp, [external, port], 8043], 5000),
-    IntPort = rpc:call(N1, aeu_env, user_config_or_env,
-                       [ [<<"http">>, <<"internal">>, <<"port">>],
-                         aehttp, [internal, port], 8143], 5000),
     Params = #{sender_id => aeser_api_encoder:encode(account_pubkey, PK1),
                recipient_id => aeser_api_encoder:encode(account_pubkey, PK2),
                amount => Am,
                fee => Fee,
                payload => <<"foo">>},
     %% It's internal API so ext_addr is not included here.
-    Cfg = [{ext_http, "http://127.0.0.1:" ++ integer_to_list(ExtPort)},
-           {int_http, "http://127.0.0.1:" ++ integer_to_list(IntPort)}],
+    Cfg = http_config(N1),
     ct:log(">>> PARAMS: ~p", [Params]),
 
     {ok, 200, #{tx := SpendTx}} = aehttp_client:request('PostSpend', Params, Cfg),
     SignedSpendTx = sign_tx(T1, SpendTx),
     {ok, 200, _} = aehttp_client:request('PostTransaction', #{tx => SignedSpendTx}, Cfg),
     ok.
+
+http_get_network_status(N) ->
+    Cfg = http_config(N),
+    aehttp_client:request('GetNetworkStatus', #{}, Cfg).
+
+http_config(N) ->
+    ExtPort = rpc:call(N, aeu_env, user_config_or_env,
+                       [ [<<"http">>, <<"external">>, <<"port">>],
+                         aehttp, [external, port], 8043], 5000),
+    IntPort = rpc:call(N, aeu_env, user_config_or_env,
+                       [ [<<"http">>, <<"internal">>, <<"port">>],
+                         aehttp, [internal, port], 8143], 5000),
+    [ {ext_http, "http://127.0.0.1:" ++ integer_to_list(ExtPort)},
+      {int_http, "http://127.0.0.1:" ++ integer_to_list(IntPort)} ].
 
 ensure_new_tx(T, Tx) ->
     retry(fun() -> ensure_new_tx_(T, Tx) end,
@@ -1262,32 +1299,75 @@ first_fetch_node_infos(Successes, Fails) ->
     end,
     ok.
 
-stop_three_nodes(Cfg) ->
-    lists:foreach(
-        fun(Node) ->
-            {ok, DbCfg} = node_db_cfg(Node),
-            aecore_suite_utils:stop_node(Node, Cfg),
-            aecore_suite_utils:delete_node_db_if_persisted(DbCfg)
-        end,
-        [dev1, dev2, dev3]),
+first_fetch_analytics(_Cfg) ->
+    %% Verify preconditions
+    [{N1, true}, {N2, S2}, {_, S3}] = lists:map(fun({Dev, R}) ->
+        N = aecore_suite_utils:node_name(Dev),
+        R = rpc:call(N, aec_peer_analytics, enabled, []),
+        S = rpc:call(N, aec_peer_connection, is_node_info_sharing_enabled, []),
+        {N, S} end,
+        [{dev1, true}, {dev2, false}, {dev3, false}]),
+    timer:sleep(2000), %% Give the first node 2s to gather analytics
+    %% Check that results obtained via different methods agree
+    A1 = ensure_fixpoint(fun() -> rpc:call(N1, aec_peer_analytics, get_stats, []) end),
+    A2 = ensure_fixpoint(fun() -> rpc:call(N1, aec_peer_analytics, get_stats_for_client, []) end),
+    {ok, 200, A3} = ensure_fixpoint(fun() -> http_get_network_status(N1) end),
+    {ok, 404, #{reason := <<"Network analytics disabled in node config">>}}
+        = http_get_network_status(N2),
+    ct:log("Direct: ~p", [A1]),
+    ct:log("Direct client encoded: ~p", [A2]),
+    ct:log("Over http: ~p", [A3]),
+    true = maps:size(A1) =:= maps:size(A3),
+    true = maps:size(A2) =:= maps:size(A3),
+    A4 = maps:map(fun(_, X) ->
+        maps:fold(fun(K, V, Acc) when is_atom(K) -> Acc#{atom_to_binary(K) => V};
+                     (K, V, Acc) -> Acc#{K => V}
+                  end, #{}, X) end, A3),
+    true = A2 =:= A4, %% Map match semantics
+    %% Check how many peers responded to the info probe
+    C1 = fun(true) -> 1; (false) -> 0 end,
+    C2 = fun(#{info := #{vendor := _}}) -> 1; (#{}) -> 0 end,
+    R = lists:sum(lists:map(C1, [S2, S3])),
+    R = lists:sum(lists:map(C2, maps:values(A1))),
     ok.
 
-start_second_with_disabled_node_info(Cfg) ->
-    start_a_node_with_node_info(Cfg, dev2, false).
+ensure_fixpoint(F) ->
+    X = F(),
+    X = F(),
+    X.
 
-start_second_with_enabled_node_info(Cfg) ->
-    start_a_node_with_node_info(Cfg, dev2, true).
+stop_three_nodes(Cfg) ->
+    MRefs = lists:map(
+        fun(Node) ->
+            {_, MRef} = spawn_monitor(fun() ->
+                {ok, DbCfg} = node_db_cfg(Node),
+                aecore_suite_utils:stop_node(Node, Cfg),
+                aecore_suite_utils:delete_node_db_if_persisted(DbCfg)
+            end),
+            MRef
+        end,
+        [dev1, dev2, dev3]),
+    [receive {'DOWN', MRef, process, _, _} -> ok end || MRef <- MRefs],
+    ok.
 
-start_third_with_disabled_node_info(Cfg) ->
-    start_a_node_with_node_info(Cfg, dev3, false).
+start_second_with_disabled_node_info_no_analytics(Cfg) ->
+    start_a_node_with_node_info_and_analytics(Cfg, dev2, false, false).
 
-start_third_with_enabled_node_info(Cfg) ->
-    start_a_node_with_node_info(Cfg, dev3, true).
+start_second_with_enabled_node_info_no_analytics(Cfg) ->
+    start_a_node_with_node_info_and_analytics(Cfg, dev2, true, false).
 
-start_a_node_with_node_info(Cfg, Node, NodeInfoFlag) ->
+start_third_with_disabled_node_info_no_analytics(Cfg) ->
+    start_a_node_with_node_info_and_analytics(Cfg, dev3, false, false).
+
+start_third_with_enabled_node_info_no_analytics(Cfg) ->
+    start_a_node_with_node_info_and_analytics(Cfg, dev3, true, false).
+
+start_a_node_with_node_info_and_analytics(Cfg, Node, NodeInfoFlag, AnalyticsFlag) ->
     EpochCfg0 = aecore_suite_utils:epoch_config(Node, Cfg),
     Sync0 = maps:get(<<"sync">>, EpochCfg0, #{}),
-    Sync = Sync0#{<<"provide_node_info">> => NodeInfoFlag},
+    Sync = Sync0#{ <<"provide_node_info">> => NodeInfoFlag
+                 , <<"peer_analytics">> => AnalyticsFlag
+                 },
     EpochCfg = EpochCfg0#{<<"sync">> => Sync},
     aecore_suite_utils:create_config(Node, Cfg, EpochCfg,
                                             [

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -947,7 +947,7 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/Status'
-  /status/network:
+  /debug/network:
     get:
       tags:
         - internal

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -952,6 +952,7 @@ paths:
       tags:
         - internal
         - node_info
+        - debug
       operationId: GetNetworkStatus
       description: 'Get detailed analytics on peers'
       produces:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -950,7 +950,7 @@ paths:
   /status/network:
     get:
       tags:
-        - external
+        - internal
         - node_info
       operationId: GetNetworkStatus
       description: 'Get detailed analytics on peers'
@@ -958,7 +958,7 @@ paths:
         - application/json
       parameters: []
       responses:
-        '400':
+        '404':
           description: Analytics disabled
           schema:
             $ref: '#/definitions/Error'

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -947,7 +947,25 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/Status'
-
+  /status/network:
+    get:
+      tags:
+        - external
+        - node_info
+      operationId: GetNetworkStatus
+      description: 'Get detailed analytics on peers'
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '400':
+          description: Analytics disabled
+          schema:
+            $ref: '#/definitions/Error'
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/NetworkStatus'
   /debug/contracts/create:
     post:
       tags:
@@ -2624,6 +2642,52 @@ definitions:
     required:
       - inbound
       - outbound
+  NetworkStatus:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/PeerDetails'
+  PeerDetails:
+    type: object
+    properties:
+      host:
+        description: 'Hostname of peer'
+        type: string
+      port:
+        description: 'Port of peer'
+        $ref: '#/definitions/UInt32'
+      first_seen:
+        description: 'Unix timestamp of when the peer was first pinged'
+        $ref: '#/definitions/UInt32'
+      last_seen:
+        description: 'Unix timestamp of when the peer was last pinged'
+        $ref: '#/definitions/UInt32'
+      genesis_hash:
+        description: 'The genesis hash the remote node reports'
+        $ref: '#/definitions/EncodedHash'
+      top_hash:
+        description: 'The top hash the remote node reports'
+        $ref: '#/definitions/EncodedHash'
+      top_difficulty:
+        description: 'The total top difficulty the node reports'
+        $ref: '#/definitions/UInt64'
+      network_id:
+        type: string
+      node_version:
+        type: string
+      node_revision:
+        type: string
+      node_vendor:
+        type: string
+      node_os:
+        type: string
+    required:
+      - host
+      - port
+      - first_seen
+      - last_seen
+      - genesis_hash
+      - top_hash
+      - top_difficulty
   GenericSignedTx:
     type: object
     properties:

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -90,6 +90,7 @@ queue('GetNameEntryByName')                     -> ?READ_Q;
 queue('GetChannelByPubkey')                     -> ?READ_Q;
 queue('GetPeerPubkey')                          -> ?READ_Q;
 queue('GetStatus')                              -> ?READ_Q;
+queue('GetNetworkStatus')                       -> ?READ_Q;
 queue('GetPeerKey')                             -> ?READ_Q;
 %% update transactions (default to update in catch-all)
 queue('PostTransaction')                        -> ?WRITE_Q;
@@ -629,7 +630,19 @@ handle_request_('GetStatus', _Params, _Context) ->
        <<"peer_pubkey">>                => aeser_api_encoder:encode(peer_pubkey, PeerPubkey),
        <<"top_key_block_hash">>         => aeser_api_encoder:encode(key_block_hash, TopBlockHash),
        <<"top_block_height">>           => TopBlockHeight}};
-
+handle_request_('GetNetworkStatus', _Params, _Context) ->
+    case aec_peer_analytics:enabled() of
+        false ->
+            {400, [], #{reason => <<"Network analytics disabled in node config">>}};
+        true ->
+            Stats0 = maps:to_list(aec_peer_analytics:get_stats()),
+            Stats1 = lists:map(fun({K, V}) ->
+                { aeser_api_encoder:encode(peer_pubkey, K)
+                , encode_peer_details(V)} end,
+                Stats0),
+            Stats2 = maps:from_list(Stats1),
+            {200, [], Stats2}
+    end;
 handle_request_(OperationID, Req, Context) ->
     error_logger:error_msg(
       ">>> Got not implemented request to process: ~p~n",
@@ -662,6 +675,39 @@ encode_generation(KeyBlock, MicroBlocks, PrevBlockType) ->
                            aeser_api_encoder:encode(micro_block_hash, Hash)
                        end || M <- MicroBlocks]}.
 
+encode_peer_details(#{ host := Host
+                     , port := Port
+                     , first_seen := FT
+                     , last_seen := LT
+                     , genesis_hash := GH
+                     , top_hash := TH
+                     , difficulty := D
+                     , info := Info}) ->
+    EInfo = encode_peer_info(Info),
+    EStatus = #{ <<"host">> => Host
+               , <<"port">> => Port
+               , <<"first_seen">> => FT
+               , <<"last_seen">> => LT
+               , <<"genesis_hash">> => aeser_api_encoder:encode(key_block_hash, GH)
+               , <<"top_hash">> => aeser_api_encoder:encode(key_block_hash, TH)
+               , <<"top_difficulty">> => D
+               },
+    maps:merge(EStatus, EInfo).
+
+encode_peer_info(unresolved) -> #{};
+encode_peer_info(unknown) -> #{};
+encode_peer_info(#{ network_id := NetID
+                  , version := Ver
+                  , os := Os
+                  , revision := Rev
+                  , vendor := Vendor
+                  }) ->
+    #{ <<"network_id">> => NetID
+     , <<"node_version">> => Ver
+     , <<"node_revision">> => Rev
+     , <<"node_vendor">> => Vendor
+     , <<"node_os">> => Os
+     }.
 
 deserialize_transaction(Tx) ->
     try

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -208,6 +208,11 @@
                     "description": "Provide node version to peers",
                     "type" : "boolean",
                     "default": true 
+                },
+                "peer_analytics" : {
+                    "description": "If enabled aggregates info about remote peers and exposes them via HTTP. Overrides max_inbound and max_outbound",
+                    "type" : "boolean",
+                    "default": false
                 }
             }
         },

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -63,6 +63,8 @@ sync:
       standby_times: [5000, 15000, 30000, 60000, 120000, 300000, 600000]
       # The default maximum number of times a peer can get rejected. When reached, the peer is downgraded or removed (if not trusted)
       max_rejections: 7
+    provide_node_info: true
+    peer_analytics: false
 
 mempool:
     # Number of blocks before inactive TXs are garbage collected


### PR DESCRIPTION
This PR is part of a joint effort between the core team and the SH team to give the community more transparency about the network.
Adds a special "monitoring" mode in which:

1. Peer connection limits are disregarded - the node tries to connect to as many peers as possible and as agressively as possible
2. The remote top hashes and difficulty are kept locally - might be useful for determining the source node of a new competing fork
3. We ask the peers once an hour about their version and vendor string
4. Keeps the data even when the peer disconnects - a "last pinged" timer is maintained - it's up to the frontend to filter out active nodes(last seen < 3-5 minutes)

No tests so far besides testing that it works in an erlang console:
![image](https://user-images.githubusercontent.com/1352848/104381499-d414ff80-552c-11eb-90ba-d66ebc471057.png)
![image](https://user-images.githubusercontent.com/1352848/104381551-ed1db080-552c-11eb-9065-95abe9e93c98.png)
