### PR TITLE
Fix forking orphan txs

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -758,7 +758,9 @@ remove_locations(Hash, Hash) ->
 remove_locations(StopHash, CurrentHash) ->
     lists:foreach(fun(TxHash) ->
                           aec_db:remove_tx_location(TxHash),
-                          aec_db:add_tx_hash_to_mempool(TxHash)
+                          aec_db:add_tx_hash_to_mempool(TxHash),
+                          Tx = aec_db:get_signed_tx(TxHash),
+                          aec_events:publish(tx_received, Tx)
                   end, db_safe_get_tx_hashes(CurrentHash)),
     remove_locations(StopHash, db_get_prev_hash(CurrentHash)).
 

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -312,7 +312,7 @@ handle_info({gproc_ps_event, Event, #{info := Info}},
             %% with other chains, we just keep them in mempool
             enqueue(tx, Info, PeerIds);
         tx_received when GossipTxs ->
-            enqueue(tx, Info, NonSyncingPeerIds);
+            enqueue(tx, Info, PeerIds);
         _             -> ignore
     end,
     {noreply, State};

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -1829,12 +1829,15 @@ setup_meck_and_keys() ->
     aec_test_utils:mock_governance(),
     aec_test_utils:mock_genesis_and_forks(),
     aec_consensus_bitcoin_ng:load_whitelist(),
+    meck:new(aec_events, [passthrough]),
+    meck:expect(aec_events, publish, fun(tx_received, _Tx) -> ok end),
     aec_test_utils:aec_keys_setup().
 
 teardown_meck_and_keys(TmpDir) ->
     aec_test_utils:unmock_difficulty_as_target(),
     aec_test_utils:unmock_governance(),
     aec_test_utils:unmock_genesis_and_forks(),
+    meck:unload(aec_events),
     aec_test_utils:aec_keys_cleanup(TmpDir).
 
 write_blocks_to_chain([H|T]) ->

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -14,7 +14,6 @@
 %% test case exports
 -export(
    [
-    sync_fork_in_wrong_order/1,
     add_dev3_node/1,
     dev3_failed_attack/1,
     dev3_syncs_to_community/1,
@@ -26,7 +25,10 @@
     mine_a_key_block_on_dev2/1,
     spend_on_dev1/1,
     spend_on_dev2/1,
-    mine_a_micro_block_on_dev1/1
+    mine_a_micro_block_on_dev1/1,
+    start_nodes_and_wait_sync_dev1_chain_wins/1,
+    start_nodes_and_wait_sync_dev2_chain_wins/1,
+    assert_orphaned_tx_in_pool/1
    ]).
 
 %% tr_ttb behavior callbacks
@@ -58,7 +60,9 @@ groups() ->
        start_dev2,
        mine_a_key_block_on_dev2,
        stop_dev2,
-       sync_fork_in_wrong_order]},
+       start_nodes_and_wait_sync_dev1_chain_wins,
+       stop_dev1,
+       stop_dev2]},
      {three_nodes, [sequence],
       [add_dev3_node,
        dev3_failed_attack,
@@ -74,6 +78,15 @@ groups() ->
        stop_dev1,
        start_dev2,
        mine_a_key_block_on_dev2,
+       mine_a_key_block_on_dev2,
+       mine_a_key_block_on_dev2,
+       mine_a_key_block_on_dev2,
+       mine_a_key_block_on_dev2,
+       mine_a_key_block_on_dev2,
+       stop_dev2,
+       start_nodes_and_wait_sync_dev2_chain_wins,
+       assert_orphaned_tx_in_pool,
+       stop_dev1,
        stop_dev2
        ]}
     ].
@@ -129,36 +142,6 @@ end_per_testcase(_Case, Config) ->
 %% ============================================================
 %% Test cases
 %% ============================================================
