### PR TITLE
Add whitelisting extension script

### DIFF
--- a/apps/aeutils/priv/create_whitelist
+++ b/apps/aeutils/priv/create_whitelist
@@ -12,10 +12,21 @@ main(Args) ->
               end
           catch
               error:_ ->
-                  io:fwrite("Exiting~n", []),
+                  help(),
                   1
           end,
     init:stop(Res).
+
+help() ->
+    io:fwrite("Usage: create_whitelist [-start Start] [-n N] [-step Step] [-o Outfile]~n"
+              "-start Start : Begin <Start> key blocks below the current top (default: 100)~n"
+              "-n     N     : Collect <N> hashes for the whitelist (default: 1000)~n"
+              "-step  Step  : Separate the whitelisted hashes by <Step> (default: 1)~n"
+              "-outfile F   : Write JSON to file <F> (default: ./block_whitelist-X-Y-Z.json)~n"
+              "~n"
+              "When running as standalone script (not via bin/aeternity), connection params~n"
+              "must be provided: -sname (or -name) and -setcookie, matching the node~n",
+              []).
 
 continue(Opts, TargetNode) ->
     ok = connect_node(TargetNode),
@@ -81,6 +92,8 @@ tmp_outfile() ->
     {MS,S,US} = os:timestamp(),
     lists:flatten(io_lib:fwrite("block_whitelist-~w-~w-~w.json", [MS,S,US])).
 
+check_args([]) ->
+    error(help_needed);
 check_args(Args) ->
     check_args(Args, defaults()).
 

