### PR TITLE
[RUN TESTS ONLY] Updated swagger_endpoints with swagger:2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,13 @@ references:
     restore_cache:
       key: *build_nix_cache_key
 
-  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v11-{{ .Branch }}-{{ .Revision }}
+  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v12-{{ .Branch }}-{{ .Revision }}
   restore_machine_build_cache: &restore_machine_build_cache
     restore_cache:
       keys:
         - *machine_build_cache_key
-        - machine-build-cache-v11-{{ .Branch }}-
-        - machine-build-cache-v11-
+        - machine-build-cache-v12-{{ .Branch }}-
+        - machine-build-cache-v12-
 
   save_machine_build_cache: &save_machine_build_cache
     save_cache:

--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -185,10 +185,20 @@ prepare_param_({"type", "integer"}, Value, Name, _) ->
     end;
 prepare_param_({"type", "string"}, _, _, _) -> ok;
 % schema
-prepare_param_({"schema", #{<<"$ref">> := <<"/definitions/", Ref/binary>>}},
+prepare_param_({"schema", #{<<"$ref">> := FullRef}},
                Value, Name, Validator) ->
     try
-        Schema = #{<<"$ref">> => <<"#/definitions/", Ref/binary>>},
+        Prefix = list_to_binary(endpoints:definitions_prefix()),
+        Ref =
+            case endpoints:definitions_prefix() of
+                "/definitions/" ->
+                    <<"/definitions/", Ref0/binary>> = FullRef,
+                    Ref0;
+                "/components/schemas/" ->
+                    <<"/components/schemas/", Ref0/binary>> = FullRef,
+                    Ref0
+            end,
+        Schema = #{<<"$ref">> => <<"#", Prefix/binary, Ref/binary>>},
         jesse_schema_validator:validate_with_state(Schema, Value, Validator),
         {ok, Value, Ref}
     catch

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -403,7 +403,6 @@ handle_request_('GetPeers', _Req, _Context) ->
     InboundPeers = aehttp_logic:connected_peers(inbound),
     OutboundPeers = aehttp_logic:connected_peers(outbound),
     Blocked = aehttp_logic:blocked_peers(),
-
     {200, [], #{peers => lists:map(fun aec_peers:encode_peer_address/1, Peers),
                 inbound => lists:map(fun aec_peers:encode_peer_address/1, InboundPeers),
                 outbound => lists:map(fun aec_peers:encode_peer_address/1, OutboundPeers),

--- a/apps/aehttp/test/aehttp_discriminator_SUITE.erl
+++ b/apps/aehttp/test/aehttp_discriminator_SUITE.erl
@@ -81,13 +81,15 @@ groups() ->
 
 %% Swagger discriminator must be definition. See https://github.com/OAI/OpenAPI-Specification/blob/04f659aeffd3082de70212189477def845c68aa6/versions/2.0.md#composition-and-inheritance-polymorphism
 is_definition(X) when is_list(X) ->
+    Prefix = endpoints:definitions_prefix(),
+    Len = length(Prefix),
     case
         lists:filter(
           fun
-              ({"/definitions/" ++ D, _}) when D =:= X ->
-                  true;
-              ({K, _}) when is_list(K) ->
-                  false
+              ({Def, _}) ->
+                  Prefix1 = string:substr(Def, 1, Len),
+                  D = string:substr(Def, Len + 1),
+                  Prefix =:= Prefix1 andalso D =:= X
           end,
           endpoints:definitions())
     of

--- a/apps/aeutils/test/endpoints_tests.erl
+++ b/apps/aeutils/test/endpoints_tests.erl
@@ -8,7 +8,8 @@ operation_method_test() ->
    ?assertEqual([get], maps:keys(endpoints:operation('GetTopBlock'))).
 
 path_without_test() ->
-   ?assertEqual(<<"/v2/blocks/top">>, endpoints:path(get, 'GetTopBlock', #{})).
+   ?assertEqual(<<"/v2/blocks/top">>, endpoints:path(get, 'GetTopBlock', #{})),
+   ?assertEqual(<<"/v2/debug/peers">>, endpoints:path(get, 'GetPeers', #{})).
 
 path_with_params_test() ->
    ?assertEqual(<<"/v2/key-blocks/height/3">>,

--- a/rebar.config
+++ b/rebar.config
@@ -108,7 +108,7 @@
        ]}.
 
 {plugins, [
-        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "d5a9f07"}}},
+        {swagger_endpoints, {git, "https://github.com/velzevur/swagger_endpoints", {ref, "6022a10"}}},
         {aesophia_rebar_plugin, {git, "https://github.com/aeternity/aesophia_rebar_plugin", {ref, "df113cc"}}}
     ]}.
 


### PR DESCRIPTION
This PR is meant to publicly run all tests using the new implementation of
`swagger_endpoints` provided by PR aeternity/swagger_endpoints#9.

**THIS IS NOT TO BE MERGED**

The work on this PR is supported by ACF.