-
-sync_fork_in_wrong_order(Config) ->
-    aecore_suite_utils:start_node(dev1, Config),
-    N1 = aecore_suite_utils:node_name(dev1),
-    aecore_suite_utils:connect(N1),
-    N1Top = rpc:call(N1, aec_chain, top_block, [], 5000),
-    ct:log("top of chain dev1: ~p", [ N1Top ]),
-    aecore_suite_utils:stop_node(dev1, Config),
-
-    aecore_suite_utils:start_node(dev2, Config),
-    N2 = aecore_suite_utils:node_name(dev2),
-    aecore_suite_utils:connect(N2),
-    ForkTop = rpc:call(N2, aec_chain, top_block, [], 5000),
-    ct:log("top of chain dev2: ~p", [ ForkTop ]),
-
-    false = (ForkTop == N1Top),
-    timer:sleep(100),
-    %% unexepctedly last block of dev1 arrives before rest of the chain
-    %% This is no longer allowed, so it should fail.
-    ?assertMatch({error, {illegal_orphan, _}},
-                  rpc:call(N2, aec_conductor, post_block, [N1Top], 5000)),
-
-    T0 = os:timestamp(),
-    aecore_suite_utils:start_node(dev1, Config),
-    aecore_suite_utils:connect(N1),
-    done = aecore_suite_utils:await_sync_complete(T0, [N2]),
-    aec_test_utils:wait_for_it(
-      fun() -> rpc:call(N2, aec_chain, top_block, [], 5000) end,
-      N1Top),
-    ok = stop_and_check([dev1, dev2], Config).
 
 add_dev3_node(Config) ->
     %% dev1 and dev2 are in sync
@@ -328,12 +311,12 @@ mine_a_key_block_on_dev2(_Config) -> mine_a_key_block(dev2).
 mine_a_micro_block_on_dev1(_Config) -> mine_a_micro_block(dev1).
 
 mine_a_micro_block(Node) -> 
-    NName= aecore_suite_utils:node_name(Node),
+    NName = aecore_suite_utils:node_name(Node),
     aecore_suite_utils:mine_blocks(NName, 1, ?MINE_RATE, micro, #{}).
 
 spend(Node) ->
     {_, Pub} = aecore_suite_utils:sign_keys(Node),
-    NName= aecore_suite_utils:node_name(Node),
+    NName = aecore_suite_utils:node_name(Node),
     {ok, Tx} = aecore_suite_utils:spend(NName, Pub, Pub, 1, ?SPEND_FEE),
     {ok, [Tx]} = rpc:call(NName, aec_tx_pool, peek, [infinity]),
     ct:log("Spend tx ~p", [Tx]),
@@ -342,3 +325,49 @@ spend(Node) ->
 spend_on_dev1(_Config) -> spend(dev1).
 spend_on_dev2(_Config) -> spend(dev2).
 
+wait_nodes_to_sync(ExpectedTop, WrongForkNode, T0) ->
+    WFNName = aecore_suite_utils:node_name(WrongForkNode),
+    done = aecore_suite_utils:await_sync_complete(T0, [WFNName]),
+    aec_test_utils:wait_for_it(
+        fun() -> rpc:call(WFNName, aec_chain, top_block, [], 5000) end,
+        ExpectedTop),
+    ok.
+
+start_nodes_and_wait_sync_dev1_chain_wins(Config) ->
+    start_nodes_and_wait_sync(dev1, dev2, Config).
+
+start_nodes_and_wait_sync_dev2_chain_wins(Config) ->
+    start_nodes_and_wait_sync(dev2, dev1, Config).
+
+start_nodes_and_wait_sync(CorrectForkNode, OtherNode, Config) ->
+    start_node(CorrectForkNode, Config), 
+    CFNName = aecore_suite_utils:node_name(CorrectForkNode),
+    CFTop = rpc:call(CFNName, aec_chain, top_block, [], 5000),
+    ct:log("top of chain ~p: ~p", [ CorrectForkNode, CFTop ]),
+    stop_and_check([CorrectForkNode], Config), 
+
+    start_node(OtherNode, Config), 
+    ForkNName = aecore_suite_utils:node_name(OtherNode),
+    ForkTop = rpc:call(ForkNName, aec_chain, top_block, [], 5000),
+    ct:log("top of chain ~p: ~p", [ OtherNode, ForkTop ]),
+
+    false = (ForkTop == CFTop),
+    timer:sleep(100),
+    %% unexepctedly last block of dev1 arrives before rest of the chain
+    %% This is no longer allowed, so it should fail.
+    ?assertMatch({error, {illegal_orphan, _}},
+                  rpc:call(ForkNName, aec_conductor, post_block, [CFTop], 5000)),
+
+    T0 = os:timestamp(),
+    start_node(CorrectForkNode, Config), 
+    wait_nodes_to_sync(CFTop, OtherNode, T0),
+    ok.
+
+assert_orphaned_tx_in_pool(_Config) ->
+    NName = aecore_suite_utils:node_name(dev1),
+    {ok, [Tx]} = rpc:call(NName, aec_tx_pool, peek, [infinity], 5000),
+
+    timer:sleep(10000),
+    N2Name = aecore_suite_utils:node_name(dev2),
+    {ok, [Tx]} = rpc:call(N2Name, aec_tx_pool, peek, [infinity], 5000),
+    ok.

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -25,7 +25,8 @@
     mine_a_key_block_on_dev1/1,
     mine_a_key_block_on_dev2/1,
     spend_on_dev1/1,
-    spend_on_dev2/1
+    spend_on_dev2/1,
+    mine_a_micro_block_on_dev1/1
    ]).
 
 %% tr_ttb behavior callbacks
