### PR TITLE
Fix swagger versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ REVISION:
 	@git rev-parse HEAD > $@ || echo "unknown" > $@
 
 VERSION:
-	@git describe --tags | sed -E "s/^v(.*)\-([0-9]+)\-g([a-f0-9]+)$$/v\1+\2.\3/" > $@
+	@git describe --tags | sed -E "s/^v([0-9]+)\.([0-9]+)\.([[0-9]+)$$/\1.\2.\3/" > $@
 
 eunit-%: KIND=test
 eunit-%: internal-build

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ REVISION:
 	@git rev-parse HEAD > $@ || echo "unknown" > $@
 
 VERSION:
-	@git describe --tags | sed -E "s/^v([0-9]+)\.([0-9]+)\.([[0-9]+)$$/\1.\2.\3/" > $@
+	@git describe --tags | sed -E "s/^v([0-9]+)\.([0-9]+)\.([[0-9]+)(-.*)?$$/\1.\2.\3/" > $@
 
 eunit-%: KIND=test
 eunit-%: internal-build


### PR DESCRIPTION
It looks like the `sed` command was broken, resulting in `VERSION` file being `v5.7.0` instead of expected `5.7.0` which broke the semver.

The work on this PR is supported by Aeternity Crypto Foundation.