--- a/apps/aeutils/priv/create_whitelist
+++ b/apps/aeutils/priv/create_whitelist
@@ -1,0 +1,152 @@
+#!/usr/bin/env escript
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
+
+-mode(compile).
+
+
+main(Args) ->
+    Res = try begin
+                  {RestArgs, TargetNode} = process_node_args(Args, [], undefined),
+                  Opts = check_args(RestArgs),
+                  continue(Opts, TargetNode)
+              end
+          catch
+              error:_ ->
+                  io:fwrite("Exiting~n", []),
+                  1
+          end,
+    init:stop(Res).
+
+continue(Opts, TargetNode) ->
+    ok = connect_node(TargetNode),
+    CallF = fun(M,F,A) -> rpc:call(TargetNode, M, F, A) end,
+    Hashes = fetch_whitelist_hashes(Opts, CallF),
+    load_jsx(CallF),
+    JSON = jsx:prettify(jsx:encode(maps:from_list(Hashes))),
+    write_to_file(maps:get(outfile, Opts), JSON),
+    0.
+
+fetch_whitelist_hashes(#{start := Start, n := N, step := Step}, CallF) ->
+    TopHeight = get_top_height(CallF),
+    case TopHeight - Start of
+        Low when Low =< 0 ->
+            io:fwrite("Start height too low~n", []),
+            error(start_value_too_low);
+        StartHeight ->
+            fetch_whitelist_hashes(N, StartHeight, Step, CallF, [])
+    end.
+
+fetch_whitelist_hashes(N, Height, Step, CallF, Acc) when N > 0, Height > 0 ->
+    case get_hash_at_height(Height, CallF) of
+        {ok, Hash} ->
+            Enc = CallF(aeser_api_encoder, encode, [key_block_hash, Hash]),
+            fetch_whitelist_hashes(N-1, Height - Step, Step, CallF, [{Height, Enc}|Acc]);
+        error ->
+            Acc
+    end;
+fetch_whitelist_hashes(_, _, _, _, Acc) ->
+    Acc.
+
+get_top_height(CallF) ->
+    TopHeader = CallF(aec_chain, top_header, []),
+    CallF(aec_headers, height, [TopHeader]).
+
+get_hash_at_height(Height, CallF) ->
+    CallF(aec_chain_state, get_key_block_hash_at_height, [Height]).
+
+load_jsx(CallF) ->
+    LibDir = CallF(code, lib_dir, [jsx]),
+    code:add_path(filename:join(LibDir, "ebin")).
+
+write_to_file(F, String) ->
+    io:fwrite("Writing to file: ~s~n", [F]),
+    case file:open(F, [write]) of
+        {ok, Fd} ->
+            try io:fwrite(Fd, "~s~n", [String])
+            after
+                file:close(Fd)
+            end;
+        {error, Reason} ->
+            io:fwrite("Couldn't open file ~s: ~p~n", [F, Reason]),
+            error({output, Reason})
+    end.
+
+defaults() ->
+    #{ start => 100
+     , step  => 1
+     , n     => 1000
+     , outfile => tmp_outfile() }.
+
+tmp_outfile() ->
+    {MS,S,US} = os:timestamp(),
+    lists:flatten(io_lib:fwrite("block_whitelist-~w-~w-~w.json", [MS,S,US])).
+
+check_args(Args) ->
+    check_args(Args, defaults()).
+
+check_args([], O) ->
+    O;
+check_args(["-start", Start | Args], O) ->
+    StartN = to_integer(Start, "-start"),
+    check_args(Args, O#{start => StartN});
+check_args(["-n", NStr | Args], O) ->
+    N = to_integer(NStr, "-n"),
+    check_args(Args, O#{n => N});
+check_args(["-step", NStr | Args], O) ->
+    N = to_integer(NStr, "-step"),
+    check_args(Args, O#{step => N});
+check_args(["-o", OutFile | Args], O) ->
+    check_args(Args, O#{outfile => OutFile});
+check_args(Args, _) ->
+    io:fwrite("Unknown arguments: ~p~n", [Args]),
+    error({unknown_arguments, Args}).
+
+to_integer(Str, Arg) ->            
+    try list_to_integer(Str)
+    catch
+        error:_ ->
+            io:fwrite("Not an integer: ~s~n", [Arg]),
+            error({invalid_arg, Arg})
+    end.
+
+process_node_args([], Acc, TargetNode) ->
+    {lists:reverse(Acc), TargetNode};
+process_node_args(["-setcookie", Cookie | Rest], Acc, TargetNode) ->
+    erlang:set_cookie(node(), list_to_atom(Cookie)),
+    process_node_args(Rest, Acc, TargetNode);
+process_node_args(["-name", TargetName | Rest], Acc, _) ->
+    ThisNode = append_node_suffix(TargetName, "_util_"),
+    {ok, _} = net_kernel:start([ThisNode, longnames]),
+    process_node_args(Rest, Acc, nodename(TargetName));
+process_node_args(["-sname", TargetName | Rest], Acc, _) ->
+    ThisNode = append_node_suffix(TargetName, "_util_"),
+    {ok, _} = net_kernel:start([ThisNode, shortnames]),
+    process_node_args(Rest, Acc, nodename(TargetName));
+process_node_args([Arg | Rest], Acc, Opts) ->
+    process_node_args(Rest, [Arg | Acc], Opts).
+
+append_node_suffix(Name, Suffix) ->
+    case re:split(Name, "@", [{return, list}, unicode]) of
+        [Node, Host] ->
+            list_to_atom(lists:concat([Node, Suffix, os:getpid(), "@", Host]));
+        [Node] ->
+            list_to_atom(lists:concat([Node, Suffix, os:getpid()]))
+    end.
+
+nodename(Name) ->
+    case re:split(Name, "@", [{return, list}, unicode]) of
+        [_Node, _Host] ->
+            list_to_atom(Name);
+        [Node] ->
+            [_, Host] = re:split(atom_to_list(node()), "@", [{return, list}, unicode]),
+            list_to_atom(lists:concat([Node, "@", Host]))
+    end.
+
+connect_node(TargetNode) ->
+    case {net_kernel:hidden_connect_node(TargetNode), net_adm:ping(TargetNode)} of
+        {true, pong} ->
+            ok;
+        {_, pang} ->
+            io:fwrite("Cannot connect to ~p~n", [TargetNode]),
+            error
+    end.

--- a/apps/aeutils/priv/extensions/create_whitelist.cmd
+++ b/apps/aeutils/priv/extensions/create_whitelist.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+:: Wrapper to run create_whitelist
+
+set "PATH=%BINDIR%;%PATH%"
+set "ERL_LIBS=%ROOTDIR%\lib"
+set "APPS_VSN=%REL_VSN%"
+
+"%ERTS_DIR%\bin\escript" "%ROOTDIR%\lib\aeutils-%APPS_VSN%\priv\create_whitelist" "%NAME_TYPE%" "%NAME%" -setcookie "%COOKIE%" %*

--- a/apps/aeutils/priv/extensions/create_whitelist.sh
+++ b/apps/aeutils/priv/extensions/create_whitelist.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Wrapper to run create_whitelist
+
+PATH=$BINDIR:$PATH
+export ERL_LIBS=$ROOTDIR/lib
+APPS_VSN=${REL_VSN:?}
+
+relx_escript "lib/aeutils-${APPS_VSN:?}/priv/create_whitelist" "$NAME_TYPE" "$NAME" -setcookie "$COOKIE" $*
+
+exit $?

--- a/rebar.config
+++ b/rebar.config
@@ -167,6 +167,7 @@
                    {copy, "apps/aeutils/priv/extensions/keys_gen.sh", "bin/extensions/keys_gen"},
                    {copy, "apps/aeutils/priv/extensions/get_peer_key.sh", "bin/extensions/peer_key"},
                    {copy, "apps/aeutils/priv/extensions/export_chain.sh", "bin/extensions/export_chain"},
+                   {copy, "apps/aeutils/priv/extensions/create_whitelist.sh", "bin/extensions/create_whitelist"},
                    {copy, "apps/aeutils/priv/extensions/messages_hash.sh", "bin/extensions/messages_hash"}
                   ]},
 
@@ -179,6 +180,7 @@
               {keys_gen, "extensions/keys_gen"},
               {peer_key, "extensions/peer_key"},
               {export, "extensions/export_chain"},
+              {create_whitelist, "extensions/create_whitelist"},
               {messages_hash, "extensions/messages_hash"}
         ]}]
 }.


