### PR TITLE
Include full FATE 2 code with init in trees

### DIFF
--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -75,14 +75,15 @@ run_new(ContractPubKey, Call, CallData, Trees0, OnChainTrees,
 
 prepare_init_call(VmVersion, Protocol, Contract, Trees0) when ?IS_FATE_SOPHIA(VmVersion) ->
     Code = #{ byte_code := ByteCode } = aeser_contract_code:deserialize(aect_contracts:code(Contract)),
-    FateCode  = aeb_fate_code:deserialize(ByteCode),
-    FateCode1 =
+    ByteCode1 =
         if
-        % Before FATE 2 we do not include init function in code put in trees
-            VmVersion == ?VM_FATE_SOPHIA_1 -> aeb_fate_code:strip_init_function(FateCode);
-            true -> FateCode
+            % Before FATE 2 we do not include init function in code put in trees
+            VmVersion == ?VM_FATE_SOPHIA_1 ->
+                FateCode  = aeb_fate_code:deserialize(ByteCode),
+                FateCode1 = aeb_fate_code:strip_init_function(FateCode),
+                aeb_fate_code:serialize(FateCode1);
+            true -> ByteCode
         end,
-    ByteCode1 = aeb_fate_code:serialize(FateCode1),
     Code1     = Code#{ byte_code := ByteCode1 },
     %% The serialization was broken in the Lima release - setting the
     %% compiler version to "unknown" regardless of the actual value.

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -158,7 +158,7 @@ run(ContractPubKey, ABIVersion, Call, CallData, CallStack, Trees0,
         false                                -> erlang:error(wrong_abi_version)
     end,
     CallDef = make_call_def(CallerPubkey, OwnerPubkey, ContractPubKey, Gas, GasPrice, Amount,
-              CallData, false, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees0),
+              CallData, _AllowInit = false, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees0),
     {CallRes, Trees, _} = aect_dispatch:run(#{vm => VmVersion, abi => ABIVersion}, CallDef),
     UpdatedTrees = aect_utils:insert_call_in_trees(CallRes, Trees),
     {aec_trees:gc_cache(UpdatedTrees, [accounts, contracts]), CallRes}.

--- a/apps/aecontract/src/aect_channel_contract.erl
+++ b/apps/aecontract/src/aect_channel_contract.erl
@@ -43,7 +43,7 @@ run_new(ContractPubKey, Call, CallData, Trees0, OnChainTrees,
     CallDef = make_call_def(OwnerPubKey, OwnerPubKey, ContractPubKey,
                             _Gas = 1000000, _GasPrice = 1,
                             _Amount = 0, %TODO: make this configurable
-                            CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees1),
+                            CallData, _AllowInit = true, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees1),
     CTVersion = aect_contracts:ct_version(Contract),
     {CallRes, Trees, _} = aect_dispatch:run(CTVersion, CallDef),
     case aect_call:return_type(CallRes) of
@@ -76,7 +76,12 @@ run_new(ContractPubKey, Call, CallData, Trees0, OnChainTrees,
 prepare_init_call(VmVersion, Protocol, Contract, Trees0) when ?IS_FATE_SOPHIA(VmVersion) ->
     Code = #{ byte_code := ByteCode } = aeser_contract_code:deserialize(aect_contracts:code(Contract)),
     FateCode  = aeb_fate_code:deserialize(ByteCode),
-    FateCode1 = aeb_fate_code:strip_init_function(FateCode),
+    FateCode1 =
+        if
+        % Before FATE 2 we do not include init function in code put in trees
+            VmVersion == ?VM_FATE_SOPHIA_1 -> aeb_fate_code:strip_init_function(FateCode);
+            true -> FateCode
+        end,
     ByteCode1 = aeb_fate_code:serialize(FateCode1),
     Code1     = Code#{ byte_code := ByteCode1 },
     %% The serialization was broken in the Lima release - setting the
@@ -153,7 +158,7 @@ run(ContractPubKey, ABIVersion, Call, CallData, CallStack, Trees0,
         false                                -> erlang:error(wrong_abi_version)
     end,
     CallDef = make_call_def(CallerPubkey, OwnerPubkey, ContractPubKey, Gas, GasPrice, Amount,
-              CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees0),
+              CallData, false, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv, Trees0),
     {CallRes, Trees, _} = aect_dispatch:run(#{vm => VmVersion, abi => ABIVersion}, CallDef),
     UpdatedTrees = aect_utils:insert_call_in_trees(CallRes, Trees),
     {aec_trees:gc_cache(UpdatedTrees, [accounts, contracts]), CallRes}.
@@ -161,7 +166,7 @@ run(ContractPubKey, ABIVersion, Call, CallData, CallStack, Trees0,
 
 
 make_call_def(CallerPubkey, OwnerPubKey, ContractPubKey, GasLimit, GasPrice, Amount,
-              CallData, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv,
+              CallData, AllowInit, CallStack, Code, Store, Call, OnChainTrees, OnChainEnv,
               OffChainTrees) ->
     #{caller          => CallerPubkey
     , contract        => ContractPubKey
@@ -179,6 +184,7 @@ make_call_def(CallerPubkey, OwnerPubKey, ContractPubKey, GasLimit, GasPrice, Amo
     , on_chain_trees  => OnChainTrees
     , origin          => CallerPubkey
     , creator         => OwnerPubKey
+    , allow_init      => AllowInit
     }.
 
 

--- a/apps/aecontract/src/aect_dispatch.erl
+++ b/apps/aecontract/src/aect_dispatch.erl
@@ -110,6 +110,7 @@ run_common(#{vm := VMVersion, abi := ABIVersion},
                     , gas        => Gas
                     , value      => Value
                     , vm_version => VMVersion
+                    , allow_init => maps:get(allow_init, CallDef, false)
                     },
             Env0 = maps:with(?FATE_VM_SPEC_FIELDS, CallDef),
             Env1  = Env0#{ tx_env   => aetx_env:set_context(TxEnv0, aetx_contract)

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -6636,35 +6636,37 @@ lima_migration(_Config) ->
 
 fate_vm_interaction(Cfg) ->
     state(aect_test_utils:new_state()),
-    ForkHeights   = ?config(fork_heights, Cfg),
+    ForkHeights = ?config(fork_heights, Cfg),
     LimaHeight = maps:get(lima, ForkHeights),
     IrisHeight = maps:get(iris, ForkHeights),
     Protocol = aec_hard_forks:protocol_effective_at_height(LimaHeight),
     GasPrice = aec_governance:minimum_gas_price(Protocol),
-    MinerMinGasPrice= aec_tx_pool:minimum_miner_gas_price(),
-    MinGasPrice   = max(GasPrice, MinerMinGasPrice),
-    Acc           = ?call(new_account, 10000000000 * MinGasPrice),
-    LimaSpec      = #{height => LimaHeight, vm_version => ?VM_FATE_SOPHIA_1,
-        amount => 100,
-        gas_price => MinGasPrice,
-        fee => 1000000 * MinGasPrice},
-    IrisSpec      = #{height => IrisHeight, vm_version => ?VM_FATE_SOPHIA_2,
-        amount => 100,
-        gas_price => MinGasPrice,
-        fee => 1000000 * MinGasPrice},
+    MinerMinGasPrice = aec_tx_pool:minimum_miner_gas_price(),
+    MinGasPrice = max(GasPrice, MinerMinGasPrice),
+    Acc = ?call(new_account, 10000000000 * MinGasPrice),
+    LimaSpec = #{height => LimaHeight,
+                 vm_version => ?VM_FATE_SOPHIA_1,
+                 amount => 100,
+                 gas_price => MinGasPrice,
+                 fee => 1000000 * MinGasPrice},
+    IrisSpec = #{height => IrisHeight,
+                 vm_version => ?VM_FATE_SOPHIA_2,
+                 amount => 100,
+                 gas_price => MinGasPrice,
+                 fee => 1000000 * MinGasPrice},
     {ok, IdCode}  = compile_contract(identity),
     {ok, RemCode} = compile_contract(remote_call),
 
     %% Create contracts on both sides of the fork
-    IdCLima     = ?call(create_contract_with_code, Acc, IdCode, {}, LimaSpec),
-    RemCLima    = ?call(create_contract_with_code, Acc, RemCode, {}, LimaSpec),
-    Rem2CLima    = ?call(create_contract_with_code, Acc, RemCode, {}, LimaSpec),
-    IdCIris     = ?call(create_contract_with_code, Acc, IdCode, {}, IrisSpec),
-    RemCIris    = ?call(create_contract_with_code, Acc, RemCode, {}, IrisSpec),
-    Rem2CIris    = ?call(create_contract_with_code, Acc, RemCode, {}, IrisSpec),
+    IdCLima   = ?call(create_contract_with_code, Acc, IdCode, {}, LimaSpec),
+    RemCLima  = ?call(create_contract_with_code, Acc, RemCode, {}, LimaSpec),
+    Rem2CLima = ?call(create_contract_with_code, Acc, RemCode, {}, LimaSpec),
+    IdCIris   = ?call(create_contract_with_code, Acc, IdCode, {}, IrisSpec),
+    RemCIris  = ?call(create_contract_with_code, Acc, RemCode, {}, IrisSpec),
+    Rem2CIris = ?call(create_contract_with_code, Acc, RemCode, {}, IrisSpec),
 
     %% Check that we cannot create contracts with old vms after the forks
-    BadSpec   = LimaSpec#{height => IrisHeight},
+    BadSpec = LimaSpec#{height => IrisHeight},
     {error, illegal_vm_version} = ?call(tx_fail_create_contract_with_code, Acc, IdCode, {}, BadSpec),
 
     LatestCallSpec = #{height => IrisHeight,
@@ -6680,10 +6682,10 @@ fate_vm_interaction(Cfg) ->
     %% Call new/oldVM -> old/newVM
     [?assertEqual(98, ?call(call_contract, Acc, Rem, call, word, {?cid(Id), 98},
         LatestCallSpec))
-        || {Rem, Id} <- [ {RemCLima,    IdCLima}
-                        , {RemCIris,    IdCLima}
-                        , {RemCLima,    IdCIris}
-                        , {RemCIris,    IdCIris}
+        || {Rem, Id} <- [ {RemCLima, IdCLima}
+                        , {RemCIris, IdCLima}
+                        , {RemCLima, IdCIris}
+                        , {RemCIris, IdCIris}
                         ]],
 
     %% Call new/oldVM -> new/oldVM -> new/oldVM in different orders
@@ -6703,32 +6705,34 @@ fate_vm_interaction(Cfg) ->
 
 fate_vm_version_switching(Cfg) ->
     state(aect_test_utils:new_state()),
-    ForkHeights   = ?config(fork_heights, Cfg),
+    ForkHeights = ?config(fork_heights, Cfg),
     LimaHeight = maps:get(lima, ForkHeights),
     IrisHeight = maps:get(iris, ForkHeights),
     Protocol = aec_hard_forks:protocol_effective_at_height(LimaHeight),
     GasPrice = aec_governance:minimum_gas_price(Protocol),
-    MinerMinGasPrice= aec_tx_pool:minimum_miner_gas_price(),
-    MinGasPrice   = max(GasPrice, MinerMinGasPrice),
-    Acc           = ?call(new_account, 10000000000 * MinGasPrice),
-    LimaSpec      = #{height => LimaHeight, vm_version => ?VM_FATE_SOPHIA_1,
-        amount => 100,
-        gas_price => MinGasPrice,
-        fee => 1000000 * MinGasPrice},
-    IrisSpec      = #{height => IrisHeight, vm_version => ?VM_FATE_SOPHIA_2,
-        amount => 100,
-        gas_price => MinGasPrice,
-        fee => 1000000 * MinGasPrice},
+    MinerMinGasPrice = aec_tx_pool:minimum_miner_gas_price(),
+    MinGasPrice = max(GasPrice, MinerMinGasPrice),
+    Acc = ?call(new_account, 10000000000 * MinGasPrice),
+    LimaSpec = #{height => LimaHeight,
+                 vm_version => ?VM_FATE_SOPHIA_1,
+                 amount => 100,
+                 gas_price => MinGasPrice,
+                 fee => 1000000 * MinGasPrice},
+    IrisSpec = #{height => IrisHeight,
+                 vm_version => ?VM_FATE_SOPHIA_2,
+                 amount => 100,
+                 gas_price => MinGasPrice,
+                 fee => 1000000 * MinGasPrice},
     {ok, DetectorContract} = compile_contract(vm_detector),
     {ok, RemCode} = compile_contract(remote_call),
 
     %% Create contracts on both sides of the fork
