### PR TITLE
Add docs on finalized_depth

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -603,11 +603,17 @@ assert_height_delta(sync, Height, TopHeight) ->
         {yes, Delta} ->
             Height >= (TopHeight - Delta);
         no ->
-            case aec_db:dirty_get_finalized_height() of
-                undefined ->
-                    true;
-                FHeight ->
-                    Height > FHeight
+            case aec_resilience:fork_resistance_configured() of
+                {yes, _} ->
+                    case aec_db:dirty_get_finalized_height() of
+                        undefined ->
+                            true;
+                        FHeight ->
+                            Height > FHeight
+                    end;
+                no ->
+                    %% Don't enforce finalized_height if FR not configured
+                    true
             end
     end;
 assert_height_delta(undefined, Height, TopHeight) ->

--- a/apps/aecore/src/aec_resilience.erl
+++ b/apps/aecore/src/aec_resilience.erl
@@ -115,6 +115,7 @@ maybe_enable_fork_resistance() ->
     maybe_enable_fork_resistance(read_and_cache_config()).
 
 maybe_enable_fork_resistance(Config) ->
+    lager:debug("Config = ~p", [Config]),
     Res = case Config of
               {yes, Height} when Height > 0 ->
                   lager:debug("Activating fork resistance for Height = ~p", [Height]),
@@ -129,8 +130,8 @@ maybe_enable_fork_resistance(Config) ->
 read_and_cache_config() ->
     Res = case aeu_env:find_config([<<"sync">>, <<"sync_allowed_height_from_top">>],
                                    [ user_config, schema_default ]) of
-              {yes, Height} = Ok when Height > 0 ->
-                  Ok;
+              {ok, Height} when Height > 0 ->
+                  {yes, Height};
               _ ->
                   no
           end,

--- a/apps/aecore/src/aec_resilience.erl
+++ b/apps/aecore/src/aec_resilience.erl
@@ -1,11 +1,27 @@
 -module(aec_resilience).
 -behaviour(gen_server).
 