@@ -69,6 +70,7 @@ groups() ->
        mine_a_key_block_on_dev1,
        mine_a_key_block_on_dev1,
        spend_on_dev1,
+       mine_a_micro_block_on_dev1,
        stop_dev1,
        start_dev2,
        mine_a_key_block_on_dev2,
@@ -323,7 +325,11 @@ mine_a_key_block_on_dev1(_Config) -> mine_a_key_block(dev1).
 
 mine_a_key_block_on_dev2(_Config) -> mine_a_key_block(dev2).
 
-%%mine_a_micro_block_on_dev1(_Config) -> 
+mine_a_micro_block_on_dev1(_Config) -> mine_a_micro_block(dev1).
+
+mine_a_micro_block(Node) -> 
+    NName= aecore_suite_utils:node_name(Node),
+    aecore_suite_utils:mine_blocks(NName, 1, ?MINE_RATE, micro, #{}).
 
 spend(Node) ->
     {_, Pub} = aecore_suite_utils:sign_keys(Node),

--- a/docs/release-notes/next/expose_forking_orphan_txs.md
+++ b/docs/release-notes/next/expose_forking_orphan_txs.md
@@ -1,0 +1,3 @@
+* Improves the gossiping of orphaned transactions. Now, as soon a transaction
+  ends up on a micro fork, the node broadcasts it to one's peers, even if some
+  of them are still syncing.


### PR DESCRIPTION
Exposes and fixs an issue with oprhaned transactions: while they rightfully
are returned to the tx pool, this only helps if the node actually becomes a
generation leader. Those were not broadcasted.

This fixes the following scenario:

We have 3 miners: `Alice`, `Bob` and `Carol`. The current leader is `Alice`.
`Alice` receives a transaction `Tx1` and imidiately includes it in a
microblock, as she should. Since she is including it in a block, she
broadcasts it to `Bob` but she also sends him the microblock. Meanwhile
`Carol` produces a new keyblock but since `Carol` had not seen yet this
microblock, the keyblock is based on a previous block instead. Once `Carol`'s
keyblock propagates the network, it orphans Alice's microblock and rolls back
`Tx1`. This transaction now is in the mempool of both `Alice` and `Bob` but
they don't broadcast it.  `Alice`'s microblock could reach `Carol` via gossip
but since there is a heavier fork with more mining being done (`Carol`'s fork)
- it is rejected and `Carol` ignores those transactions that come in the
microblock. Because of races in the network, `Carol` might also not receive
the microblock at all. This opens the door for a race condition where the
transaction is initially included in a microblock but then rolled back and not
re-included as long as `Carol` is the generation leader. It would be included
only after either `Alice` or `Bob` are elected for a generation leader.

What this PR does is once a transaction is orphaned and returned to the
mempool, an event is created so that the transaction is also picked by `sync`
and being gossiped as it would be if received for the first time. Instead of
broadcasting it to only already fully synced nodes, it is being sent to all
connected peers (even not synced ones yet), which aims at further improving
the network propagation time.

It is worth mentioning that this does not impact consensus and if a
participant had already seen this transaction, they would simply ignore the
gossiped message. If they have not yet received it, though, it would end up in
their mempool, which is what we aim for.


This could be further improved by #3549.