-    DetC1Lima  = ?call(create_contract_with_code, Acc, DetectorContract, {}, LimaSpec),
-    DetC2Lima  = ?call(create_contract_with_code, Acc, DetectorContract, {}, LimaSpec),
-    DetC3Lima  = ?call(create_contract_with_code, Acc, DetectorContract, {}, LimaSpec),
-    DetC1Iris  = ?call(create_contract_with_code, Acc, DetectorContract, {}, IrisSpec),
-    DetC2Iris  = ?call(create_contract_with_code, Acc, DetectorContract, {}, IrisSpec),
-    DetC3Iris  = ?call(create_contract_with_code, Acc, DetectorContract, {}, IrisSpec),
+    DetC1Lima = ?call(create_contract_with_code, Acc, DetectorContract, {}, LimaSpec),
+    DetC2Lima = ?call(create_contract_with_code, Acc, DetectorContract, {}, LimaSpec),
+    DetC3Lima = ?call(create_contract_with_code, Acc, DetectorContract, {}, LimaSpec),
+    DetC1Iris = ?call(create_contract_with_code, Acc, DetectorContract, {}, IrisSpec),
+    DetC2Iris = ?call(create_contract_with_code, Acc, DetectorContract, {}, IrisSpec),
+    DetC3Iris = ?call(create_contract_with_code, Acc, DetectorContract, {}, IrisSpec),
 
     LatestCallSpec = #{height => IrisHeight,
                        gas_price => MinGasPrice,
