### PR TITLE
Detailed fork tracker

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1275,6 +1275,3 @@ chain_ends_maybe_apply([H1|T1] = OldTops, [H2|T2], NewTops) -> %% Check if H1 is
             lager:info("[Orphan key blocks scan] ignoring deleted header: find_common_ancestor(~p, ~p)", [EH1, EH2]),
             chain_ends_maybe_apply(T1, NewTops, NewTops)
     end.
-
-save_migration_state(Height, Tops) ->
-    aec_db:write_chain_end_migration_state({Height, Tops}).

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1229,7 +1229,7 @@ start_chain_ends_migration() ->
                                                   , [{{'$1', {element, 4, '$2'}, '$3'}}]
                                                   }])
               end),
-            lager:info("[Orphan key blocks scan] Retrieved the key header chain in ~p seconds", [Time]),
+            lager:info("[Orphan key blocks scan] Retrieved the key header chain in ~p microseconds", [Time]),
             R1 = lists:keysort(3, R0),
             S = lists:foldl(fun({Hash, PrevKeyHash, _}, S0) ->
                 S1 = sets:del_element(PrevKeyHash, S0),
@@ -1238,7 +1238,8 @@ start_chain_ends_migration() ->
             chain_ends_finish_migration(S)
         catch
             E:R:Stack ->
-                io:format(user, "[Orphan key blocks scan] Terminating node: ~p ~p ~p", [E, R, Stack]),
+                (catch io:format(user, "[Orphan key blocks scan] Terminating node: ~p ~p ~p", [E, R, Stack])),
+                (catch lager:error("[Orphan key blocks scan] Terminating node: ~p ~p ~p", [E, R, Stack])),
                 init:stop("[Orphan key blocks scan] Encountered a fatal error during the migration. Terminating the node")
         end
       end).

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1259,6 +1259,7 @@ chain_ends_finish_migration(Height, OldTops0) ->
     lager:info("[Orphan key blocks scan] Finished - applying the scan result"),
     save_migration_state(Height, OldTops0),
     OldTops = sets:to_list(OldTops0),
+    lager:debug("[Orphan key blocks scan] Finished - found ~p orphans: ~p", [length(OldTops), OldTops]),
     %% This needs to respect ACID!
     ok = aec_db:ensure_transaction(fun() ->
         NewTops = aec_db:find_chain_end_hashes(),
@@ -1274,6 +1275,7 @@ chain_ends_maybe_apply([H|T], [], NewTops) -> %% No objections
 chain_ends_maybe_apply([H|T], [H|_], NewTops) -> %% Already found
     chain_ends_maybe_apply(T, NewTops, NewTops);
 chain_ends_maybe_apply([H1|T1] = OldTops, [H2|T2], NewTops) -> %% Check if H1 is a direct predecessor of H2
+    lager:debug("[Orphan key blocks scan] Finished - find_common_ancestor(~p, ~p)", [H1, H2]),
     case find_common_ancestor(H1, H2) of
         {ok, H1} -> chain_ends_maybe_apply(T1, NewTops, NewTops); %% H2 is more recent than H1
         {ok, _} -> chain_ends_maybe_apply(OldTops, T2, NewTops) %% H1 might be new

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1223,7 +1223,11 @@ start_chain_ends_migration() ->
       end).
 
 chain_ends_migration_step(Height, Tops) when Height > 0, Height rem 10000 =:= 0 ->
