### PR TITLE
Add missing next-iris release notes material

### DIFF
--- a/docs/release-notes/next-iris/AENS_sophia.md
+++ b/docs/release-notes/next-iris/AENS_sophia.md
@@ -4,7 +4,3 @@
   set to 0, from `VM_FATE_SOPHIA_2` it has the correct value.
 * Fixed bug in `AENS.resolve` in FATE VM - for invalid names `VM_FATE_SOPHIA_1`
   will crash. From `VM_FATE_SOPHIA_2` it will not crash, rather return `None`.
-* Changed `Chain.block_hash` - in `VM_FATE_SOPHIA_2` it will return
-  `Some(<blockhash>)` for `Chain.block_height` (i.e. current generation)
-  previously it returned `None`. With Bitcoin-NG we do have the block hash of
-  the current generation, so no reason not to allow this.

--- a/docs/release-notes/next-iris/FATE.md
+++ b/docs/release-notes/next-iris/FATE.md
@@ -1,0 +1,20 @@
+* Changed `Chain.block_hash` - in `VM_FATE_SOPHIA_2` it will return
+  `Some(<blockhash>)` for `Chain.block_height` (i.e. current generation)
+  previously it returned `None`. With Bitcoin-NG we do have the block hash of
+  the current generation, so no reason not to allow this.
+
+* Generalized accounts, allow access to the signed transaction within the authentication context:
+```
+switch(Auth.tx)
+  Spend(from, to, amount, payload) => ...
+  AENSTransfer(from, to, name) => ...
+  ...
+```
+  This enables more use-cases, for example in combination with PayingForTx.
+
+* Added more crypto primitives (mainly pairing operations) for BLS12-381. This
+  enables for example Zero-knowledge proofs and more multi-signature schemes.
+
+* Added functions related to strings. It introduces `to_list` and `from_list`
+  primitives that enables flexible string manipulation. `Strings.aes` standard
+  library functions include many useful string functions.

--- a/docs/release-notes/next-iris/GH-2797-query_oracle_by_name.md
+++ b/docs/release-notes/next-iris/GH-2797-query_oracle_by_name.md
@@ -1,0 +1,2 @@
+* Adds the possibility to query a an oracle by name hash. A name pointer can
+  map `oracle_pubkey` to a an oracle to enable query by name hash.

--- a/docs/release-notes/next-iris/GH-2851-PayingForTx.md
+++ b/docs/release-notes/next-iris/GH-2851-PayingForTx.md
@@ -1,0 +1,5 @@
+* Add a new transaction to the protocol. PayingForTx allows an account to pay
+  for a transaction on behalf of someone else. This means paying for fees and
+  gas cost, but it will **not** cover the amount spent by the transaction just
+  the "the cost of the transaction" (and the extra size added by wrapping the
+  original transaction).

--- a/docs/release-notes/next-iris/GH-3145-store-map-gc-bug.md
+++ b/docs/release-notes/next-iris/GH-3145-store-map-gc-bug.md
@@ -1,0 +1,2 @@
+* Fix a bug in the contract store garbage collector causing maps to me
+  more expensive than they should be.

--- a/docs/release-notes/next-iris/GH-3162-protected-remote-calls.md
+++ b/docs/release-notes/next-iris/GH-3162-protected-remote-calls.md
@@ -1,0 +1,4 @@
+* Add support for protected contract calls. Making a contract call with the named
+  argument `protected` set to `true` wraps the result of the call in an
+  `option` type, returning `Some(res)` if the call succeeds with result `res`
+  and `None` if the call fails for any reason.

--- a/docs/release-notes/next-iris/GH-3162-protected-remote-calls.md
+++ b/docs/release-notes/next-iris/GH-3162-protected-remote-calls.md
@@ -1,4 +1,5 @@
 * Add support for protected contract calls. Making a contract call with the named
   argument `protected` set to `true` wraps the result of the call in an
   `option` type, returning `Some(res)` if the call succeeds with result `res`
-  and `None` if the call fails for any reason.
+  and `None` if the call fails for any reason. If the call fails, any
+  side-effects it performed are rolled back.

--- a/docs/release-notes/next-iris/GH-3256-fix-store-map-bug.md
+++ b/docs/release-notes/next-iris/GH-3256-fix-store-map-bug.md
@@ -1,0 +1,1 @@
+* Fix a bug when returning maps from remote calls.

--- a/docs/release-notes/next-iris/GH-3256-fix-store-map-bug.md
+++ b/docs/release-notes/next-iris/GH-3256-fix-store-map-bug.md
@@ -1,1 +1,0 @@
-* Fix a bug when returning maps from remote calls.


### PR DESCRIPTION
While discussing other things we realized that things are missing from the `next-iris` release notes. Here is an attempt to fix this - @UlfNorell will add a few more things hence WIP.

NOTE: All of these things are documented either in `protocol` repo (mainly in the `iris` branch) and in `aesophia` repo (`master` branch - but @radrow and @nikita-fuchs  has moved docs around slightly.)