@@ -6758,42 +6762,47 @@ fate_vm_version_switching(Cfg) ->
 
 contract_init_on_chain_fate(Cfg) ->
     state(aect_test_utils:new_state()),
-    ForkHeights   = ?config(fork_heights, Cfg),
+    ForkHeights = ?config(fork_heights, Cfg),
     LimaHeight = maps:get(lima, ForkHeights),
     IrisHeight = maps:get(iris, ForkHeights),
     Protocol = aec_hard_forks:protocol_effective_at_height(LimaHeight),
     GasPrice = aec_governance:minimum_gas_price(Protocol),
-    MinerMinGasPrice= aec_tx_pool:minimum_miner_gas_price(),
-    MinGasPrice   = max(GasPrice, MinerMinGasPrice),
-    Acc           = ?call(new_account, 10000000000 * MinGasPrice),
-    LimaSpec      = #{height => LimaHeight, vm_version => ?VM_FATE_SOPHIA_1,
-                      amount => 100,
-                      gas_price => MinGasPrice,
-                      fee => 1000000 * MinGasPrice},
-    IrisSpec      = #{height => IrisHeight, vm_version => ?VM_FATE_SOPHIA_2,
-                      amount => 100,
-                      gas_price => MinGasPrice,
-                      fee => 1000000 * MinGasPrice},
-    {ok, IdCode}  = compile_contract(identity),
+    MinerMinGasPrice = aec_tx_pool:minimum_miner_gas_price(),
+    MinGasPrice = max(GasPrice, MinerMinGasPrice),
+    Acc = ?call(new_account, 10000000000 * MinGasPrice),
+    LimaSpec = #{height => LimaHeight,
+                 vm_version => ?VM_FATE_SOPHIA_1,
+                 amount => 100,
+                 gas_price => MinGasPrice,
+                 fee => 1000000 * MinGasPrice},
+    IrisSpec = #{height => IrisHeight,
+                 vm_version => ?VM_FATE_SOPHIA_2,
+                 amount => 100,
+                 gas_price => MinGasPrice,
+                 fee => 1000000 * MinGasPrice},
+    {ok, IdCode} = compile_contract(identity),
 