### PR DESCRIPTION
See issue #3467

The script is designed so that it can be run separately, e.g. by simply downloading the `aeutils/priv/create_whitelist` file and calling it as a normal escript. In this case, connect parameters must be explicitly provided.

Example:

```
~/test$ escript ~/ae/3/aeternity/apps/aeutils/priv/create_whitelist -sname aeternity@localhost -setcookie aeternity_cookie -start 100 -n 10 -step 10 -o mywhitelist.json
Writing to file: mywhitelist.json

~/test$ cat mywhitelist.json 
{
  "48278": "kh_2mUakNK4UuFHsgBFkVTUQu7h1pAeDFwMh5DzzbPwAAnJ6SrnjK",
  "48288": "kh_wPNz6CHSgnPSP6mMPhDuidSCrcuRSAPkQQwdYAeQzC4h5GLao",
  "48298": "kh_D6cRdye4Ffvmze26Dgq1bVtdnRbcHmbjLsFY3FqTsLgbhMDvj",
  "48308": "kh_27G4Jsejy2CqBvZvuCbprJah8eyncLJ6Q3eqkxe6KvpUqEKAzW",
  "48318": "kh_2nDQ4VT7YGXT3ktvdVV4w1cHNF6Rqe642xyALbTzzubHyAHSQm",
  "48328": "kh_2uEqQq4N8He966t4uoMWe4VxtgwKSU8ZW9NC3AHpQ6y3SkVrFa",
  "48338": "kh_2sXTdrKnLQCAdpUzeYoXczNDNvkjzdhUhhzfHVzTyiLFxAygKj",
  "48348": "kh_8QFcgn3yC25sFtikbJqXbXNe9P4ww8ELMXs6MwTRobugPEbkR",
  "48358": "kh_28wxVJzXyCXJUJdayHTwtUtyGytRSw8zeCRjRHexj3bnXde4MC",
  "48368": "kh_2UhGTzeNiiz5VLkzEXmL5QxjMBJUgBkKsp24tjZLEVFkbUXWo5"
}
```

The script currently doesn't provide a help text. The idea is:
* Start `<start>` blocks below the current top
* Collect `<n>` hashes from, and including, the `<start>` height, `<step>` steps apart
* Convert to JSON and write to the filename provided with `-o`. Default is a temporary file in the current directory

In order to prevent against long-range attacks, the whitelist should go at least 1000 or so blocks deep. The whitelisted blocks shouldn't be too far apart, since an attacker with enormous hash power could bump the difficulty with relatively few blocks (esp. if the current chain has very low hash power).

If this script is called periodically from a wrapper script that also exports a config variable, `AE__SYNC__WHITELIST_FILE` to the generated file, it could provide a short-term protection against fork injection attacks. PR #3486 should give stronger protection once merged.

The work on this PR is supported by the Aeternity Crypto Foundation.