### PR TITLE
HTTP API param ints as strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,13 @@ references:
     restore_cache:
       key: *build_nix_cache_key
 
-  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v13-{{ .Branch }}-{{ .Revision }}
+  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v14-{{ .Branch }}-{{ .Revision }}
   restore_machine_build_cache: &restore_machine_build_cache
     restore_cache:
       keys:
         - *machine_build_cache_key
-        - machine-build-cache-v13-{{ .Branch }}-
-        - machine-build-cache-v13-
+        - machine-build-cache-v14-{{ .Branch }}-
+        - machine-build-cache-v14-
 
   save_machine_build_cache: &save_machine_build_cache
     save_cache:

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -1316,9 +1316,17 @@ httpc_request(Method, Request, HTTPOptions, Options, Profile) ->
 encode_get_params(#{} = Ps) ->
     encode_get_params(maps:to_list(Ps));
 encode_get_params([{K,V}|T]) ->
-    ["?", [str(K),"=",uenc(V)
-           | [["&", str(K1), "=", uenc(V1)]
-              || {K1, V1} <- T]]];
+    Enc =
+        fun(Key, Value) ->
+            case Value of
+                true -> str(Key);
+                _ -> [str(Key), "=", uenc(Value)]
+            end
+        end,
+    lists:flatten(
+        ["?", [Enc(K, V)
+              | [["&", Enc(K1, V1)]
+                  || {K1, V1} <- T]]]);
 encode_get_params([]) ->
     [].
 
@@ -1327,6 +1335,8 @@ str(A) when is_atom(A) ->
 str(S) when is_list(S); is_binary(S) ->
     S.
 
+uenc(B) when is_boolean(B) ->
+    uenc(atom_to_list(B));
 uenc(I) when is_integer(I) ->
     uenc(integer_to_list(I));
 uenc(V) ->

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3390,7 +3390,7 @@ components:
   parameters:
     bigIngAsString:
       in: query
-      name: "big-int-as-string"
+      name: "int-as-string"
       description: 'If this flag is set to true, the response will have all integers set as strings'
       required: false
       type: boolean

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -48,7 +48,7 @@ paths:
       operationId: GetTopHeader
       description: Get the top header (either key or micro block)
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -70,7 +70,7 @@ paths:
       operationId: GetCurrentKeyBlock
       description: Get the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -92,7 +92,7 @@ paths:
       operationId: GetCurrentKeyBlockHash
       description: Get the hash of the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -117,7 +117,7 @@ paths:
       operationId: GetCurrentKeyBlockHeight
       description: Get the height of the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -142,7 +142,7 @@ paths:
       operationId: GetPendingKeyBlock
       description: Get the pending key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -170,8 +170,8 @@ paths:
       operationId: GetKeyBlockByHash
       description: Get a key block by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - $ref: '#/components/parameters/blockHashParam'
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/blockHash'
       responses:
         "200":
           description: Successful operation
@@ -199,16 +199,8 @@ paths:
       operationId: GetKeyBlockByHeight
       description: Get a key block by height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: height
-          description: The height
-          required: true
-          schema:
-            type: integer
-            minimum: 0
-            maximum: 18446744073709552000
-            example: 42
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/height'
       responses:
         "200":
           description: Successful operation
@@ -230,8 +222,8 @@ paths:
       operationId: GetMicroBlockHeaderByHash
       description: Get a micro block header by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - $ref: '#/components/parameters/blockHashParam'
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/blockHash'
       responses:
         "200":
           description: Successful operation
@@ -259,8 +251,8 @@ paths:
       operationId: GetMicroBlockTransactionsByHash
       description: Get micro block transactions by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - $ref: '#/components/parameters/microBlockHashParam'
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/microBlockHash'
       responses:
         "200":
           description: Successful operation
@@ -292,8 +284,8 @@ paths:
       operationId: GetMicroBlockTransactionByHashAndIndex
       description: Get a micro block transaction by hash and index
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - $ref: '#/components/parameters/microBlockHashParam'
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/microBlockHash'
         - in: path
           name: index
           description: The index of the transaction in a block
@@ -329,8 +321,8 @@ paths:
       operationId: GetMicroBlockTransactionsCountByHash
       description: Get micro block transaction count by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - $ref: '#/components/parameters/microBlockHashParam'
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/microBlockHash'
       responses:
         "200":
           description: Successful operation
@@ -361,7 +353,7 @@ paths:
       operationId: GetCurrentGeneration
       description: Get the current generation
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -383,14 +375,8 @@ paths:
       operationId: GetGenerationByHash
       description: Get a generation by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: hash
-          description: The hash of the generation
-          required: true
-          schema:
-            type: string
-            example: "kh_2ikjGFZGFpE99mDtsgkGFsTCqpPpXZRNRa5Pic989FJLcJStgx"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/keyBlockHash'
       responses:
         "200":
           description: Successful operation
@@ -418,16 +404,8 @@ paths:
       operationId: GetGenerationByHeight
       description: Get a generation by height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: height
-          description: The height
-          required: true
-          schema:
-            type: integer
-            minimum: 0
-            maximum: 18446744073709552000
-            example: 1
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/height'
       responses:
         "200":
           description: Successful operation
@@ -449,14 +427,8 @@ paths:
       operationId: GetAccountByPubkey
       description: Get an account by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The public key of the account
-          required: true
-          schema:
-            type: string
-            example: "ak_dArxCkAsk1mZB1L9CX3cdz1GDN4hN84L3Q8dMLHN4v8cU85TF"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/accountPubkey'
       responses:
         "200":
           description: Successful operation
@@ -485,23 +457,9 @@ paths:
       description: Get an account by public key after the opening key block of the
         generation at height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The public key of the account
-          required: true
-          schema:
-            type: string
-            example: "ak_dArxCkAsk1mZB1L9CX3cdz1GDN4hN84L3Q8dMLHN4v8cU85TF"
-        - in: path
-          name: height
-          description: The height
-          required: true
-          schema:
-            type: integer
-            minimum: 0
-            maximum: 18446744073709552000
-            example: 42
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/accountPubkey'
+        - $ref: '#/components/parameters/height'
       responses:
         "200":
           description: Successful operation
@@ -529,21 +487,9 @@ paths:
       operationId: GetAccountByPubkeyAndHash
       description: "Get an account by public key after the block indicated by hash. Can be either a micro block or a keyblock hash"
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The public key of the account
-          required: true
-          schema:
-            type: string
-            example: "ak_dArxCkAsk1mZB1L9CX3cdz1GDN4hN84L3Q8dMLHN4v8cU85TF"
-        - in: path
-          name: hash
-          description: The hash of the block
-          required: true
-          schema:
-            type: string
-            example: "kh_2ikjGFZGFpE99mDtsgkGFsTCqpPpXZRNRa5Pic989FJLcJStgx"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/accountPubkey'
+        - $ref: '#/components/parameters/blockHash'
       responses:
         "200":
           description: Successful operation
@@ -571,14 +517,8 @@ paths:
       operationId: GetPendingAccountTransactionsByPubkey
       description: Get pending account transactions by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The public key of the account
-          required: true
-          schema:
-            type: string
-            example: "ak_dArxCkAsk1mZB1L9CX3cdz1GDN4hN84L3Q8dMLHN4v8cU85TF"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/accountPubkey'
       responses:
         "200":
           description: Successful operation
@@ -610,14 +550,8 @@ paths:
       operationId: GetTransactionByHash
       description: Get a transaction by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: hash
-          description: The hash of the transaction
-          required: true
-          schema:
-            type: string
-            example: "th_2w75xjDjHEmphsHDSXrThRnPx6hSUiS7hhSRcuytJABZZ2KkdG"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/txHash'
       responses:
         "200":
           description: Successful operation
@@ -644,14 +578,8 @@ paths:
         - transaction
       operationId: GetTransactionInfoByHash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: hash
-          description: The hash of the transaction
-          required: true
-          schema:
-            type: string
-            example: "th_2w75xjDjHEmphsHDSXrThRnPx6hSUiS7hhSRcuytJABZZ2KkdG"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/txHash'
       responses:
         "200":
           description: Successful operation
@@ -679,7 +607,7 @@ paths:
       operationId: PostTransaction
       description: Post a new transaction
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -708,14 +636,8 @@ paths:
       operationId: GetContract
       description: Get a contract by pubkey
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The pubkey of the contract
-          required: true
-          schema:
-            type: string
-            example: "ct_TV5KbBYdjw1ufKWvAtNNjUnagvRmWMMugFzLKzmLASXB5iH1E"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
           description: Successful operation
@@ -739,14 +661,8 @@ paths:
       operationId: GetContractCode
       description: Get contract code by pubkey
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The pubkey of the contract
-          required: true
-          schema:
-            type: string
-            example: "ct_TV5KbBYdjw1ufKWvAtNNjUnagvRmWMMugFzLKzmLASXB5iH1E"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
           description: Contract code
@@ -774,14 +690,8 @@ paths:
       operationId: GetContractPoI
       description: Get a proof of inclusion for a contract
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: Contract pubkey to get proof for
-          required: true
-          schema:
-            type: string
-            example: "ct_TV5KbBYdjw1ufKWvAtNNjUnagvRmWMMugFzLKzmLASXB5iH1E"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
           description: Successful operation
@@ -809,14 +719,8 @@ paths:
       operationId: GetOracleByPubkey
       description: Get an oracle by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The public key of the oracle
-          required: true
-          schema:
-            type: string
-            example: "ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/oraclePubkey'
       responses:
         "200":
           description: Successful operation
@@ -844,14 +748,8 @@ paths:
       operationId: GetOracleQueriesByPubkey
       description: Get oracle queries by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The public key of the oracle
-          required: true
-          schema:
-            type: string
-            example: "ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/oraclePubkey'
         - in: query
           name: from
           description: Last query id in previous page
@@ -906,14 +804,8 @@ paths:
       operationId: GetOracleQueryByPubkeyAndQueryId
       description: Get an oracle query by public key and query ID
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: pubkey
-          description: The public key of the oracle
-          required: true
-          schema:
-            type: string
-            example: "ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/oraclePubkey'
         - in: path
           name: query-id
           description: The ID of the query
@@ -948,7 +840,7 @@ paths:
       operationId: GetNameEntryByName
       description: Get name entry from naming system
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
         - in: path
           name: name
           description: The name key of the name entry
@@ -983,7 +875,7 @@ paths:
       operationId: GetChannelByPubkey
       description: Get channel by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
         - in: path
           name: pubkey
           description: The pubkey of the channel
@@ -1018,7 +910,7 @@ paths:
       operationId: GetPeerPubkey
       description: Get peer public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -1034,7 +926,7 @@ paths:
       operationId: GetStatus
       description: Get the status of a node
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -1050,7 +942,7 @@ paths:
       operationId: GetChainEnds
       description: Get oldest keyblock hashes counting from genesis including orphans
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -1095,7 +987,7 @@ paths:
       operationId: GetNetworkStatus
       description: Get detailed analytics on peers
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -1118,7 +1010,7 @@ paths:
       operationId: PostContractCreate
       description: Get a contract_create transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1153,7 +1045,7 @@ paths:
       operationId: PostContractCall
       description: Get a contract_call transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1188,7 +1080,7 @@ paths:
       operationId: PostOracleRegister
       description: Get a oracle_register transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1223,7 +1115,7 @@ paths:
       operationId: PostOracleExtend
       description: Get an oracle_extend transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1258,7 +1150,7 @@ paths:
       operationId: PostOracleQuery
       description: Get an oracle_query transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1293,7 +1185,7 @@ paths:
       operationId: PostOracleRespond
       description: Get an oracle_response transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1328,7 +1220,7 @@ paths:
       operationId: PostNamePreclaim
       description: Get a name_preclaim transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1363,7 +1255,7 @@ paths:
       operationId: PostNameClaim
       description: Get a name_claim transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1398,7 +1290,7 @@ paths:
       operationId: PostNameUpdate
       description: Get a name_update transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1433,7 +1325,7 @@ paths:
       operationId: PostNameTransfer
       description: Get a name_transfer transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1468,7 +1360,7 @@ paths:
       operationId: PostNameRevoke
       description: Get a name_revoke transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1503,7 +1395,7 @@ paths:
       operationId: PostSpend
       description: Get a spend transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1539,7 +1431,7 @@ paths:
       operationId: PostChannelCreate
       description: Get a channel_create transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1574,7 +1466,7 @@ paths:
       operationId: PostChannelDeposit
       description: Get a channel_deposit transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1603,7 +1495,7 @@ paths:
       operationId: PostChannelWithdraw
       description: Get a channel_withdrawal transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1632,7 +1524,7 @@ paths:
       operationId: PostChannelSnapshotSolo
       description: Get a channel_snapshot_solo transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1661,7 +1553,7 @@ paths:
       operationId: PostChannelCloseMutual
       description: Get a channel_close_mutual transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1690,7 +1582,7 @@ paths:
       operationId: PostChannelCloseSolo
       description: Get a channel_close_solo transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1719,7 +1611,7 @@ paths:
       operationId: PostChannelSlash
       description: Get a channel_slash transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1748,7 +1640,7 @@ paths:
       operationId: PostChannelSettle
       description: Get a channel_settle transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1777,7 +1669,7 @@ paths:
       operationId: GetPendingTransactions
       description: Get pending transactions
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -1798,7 +1690,7 @@ paths:
       operationId: GetCommitmentId
       description: Compute commitment ID for a given salt and name
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
         - in: query
           name: name
           description: Name
@@ -1855,7 +1747,7 @@ paths:
       operationId: GetNodePubkey
       description: Get node's public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: Successful operation
@@ -1878,7 +1770,7 @@ paths:
       operationId: GetPeers
       description: Get node Peers
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       responses:
         "200":
           description: successful operation
@@ -1901,7 +1793,7 @@ paths:
       description: Dry-run transactions on top of a given block. Supports all TXs except
         GAMetaTx, PayingForTx and OffchainTx
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/bigIngAsString'
       requestBody:
         content:
           application/json:
@@ -1930,15 +1822,8 @@ paths:
       operationId: GetTokenSupplyByHeight
       description: Get total token supply at height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsStringParam'
-        - in: path
-          name: height
-          description: The height
-          required: true
-          schema:
-            type: integer
-            minimum: 0
-            maximum: 18446744073709552000
+        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/height'
       responses:
         "200":
           description: Total token supply at height divided in categories
@@ -3503,22 +3388,30 @@ components:
         - $ref: "#/components/schemas/KeyBlock"
         - $ref: "#/components/schemas/MicroBlockHeader"
   parameters:
-    bigIngAsStringParam:
+    bigIngAsString:
       in: query
       name: "big-int-as-string"
       description: 'If this flag is set to true, the response will have all integers set as strings'
       required: false
       type: boolean
       default: false
-    blockHashParam:
+    blockHash:
       in: path
       name: hash
-      description: The hash of the block
+      description: The hash of the block - either a keyblock or a microblock
       required: true
       schema:
         type: string
         example: "kh_2ikjGFZGFpE99mDtsgkGFsTCqpPpXZRNRa5Pic989FJLcJStgx"
-    microBlockHashParam:
+    keyBlockHash:
+      in: path
+      name: hash
+      description: The hash of the key block
+      required: true
+      schema:
+        type: string
+        example: "kh_2ikjGFZGFpE99mDtsgkGFsTCqpPpXZRNRa5Pic989FJLcJStgx"
+    microBlockHash:
       in: path
       name: hash
       description: The hash of the micro block
@@ -3526,7 +3419,7 @@ components:
       schema:
         type: string
         example: "mh_ZCWcnCG5YF2LhQMTmZ5K5rRmGxatgc5YWxDpGNy2YBAHP6urH"
-    AccountPubkeyParam:
+    accountPubkey:
       in: path
       name: pubkey
       description: The public key of the account
@@ -3534,3 +3427,37 @@ components:
       schema:
         type: string
         example: "ak_dArxCkAsk1mZB1L9CX3cdz1GDN4hN84L3Q8dMLHN4v8cU85TF"
+    height:
+      in: path
+      name: height
+      description: The height
+      required: true
+      schema:
+        type: integer
+        minimum: 0
+        maximum: 18446744073709552000
+        example: 42
+    txHash:
+      in: path
+      name: hash
+      description: The hash of the transaction
+      required: true
+      schema:
+        type: string
+        example: "th_2w75xjDjHEmphsHDSXrThRnPx6hSUiS7hhSRcuytJABZZ2KkdG"
+    contractPubkey:
+      in: path
+      name: pubkey
+      description: Contract pubkey to get proof for
+      required: true
+      schema:
+        type: string
+        example: "ct_TV5KbBYdjw1ufKWvAtNNjUnagvRmWMMugFzLKzmLASXB5iH1E"
+    oraclePubkey:
+      in: path
+      name: pubkey
+      description: The public key of the oracle
+      required: true
+      schema:
+        type: string
+        example: "ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -47,6 +47,8 @@ paths:
         - chain
       operationId: GetTopHeader
       description: Get the top header (either key or micro block)
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -395,6 +397,7 @@ paths:
       operationId: GetGenerationByHash
       description: Get a generation by hash
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: hash
           description: The hash of the generation
@@ -1891,20 +1894,28 @@ paths:
 components:
   schemas:
     UInt:
-      type: integer
-      minimum: 0
+      oneOf:
+        - type: integer
+          minimum: 0
+        - type: string
     UInt16:
-      type: integer
-      minimum: 0
-      maximum: 65535
+      oneOf:
+        - type: integer
+          minimum: 0
+          maximum: 65535
+        - type: string
     UInt32:
-      type: integer
-      minimum: 0
-      maximum: 4294967295
+      oneOf:
+        - type: integer
+          minimum: 0
+          maximum: 4294967295
+        - type: string
     UInt64:
-      type: integer
-      minimum: 0
-      maximum: 18446744073709552000
+      oneOf:
+        - type: integer
+          minimum: 0
+          maximum: 18446744073709552000
+        - type: string
     TxBlockHeight:
       type: integer
       minimum: -1
@@ -3426,3 +3437,15 @@ components:
         - fee
         - auth_data
         - tx
+    Header:
+      anyOf:
+        - $ref: "#/components/schemas/KeyBlock"
+        - $ref: "#/components/schemas/MicroBlockHeader"
+  parameters:
+    bigIngAsStringParam:
+      in: query
+      name: "big-int-as-string"
+      description: 'If this flag is set to true, the response will have all integers set as strings'
+      required: false
+      type: boolean
+      default: false

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -69,6 +69,8 @@ paths:
         - chain
       operationId: GetCurrentKeyBlock
       description: Get the current key block
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -89,6 +91,8 @@ paths:
         - chain
       operationId: GetCurrentKeyBlockHash
       description: Get the hash of the current key block
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -112,6 +116,8 @@ paths:
         - chain
       operationId: GetCurrentKeyBlockHeight
       description: Get the height of the current key block
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -135,6 +141,8 @@ paths:
         - chain
       operationId: GetPendingKeyBlock
       description: Get the pending key block
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -162,13 +170,8 @@ paths:
       operationId: GetKeyBlockByHash
       description: Get a key block by hash
       parameters:
-        - in: path
-          name: hash
-          description: The hash of the block
-          required: true
-          schema:
-            type: string
-            example: "kh_2ikjGFZGFpE99mDtsgkGFsTCqpPpXZRNRa5Pic989FJLcJStgx"
+        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/blockHashParam'
       responses:
         "200":
           description: Successful operation
@@ -196,6 +199,7 @@ paths:
       operationId: GetKeyBlockByHeight
       description: Get a key block by height
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: height
           description: The height
@@ -226,13 +230,8 @@ paths:
       operationId: GetMicroBlockHeaderByHash
       description: Get a micro block header by hash
       parameters:
-        - in: path
-          name: hash
-          description: The hash of the block
-          required: true
-          schema:
-            type: string
-            example: "mh_ZCWcnCG5YF2LhQMTmZ5K5rRmGxatgc5YWxDpGNy2YBAHP6urH"
+        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/blockHashParam'
       responses:
         "200":
           description: Successful operation
@@ -260,13 +259,8 @@ paths:
       operationId: GetMicroBlockTransactionsByHash
       description: Get micro block transactions by hash
       parameters:
-        - in: path
-          name: hash
-          description: The hash of the block
-          required: true
-          schema:
-            type: string
-            example: "mh_ZCWcnCG5YF2LhQMTmZ5K5rRmGxatgc5YWxDpGNy2YBAHP6urH"
+        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/microBlockHashParam'
       responses:
         "200":
           description: Successful operation
@@ -298,13 +292,8 @@ paths:
       operationId: GetMicroBlockTransactionByHashAndIndex
       description: Get a micro block transaction by hash and index
       parameters:
-        - in: path
-          name: hash
-          description: The hash of the block
-          required: true
-          schema:
-            type: string
-            example: "mh_ZCWcnCG5YF2LhQMTmZ5K5rRmGxatgc5YWxDpGNy2YBAHP6urH"
+        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/microBlockHashParam'
         - in: path
           name: index
           description: The index of the transaction in a block
@@ -340,13 +329,8 @@ paths:
       operationId: GetMicroBlockTransactionsCountByHash
       description: Get micro block transaction count by hash
       parameters:
-        - in: path
-          name: hash
-          description: The hash of the block
-          required: true
-          schema:
-            type: string
-            example: "mh_ZCWcnCG5YF2LhQMTmZ5K5rRmGxatgc5YWxDpGNy2YBAHP6urH"
+        - $ref: '#/components/parameters/bigIngAsStringParam'
+        - $ref: '#/components/parameters/microBlockHashParam'
       responses:
         "200":
           description: Successful operation
@@ -376,6 +360,8 @@ paths:
         - chain
       operationId: GetCurrentGeneration
       description: Get the current generation
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -432,6 +418,7 @@ paths:
       operationId: GetGenerationByHeight
       description: Get a generation by height
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: height
           description: The height
@@ -462,6 +449,7 @@ paths:
       operationId: GetAccountByPubkey
       description: Get an account by public key
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The public key of the account
@@ -497,6 +485,7 @@ paths:
       description: Get an account by public key after the opening key block of the
         generation at height
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The public key of the account
@@ -540,6 +529,7 @@ paths:
       operationId: GetAccountByPubkeyAndHash
       description: "Get an account by public key after the block indicated by hash. Can be either a micro block or a keyblock hash"
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The public key of the account
@@ -581,6 +571,7 @@ paths:
       operationId: GetPendingAccountTransactionsByPubkey
       description: Get pending account transactions by public key
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The public key of the account
@@ -619,6 +610,7 @@ paths:
       operationId: GetTransactionByHash
       description: Get a transaction by hash
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: hash
           description: The hash of the transaction
@@ -652,6 +644,7 @@ paths:
         - transaction
       operationId: GetTransactionInfoByHash
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: hash
           description: The hash of the transaction
@@ -685,6 +678,8 @@ paths:
         - transaction
       operationId: PostTransaction
       description: Post a new transaction
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -713,6 +708,7 @@ paths:
       operationId: GetContract
       description: Get a contract by pubkey
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The pubkey of the contract
@@ -743,6 +739,7 @@ paths:
       operationId: GetContractCode
       description: Get contract code by pubkey
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The pubkey of the contract
@@ -777,6 +774,7 @@ paths:
       operationId: GetContractPoI
       description: Get a proof of inclusion for a contract
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: Contract pubkey to get proof for
@@ -811,6 +809,7 @@ paths:
       operationId: GetOracleByPubkey
       description: Get an oracle by public key
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The public key of the oracle
@@ -845,6 +844,7 @@ paths:
       operationId: GetOracleQueriesByPubkey
       description: Get oracle queries by public key
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The public key of the oracle
@@ -906,6 +906,7 @@ paths:
       operationId: GetOracleQueryByPubkeyAndQueryId
       description: Get an oracle query by public key and query ID
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The public key of the oracle
@@ -947,6 +948,7 @@ paths:
       operationId: GetNameEntryByName
       description: Get name entry from naming system
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: name
           description: The name key of the name entry
@@ -981,6 +983,7 @@ paths:
       operationId: GetChannelByPubkey
       description: Get channel by public key
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: pubkey
           description: The pubkey of the channel
@@ -1014,6 +1017,8 @@ paths:
         - node_info
       operationId: GetPeerPubkey
       description: Get peer public key
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -1028,6 +1033,8 @@ paths:
         - node_info
       operationId: GetStatus
       description: Get the status of a node
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -1042,6 +1049,8 @@ paths:
         - chain
       operationId: GetChainEnds
       description: Get oldest keyblock hashes counting from genesis including orphans
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -1085,6 +1094,8 @@ paths:
         - debug
       operationId: GetNetworkStatus
       description: Get detailed analytics on peers
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -1106,6 +1117,8 @@ paths:
         - debug
       operationId: PostContractCreate
       description: Get a contract_create transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1139,6 +1152,8 @@ paths:
         - debug
       operationId: PostContractCall
       description: Get a contract_call transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1172,6 +1187,8 @@ paths:
         - debug
       operationId: PostOracleRegister
       description: Get a oracle_register transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1205,6 +1222,8 @@ paths:
         - debug
       operationId: PostOracleExtend
       description: Get an oracle_extend transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1238,6 +1257,8 @@ paths:
         - debug
       operationId: PostOracleQuery
       description: Get an oracle_query transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1271,6 +1292,8 @@ paths:
         - debug
       operationId: PostOracleRespond
       description: Get an oracle_response transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1304,6 +1327,8 @@ paths:
         - debug
       operationId: PostNamePreclaim
       description: Get a name_preclaim transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1337,6 +1362,8 @@ paths:
         - debug
       operationId: PostNameClaim
       description: Get a name_claim transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1370,6 +1397,8 @@ paths:
         - debug
       operationId: PostNameUpdate
       description: Get a name_update transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1403,6 +1432,8 @@ paths:
         - debug
       operationId: PostNameTransfer
       description: Get a name_transfer transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1436,6 +1467,8 @@ paths:
         - debug
       operationId: PostNameRevoke
       description: Get a name_revoke transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1469,6 +1502,8 @@ paths:
         - debug
       operationId: PostSpend
       description: Get a spend transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1503,6 +1538,8 @@ paths:
         - debug
       operationId: PostChannelCreate
       description: Get a channel_create transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1536,6 +1573,8 @@ paths:
         - debug
       operationId: PostChannelDeposit
       description: Get a channel_deposit transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1563,6 +1602,8 @@ paths:
         - debug
       operationId: PostChannelWithdraw
       description: Get a channel_withdrawal transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1590,6 +1631,8 @@ paths:
         - debug
       operationId: PostChannelSnapshotSolo
       description: Get a channel_snapshot_solo transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1617,6 +1660,8 @@ paths:
         - debug
       operationId: PostChannelCloseMutual
       description: Get a channel_close_mutual transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1644,6 +1689,8 @@ paths:
         - debug
       operationId: PostChannelCloseSolo
       description: Get a channel_close_solo transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1671,6 +1718,8 @@ paths:
         - debug
       operationId: PostChannelSlash
       description: Get a channel_slash transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1698,6 +1747,8 @@ paths:
         - debug
       operationId: PostChannelSettle
       description: Get a channel_settle transaction object
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1725,6 +1776,8 @@ paths:
         - debug
       operationId: GetPendingTransactions
       description: Get pending transactions
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -1745,6 +1798,7 @@ paths:
       operationId: GetCommitmentId
       description: Compute commitment ID for a given salt and name
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: query
           name: name
           description: Name
@@ -1800,6 +1854,8 @@ paths:
         - debug
       operationId: GetNodePubkey
       description: Get node's public key
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: Successful operation
@@ -1821,6 +1877,8 @@ paths:
         - debug
       operationId: GetPeers
       description: Get node Peers
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       responses:
         "200":
           description: successful operation
@@ -1842,6 +1900,8 @@ paths:
       operationId: DryRunTxs
       description: Dry-run transactions on top of a given block. Supports all TXs except
         GAMetaTx, PayingForTx and OffchainTx
+      parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
       requestBody:
         content:
           application/json:
@@ -1870,6 +1930,7 @@ paths:
       operationId: GetTokenSupplyByHeight
       description: Get total token supply at height
       parameters:
+        - $ref: '#/components/parameters/bigIngAsStringParam'
         - in: path
           name: height
           description: The height
@@ -3449,3 +3510,27 @@ components:
       required: false
       type: boolean
       default: false
+    blockHashParam:
+      in: path
+      name: hash
+      description: The hash of the block
+      required: true
+      schema:
+        type: string
+        example: "kh_2ikjGFZGFpE99mDtsgkGFsTCqpPpXZRNRa5Pic989FJLcJStgx"
+    microBlockHashParam:
+      in: path
+      name: hash
+      description: The hash of the micro block
+      required: true
+      schema:
+        type: string
+        example: "mh_ZCWcnCG5YF2LhQMTmZ5K5rRmGxatgc5YWxDpGNy2YBAHP6urH"
+    AccountPubkeyParam:
+      in: path
+      name: pubkey
+      description: The public key of the account
+      required: true
+      schema:
+        type: string
+        example: "ak_dArxCkAsk1mZB1L9CX3cdz1GDN4hN84L3Q8dMLHN4v8cU85TF"

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -48,7 +48,7 @@ paths:
       operationId: GetTopHeader
       description: Get the top header (either key or micro block)
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -70,7 +70,7 @@ paths:
       operationId: GetCurrentKeyBlock
       description: Get the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -92,7 +92,7 @@ paths:
       operationId: GetCurrentKeyBlockHash
       description: Get the hash of the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -117,7 +117,7 @@ paths:
       operationId: GetCurrentKeyBlockHeight
       description: Get the height of the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -142,7 +142,7 @@ paths:
       operationId: GetPendingKeyBlock
       description: Get the pending key block
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -170,7 +170,7 @@ paths:
       operationId: GetKeyBlockByHash
       description: Get a key block by hash
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/blockHash'
       responses:
         "200":
@@ -199,7 +199,7 @@ paths:
       operationId: GetKeyBlockByHeight
       description: Get a key block by height
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/height'
       responses:
         "200":
@@ -222,7 +222,7 @@ paths:
       operationId: GetMicroBlockHeaderByHash
       description: Get a micro block header by hash
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/blockHash'
       responses:
         "200":
@@ -251,7 +251,7 @@ paths:
       operationId: GetMicroBlockTransactionsByHash
       description: Get micro block transactions by hash
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/microBlockHash'
       responses:
         "200":
@@ -284,7 +284,7 @@ paths:
       operationId: GetMicroBlockTransactionByHashAndIndex
       description: Get a micro block transaction by hash and index
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/microBlockHash'
         - in: path
           name: index
@@ -321,7 +321,7 @@ paths:
       operationId: GetMicroBlockTransactionsCountByHash
       description: Get micro block transaction count by hash
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/microBlockHash'
       responses:
         "200":
@@ -353,7 +353,7 @@ paths:
       operationId: GetCurrentGeneration
       description: Get the current generation
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -375,7 +375,7 @@ paths:
       operationId: GetGenerationByHash
       description: Get a generation by hash
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/keyBlockHash'
       responses:
         "200":
@@ -404,7 +404,7 @@ paths:
       operationId: GetGenerationByHeight
       description: Get a generation by height
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/height'
       responses:
         "200":
@@ -427,7 +427,7 @@ paths:
       operationId: GetAccountByPubkey
       description: Get an account by public key
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/accountPubkey'
       responses:
         "200":
@@ -457,7 +457,7 @@ paths:
       description: Get an account by public key after the opening key block of the
         generation at height
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/accountPubkey'
         - $ref: '#/components/parameters/height'
       responses:
@@ -487,7 +487,7 @@ paths:
       operationId: GetAccountByPubkeyAndHash
       description: "Get an account by public key after the block indicated by hash. Can be either a micro block or a keyblock hash"
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/accountPubkey'
         - $ref: '#/components/parameters/blockHash'
       responses:
@@ -517,7 +517,7 @@ paths:
       operationId: GetPendingAccountTransactionsByPubkey
       description: Get pending account transactions by public key
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/accountPubkey'
       responses:
         "200":
@@ -550,7 +550,7 @@ paths:
       operationId: GetTransactionByHash
       description: Get a transaction by hash
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/txHash'
       responses:
         "200":
@@ -578,7 +578,7 @@ paths:
         - transaction
       operationId: GetTransactionInfoByHash
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/txHash'
       responses:
         "200":
@@ -607,7 +607,7 @@ paths:
       operationId: PostTransaction
       description: Post a new transaction
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -636,7 +636,7 @@ paths:
       operationId: GetContract
       description: Get a contract by pubkey
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
@@ -661,7 +661,7 @@ paths:
       operationId: GetContractCode
       description: Get contract code by pubkey
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
@@ -690,7 +690,7 @@ paths:
       operationId: GetContractPoI
       description: Get a proof of inclusion for a contract
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
@@ -719,7 +719,7 @@ paths:
       operationId: GetOracleByPubkey
       description: Get an oracle by public key
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/oraclePubkey'
       responses:
         "200":
@@ -748,7 +748,7 @@ paths:
       operationId: GetOracleQueriesByPubkey
       description: Get oracle queries by public key
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/oraclePubkey'
         - in: query
           name: from
@@ -804,7 +804,7 @@ paths:
       operationId: GetOracleQueryByPubkeyAndQueryId
       description: Get an oracle query by public key and query ID
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/oraclePubkey'
         - in: path
           name: query-id
@@ -840,7 +840,7 @@ paths:
       operationId: GetNameEntryByName
       description: Get name entry from naming system
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - in: path
           name: name
           description: The name key of the name entry
@@ -875,7 +875,7 @@ paths:
       operationId: GetChannelByPubkey
       description: Get channel by public key
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - in: path
           name: pubkey
           description: The pubkey of the channel
@@ -910,7 +910,7 @@ paths:
       operationId: GetPeerPubkey
       description: Get peer public key
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -926,7 +926,7 @@ paths:
       operationId: GetStatus
       description: Get the status of a node
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -942,7 +942,7 @@ paths:
       operationId: GetChainEnds
       description: Get oldest keyblock hashes counting from genesis including orphans
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -987,7 +987,7 @@ paths:
       operationId: GetNetworkStatus
       description: Get detailed analytics on peers
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -1010,7 +1010,7 @@ paths:
       operationId: PostContractCreate
       description: Get a contract_create transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1045,7 +1045,7 @@ paths:
       operationId: PostContractCall
       description: Get a contract_call transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1080,7 +1080,7 @@ paths:
       operationId: PostOracleRegister
       description: Get a oracle_register transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1115,7 +1115,7 @@ paths:
       operationId: PostOracleExtend
       description: Get an oracle_extend transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1150,7 +1150,7 @@ paths:
       operationId: PostOracleQuery
       description: Get an oracle_query transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1185,7 +1185,7 @@ paths:
       operationId: PostOracleRespond
       description: Get an oracle_response transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1220,7 +1220,7 @@ paths:
       operationId: PostNamePreclaim
       description: Get a name_preclaim transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1255,7 +1255,7 @@ paths:
       operationId: PostNameClaim
       description: Get a name_claim transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1290,7 +1290,7 @@ paths:
       operationId: PostNameUpdate
       description: Get a name_update transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1325,7 +1325,7 @@ paths:
       operationId: PostNameTransfer
       description: Get a name_transfer transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1360,7 +1360,7 @@ paths:
       operationId: PostNameRevoke
       description: Get a name_revoke transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1395,7 +1395,7 @@ paths:
       operationId: PostSpend
       description: Get a spend transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1431,7 +1431,7 @@ paths:
       operationId: PostChannelCreate
       description: Get a channel_create transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1466,7 +1466,7 @@ paths:
       operationId: PostChannelDeposit
       description: Get a channel_deposit transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1495,7 +1495,7 @@ paths:
       operationId: PostChannelWithdraw
       description: Get a channel_withdrawal transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1524,7 +1524,7 @@ paths:
       operationId: PostChannelSnapshotSolo
       description: Get a channel_snapshot_solo transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1553,7 +1553,7 @@ paths:
       operationId: PostChannelCloseMutual
       description: Get a channel_close_mutual transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1582,7 +1582,7 @@ paths:
       operationId: PostChannelCloseSolo
       description: Get a channel_close_solo transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1611,7 +1611,7 @@ paths:
       operationId: PostChannelSlash
       description: Get a channel_slash transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1640,7 +1640,7 @@ paths:
       operationId: PostChannelSettle
       description: Get a channel_settle transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1669,7 +1669,7 @@ paths:
       operationId: GetPendingTransactions
       description: Get pending transactions
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -1690,7 +1690,7 @@ paths:
       operationId: GetCommitmentId
       description: Compute commitment ID for a given salt and name
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - in: query
           name: name
           description: Name
@@ -1747,7 +1747,7 @@ paths:
       operationId: GetNodePubkey
       description: Get node's public key
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: Successful operation
@@ -1770,7 +1770,7 @@ paths:
       operationId: GetPeers
       description: Get node Peers
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       responses:
         "200":
           description: successful operation
@@ -1793,7 +1793,7 @@ paths:
       description: Dry-run transactions on top of a given block. Supports all TXs except
         GAMetaTx, PayingForTx and OffchainTx
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
       requestBody:
         content:
           application/json:
@@ -1822,7 +1822,7 @@ paths:
       operationId: GetTokenSupplyByHeight
       description: Get total token supply at height
       parameters:
-        - $ref: '#/components/parameters/bigIntAsString'
+        - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/height'
       responses:
         "200":
@@ -3388,7 +3388,7 @@ components:
         - $ref: "#/components/schemas/KeyBlock"
         - $ref: "#/components/schemas/MicroBlockHeader"
   parameters:
-    bigIntAsString:
+    intAsString:
       in: query
       name: "int-as-string"
       description: 'If this flag is set to true, the response will have all integers set as strings'

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -48,7 +48,7 @@ paths:
       operationId: GetTopHeader
       description: Get the top header (either key or micro block)
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -70,7 +70,7 @@ paths:
       operationId: GetCurrentKeyBlock
       description: Get the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -92,7 +92,7 @@ paths:
       operationId: GetCurrentKeyBlockHash
       description: Get the hash of the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -117,7 +117,7 @@ paths:
       operationId: GetCurrentKeyBlockHeight
       description: Get the height of the current key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -142,7 +142,7 @@ paths:
       operationId: GetPendingKeyBlock
       description: Get the pending key block
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -170,7 +170,7 @@ paths:
       operationId: GetKeyBlockByHash
       description: Get a key block by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/blockHash'
       responses:
         "200":
@@ -199,7 +199,7 @@ paths:
       operationId: GetKeyBlockByHeight
       description: Get a key block by height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/height'
       responses:
         "200":
@@ -222,7 +222,7 @@ paths:
       operationId: GetMicroBlockHeaderByHash
       description: Get a micro block header by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/blockHash'
       responses:
         "200":
@@ -251,7 +251,7 @@ paths:
       operationId: GetMicroBlockTransactionsByHash
       description: Get micro block transactions by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/microBlockHash'
       responses:
         "200":
@@ -284,7 +284,7 @@ paths:
       operationId: GetMicroBlockTransactionByHashAndIndex
       description: Get a micro block transaction by hash and index
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/microBlockHash'
         - in: path
           name: index
@@ -321,7 +321,7 @@ paths:
       operationId: GetMicroBlockTransactionsCountByHash
       description: Get micro block transaction count by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/microBlockHash'
       responses:
         "200":
@@ -353,7 +353,7 @@ paths:
       operationId: GetCurrentGeneration
       description: Get the current generation
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -375,7 +375,7 @@ paths:
       operationId: GetGenerationByHash
       description: Get a generation by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/keyBlockHash'
       responses:
         "200":
@@ -404,7 +404,7 @@ paths:
       operationId: GetGenerationByHeight
       description: Get a generation by height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/height'
       responses:
         "200":
@@ -427,7 +427,7 @@ paths:
       operationId: GetAccountByPubkey
       description: Get an account by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/accountPubkey'
       responses:
         "200":
@@ -457,7 +457,7 @@ paths:
       description: Get an account by public key after the opening key block of the
         generation at height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/accountPubkey'
         - $ref: '#/components/parameters/height'
       responses:
@@ -487,7 +487,7 @@ paths:
       operationId: GetAccountByPubkeyAndHash
       description: "Get an account by public key after the block indicated by hash. Can be either a micro block or a keyblock hash"
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/accountPubkey'
         - $ref: '#/components/parameters/blockHash'
       responses:
@@ -517,7 +517,7 @@ paths:
       operationId: GetPendingAccountTransactionsByPubkey
       description: Get pending account transactions by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/accountPubkey'
       responses:
         "200":
@@ -550,7 +550,7 @@ paths:
       operationId: GetTransactionByHash
       description: Get a transaction by hash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/txHash'
       responses:
         "200":
@@ -578,7 +578,7 @@ paths:
         - transaction
       operationId: GetTransactionInfoByHash
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/txHash'
       responses:
         "200":
@@ -607,7 +607,7 @@ paths:
       operationId: PostTransaction
       description: Post a new transaction
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -636,7 +636,7 @@ paths:
       operationId: GetContract
       description: Get a contract by pubkey
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
@@ -661,7 +661,7 @@ paths:
       operationId: GetContractCode
       description: Get contract code by pubkey
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
@@ -690,7 +690,7 @@ paths:
       operationId: GetContractPoI
       description: Get a proof of inclusion for a contract
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/contractPubkey'
       responses:
         "200":
@@ -719,7 +719,7 @@ paths:
       operationId: GetOracleByPubkey
       description: Get an oracle by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/oraclePubkey'
       responses:
         "200":
@@ -748,7 +748,7 @@ paths:
       operationId: GetOracleQueriesByPubkey
       description: Get oracle queries by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/oraclePubkey'
         - in: query
           name: from
@@ -804,7 +804,7 @@ paths:
       operationId: GetOracleQueryByPubkeyAndQueryId
       description: Get an oracle query by public key and query ID
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/oraclePubkey'
         - in: path
           name: query-id
@@ -840,7 +840,7 @@ paths:
       operationId: GetNameEntryByName
       description: Get name entry from naming system
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - in: path
           name: name
           description: The name key of the name entry
@@ -875,7 +875,7 @@ paths:
       operationId: GetChannelByPubkey
       description: Get channel by public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - in: path
           name: pubkey
           description: The pubkey of the channel
@@ -910,7 +910,7 @@ paths:
       operationId: GetPeerPubkey
       description: Get peer public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -926,7 +926,7 @@ paths:
       operationId: GetStatus
       description: Get the status of a node
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -942,7 +942,7 @@ paths:
       operationId: GetChainEnds
       description: Get oldest keyblock hashes counting from genesis including orphans
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -987,7 +987,7 @@ paths:
       operationId: GetNetworkStatus
       description: Get detailed analytics on peers
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -1010,7 +1010,7 @@ paths:
       operationId: PostContractCreate
       description: Get a contract_create transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1045,7 +1045,7 @@ paths:
       operationId: PostContractCall
       description: Get a contract_call transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1080,7 +1080,7 @@ paths:
       operationId: PostOracleRegister
       description: Get a oracle_register transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1115,7 +1115,7 @@ paths:
       operationId: PostOracleExtend
       description: Get an oracle_extend transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1150,7 +1150,7 @@ paths:
       operationId: PostOracleQuery
       description: Get an oracle_query transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1185,7 +1185,7 @@ paths:
       operationId: PostOracleRespond
       description: Get an oracle_response transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1220,7 +1220,7 @@ paths:
       operationId: PostNamePreclaim
       description: Get a name_preclaim transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1255,7 +1255,7 @@ paths:
       operationId: PostNameClaim
       description: Get a name_claim transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1290,7 +1290,7 @@ paths:
       operationId: PostNameUpdate
       description: Get a name_update transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1325,7 +1325,7 @@ paths:
       operationId: PostNameTransfer
       description: Get a name_transfer transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1360,7 +1360,7 @@ paths:
       operationId: PostNameRevoke
       description: Get a name_revoke transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1395,7 +1395,7 @@ paths:
       operationId: PostSpend
       description: Get a spend transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1431,7 +1431,7 @@ paths:
       operationId: PostChannelCreate
       description: Get a channel_create transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1466,7 +1466,7 @@ paths:
       operationId: PostChannelDeposit
       description: Get a channel_deposit transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1495,7 +1495,7 @@ paths:
       operationId: PostChannelWithdraw
       description: Get a channel_withdrawal transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1524,7 +1524,7 @@ paths:
       operationId: PostChannelSnapshotSolo
       description: Get a channel_snapshot_solo transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1553,7 +1553,7 @@ paths:
       operationId: PostChannelCloseMutual
       description: Get a channel_close_mutual transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1582,7 +1582,7 @@ paths:
       operationId: PostChannelCloseSolo
       description: Get a channel_close_solo transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1611,7 +1611,7 @@ paths:
       operationId: PostChannelSlash
       description: Get a channel_slash transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1640,7 +1640,7 @@ paths:
       operationId: PostChannelSettle
       description: Get a channel_settle transaction object
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1669,7 +1669,7 @@ paths:
       operationId: GetPendingTransactions
       description: Get pending transactions
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -1690,7 +1690,7 @@ paths:
       operationId: GetCommitmentId
       description: Compute commitment ID for a given salt and name
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - in: query
           name: name
           description: Name
@@ -1747,7 +1747,7 @@ paths:
       operationId: GetNodePubkey
       description: Get node's public key
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: Successful operation
@@ -1770,7 +1770,7 @@ paths:
       operationId: GetPeers
       description: Get node Peers
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       responses:
         "200":
           description: successful operation
@@ -1793,7 +1793,7 @@ paths:
       description: Dry-run transactions on top of a given block. Supports all TXs except
         GAMetaTx, PayingForTx and OffchainTx
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
       requestBody:
         content:
           application/json:
@@ -1822,7 +1822,7 @@ paths:
       operationId: GetTokenSupplyByHeight
       description: Get total token supply at height
       parameters:
-        - $ref: '#/components/parameters/bigIngAsString'
+        - $ref: '#/components/parameters/bigIntAsString'
         - $ref: '#/components/parameters/height'
       responses:
         "200":
@@ -3388,7 +3388,7 @@ components:
         - $ref: "#/components/schemas/KeyBlock"
         - $ref: "#/components/schemas/MicroBlockHeader"
   parameters:
-    bigIngAsString:
+    bigIntAsString:
       in: query
       name: "int-as-string"
       description: 'If this flag is set to true, the response will have all integers set as strings'

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -82,11 +82,14 @@ handle_request_json(Req0, State = #state{
     try aehttp_api_validate:request(OperationId, Method, Req0, Validator, Mod) of
         {ok, Params, Req1} ->
             Context = #{},
-            {Code, Headers, Body} = LogicHandler:handle_request(OperationId, Params, Context),
-
+            {Code, Headers, Body0} = LogicHandler:handle_request(OperationId, Params, Context),
+            Body =
+                case maps:get('big-int-as-string', Params) of
+                    false -> Body0;
+                    true -> convert_all_ints_to_string(Body0)
+                end,
             _ = aehttp_api_validate:response(OperationId, Method, Code, Body,
                                              Validator, Mod),
-
             Req = cowboy_req:reply(Code, to_headers(Headers), jsx:encode(Body), Req1),
             {stop, Req, State};
         {error, Reason, Req1} ->
@@ -114,3 +117,11 @@ to_error({Reason, Name, Info}) ->
 cache_enabled() ->
     aeu_env:user_config_or_env([<<"http">>, <<"cache">>, <<"enabled">>],
                                aehttp, [cache, enabled], ?DEFAULT_HTTP_CACHE_ENABLED).
+
+convert_all_ints_to_string(Map) ->
+   maps:map(
+      fun(_, I) when is_integer(I) -> integer_to_binary(I);
+         (_, M) when is_map(M) -> convert_all_ints_to_string(M);
+         (_, Other) -> Other
+      end,
+      Map).

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -84,7 +84,7 @@ handle_request_json(Req0, State = #state{
             Context = #{},
             {Code, Headers, Body0} = LogicHandler:handle_request(OperationId, Params, Context),
             Body =
-                case maps:get('big-int-as-string', Params, false) of
+                case maps:get('int-as-string', Params, false) of
                     false -> Body0;
                     true -> convert_all_ints_to_string(Body0)
                 end,

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -84,7 +84,7 @@ handle_request_json(Req0, State = #state{
             Context = #{},
             {Code, Headers, Body0} = LogicHandler:handle_request(OperationId, Params, Context),
             Body =
-                case maps:get('big-int-as-string', Params) of
+                case maps:get('big-int-as-string', Params, false) of
                     false -> Body0;
                     true -> convert_all_ints_to_string(Body0)
                 end,
@@ -108,7 +108,15 @@ to_headers(Headers) when is_list(Headers) ->
 to_headers(Headers) ->
     Headers.
 
-to_error({Reason, Name, Info}) ->
+to_error({Reason, Name, Info0}) ->
+    Info = 
+        case is_map(Info0) of
+            true -> Info0;
+            false ->
+                [{K, V} || {K, V} <- Info0, K =:= error
+                                    orelse K =:= data
+                                    orelse K =:= path]
+        end,
     #{ reason => Reason,
        parameter => Name,
        info => Info }.

--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -221,6 +221,7 @@ prepare_param_({"schema", #{<<"$ref">> := FullRef}},
             param_error({schema, Info2}, Name)
     end;
 prepare_param_({"schema",#{<<"type">> := _}}, _, _, _, _) -> ok;
+prepare_param_({"schema",[{"type",  _} | _]}, _, _, _, _) -> ok;
 % enum
 prepare_param_({"enum", Values0}, Value0, Name, _, _) ->
     try

--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -148,7 +148,8 @@ prepare_param_({"in", _}, _, _, _, _) -> ok;
 prepare_param_({"name", _}, _, _, _, _) -> ok;
 prepare_param_({"description", _}, _, _, _, _) -> ok;
 prepare_param_({"example", _}, _, _, _, _) -> ok;
-prepare_param_({"default", _}, _, _, _, _) -> ok;
+prepare_param_({"default", Default}, undefined, _, _, _) -> {ok, Default};
+prepare_param_({"default", _Default}, _, _, _, _) -> ok;
 % required
 prepare_param_({"required",true}, undefined, Name, _, _) -> param_error(required, Name);
 prepare_param_({"required",_}, _, _, _, _) -> ok;

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -230,7 +230,7 @@ handle_request_('GetKeyBlockByHash', Params, _Context) ->
     end;
 
 handle_request_('GetKeyBlockByHeight', Params, _Context) ->
-    Height = maps:get(height, Params),
+    Height =  aehttp_helpers:to_int(maps:get(height, Params)),
     case aec_chain:get_key_block_by_height(Height) of
         {ok, Block} ->
             Header = aec_blocks:to_header(Block),
@@ -290,7 +290,7 @@ handle_request_('GetMicroBlockTransactionsByHash', Params, _Context) ->
 
 handle_request_('GetMicroBlockTransactionByHashAndIndex', Params, _Context) ->
     HashDec = aeser_api_encoder:safe_decode(micro_block_hash, maps:get(hash, Params)),
-    IndexDec = maps:get(index, Params),
+    IndexDec = aehttp_helpers:to_int(maps:get(index, Params)),
     case {HashDec, IndexDec} of
         {{ok, Hash}, Index} when is_integer(Index) ->
             case aehttp_logic:get_micro_block_by_hash(Hash) of
@@ -339,7 +339,7 @@ handle_request_('GetGenerationByHash', Params, _Context) ->
             end
     end;
 handle_request_('GetGenerationByHeight', Params, _Context) ->
-    Height = maps:get('height', Params),
+    Height = aehttp_helpers:to_int(maps:get('height', Params)),
     case aec_chain_state:get_key_block_hash_at_height(Height) of
         error -> {404, [], #{reason => <<"Chain too short">>}};
         {ok, Hash} -> generation_rsp(aec_chain:get_generation_by_hash(Hash, forward))
@@ -365,7 +365,7 @@ handle_request_('GetAccountByPubkeyAndHeight', Params, _Context) ->
     case aeser_api_encoder:safe_decode({id_hash, AllowedTypes}, maps:get(pubkey, Params)) of
         {ok, Id} ->
             {_IdType, Pubkey} = aeser_id:specialize(Id),
-            Height = maps:get(height, Params),
+            Height = aehttp_helpers:to_int(maps:get(height, Params)),
             case aec_chain:get_account_at_height(Pubkey, Height) of
                 {value, Account} ->
                     {200, [], aec_accounts:serialize_for_client(Account)};
@@ -702,3 +702,4 @@ deserialize_transaction(Tx) ->
     catch
         _:_ -> {error, broken_tx}
     end.
+

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -107,6 +107,7 @@ api_str_to_int(Params) ->
                 undefined             -> no_value;
                 Str when is_list(Str) -> {ok, list_to_integer(Str)};
                 I when is_integer(I)  -> {ok, I};
+                B when is_binary(B)   -> {ok, binary_to_integer(B)};
                 #{type := _, value := V} = TTL -> {ok, TTL#{value => to_int(V)}}
             end
         end,

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -7,6 +7,7 @@
         , api_decode/1
         , api_optional_decode/1
         , api_conditional_decode/1
+        , api_str_to_int/1
         , contract_bytearray_params_decode/1
         , ttl_decode/1
         , poi_decode/1
@@ -27,6 +28,7 @@
         , safe_get_txs/1
         , do_dry_run/0
         , dry_run_results/1
+        , to_int/1
         ]).
 
 -export([ get_transaction/2
@@ -95,6 +97,20 @@ api_opt_decode_fun({Name, Type}, _, Data) ->
 api_conditional_decode(Params) ->
     params_read_fun([ {K, K, T} || {K, T} <- Params ],
                     fun api_cond_decode_fun/3, "Invalid decode").
+
+api_str_to_int(Params) ->
+    params_read_fun(Params,
+        fun(Name, Req, _) ->
+            %% swagger puts an 'undefined' value for missing not reqired
+            %% params
+            case maps:get(Name, Req, undefined) of
+                undefined             -> no_value;
+                Str when is_list(Str) -> {ok, list_to_integer(Str)};
+                I when is_integer(I)  -> {ok, I};
+                #{type := _, value := V} = TTL -> {ok, TTL#{value => to_int(V)}}
+            end
+        end,
+        "Invalid encoding").
 
 api_cond_decode_fun({Name, {Type, Cond}}, _, Data) ->
     Encoded = maps:get(Name, Data),
@@ -201,7 +217,7 @@ get_nonce(AccountKey) ->
                         {error, {404, [], #{<<"reason">> => list_to_binary(Msg)}}}
                 end;
             Nonce ->
-                {ok, maps:put(nonce, Nonce, State)}
+                {ok, maps:put(nonce, to_int(Nonce), State)}
         end
     end.
 
@@ -233,7 +249,7 @@ get_nonce_from_account_id(AccountKey) ->
                         end
                 end;
             Nonce ->
-                {ok, maps:put(nonce, Nonce, State)}
+                {ok, maps:put(nonce, to_int(Nonce), State)}
         end
     end.
 
@@ -877,3 +893,8 @@ safe_get_txs(Block) ->
         'key' -> [];
         'micro' -> aec_blocks:txs(Block)
     end.
+
+to_int(I) when is_integer(I) -> I;
+to_int(Str) when is_list(Str) -> list_to_integer(Str);
+to_int(Bin) when is_binary(Bin) -> binary_to_integer(Bin).
+

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -4158,8 +4158,8 @@ get_top_header(_Config) ->
       <<"time">> := Time,<<"version">> := Version} = HeaderOrig,
     %% this is not present in oas3.yaml but swagger.yaml
     {ok, 404, #{}} = get_top_sut(),
-    {ok, 200, HeaderOrig}= get_top_header_sut([{'big-int-as-string', false}]),
-    {ok, 200, HeaderStrings}= get_top_header_sut([{'big-int-as-string', true}]),
+    {ok, 200, HeaderOrig}= get_top_header_sut([{'int-as-string', false}]),
+    {ok, 200, HeaderStrings}= get_top_header_sut([{'int-as-string', true}]),
     #{<<"beneficiary">> := <<"ak_",Acc/binary>>,
       <<"hash">> := <<"kh_",Hash/binary>>,
       <<"height">> := HeightStr,

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3711,20 +3711,6 @@ swagger_validation_schema(_Config) ->
             <<"reason">> := <<"validation_error">>,
             <<"parameter">> := <<"body">>,
             <<"info">> :=  #{
-                        <<"data">> := <<"wrong_fee_data">>,
-                        <<"error">> := <<"wrong_type">>,
-                        <<"path">> := [<<"fee">>]
-        }}} = http_request(Host, post, "debug/transactions/spend", #{
-                   sender_id => <<"">>,
-                   recipient_id => <<"">>,
-                   amount => 0,
-                   fee => <<"wrong_fee_data">>,
-                   ttl => 100,
-                   payload => <<"">>}),
-    {ok, 400, #{
-            <<"reason">> := <<"validation_error">>,
-            <<"parameter">> := <<"body">>,
-            <<"info">> :=  #{
                         <<"data">> := <<"recipient_id">>,
                         <<"error">> := <<"missing_required_property">>,
                         <<"path">> := []
@@ -3739,7 +3725,7 @@ swagger_validation_schema(_Config) ->
             <<"parameter">> := <<"body">>,
             <<"info">> :=  #{
                         <<"data">> := -1,
-                        <<"error">> := <<"not_in_range">>,
+                        <<"error">> := Error,
                         <<"path">> := [<<"amount">>]
         }}} = http_request(Host, post, "debug/transactions/spend", #{
                    sender_id => <<"">>,
@@ -3747,7 +3733,8 @@ swagger_validation_schema(_Config) ->
                    amount => -1,
                    fee => 0,
                    ttl => 100,
-                   payload => <<"">>}).
+                   payload => <<"">>}),
+    true = lists:member(Error, [<<"not_in_range">>, <<"not_one_schema_valid">>]) .
 
 %%swagger_validation_types(_Config) ->
 %%    Host = internal_address(),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -927,8 +927,11 @@ get_top_sut() ->
     http_request(Host, get, "blocks/top", []).
 
 get_top_header_sut() ->
+    get_top_header_sut([]).
+
+get_top_header_sut(Opts) ->
     Host = external_address(),
-    http_request(Host, get, "headers/top", []).
+    http_request(Host, get, "headers/top", Opts).
 
 %% /key-blocks/*
 
@@ -4143,7 +4146,33 @@ setup_name_pointing_to_oracle(NameNoPrefix, OraclePubKey) ->
 %%%%%
 get_top_header(_Config) ->
     %% this is present in oas3.yaml
-    {ok, 200, #{<<"hash">> := <<"kh_",_/binary>>}}= get_top_header_sut(),
+    {ok, 200, HeaderOrig}= get_top_header_sut(),
+    #{<<"beneficiary">> := <<"ak_",Acc/binary>>,
+      <<"hash">> := <<"kh_",Hash/binary>>,
+      <<"height">> := Height,
+      <<"info">> := <<"cb_Xfbg4g==">>,
+      <<"miner">> := <<"ak_",Miner/binary>>,
+      <<"prev_hash">> := <<"kh_",PrevHash/binary>>,
+      <<"prev_key_hash">> := <<"kh_",PrevKeyHash/binary>>,
+      <<"state_hash">> := <<"bs_",StateHash/binary>>,
+      <<"target">> := Target,
+      <<"time">> := Time,<<"version">> := Version} = HeaderOrig,
     %% this is not present in oas3.yaml but swagger.yaml
     {ok, 404, #{}} = get_top_sut(),
+    {ok, 200, HeaderOrig}= get_top_header_sut([{'big-int-as-string', false}]),
+    {ok, 200, HeaderStrings}= get_top_header_sut([{'big-int-as-string', true}]),
+    #{<<"beneficiary">> := <<"ak_",Acc/binary>>,
+      <<"hash">> := <<"kh_",Hash/binary>>,
+      <<"height">> := HeightStr,
+      <<"info">> := <<"cb_Xfbg4g==">>,
+      <<"miner">> := <<"ak_",Miner/binary>>,
+      <<"prev_hash">> := <<"kh_",PrevHash/binary>>,
+      <<"prev_key_hash">> := <<"kh_",PrevKeyHash/binary>>,
+      <<"state_hash">> := <<"bs_",StateHash/binary>>,
+      <<"target">> := TargetStr,
+      <<"time">> := TimeStr,<<"version">> := VersionStr} = HeaderStrings,
+    Height = binary_to_integer(HeightStr),
+    Target = binary_to_integer(TargetStr),
+    Time = binary_to_integer(TimeStr),
+    Version = binary_to_integer(VersionStr),
     ok.

--- a/docs/release-notes/next/GH-XX-http_api_param_ints_as_strings.md
+++ b/docs/release-notes/next/GH-XX-http_api_param_ints_as_strings.md
@@ -1,0 +1,8 @@
+* Introduces a new query param in relevant HTTP APIs. It is called
+  `int-to-str` and specifies that all integers in the response shall be
+  represented as strings instead. This will allow SDKs to pick their
+  prefferance for the data representation and will help them solve precision
+  issues. This applies only for v3 API that supports `oas3` and is not
+  supported by the `swagger v2` API
+* Allows passing strings instead of integers in `post` requests for `debug`
+  APIs that are convenience for testing and developing SDKs. 

--- a/docs/release-notes/next/GH-XX-http_api_param_ints_as_strings.md
+++ b/docs/release-notes/next/GH-XX-http_api_param_ints_as_strings.md
@@ -1,7 +1,7 @@
 * Introduces a new query param in relevant HTTP APIs. It is called
   `int-to-str` and specifies that all integers in the response shall be
   represented as strings instead. This will allow SDKs to pick their
-  prefferance for the data representation and will help them solve precision
+  preference for the data representation and will help them solve precision
   issues. This applies only for v3 API that supports `oas3` and is not
   supported by the `swagger v2` API
 * Allows passing strings instead of integers in `post` requests for `debug`

--- a/rebar.config
+++ b/rebar.config
@@ -108,7 +108,7 @@
        ]}.
 
 {plugins, [
-        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "379dc43"}}},
+        {swagger_endpoints, {git, "https://github.com/velzevur/swagger_endpoints", {ref, "d7c6b83"}}},
         {aesophia_rebar_plugin, {git, "https://github.com/aeternity/aesophia_rebar_plugin", {ref, "df113cc"}}}
     ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -108,7 +108,7 @@
        ]}.
 
 {plugins, [
-        {swagger_endpoints, {git, "https://github.com/velzevur/swagger_endpoints", {ref, "d7c6b83"}}},
+        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "88838a2"}}},
         {aesophia_rebar_plugin, {git, "https://github.com/aeternity/aesophia_rebar_plugin", {ref, "df113cc"}}}
     ]}.
 


### PR DESCRIPTION
Refactor the oas3 specification and adopt the `int-as-strings` param.