-    GetFunctionsOnHardFork = fun(CallSpec) ->
-        Id = ?call(create_contract_with_code, Acc, IdCode, {}, CallSpec),
-        {value, Contract} = ?call(lookup_contract_by_id, Id),
-        aeb_fate_code:functions(
-            aeb_fate_code:deserialize(
-                aect_contracts:code(Contract)))
-                             end,
+    GetFunctionsOnHardFork =
+        fun(CallSpec) ->
+            Id = ?call(create_contract_with_code, Acc, IdCode, {}, CallSpec),
+            {value, Contract} = ?call(lookup_contract_by_id, Id),
+            aeb_fate_code:functions(
+                aeb_fate_code:deserialize(
+                    aect_contracts:code(Contract)))
+        end,
 
-    HasInit = fun(Functions) ->
-        InitIdentifier = aeb_fate_code:symbol_identifier(<<"init">>),
-        maps:is_key(InitIdentifier, Functions)
-              end,
+    HasInit =
+        fun(Functions) ->
+            InitIdentifier = aeb_fate_code:symbol_identifier(<<"init">>),
+            maps:is_key(InitIdentifier, Functions)
+        end,
 
     FunctionsLima = GetFunctionsOnHardFork(LimaSpec),
     ?assertEqual(false, HasInit(FunctionsLima)),
     FunctionsIris = GetFunctionsOnHardFork(IrisSpec),
     ?assertEqual(true, HasInit(FunctionsIris)),
     ok.