-    lager:debug("[Orphan key blocks scan] Scanned 10k generations"),
+    TH = mnesia:activity(async_dirty, fun() ->
+        aec_headers:height(aec_chain:top_header())
+      end),
+    Progress = round(10000000 * Height / TH) / 100000,
+    lager:debug("[Orphan key blocks scan] Scanned 10k generations. Progress ~p%", [Progress]),
     save_migration_state(Height, Tops),
     chain_ends_migration_scan(Height, Tops);
 chain_ends_migration_step(Height, Tops) when Height > 0, Height rem 1000 =:= 0 ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -577,7 +577,9 @@ find_chain_end_hashes() ->
     mnesia:dirty_select(aec_chain_state, [{ #aec_chain_state{key = {end_block_hash, '$1'}, _ = '_'}, [], ['$1'] }]).
 
 write_chain_end_migration_state(State) ->
-    ?t(mnesia:write(#aec_chain_state{key = end_block_migration, value = State})). %% Crashes when error keys are present
+    %% Writes occur before the error store is initialized - if error keys are present then this will crash
+    %% Fortunately this write will be correctly handled by the rocksdb bypass logic
+    ?t(mnesia:write(#aec_chain_state{key = end_block_migration, value = State})).
 
 delete_chain_end_migration_state() ->
     ?t(mnesia:delete(aec_chain_state, end_block_migration, write)).

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -39,6 +39,7 @@
          find_header/1,
          dirty_find_header/1,
          find_headers_at_height/1,
+         find_key_headers_and_hash_at_height/1,
          find_headers_and_hash_at_height/1,
          find_key_block/1,
          find_signed_tx/1,
@@ -498,6 +499,14 @@ find_headers_at_height(Height) when is_integer(Height), Height >= 0 ->
 find_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
     ?t([{K, aec_headers:from_db_header(H)} || #aec_headers{key = K, value = H}
                  <- mnesia:index_read(aec_headers, Height, #aec_headers.height)]).
+
+-spec find_key_headers_and_hash_at_height(pos_integer()) -> [{binary(), aec_headers:key_header()}].
+find_key_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
+    R = mnesia:dirty_select(aec_headers, [{ #aec_headers{key = '_', value = '$1', height = Height}
+                                          , [{'=:=', {element, 1, '$1'}, key_header}]
+                                          , ['$_']
+                                          }]),
+    [{Hash, aec_headers:from_db_header(Header)} || #aec_headers{key = Hash, value = Header} <- R].
 
 find_discovered_pof(Hash) ->
     case ?t(read(aec_discovered_pof, Hash)) of

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -574,7 +574,7 @@ unmark_chain_end_hash(Hash) when is_binary(Hash) ->
     ?t(mnesia:delete(aec_chain_state, {end_block_hash, Hash}, write)).
 
 find_chain_end_hashes() ->
-    [H || {end_block_hash, H} <- mnesia:dirty_all_keys(aec_chain_state)].
+    mnesia:dirty_select(aec_chain_state, [{ #aec_chain_state{key = {end_block_hash, '$1'}, _ = '_'}, [], ['$1'] }]).
 
 write_chain_end_migration_state(State) ->
     ?t(mnesia:write(#aec_chain_state{key = end_block_migration, value = State})). %% Crashes when error keys are present

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -117,6 +117,9 @@
 -export([ find_chain_end_hashes/0
         , mark_chain_end_hash/1
         , unmark_chain_end_hash/1
+        , write_chain_end_migration_state/1
+        , delete_chain_end_migration_state/0
+        , find_chain_end_migration_state/0
         ]).
 
 %%
@@ -572,6 +575,18 @@ unmark_chain_end_hash(Hash) when is_binary(Hash) ->
 
 find_chain_end_hashes() ->
     [H || {end_block_hash, H} <- mnesia:dirty_all_keys(aec_chain_state)].
+
+write_chain_end_migration_state(State) ->
+    ?t(mnesia:write(#aec_chain_state{key = end_block_migration, value = State})). %% Crashes when error keys are present
+
+delete_chain_end_migration_state() ->
+    ?t(mnesia:delete(aec_chain_state, end_block_migration, write)).
+
+find_chain_end_migration_state() ->
+    case ?t(mnesia:read(aec_chain_state, end_block_migration)) of
+        [#aec_chain_state{value = State}] -> {ok, State};
+        _ -> error
+    end.
 
 write_signal_count(Hash, Count) when is_binary(Hash), is_integer(Count) ->
     ?t(mnesia:write(#aec_signal_count{key = Hash, value = Count}),

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -112,6 +112,13 @@
         , delete_peer/1
         , read_all_peers/0
         ]).
+
+%% Fork tracking and selection
+-export([ find_chain_end_hashes/0
+        , mark_chain_end_hash/1
+        , unmark_chain_end_hash/1
+        ]).
+
 %%
 %% for testing
 -export([backend_mode/0]).
@@ -555,6 +562,16 @@ write_genesis_hash(Hash) when is_binary(Hash) ->
 write_top_block_hash(Hash) when is_binary(Hash) ->
     ?t(mnesia:write(#aec_chain_state{key = top_block_hash, value = Hash}),
        [{aec_chain_state, top_block_hash}]).
+
+mark_chain_end_hash(Hash) when is_binary(Hash) ->
+    ?t(mnesia:write(#aec_chain_state{key = {end_block_hash, Hash}, value = []}),
+       [{aec_chain_state, {end_block_hash, Hash}}]).
+
+unmark_chain_end_hash(Hash) when is_binary(Hash) ->
+    ?t(mnesia:delete(aec_chain_state, {end_block_hash, Hash}, write)).
+
+find_chain_end_hashes() ->
+    [H || {end_block_hash, H} <- mnesia:dirty_all_keys(aec_chain_state)].
 
 write_signal_count(Hash, Count) when is_binary(Hash), is_integer(Count) ->
     ?t(mnesia:write(#aec_signal_count{key = Hash, value = Count}),

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -19,6 +19,7 @@ start(_StartType, _StartArgs) ->
     aec_db:load_database(),
     case aec_db:persisted_valid_genesis_block() of
         true ->
+            aec_chain_state:ensure_chain_ends(),
             aecore_sup:start_link();
         false ->
             lager:error("Persisted chain has a different genesis block than "

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -698,15 +698,21 @@ fork_common_block(EasyChain, TopHashEasy, HardChain, TopHashHard) ->
     %% The second chain should take over
     ok = write_blocks_to_chain(EasyChain),
     ?assertEqual(TopHashEasy, top_block_hash()),
+    ?assertEqual([TopHashEasy], aec_db:find_chain_end_hashes()),
     ok = write_blocks_to_chain(HardChain),
     ?assertEqual(TopHashHard, top_block_hash()),
+    ?assertEqual( lists:usort([TopHashEasy, TopHashHard])
+                , lists:usort(aec_db:find_chain_end_hashes())),
 
     restart_chain_db(),
     %% The second chain should not take over
     ok = write_blocks_to_chain(HardChain),
     ?assertEqual(TopHashHard, top_block_hash()),
+    ?assertEqual([TopHashHard], aec_db:find_chain_end_hashes()),
     ok = write_blocks_to_chain(EasyChain),
     ?assertEqual(TopHashHard, top_block_hash()),
+    ?assertEqual( lists:usort([TopHashEasy, TopHashHard])
+                , lists:usort(aec_db:find_chain_end_hashes())),
     ok.
 
 fork_get_by_height() ->
@@ -834,6 +840,7 @@ fork_on_micro_block() ->
 
     {ok, KB2ForkHash} = aec_blocks:hash_internal_representation(KB2Fork),
     ?assertEqual(KB2ForkHash, aec_chain:top_block_hash()),
+    ?assertEqual([KB2ForkHash], aec_db:find_chain_end_hashes()),
 
     %% Insert main chain
     ok = insert_block(MB2),
@@ -843,7 +850,8 @@ fork_on_micro_block() ->
     %% Check main chain took over
     {ok, KB3Hash} = aec_blocks:hash_internal_representation(KB3),
     ?assertEqual(KB3Hash, aec_chain:top_block_hash()),
-
+    ?assertEqual( lists:usort([KB2ForkHash, KB3Hash])
+                , lists:usort(aec_db:find_chain_end_hashes())),
     ok.
 
 fork_on_old_fork_point() ->

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -698,22 +698,34 @@ fork_common_block(EasyChain, TopHashEasy, HardChain, TopHashHard) ->
     %% The second chain should take over
     ok = write_blocks_to_chain(EasyChain),
     ?assertEqual(TopHashEasy, top_block_hash()),
-    ?assertEqual([TopHashEasy], aec_db:find_chain_end_hashes()),
+    fork_test_chain_ends_and_migration([TopHashEasy]),
     ok = write_blocks_to_chain(HardChain),
     ?assertEqual(TopHashHard, top_block_hash()),
-    ?assertEqual( lists:usort([TopHashEasy, TopHashHard])
-                , lists:usort(aec_db:find_chain_end_hashes())),
+    fork_test_chain_ends_and_migration([TopHashEasy, TopHashHard]),
 
     restart_chain_db(),
     %% The second chain should not take over
     ok = write_blocks_to_chain(HardChain),
     ?assertEqual(TopHashHard, top_block_hash()),
-    ?assertEqual([TopHashHard], aec_db:find_chain_end_hashes()),
+    fork_test_chain_ends_and_migration([TopHashHard]),
     ok = write_blocks_to_chain(EasyChain),
     ?assertEqual(TopHashHard, top_block_hash()),
-    ?assertEqual( lists:usort([TopHashEasy, TopHashHard])
-                , lists:usort(aec_db:find_chain_end_hashes())),
+    fork_test_chain_ends_and_migration([TopHashEasy, TopHashHard]),
     ok.
+
+fork_test_chain_ends_and_migration(Expected) ->
+    F = fun() -> ?assertEqual( lists:usort(Expected)
+                             , lists:usort(aec_db:find_chain_end_hashes())) end,
+    F(),
+    [aec_db:unmark_chain_end_hash(H) || H <- Expected],
+    case aec_chain_state:ensure_chain_ends() of
+        ok -> error("Migration did not trigger!");
+        Pid ->
+            MRef = erlang:monitor(process, Pid),
+            receive {'DOWN', MRef, process, _, _} -> ok end,
+            F(),
+            ok = aec_chain_state:ensure_chain_ends() %% Already migrated
+    end.
 
 fork_get_by_height() ->
     CommonChain = gen_block_chain_with_state_by_target([?GENESIS_TARGET, ?GENESIS_TARGET, 1, 1], 111),
@@ -840,7 +852,7 @@ fork_on_micro_block() ->
 
     {ok, KB2ForkHash} = aec_blocks:hash_internal_representation(KB2Fork),
     ?assertEqual(KB2ForkHash, aec_chain:top_block_hash()),
-    ?assertEqual([KB2ForkHash], aec_db:find_chain_end_hashes()),
+    fork_test_chain_ends_and_migration([KB2ForkHash]),
 
     %% Insert main chain
     ok = insert_block(MB2),
@@ -850,8 +862,7 @@ fork_on_micro_block() ->
     %% Check main chain took over
     {ok, KB3Hash} = aec_blocks:hash_internal_representation(KB3),
     ?assertEqual(KB3Hash, aec_chain:top_block_hash()),
-    ?assertEqual( lists:usort([KB2ForkHash, KB3Hash])
-                , lists:usort(aec_db:find_chain_end_hashes())),
+    fork_test_chain_ends_and_migration([KB2ForkHash, KB3Hash]),
     ok.
 
 fork_on_old_fork_point() ->

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -871,8 +871,10 @@ assert_stopped_and_genesis_at_top() ->
     Keys = beneficiary_keys(),
     Preset = preset_accounts(Keys),
     {Genesis, _} = aec_test_utils:genesis_block_with_state(Preset),
+    GenesisHash = header_hash( aec_blocks:to_header( Genesis )),
     ?assertEqual(aec_chain:top_block_hash(),
-                 header_hash( aec_blocks:to_header( Genesis ))).
+                 GenesisHash),
+    ?assertEqual([GenesisHash], aec_db:find_chain_end_hashes()).
 
 assert_leader(Value) ->
     ?assertEqual(Value, ?TEST_MODULE:is_leader()).

--- a/apps/aecore/test/aecore_app_tests.erl
+++ b/apps/aecore/test/aecore_app_tests.erl
@@ -15,10 +15,13 @@ persisted_valid_gen_block_test_() ->
              meck:expect(aecore_sup, start_link, 0, {ok, pid}),
              meck:new(aec_jobs_queues, [passthrough]),
              meck:expect(aec_jobs_queues, start, 0, ok),
+             meck:new(aec_chain_state, [passthrough]),
+             meck:expect(aec_chain_state, ensure_chain_ends, 0, ok),
              ok = lager:start(),
              InitialApps
      end,
      fun({OldRunningApps, OldLoadedApps}) ->
+             meck:unload(aec_chain_state),
              meck:unload(aec_jobs_queues),
              meck:unload(aecore_sup),
              meck:unload(aec_db),

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -947,6 +947,23 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/Status'
+  /status/chain-ends:
+    get:
+      tags:
+        - external
+        - chain
+      operationId: GetChainEnds
+      description: 'Get oldest keyblock hashes counting from genesis including orphans'
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/EncodedHash'
   /debug/network:
     get:
       tags:

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -91,6 +91,7 @@ queue('GetChannelByPubkey')                     -> ?READ_Q;
 queue('GetPeerPubkey')                          -> ?READ_Q;
 queue('GetStatus')                              -> ?READ_Q;
 queue('GetPeerKey')                             -> ?READ_Q;
+queue('GetChainEnds')                           -> ?READ_Q;
 %% update transactions (default to update in catch-all)
 queue('PostTransaction')                        -> ?WRITE_Q;
 queue(_)                                        -> ?WRITE_Q.
@@ -629,6 +630,9 @@ handle_request_('GetStatus', _Params, _Context) ->
        <<"peer_pubkey">>                => aeser_api_encoder:encode(peer_pubkey, PeerPubkey),
        <<"top_key_block_hash">>         => aeser_api_encoder:encode(key_block_hash, TopBlockHash),
        <<"top_block_height">>           => TopBlockHeight}};
+
+handle_request_('GetChainEnds', _Params, _Context) ->
+    {200, [], [aeser_api_encoder:encode(key_block_hash, H) || H <- aec_db:find_chain_end_hashes()]};
 
 handle_request_(OperationID, Req, Context) ->
     error_logger:error_msg(

--- a/docs/release-notes/next/GH-3470-fork-tracker.md
+++ b/docs/release-notes/next/GH-3470-fork-tracker.md
@@ -1,0 +1,1 @@
+* Introduces an external HTTP endpoint(/v2/status/chain-ends) which reports keyhashes for which no successor is present in the database. Useful for retrieving orphan blocks and tracking chain reorganizations.


### PR DESCRIPTION
This PR maintains a list of key block hashes for which no successor is present - this also applies to orphan blocks.
The main use case is to immediately tell whether a large chain reorganization started and how much orphans are there.
Additionally this is a crucial step towards creating a GC for old orphaned blocks, switching between forks and mining on a particular fork one likes.
The loose ends are exposed via HTTP:
![image](https://user-images.githubusercontent.com/1352848/104762661-0446e300-5765-11eb-99e1-dd9e1cdd726c.png)
Frontends can then easily visualize orphans and mark orphaned transactions by using the new endpoint @thepiwo @mradkov 

Maintaining the loose end information is really cheap - everything is stored in the aec_chain_state table - I won't create another table due the fact that right now every table is backed by a fully independent database -.- When we finally make the full DB refactor then we can create a separate table and clean this up.

Old databases are also supported - If a old DB is detected then a DB sweep is started and we walk all key headers from genesis to the current top in order to find orphan blocks - this is done in the background and can be interrupted. For safety reasons if something in the migration crashes then we purposefully crash the entire node.
