### PR TITLE
Introduce the infrastructure for OAS3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,13 @@ references:
     restore_cache:
       key: *build_nix_cache_key
 
-  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v11-{{ .Branch }}-{{ .Revision }}
+  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v12-{{ .Branch }}-{{ .Revision }}
   restore_machine_build_cache: &restore_machine_build_cache
     restore_cache:
       keys:
         - *machine_build_cache_key
-        - machine-build-cache-v11-{{ .Branch }}-
-        - machine-build-cache-v11-
+        - machine-build-cache-v12-{{ .Branch }}-
+        - machine-build-cache-v12-
 
   save_machine_build_cache: &save_machine_build_cache
     save_cache:

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,4 +27,5 @@ apps/aefate/aefateasm
 apps/aefate/aefateasm.cmd
 apps/aefate/src/aefa_fate_eval.erl
 apps/aeutils/src/endpoints.erl
+apps/aeutils/src/oas_endpoints.erl
 otp_patches/*.erl

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ apps/aefate/aefateasm
 apps/aefate/aefateasm.cmd
 apps/aefate/src/aefa_fate_eval.erl
 apps/aeutils/src/endpoints.erl
+apps/aeutils/src/oas_endpoints.erl
 otp_patches/*.erl
 *.erl~
 *.aes~

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -1267,23 +1267,21 @@ use_swagger(SpecVsn) ->
         end,
     put(api_prefix, Prefix).
 
+get(Key, Default) ->
+    case get(Key) of
+        undefined -> Default;
+        V -> V
+    end.
+
 http_request(Host, get, Path, Params) ->
-    Prefix =
-        case get(api_prefix) of
-            undefined -> "/v2/";
-            V -> V
-        end,
+    Prefix = get(api_prefix, "/v2/"),
     URL = binary_to_list(
             iolist_to_binary([Host, Prefix, Path, encode_get_params(Params)])),
     ct:log("GET ~p", [URL]),
     R = httpc_request(get, {URL, []}, [], []),
     process_http_return(R);
 http_request(Host, post, Path, Params) ->
-    Prefix =
-        case get(api_prefix) of
-            undefined -> "/v2/";
-            V -> V
-        end,
+    Prefix = get(api_prefix, "/v2/"),
     URL = binary_to_list(iolist_to_binary([Host, Prefix, Path])),
     {Type, Body} = case Params of
                        Map when is_map(Map) ->

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -75,6 +75,7 @@
          await_is_syncing/2,
          rpc/3,
          rpc/4,
+         use_swagger/1,
          http_request/4,
          httpc_request/4,
          process_http_return/1,
@@ -1258,14 +1259,32 @@ await_new_jobs_pid_recurse(N, OldP, TRef) ->
             await_new_jobs_pid(N, OldP, TRef)
     end.
 
+use_swagger(SpecVsn) ->
+    Prefix =
+        case SpecVsn of
+            oas3 -> "/v3/";
+            swagger2 -> "/v2/"
+        end,
+    put(api_prefix, Prefix).
+
 http_request(Host, get, Path, Params) ->
+    Prefix =
+        case get(api_prefix) of
+            undefined -> "/v2/";
+            V -> V
+        end,
     URL = binary_to_list(
-            iolist_to_binary([Host, "/v2/", Path, encode_get_params(Params)])),
+            iolist_to_binary([Host, Prefix, Path, encode_get_params(Params)])),
     ct:log("GET ~p", [URL]),
     R = httpc_request(get, {URL, []}, [], []),
     process_http_return(R);
 http_request(Host, post, Path, Params) ->
-    URL = binary_to_list(iolist_to_binary([Host, "/v2/", Path])),
+    Prefix =
+        case get(api_prefix) of
+            undefined -> "/v2/";
+            V -> V
+        end,
+    URL = binary_to_list(iolist_to_binary([Host, Prefix, Path])),
     {Type, Body} = case Params of
                        Map when is_map(Map) ->
                            %% JSON-encoded

--- a/apps/aehttp/include/aehttp_spec.hrl
+++ b/apps/aehttp/include/aehttp_spec.hrl
@@ -1,0 +1,5 @@
+-define(OAS3, oas3).
+-define(SWAGGER2, swagger2).
+
+-type version() :: ?OAS3 | ?SWAGGER2.
+

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1,0 +1,217 @@
+openapi: 3.0.0
+info:
+  description: This is the [Aeternity](https://www.aeternity.com/) node API.
+  version: x.y.z
+  title: Aeternity node
+  termsOfService: https://www.aeternity.com/terms/
+  contact:
+    email: apiteam@aeternity.com
+tags:
+  - name: external
+    description: External API
+  - name: internal
+    description: Internal API
+  - name: chain
+    description: Chain related endpoints
+  - name: transaction
+    description: Transaction related endpoints
+  - name: account
+    description: Account related endpoints
+  - name: contract
+    description: Contract related endpoints
+  - name: oracle
+    description: Oracle related endpoints
+  - name: name_service
+    description: Name service related endpoints
+  - name: channel
+    description: State channel related endpoints
+  - name: node_info
+    description: Node information related endpoints
+  - name: debug
+    description: Debug endpoints
+  - name: obsolete
+    description: Old endpoints that will be removed
+externalDocs:
+  description: Find out more about Aeternity
+  url: http://www.aeternity.com
+servers:
+  - url: /v3
+paths:
+###
+## External endpoints
+###
+  /headers/top:
+    get:
+      tags:
+        - external
+        - chain
+      operationId: GetTopHeader
+      description: Get the top header (either key or micro block)
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Header"
+        "404":
+          description: Block not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /key-blocks/hash/{hash}:
+    get:
+      tags:
+        - external
+        - chain
+      operationId: GetKeyBlockByHash
+      description: 'Get a key block by hash'
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: hash
+          description: 'The hash of the block'
+          required: true
+          # Encoded key block hash
+          # pattern: "^kh_[1-9A-HJ-NP-Za-km-z]*$"
+          type: string
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/KeyBlock'
+        '400':
+          description: 'Invalid hash'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Block not found'
+          schema:
+            $ref: '#/definitions/Error'
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        reason:
+          type: string
+      required:
+        - reason
+    UInt:
+      type: integer
+      minimum: 0
+    UInt16:
+      type: integer
+      minimum: 0
+      maximum: 65535
+    UInt32:
+      type: integer
+      minimum: 0
+      maximum: 4294967295
+    UInt64:
+      type: integer
+      minimum: 0
+      maximum: 18446744073709552000
+    TxBlockHeight:
+      type: integer
+      minimum: -1
+      maximum: 18446744073709552000
+    EncodedHash:
+      description: Base58Check encoded tagged hash
+      type: string
+    EncodedPubkey:
+      description: Base58Check encoded tagged pubkey
+      type: string
+    EncodedValue:
+      description: Base58Check encoded tagged value
+      type: string
+    EncodedByteArray:
+      description: Base64Check encoded tagged byte array
+      type: string
+    Pow:
+      type: array
+      items:
+        $ref: "#/components/schemas/UInt32"
+      minItems: 42
+      maxItems: 42
+    KeyBlock:
+      type: object
+      properties:
+        hash:
+          $ref: "#/components/schemas/EncodedHash"
+        height:
+          $ref: "#/components/schemas/UInt64"
+        prev_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        prev_key_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        state_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        miner:
+          $ref: "#/components/schemas/EncodedPubkey"
+        beneficiary:
+          $ref: "#/components/schemas/EncodedPubkey"
+        target:
+          $ref: "#/components/schemas/UInt32"
+        pow:
+          $ref: "#/components/schemas/Pow"
+        nonce:
+          $ref: "#/components/schemas/UInt64"
+        time:
+          $ref: "#/components/schemas/UInt64"
+        version:
+          $ref: "#/components/schemas/UInt32"
+        info:
+          $ref: "#/components/schemas/EncodedByteArray"
+      required:
+        - hash
+        - height
+        - prev_hash
+        - prev_key_hash
+        - state_hash
+        - miner
+        - beneficiary
+        - target
+        - time
+        - version
+        - info
+    MicroBlockHeader:
+      type: object
+      properties:
+        hash:
+          $ref: "#/components/schemas/EncodedHash"
+        height:
+          $ref: "#/components/schemas/UInt64"
+        pof_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        prev_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        prev_key_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        state_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        txs_hash:
+          $ref: "#/components/schemas/EncodedHash"
+        signature:
+          $ref: "#/components/schemas/EncodedValue"
+        time:
+          $ref: "#/components/schemas/UInt64"
+        version:
+          $ref: "#/components/schemas/UInt32"
+      required:
+        - hash
+        - height
+        - pof_hash
+        - prev_hash
+        - prev_key_hash
+        - state_hash
+        - txs_hash
+        - signature
+        - time
+        - version
+    Header:
+      anyOf:
+        - $ref: "#/components/schemas/KeyBlock"
+        - $ref: "#/components/schemas/MicroBlockHeader"

--- a/apps/aehttp/src/aehttp_api_router.erl
+++ b/apps/aehttp/src/aehttp_api_router.erl
@@ -3,11 +3,14 @@
 -export([get_paths/2]).
 
 -type init_args()  :: {
+    SpecVsn :: aehttp_spec:version(),
     Operations :: atom(),
     Method :: binary(),
     LogicHandler :: atom()
 
 }.
+
+-include("aehttp_spec.hrl").
 
 -spec get_paths(Target :: atom(), LogicHandler :: atom()) -> [{
     Path :: binary(),
@@ -17,14 +20,21 @@
 
 get_paths(Target, LogicHandler) ->
     {ok, EnabledGroups} = application:get_env(aehttp, enabled_endpoint_groups),
-
-    Paths = [{path(Path), aehttp_api_handler,
-        {OperationId, method(Method), LogicHandler}}
-        || {OperationId, Spec} <- maps:to_list(endpoints:operations()),
-            {Method, #{path := Path, tags := Tags}} <- maps:to_list(Spec),
-            is_enabled(Target, Tags, EnabledGroups)
-    ],
-
+    PathsFun =
+        fun(SpecVsn) ->
+            Endpoints =
+                case SpecVsn of
+                    ?OAS3 -> oas_endpoints;
+                    ?SWAGGER2 -> endpoints
+                end,
+            [{path(Path), aehttp_api_handler,
+                {SpecVsn, OperationId, method(Method), LogicHandler}}
+                || {OperationId, Spec} <- maps:to_list(Endpoints:operations()),
+                    {Method, #{path := Path, tags := Tags}} <- maps:to_list(Spec),
+                    is_enabled(Target, Tags, EnabledGroups)
+            ]
+        end,
+  Paths = PathsFun(?SWAGGER2) ++ PathsFun(?OAS3),
   %% Dirty hack to make sure /tx is not matched before /tx/{hash} is evaluated:
   %% sort it and reverse, such that longest part is matched first
   lists:reverse(lists:sort(Paths)) ++

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -28,6 +28,8 @@
 -export([check_env/0]).
 -export([enable_internal_debug_endpoints/0]).
 
+-include("aehttp_spec.hrl").
+
 %%====================================================================
 %% API
 %%====================================================================
@@ -90,7 +92,8 @@ start_http_api(Target, LogicHandler) ->
     PoolSize = get_http_api_acceptors(Target),
     Port = get_http_api_port(Target),
     ListenAddress = get_http_api_listen_address(Target),
-    _ = aehttp_api_validate:validator(),  %% caches spec and validator
+    _ = aehttp_api_validate:validator(?SWAGGER2),  %% caches spec and validator
+    _ = aehttp_api_validate:validator(?OAS3),  %% caches spec and validator
 
     Paths = aehttp_api_router:get_paths(Target, LogicHandler),
     Dispatch = cowboy_router:compile([{'_', Paths}]),

--- a/apps/aehttp/src/aehttp_spec.erl
+++ b/apps/aehttp/src/aehttp_spec.erl
@@ -1,13 +1,14 @@
 -module(aehttp_spec).
+-include("aehttp_spec.hrl").
 
--export([json/0]).
-
-
+-export([json/1]).
+-export_type([version/0]).
+%%
 %% @doc
 %% Get the json specification by parsing the swagger.yaml file and change it's version dynamicly.
--spec json() -> jsx:json_text().
-json() ->
-    Filename = filename:join(code:priv_dir(aehttp), "swagger.yaml"),
+-spec json(version()) -> jsx:json_text().
+json(SpecVsn) ->
+    Filename = filename:join(code:priv_dir(aehttp), filename(SpecVsn)),
     Yamls = yamerl_constr:file(Filename, [str_node_as_binary]),
     YamlTpl = lists:last(Yamls),
     OldInfo = proplists:get_value(<<"info">>, YamlTpl),
@@ -15,3 +16,6 @@ json() ->
     Yaml = lists:keyreplace(<<"info">>, 1, YamlTpl, {<<"info">>, UpdatedInfo}),
     Json = jsx:prettify(jsx:encode(Yaml)),
     Json.
+
+filename(?SWAGGER2) -> "swagger.yaml";
+filename(?OAS3) -> "oas3.yaml".

--- a/apps/aehttp/src/aehttp_spec_handler.erl
+++ b/apps/aehttp/src/aehttp_spec_handler.erl
@@ -18,11 +18,19 @@
     spec :: jsx:json_text()
 }).
 
+-include("aehttp_spec.hrl").
+
 init(Req, {OperationId, AllowedMethod}) ->
+    Qs = cowboy_req:parse_qs(Req),
+    Spec =
+        case proplists:get_value(<<"oas3">>, Qs, false) of
+            true -> aehttp_api_validate:json_spec(?OAS3);
+            false -> aehttp_api_validate:json_spec(?SWAGGER2)
+        end,
     State = #state{
         operation_id = OperationId,
         allowed_method = AllowedMethod,
-        spec = aehttp_api_validate:json_spec()
+        spec = Spec
     },
     {cowboy_rest, Req, State}.
 

--- a/apps/aehttp/test/aehttp_spec_SUITE.erl
+++ b/apps/aehttp/test/aehttp_spec_SUITE.erl
@@ -4,7 +4,6 @@
 %% simple tests to verify functionality of /api endpoint
 %%
 
--include("aehttp_spec.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
 -define(NODE, dev1).
@@ -120,5 +119,5 @@ validate_api(_Config) ->
                     {fail, "cannot connect to swagger validation server"}
             end
         end,
-        [?SWAGGER2, ?OAS3]).
+        [swagger2, oas3]).
 

--- a/apps/aehttp/test/aehttp_spec_SUITE.erl
+++ b/apps/aehttp/test/aehttp_spec_SUITE.erl
@@ -4,6 +4,7 @@
 %% simple tests to verify functionality of /api endpoint
 %%
 
+-include("aehttp_spec.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
 -define(NODE, dev1).
@@ -59,54 +60,65 @@ get_api(Config) ->
     %% ensure http interface is up and running
     N1 = aecore_suite_utils:node_name(?NODE),
     aecore_suite_utils:connect(N1),
-    Spec = rpc:call(N1, aehttp_spec, json, []),
-
-    Host = aecore_suite_utils:external_address(),
-    URL = binary_to_list(iolist_to_binary([Host, "/api"])),
-    Repl1 = httpc:request(URL),
-
-    {ok, {{"HTTP/1.1", 200, "OK"}, _, Json}} = Repl1,
-    ct:log("~p returned spec: ~p", [?NODE, Json]),
-
-    JsonObj = jsx:decode(Spec),
-    JsonObj = jsx:decode(list_to_binary(Json)),
     Type = "application/json",
     Body = <<"{broken_json">>,
 
-    {ok,{{"HTTP/1.1",405,"Method Not Allowed"},_,_}} =
-         httpc:request(post, {URL, [], Type, Body}, [], []),
+    Test =
+        fun(SpecVsn, Path) ->
+            Spec = rpc:call(N1, aehttp_spec, json, [SpecVsn]),
+
+            Host = aecore_suite_utils:external_address(),
+            URL = binary_to_list(iolist_to_binary([Host, Path])),
+            Repl1 = httpc:request(URL),
+
+            {ok, {{"HTTP/1.1", 200, "OK"}, _, Json}} = Repl1,
+            ct:log("~p returned spec: ~p", [?NODE, Json]),
+            JsonObj = jsx:decode(Spec),
+            JsonObj = jsx:decode(list_to_binary(Json)),
+
+            %% negative test
+            {ok,{{"HTTP/1.1",405,"Method Not Allowed"},_,_}} =
+                httpc:request(post, {URL, [], Type, Body}, [], [])
+        end,
+    Test(swagger2, "/api"),
+    Test(oas3, "/api?oas3"),
     ok.
 
-validate_api(Config) ->
-    Spec = aehttp_spec:json(),
+validate_api(_Config) ->
+    lists:foreach(
+        fun(SpecVsn) ->
+            Spec = aehttp_spec:json(SpecVsn),
 
-    Url = "https://validator.swagger.io/validator/",
-    case httpc:request(post, {Url, [],  "application/json", Spec}, [], []) of
-        {ok, {{_, 200, _}, _Headers, Body}} ->
-            %% For manual verification visit https://github.com/swagger-api/validator-badge
-            %% A picture is returned in the body
-            case aec_hash:blake2b_256_hash(list_to_binary(Body)) of
-                <<85,250,111,235,97,122,213,232,25,130,236,210,99,16,245,146,67,
-                  186,213,194,192,223,209,154,83,237,158,255,97,67,22,185>> ->
-                    %% Valid picture returned
-                    ok;
-                _ ->
-                    ct:pal("Wrong hash on swagger validation picture"),
-                    case httpc:request(post, {Url++"debug", [],  "application/json", Spec}, [], []) of
-                        {ok, {{_, 200, "OK"}, _, Msg}} ->
-                            case yamerl:decode(Msg) of
-                                [[{"messages",null},{"schemaValidationMessages",null}]] ->
-                                    ct:pal("Yaml correct. Update picture hash to speed up this test"),
-                                    {fail, update_hash};
-                                Yml ->
-                                    {fail, Yml}
-                            end;
-                        Response ->
-                            ct:log("Returned error ~s", [Response]),
-                            {fail, Response}
-                    end
-            end;
-        Other ->
-            ct:pal("Connection problem: ~p", [Other]),
-            {fail, "cannot connect to swagger validation server"}
-    end.
+            Url = "https://validator.swagger.io/validator/",
+            case httpc:request(post, {Url, [],  "application/json", Spec}, [], []) of
+                {ok, {{_, 200, _}, _Headers, Body}} ->
+                    %% For manual verification visit https://github.com/swagger-api/validator-badge
+                    %% A picture is returned in the body
+                    case aec_hash:blake2b_256_hash(list_to_binary(Body)) of
+                        <<85,250,111,235,97,122,213,232,25,130,236,210,99,16,245,146,67,
+                          186,213,194,192,223,209,154,83,237,158,255,97,67,22,185>> ->
+                            %% Valid picture returned
+                            ok;
+                        _ ->
+                            ct:pal("Wrong hash on swagger validation picture"),
+                            case httpc:request(post, {Url++"debug", [],  "application/json", Spec}, [], []) of
+                                {ok, {{_, 200, "OK"}, _, Msg}} ->
+                                    case yamerl:decode(Msg) of
+                                        [[{"messages",null},{"schemaValidationMessages",null}]] ->
+                                            ct:pal("Yaml correct. Update picture hash to speed up this test"),
+                                            {fail, update_hash};
+                                        Yml ->
+                                            {fail, Yml}
+                                    end;
+                                Response ->
+                                    ct:log("Returned error ~s", [Response]),
+                                    {fail, Response}
+                            end
+                    end;
+                Other ->
+                    ct:pal("Connection problem: ~p", [Other]),
+                    {fail, "cannot connect to swagger validation server"}
+            end
+        end,
+        [?SWAGGER2, ?OAS3]).
+

--- a/docs/release-notes/next/introduce_second_http_api_specification.md
+++ b/docs/release-notes/next/introduce_second_http_api_specification.md
@@ -1,0 +1,8 @@
+* Introduces a second HTTP specification. This is to provide the new `OAS3`
+  API under `/v3/` while we keep the `Swagger v2` API untacked under `/v2/`.
+  This would provide a smooth transition from old specification to the new
+  one. The new API is to be finalized with `iris` hardfork, please do not
+  depend on it yet.
+* Expands the `/api` endpoint with an option: while simply calling `/api`
+  keeps it old behaviour, calling `/api?oas3` would provide the new `OAS3`
+  spec instead.

--- a/rebar.config
+++ b/rebar.config
@@ -108,7 +108,7 @@
        ]}.
 
 {plugins, [
-        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "d5a9f07"}}},
+        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "379dc43"}}},
         {aesophia_rebar_plugin, {git, "https://github.com/aeternity/aesophia_rebar_plugin", {ref, "df113cc"}}}
     ]}.
 


### PR DESCRIPTION
This PR provides the means to have both old swagger v2 with the new OAS v3
specifications. The new specifications go to `oas3.yaml` while we keep the old
`swagger.yaml` untouched. Those two can share `OperationId`-s but those must
have the same expectations for params and response schemas. The idea is to
keep the old specifications as long as we need them while preparing the new
API. This would provide the time needed for SDKs and client apps to catch up.


The work on this PR is being supported by ACF.