+
 %%%===================================================================
 %%% Store
 %%%===================================================================

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -273,6 +273,10 @@
 
 -define(assertMatchFATE(__ExpVm1, __ExpVm2, __Res),
     case vm_version() of
+        ?VM_AEVM_SOPHIA_1 -> ok;
+        ?VM_AEVM_SOPHIA_2 -> ok;
+        ?VM_AEVM_SOPHIA_3 -> ok;
+        ?VM_AEVM_SOPHIA_4 -> ok;
         ?VM_FATE_SOPHIA_1 -> ?assertMatch(__ExpVm1, __Res);
         ?VM_FATE_SOPHIA_2 -> ?assertMatch(__ExpVm2, __Res)
     end).
@@ -7422,5 +7426,6 @@ sophia_no_calls_to_init(_Cfg) ->
 
     Res = ?call(call_contract_with_calldata, Acc, C, word, CallData, #{}),
     ?assertMatchAEVM(Res, 32, 32, 32, {error, <<"unknown_function">>}),
-    ?assertMatchFATE({error, <<"Trying to call undefined function: <<68,214,68,31>>">>}, Res),
+    ?assertMatchFATE({error,<<"Trying to call undefined function: <<68,214,68,31>>">>},
+                     {error, <<"Calling init is not allowed in this context">>}, Res),
     ok.

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -113,10 +113,9 @@ final_trees(EngineState) ->
     aefa_chain_api:final_trees(aefa_engine_state:chain_api(EngineState)).
 
 verify_init_calldata(CallData) ->
-    Init = ?FATE_INIT_ID,
     case decode_calldata(CallData) of
-        {Init, _Args} -> ok;
-        _             -> error
+        {?FATE_INIT_ID, _Args} -> ok;
+        _                      -> error
     end.
 
 is_valid_calldata(CallData) ->
@@ -363,7 +362,7 @@ check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, AllowIn
         false -> abort({function_is_not_payable, Function}, ES)
     end.
 
-set_local_function(Function, true, ES) ->
+set_local_function(Function, _AllowInit = true, ES) ->
     set_local_function_(Function, ES);
 set_local_function(?FATE_INIT_ID, false, ES) ->
     abort({trying_to_call_function, ?FATE_INIT_ID}, ES);
@@ -749,4 +748,3 @@ make_none() ->
 
 make_some(Val) ->
     aeb_fate_data:make_variant([0, 1], 1, {Val}).
-

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -35,8 +35,8 @@
         , push_return_type_check/5
         , runtime_exit/2
         , runtime_revert/2
-        , set_local_function/2
-        , set_remote_function/6
+        , set_local_function/3
+        , set_remote_function/7
         ]
        ).
 
