### PR TITLE
Release 5.8.0

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -12,7 +12,7 @@
 -define(KEY_HEADER_MIN_BYTES, 364).
 -define(MIC_HEADER_MIN_BYTES, 216).
 
--define(KEY_HEADER_INFO_LIMA_POINT_RELEASE, 571).
+-define(KEY_HEADER_INFO_LIMA_POINT_RELEASE, 580).
 
 -type(txs_hash() :: <<_:(?TXS_HASH_BYTES*8)>>).
 -type(state_hash() :: <<_:(?STATE_HASH_BYTES*8)>>).

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -40,10 +40,10 @@ mine_block_test_() ->
                  %% let_it_crash = generate_valid_test_data(TopBlock, 100000000000000),
                  Nonce = case aec_hard_forks:protocol_effective_at_height(Height + 1) of
                              ?ROMA_PROTOCOL_VSN    -> 1157794539819639234;
-                             ?MINERVA_PROTOCOL_VSN -> 9186874827433957562;
-                             ?FORTUNA_PROTOCOL_VSN -> 7910161413761453387;
+                             ?MINERVA_PROTOCOL_VSN -> 14355842201894252133;
+                             ?FORTUNA_PROTOCOL_VSN -> 7559967028720457330;
                              ?LIMA_PROTOCOL_VSN    -> 12722243844980722948;
-                             ?IRIS_PROTOCOL_VSN    -> 15238840292283480031 
+                             ?IRIS_PROTOCOL_VSN    -> 16960305589119113986
                          end,
                  {BlockCandidate,_} = aec_test_utils:create_keyblock_with_state(
                                         [{TopBlock, aec_trees:new()}], ?TEST_PUB),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -43,7 +43,7 @@ mine_block_test_() ->
                              ?MINERVA_PROTOCOL_VSN -> 14355842201894252133;
                              ?FORTUNA_PROTOCOL_VSN -> 7559967028720457330;
                              ?LIMA_PROTOCOL_VSN    -> 12722243844980722948;
-                             ?IRIS_PROTOCOL_VSN    -> 16960305589119113986
+                             ?IRIS_PROTOCOL_VSN    -> 6213455596009988662 
                          end,
                  {BlockCandidate,_} = aec_test_utils:create_keyblock_with_state(
                                         [{TopBlock, aec_trees:new()}], ?TEST_PUB),

--- a/docs/release-notes/RELEASE-NOTES-5.8.0.md
+++ b/docs/release-notes/RELEASE-NOTES-5.8.0.md
@@ -1,0 +1,20 @@
+# About this release
+
+[This](https://github.com/aeternity/aeternity/releases/tag/v5.8.0) is a maintenance Lima release.
+
+It:
+* Provides a finalized height of the blockchain. This further improves fork
+  resistance. The old approach had a flaw that a node was susceptible to
+  following a wrong fork when starting from an existing DB. This change fixes
+  it with following the desired fork instead.
+
+Please join the **mainnet** by following the instructions in the documentation below,
+and let us know if you have any problems by [opening a ticket](https://github.com/aeternity/aeternity/issues).
+Troubleshooting of common issues is documented [in the wiki](https://github.com/aeternity/aeternity/wiki/Troubleshooting).
+
+## Documentation
+
+For an overview of the installation process for different platforms,
+building the package from source, configuration and operation of the Aeternity
+node please refer to [Aeternity node documentation](https://docs.aeternity.io/).
+


### PR DESCRIPTION
Prepares a release `5.8.0` that is to provide finalized fork height.

The work on this PR is being supported by ACF.
