### PR TITLE
Fix OTP23 build

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -269,7 +269,8 @@
                 {platform_define, "^((1[8|9])|2)", rand_module},
                 {verbosity, trace}]
     }]},
-  {override, eper, [ {erl_opts, [debug_info]} ]}
+  {override, eper, [ {erl_opts, [debug_info]} ]},
+  {del, jesse, [{erl_opts, [warnings_as_errors]}]}
   ]}.
 
 {provider_hooks,


### PR DESCRIPTION
Jesse produces a deprecation warning on OTP23. Thus we disable
error_on_warning in jesse.