@@ -291,15 +291,10 @@ catch_protected(Err, ES) ->
 
 setup_engine(#{ contract := <<_:256>> = ContractPubkey
               , code := ByteCode
-              , vm_version := VMVersion
-              , allow_init := AllowInit } = Spec, Env) ->
+              , vm_version := VMVersion} = Spec, Env) ->
     try aeb_fate_code:deserialize(ByteCode) of
         Code ->
-            Code1 = case AllowInit of
-                        true -> Code;
-                        false -> aeb_fate_code:strip_init_function(Code)
-                    end,
-            Cache = #{ ContractPubkey => { Code1, VMVersion } },
+            Cache = #{ ContractPubkey => { Code, VMVersion } },
             setup_engine(Spec, Env, Cache)
     catch _:_ ->
             abort(bad_bytecode, no_state)
@@ -311,6 +306,7 @@ setup_engine(#{ contract := <<_:256>> = ContractPubkey
               , value := Value
               , store := Store
               , vm_version := VMVersion
+              , allow_init := AllowInit
               }, Env, Cache) ->
     {tuple, {Function, {tuple, ArgTuple}}} =
         aeb_fate_encoding:deserialize(Call),
@@ -320,7 +316,7 @@ setup_engine(#{ contract := <<_:256>> = ContractPubkey
     APIState = aefa_chain_api:new(Env),
     ES1 = aefa_engine_state:new(Gas, Value, Env, Stores, APIState, Cache, VMVersion),
     Caller = aeb_fate_data:make_address(maps:get(caller, Env)),
-    ES2 = set_remote_function(Caller, Contract, Function, Value > 0, true, ES1),
+    ES2 = set_remote_function(Caller, Contract, Function, Value > 0, true, AllowInit, ES1),
     Signature = get_function_signature(Function, ES2),
     ES3 = check_signature(Arguments, Signature, ES2),
     bind_args(Arguments, ES3).
@@ -335,40 +331,46 @@ check_remote(Contract, EngineState) ->
             abort(reentrant_call, EngineState)
     end.
 
-set_remote_function(Caller, ?FATE_CONTRACT(Pubkey), Function, CheckPayable, CheckPrivate, ES) ->
+set_remote_function(Caller, ?FATE_CONTRACT(Pubkey), Function, CheckPayable, CheckPrivate, AllowInit, ES) ->
     CodeCache = aefa_engine_state:code_cache(ES),
     case maps:get(Pubkey, CodeCache, void) of
         void ->
             APIState  = aefa_engine_state:chain_api(ES),
             case aefa_chain_api:contract_fate_code(Pubkey, APIState) of
                 {ok, {ContractCode, VMV}, APIState1} ->
-                    ContractCode1 = aeb_fate_code:strip_init_function(ContractCode),
-                    CodeCache1 = maps:put(Pubkey, {ContractCode1, VMV}, CodeCache),
+                    CodeCache1 = maps:put(Pubkey, {ContractCode, VMV}, CodeCache),
                     ES1 = aefa_engine_state:set_code_cache(CodeCache1, ES),
                     ES2 = aefa_engine_state:set_chain_api(APIState1, ES1),
-                    ES3 = aefa_engine_state:update_for_remote_call(Pubkey, ContractCode1, VMV, Caller, ES2),
-                    check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, ES3);
+                    ES3 = aefa_engine_state:update_for_remote_call(Pubkey, ContractCode, VMV, Caller, ES2),
+                    check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, AllowInit, ES3);
                 error ->
                     abort({trying_to_call_contract, Pubkey}, ES)
             end;
         {ContractCode, VMV} ->
             ES1 = aefa_engine_state:update_for_remote_call(Pubkey, ContractCode, VMV, Caller, ES),