-%%% This module implements
+%%% This module implements caching and monitoring of conditions for
+%%% enabling fork resistance.
+%%%
+%%% Workings of fork resistance:
+%%% * if config sync: sync_allowed_height_from_top is set to a value > 0,
+%%%   fork resistance will kick in as soon as our node has synced with a peer
+%%% * The aec_chain_state module persist a finalized_height, which trails the
+%%%   fork resistance depth. It checks whether fork_resistance_configured(),
+%%%   to determine whether to apply finalized_height checking. This means that if
+%%%   the fork resistance config changes to 0 (disabled), the finalized height will
+%%%   not be enforced even if present in the database.
+%%% * If the config sync: resist_forks_from_start = true, then fork resistance will
+%%%   be activated immediately. This is unlikely to ever be of use, and should
+%%%   perhaps be removed. It was introduced before the finalized_depth feature.
+%%% * The aec_resilience server subscribes to config changes, and will adapt to
+%%%   changes in the sync_allowed_height_from_top setting directly.
 
 -export([ start_link/0 ]).
 
 -export([ fork_resistance_active/0
+        , fork_resistance_configured/0
         ]).
 
 -export([ init/1
@@ -22,12 +38,18 @@
 
 -type height() :: non_neg_integer().
 -type fork_resistance() :: {yes, height()} | no.
--type mode() :: manual | auto.
 
+%% This function checks whether fork resistance is configured AND activated,
+%%
 -spec fork_resistance_active() -> fork_resistance().
 fork_resistance_active() ->
-    {Res, _} = get_fork_resistance(),
-    Res.
+    get_fork_resistance().
+
+%% This function returns 'no' if the config is Height = 0
+%%
+-spec fork_resistance_configured() -> fork_resistance().
+fork_resistance_configured() ->
+    get_cached_config().
 
 start_link() ->
     ensure_tab(),   % ets table will survive process restart
@@ -36,6 +58,7 @@ start_link() ->
 init([]) ->
     aec_events:subscribe(chain_sync),
     aec_events:subscribe(update_config),
+    _ = read_and_cache_config(),                % initialize cached value
     maybe_enable_fork_resistance_at_startup(),
     {ok, #st{}}.
 
@@ -74,12 +97,13 @@ code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
 
 maybe_enable_fork_resistance_at_startup() ->
+    Config = read_and_cache_config(),
     case lookup(fork_resistance, undefined) of
         undefined ->
             case aeu_env:find_config([<<"sync">>, <<"resist_forks_from_start">>],
                                      [ user_config, schema_default ]) of
                 {ok, true} ->
-                    maybe_enable_fork_resistance();
+                    maybe_enable_fork_resistance(Config);
                 _ ->
                     ok
             end;
@@ -88,28 +112,47 @@ maybe_enable_fork_resistance_at_startup() ->
     end.
 
 maybe_enable_fork_resistance() ->
-    case get_fork_resistance() of
-        {_, manual} -> ok;
-        _ ->
-            Res = case aeu_env:find_config([<<"sync">>, <<"sync_allowed_height_from_top">>],
-                                           [ user_config, schema_default ]) of
-                      {ok, Height} when Height > 0 ->
-                          lager:debug("Activating fork resistance for Height = ~p", [Height]),
-                          ensure_finalized_height(Height),
-                          {yes, Height};
-                      _ ->
-                          lager:debug("No fork resistance", []),
-                          no
-                  end,
-            set_fork_resistance({Res, auto})
-    end.
+    maybe_enable_fork_resistance(read_and_cache_config()).
 
--spec get_fork_resistance() -> {fork_resistance(), mode()}.
+maybe_enable_fork_resistance(Config) ->
+    Res = case Config of
+              {yes, Height} when Height > 0 ->
+                  lager:debug("Activating fork resistance for Height = ~p", [Height]),
+                  ensure_finalized_height(Height),
+                  {yes, Height};
+              no ->
+                  lager:debug("No fork resistance", []),
+                  no
+          end,
+    set_fork_resistance(Res).
+
+read_and_cache_config() ->
+    Res = case aeu_env:find_config([<<"sync">>, <<"sync_allowed_height_from_top">>],
+                                   [ user_config, schema_default ]) of
+              {yes, Height} = Ok when Height > 0 ->
+                  Ok;
+              _ ->
+                  no
+          end,
+    set_cached_config(Res),
+    Res.
+
+
+set_cached_config(Value) ->
+    ets:insert(?TAB, {cached_config_key(), Value}).
+
+get_cached_config() ->
+    lookup(cached_config_key(), no).
+
+cached_config_key() ->
+    sync_allowed_height_config.
+
+-spec get_fork_resistance() -> fork_resistance().
 get_fork_resistance() ->
-    lookup(fork_resistance, {no, auto}).
+    lookup(fork_resistance, no).
 
--spec set_fork_resistance({fork_resistance(), mode()}) -> true.
-set_fork_resistance({_, _} = Value) ->
+-spec set_fork_resistance(fork_resistance()) -> true.
+set_fork_resistance(Value) ->
     ets:insert(?TAB, {fork_resistance, Value}).
 
 -spec note_chain_sync_done(boolean()) -> true.

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -167,6 +167,7 @@ mock_genesis_and_forks(PresetAccounts, Whitelist) ->
     meck:expect(aec_fork_block_settings, block_whitelist, 0, Whitelist),
     meck:new(aec_resilience, [passthrough]),
     meck:expect(aec_resilience, fork_resistance_active, 0, no),
+    meck:expect(aec_resilience, fork_resistance_configured, 0, no),
     aec_consensus:set_consensus(),
     aec_consensus:set_genesis_hash(),
     ok.

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -174,14 +174,19 @@ add_dev3_node(Config) ->
 
 dev3_failed_attack(Config) ->
     [N1, N2, N3] = [aecore_suite_utils:node_name(D) || D <- [dev1, dev2, dev3]],
+    %%
+    %% Start node N3 (dev3), mine a malicious fork, then stop the node
+    %%
     aecore_suite_utils:start_node(dev3, Config),
     aecore_suite_utils:connect(N3),
-    %% Mine a fork on dev3
+    %% Mine a fork on N3
     {ok, BlocksN3} = mine_key_blocks(N3, 20),
     N3Top = lists:last(BlocksN3),
     ct:log("top of fork dev3 (N3Top): ~p", [ N3Top ]),
     ok = stop_and_check([dev3], Config),
-    %% restart dev1, dev2, sync, mine some and set fork resilience
+    %%
+    %% restart N1 (dev1), N2 (dev2), sync, mine some blocks and set fork resilience
+    %%
     T2 = os:timestamp(),
     aecore_suite_utils:start_node(dev1, Config),
     aecore_suite_utils:connect(N1),
@@ -190,6 +195,7 @@ dev3_failed_attack(Config) ->
     done = aecore_suite_utils:await_sync_complete(T2, [N1, N2]),
     {ok, BlocksN1N2} = mine_key_blocks(N1, 10),  %% fewer than N3
     NewTop = rpc:call(N1, aec_chain, top_block, [], 5000),
+    NewTopHeight = aec_blocks:height(NewTop),
     ct:log("top of fork dev1 (NewTop): ~p", [ NewTop ]),
     aec_test_utils:wait_for_it(
       fun() -> rpc:call(N2, aec_chain, top_block, [], 5000) end,
@@ -197,18 +203,46 @@ dev3_failed_attack(Config) ->
     SetCfg = #{<<"sync">> => #{<<"sync_allowed_height_from_top">> => 5}},
     NewTop = lists:last(BlocksN1N2),
     [ok = rpc:call(N, aeu_env, update_config, [SetCfg]) || N <- [N1, N2]],
+    FHeight = NewTopHeight - 5 - 1,
+    aec_test_utils:wait_for_it(
+      fun() -> rpc:call(N1, aec_db, get_finalized_height, [], 5000) end,
+      FHeight),
+    aec_test_utils:wait_for_it(
+      fun() -> rpc:call(N2, aec_db, get_finalized_height, [], 5000) end,
+      FHeight),
+    ct:log("finalized height (~p) set on N1 and N2", [FHeight]),
+    %%
+    %% Now, stop dev2 before trying to sync N3 against N1.
+    %% What should happen is that N1 rejects N3's fork, despite its greater
+    %% difficulty. This rejection should be based on the
+    %% `sync_allow_height_from_top` setting, as N1 is up and running.
+    %%
+    ok = stop_and_check([dev2], Config),
     T3 = os:timestamp(),
     aecore_suite_utils:start_node(dev3, Config),
     aecore_suite_utils:connect(N3),
-    [{N1,true,Ts1}, {N2,true,Ts2}] = aecore_suite_utils:await_is_syncing(T3, [N1, N2]),
-    ct:log("Sync started on dev1 and dev2", []),
+    [{N1,true,Ts1}] = aecore_suite_utils:await_is_syncing(T3, [N1]),
+    ct:log("Sync started on dev1", []),
     [{N1,false,_}] = aecore_suite_utils:await_is_syncing(Ts1, [N1]),
-    [{N2,false,_}] = aecore_suite_utils:await_is_syncing(Ts2, [N2]),
-    ct:log("Sync stopped on dev1 and dev2", []),
-    %% Ensure that dev1 and dev2 still have the same top.
+    %% [{N2,false,_}] = aecore_suite_utils:await_is_syncing(Ts2, [N2]),
+    ct:log("Sync stopped on dev1", []),
+    %% Ensure that dev1 still has the same top.
     NewTop = rpc:call(N1, aec_chain, top_block, [], 5000),
-    NewTop = rpc:call(N2, aec_chain, top_block, [], 5000),
+    %% NewTop = rpc:call(N2, aec_chain, top_block, [], 5000),
     false = (N3Top == NewTop),
+    %%
+    %% Now, start dev2. This checks that N3 can be resisted even by a restarting
+    %% node. This rejection is based on the persisted finalized_depth
+    %%
+    T4 = os:timestamp(),
+    aecore_suite_utils:start_node(dev2, Config),
+    aecore_suite_utils:connect(N2),
+    [{N2,true,Ts2}] = aecore_suite_utils:await_is_syncing(T4, [N2]),
+    ct:log("Sync started on dev2", []),
+    [{N2,false,_}] = aecore_suite_utils:await_is_syncing(Ts2, [N2]),
+    ct:log("Sync stopped on dev2", []),
+    NewTop = rpc:call(N2, aec_chain, top_block, [], 5000),
+    ct:log("dev2 synced against N1 - not N3", []),
     ok = stop_and_check([dev1, dev2, dev3], Config).
 
 

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -20,7 +20,8 @@
          set_env/4,
          unset_env/3]).
 
--export([start_node/2,
+-export([start_node/2,  % (N, Config)
+         start_node/3,  % (N, Config, ExtraEnv :: [{OSEnvVarName, Value}])
          stop_node/2,
          reinit_with_bitcoin_ng/1,
          reinit_with_ct_consensus/1,
@@ -238,16 +239,25 @@ make_shortcut(Config) ->
     ok = symlink(PrivDir, Shortcut).
 
 start_node(N, Config) ->
+    start_node(N, Config, []).
+
+start_node(N, Config, ExtraEnv) ->
     MyDir = filename:dirname(code:which(?MODULE)),
     ConfigFilename = proplists:get_value(config_name, Config, "default"),
     Flags = ["-pa ", MyDir, " -config ./" ++ ConfigFilename],
-    cmd(?OPS_BIN, node_shortcut(N, Config), "bin", ["start"],
-        [
-         {"ERL_FLAGS", Flags},
-         {"AETERNITY_CONFIG", "data/aeternity.json"},
-         {"RUNNER_LOG_DIR","log"},
-         {"CODE_LOADING_MODE", "interactive"}
-        ]).
+    Env0 = [
+            {"ERL_FLAGS", Flags},
+            {"AETERNITY_CONFIG", "data/aeternity.json"},
+            {"RUNNER_LOG_DIR","log"},
+            {"CODE_LOADING_MODE", "interactive"}
+           ],
+    Env = maybe_override(ExtraEnv, Env0),
+    cmd(?OPS_BIN, node_shortcut(N, Config), "bin", ["start"], Env).
+
+maybe_override([{K,_} = H|T], L0) ->
+    [H | maybe_override(T, lists:keydelete(K, 1, L0))];
+maybe_override([], L0) ->
+    L0.
 
 stop_node(N, _Config) ->
     ct:log("Stopping node ~p", [N]),

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,4 +15,5 @@ There is also additional documentation on mining with CUDA and build and/or join
 - [CUDA Miner](cuda-miner.md)
 - [Stratum](stratum.md)
 - [Network Monitoring](monitoring.md)
+- [Fork Resistance](fork-resistance.md)
 - [Node API](api.md)

--- a/docs/fork-resistance.md
+++ b/docs/fork-resistance.md
@@ -54,6 +54,20 @@ AE__resist__forks__from__start=true bin/aeternity start
 ```
 (see [the configuration documentation](configuration.md#configuration-from-the-command-line-or-scripts))
 
+### Finalized depth
+
+When sync fork resistance (`sync: sync_allowed_height_from_top`) is active, the node
+will persist the height just below the fork resistance depth as `finalized_height`.
+If the node should restart and starts syncing with other nodes (recall that the dynamic
+fork resistance is not activated until the node has successfully synced with one peer),
+it will reject any chain that presents a key block hash at the finalized height which 
+differs from what the node already has on record.
+
+This shores up the dynamic protection offered by `sync_allowed_height_from_top` to also defend
+against malicious nodes during node restarts. The function is automatic, once fork resistance
+has been configured. If fork resistance is later turned off, finalized height will not be
+enforced.
+
 ### Discussion
 
 When choosing a suitable fork resistance depth, it is important to consider some tradeoffs.
@@ -76,3 +90,11 @@ Network latency and network failures may increase the frequency and length of na
 competing forks, and setting the fork resistance too low might increase the risk of
 chain splits, where different nodes end up on different forks and cannot resolve the
 situation without manual intervention.
+
+From a user experience perspective, fork resistance sets an upper bound on the confirmation
+time needed to secure high-value transactions, since there is no need to wait longer than
+the configured fork resistance depth. Once the generation that contains a transaction is
+at or below the finalized depth, the transaction _cannot_ be evicted, either accidentally
+or through a malicious attack. Using the default setting of `100`, this would mean that
+a block confirmation time of 100 key blocks (5 hours) will be sufficient to protect any transaction
+amount.

--- a/docs/fork-resistance.md
+++ b/docs/fork-resistance.md
@@ -50,7 +50,7 @@ environment variables. This means that it's possible to instruct the node to res
 forks at a given node start in the following way:
 
 ```
-AE__resist__forks__from__start=true bin/aeternity start
+AE__SYNC__RESIST_FORKS_FROM_START=true bin/aeternity start
 ```
 (see [the configuration documentation](configuration.md#configuration-from-the-command-line-or-scripts))
 


### PR DESCRIPTION
As `finalized_depth` (PR #3486) was officially released in `5.8.0`, it should also be documented.