-            check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, ES1)
+            check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, AllowInit, ES1)
     end.
 
-check_flags_and_set_local_function(false, false, Function, ES) ->
-    set_local_function(Function, ES);
-check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, ES) ->
+check_flags_and_set_local_function(false, false, Function, AllowInit, ES) ->
+    set_local_function(Function, AllowInit, ES);
+check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, AllowInit, ES) ->
     case (not CheckPayable) orelse is_function_payable(Function, ES) of
         true  ->
             case CheckPrivate andalso is_function_private(Function, ES) of
-                false -> set_local_function(Function, ES);
+                false -> set_local_function(Function, AllowInit, ES);
                 true  -> abort({function_is_private, Function}, ES)
             end;
         false -> abort({function_is_not_payable, Function}, ES)
     end.
 
-set_local_function(Function, ES) ->
+set_local_function(Function, true, ES) ->
+    set_local_function_(Function, ES);
+set_local_function(?FATE_INIT_ID, false, ES) ->
+    abort({trying_to_call_function, ?FATE_INIT_ID}, ES);
+set_local_function(Function, false, ES) ->
+    set_local_function_(Function, ES).
+
+set_local_function_(Function, ES) ->
     BBs = get_function_code(Function, ES),
     ES1 = aefa_engine_state:set_current_function(Function, ES),
     ES2 = aefa_engine_state:set_current_bb(0, ES1),
@@ -620,7 +622,8 @@ pop_call_stack(ES) ->
             ES2 = check_return_type_protected(Protected, RetType, TVars, Stores, API, ES1),
             pop_call_stack(ES2);
         {local, Function, TVars, BB, ES1} ->
-            ES2 = set_local_function(Function, ES1),
+            % Allow returning to init
+            ES2 = set_local_function(Function, true, ES1),
             ES3 = aefa_engine_state:set_current_tvars(TVars, ES2),
             {jump, BB, ES3};
         {remote, Caller, Contract, Function, TVars, BB, ES1} ->
@@ -628,7 +631,8 @@ pop_call_stack(ES) ->
             %% but we need to unfold the store maps as the callee.
             Callee = aefa_engine_state:current_contract(ES),
             ES2    = with_current_contract(Callee, ES1, fun unfold_store_maps/1),
-            ES3 = set_remote_function(Caller, Contract, Function, false, false, ES2),
+            % Allow returning to init
+            ES3 = set_remote_function(Caller, Contract, Function, false, false, true, ES2),
             ES4 = aefa_engine_state:set_current_tvars(TVars, ES3),
             {jump, BB, ES4}
     end.

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -209,6 +209,8 @@ abort({trying_to_reach_bb, BB}, ES) ->
     ?t("Trying to jump to non existing bb: ~p", [BB], ES);
 abort({trying_to_call_function, Name}, ES) ->
     ?t("Trying to call undefined function: ~w", [Name], ES);
+abort(invalid_init_call, ES) ->
+    ?t("Calling init is not allowed in this context", [], ES);
 abort({trying_to_call_contract, Pubkey}, ES) ->
     ?t("Trying to call invalid contract: ~w", [Pubkey], ES);
 abort({not_allowed_in_auth_context, Op}, ES) ->
@@ -365,7 +367,7 @@ check_flags_and_set_local_function(CheckPayable, CheckPrivate, Function, AllowIn
 set_local_function(Function, _AllowInit = true, ES) ->
     set_local_function_(Function, ES);
 set_local_function(?FATE_INIT_ID, false, ES) ->
-    abort({trying_to_call_function, ?FATE_INIT_ID}, ES);
+    abort(invalid_init_call, ES);
 set_local_function(Function, false, ES) ->
     set_local_function_(Function, ES).
 

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -113,7 +113,7 @@ final_trees(EngineState) ->
     aefa_chain_api:final_trees(aefa_engine_state:chain_api(EngineState)).
 
 verify_init_calldata(CallData) ->
-    Init = aeb_fate_code:symbol_identifier(<<"init">>),
+    Init = ?FATE_INIT_ID,
     case decode_calldata(CallData) of
         {Init, _Args} -> ok;
         _             -> error

--- a/apps/aefate/src/aefate.erl
+++ b/apps/aefate/src/aefate.erl
@@ -65,7 +65,8 @@ load_file(FileName, Opts) ->
             Code = aeb_fate_code:deserialize(File),
             SerializedCall = aeb_fate_asm:function_call(Call),
             What = #{ contract => FileName
-                    , call => SerializedCall},
+                    , call => SerializedCall
+                    , allow_init => true},
             Chain = #{ contracts =>
                            #{ FileName => Code}},
             case aefa_fate:run(What, Chain) of

--- a/apps/aefate/test/aefa_sophia_test.erl
+++ b/apps/aefate/test/aefa_sophia_test.erl
@@ -131,7 +131,8 @@ make_call_spec(Contract, Function0, Arguments, Store) ->
        value      => 0,
        call       => aeb_fate_encoding:serialize(Calldata),
        store      => CtStore,
-       vm_version => ?VM_FATE_SOPHIA_2
+       vm_version => ?VM_FATE_SOPHIA_2,
+       allow_init => true
      }.
 
 pad_contract_name(Name) ->

--- a/apps/aefate/test/aefate_engine_test.erl
+++ b/apps/aefate/test/aefate_engine_test.erl
@@ -279,6 +279,7 @@ make_call(Contract, Function0, Arguments) ->
                  }
                 )
      , vm_version => ?VM_FATE_SOPHIA_2
+     , allow_init => true
      }.
 
 setup_contracts() ->

--- a/docs/release-notes/next-iris/GH-3546-fate-include-init.md
+++ b/docs/release-notes/next-iris/GH-3546-fate-include-init.md
@@ -1,1 +1,1 @@
-* Include full FATE 2 code with init in trees
+* Include full FATE 2 code with init in trees this improvement includes state channels

--- a/docs/release-notes/next-iris/GH-3546-fate-include-init.md
+++ b/docs/release-notes/next-iris/GH-3546-fate-include-init.md
@@ -1,0 +1,1 @@
+* Include full FATE 2 code with init in trees

--- a/docs/release-notes/next-iris/GH-3546-fate-include-init.md
+++ b/docs/release-notes/next-iris/GH-3546-fate-include-init.md
@@ -1,1 +1,1 @@
-* Include full FATE 2 code with init in trees this improvement includes state channels
+* Include full FATE 2 code with init in state trees. This also applies to offchain contracts in state channels

--- a/rebar.config
+++ b/rebar.config
@@ -67,7 +67,7 @@
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                    {ref, "0a82f0f"}}},
 
-        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "7f0d309"}}},
+        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "3910095"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"58e34ae"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -67,7 +67,7 @@
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                    {ref, "0a82f0f"}}},
 
-        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "3910095"}}},
+        {aebytecode, {git, "https://github.com/aeternity/aebytecode.git", {ref, "135a27c"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
                           {ref,"58e34ae"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.2.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"391009501820c28767adc2c861f12ab954fcc922"}},
+      {ref,"135a27c992b4dfc8af920ac42c67a5c07ba141e4"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.2.0",
 [{<<"aebytecode">>,
   {git,"https://github.com/aeternity/aebytecode.git",
-      {ref,"7f0d3090d4dc6c4d5fca7645b0c21eb0e65ad208"}},
+      {ref,"391009501820c28767adc2c861f12ab954fcc922"}},
   0},
  {<<"aecuckoo">>,
   {git,"https://github.com/aeternity/aecuckoo.git",


### PR DESCRIPTION
Init removal is done in aefate unless `allow_init` is passed.

aeternity/protocol#482