### PR TITLE
Store contract code by reference (for contract clone)

### DIFF
--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -5838,7 +5838,7 @@ fp_sophia_versions(Cfg) ->
                 fun(#{contract_id := ContractId,
                       trees := Trees0} = Props) ->
                     Contract = aect_test_utils:get_contract(ContractId, #{trees => Trees0}),
-                    Code = aect_contracts:code(Contract),
+                    {code, Code} = aect_contracts:code(Contract),
                     Deserialized = aect_sophia:deserialize(Code),
                     %% ensure contract serialization version
                     CodeSVsn = maps:get(contract_vsn, Deserialized),

--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -253,7 +253,7 @@ new(Owner, Nonce, CTVersion, Code, Deposit) ->
 -spec new_clone(aec_keys:pubkey(), ct_nonce(), version(), aec_keys:pubkey(), amount()) -> contract().
 new_clone(Owner, Nonce, CTVersion, CodeRefPK, Deposit) ->
     CodeRef = aeser_id:create(contract, CodeRefPK),
-    new_internal(Owner, Nonce, CTVersion, <<>>, CodeRef, Deposit).
+    new_internal(Owner, Nonce, CTVersion, <<>>, {ref, CodeRef}, Deposit).
 
 new_internal(Owner, Nonce, CTVersion, Code, CodeRef, Deposit) ->
     Pubkey = compute_contract_pubkey(Owner, Nonce),

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -1398,7 +1398,7 @@ state_tree(_Cfg) ->
     Call1 = ?call(get_call, Ct1, Call1),
     Call2 = ?call(get_call, Ct1, Call2),
     Ct1   = ?call(get_contract, Ct1),
-    <<"Code for C1">> = aect_contracts:code(Ct1),
+    {code, <<"Code for C1">>} = aect_contracts:code(Ct1),
     ok.
 
 %%%===================================================================
@@ -1620,7 +1620,8 @@ make_fate_function_id(FunctionName) when is_binary(FunctionName) ->
 
 make_calldata_from_id(Id, Fun, Args, State) ->
     {{value, C}, _S} = lookup_contract_by_id(Id, State),
-    make_calldata_from_code(aect_contracts:code(C), Fun, Args).
+    {code, Code} = aect_contracts:code(C),
+    make_calldata_from_code(Code, Fun, Args).
 
 format_aevm_type({bytes, N}) ->
     case lists:seq(1, N, 32) of
@@ -5545,7 +5546,8 @@ sophia_compiler_version(_Cfg) ->
     Acc = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     IdC = ?call(create_contract, Acc, identity, {}, #{}),
     {value, C} = ?call(lookup_contract_by_id, IdC),
-    CMap = aeser_contract_code:deserialize(aect_contracts:code(C)),
+    {code, Code} = aect_contracts:code(C),
+    CMap = aeser_contract_code:deserialize(Code),
     ?assertMatchProtocol(maps:get(compiler_version, CMap, undefined),
                          undefined, <<"2.1.0">>, <<"3.2.0">>, <<"unknown">>, <<"4.3.0">>),
     ok.

--- a/apps/aecontract/test/aect_clone_dereference_test.erl
+++ b/apps/aecontract/test/aect_clone_dereference_test.erl
@@ -1,0 +1,52 @@
+-module(aect_clone_dereference_test).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("../include/aecontract.hrl").
+
+dereference_test() ->
+    T0 = aect_state_tree:empty(),
+
+    Code0 = <<"0000000 - THIS IS NOT ACTUALLY PROPER BYTE CODE">>,
+    Code1 = <<"1111111 - SOME OTHER NOT PROPER BYTE CODE">>,
+
+    C0 = new_contract(#{code => Code0}),
+    C1 = new_contract(#{code => Code1, nonce => 43}),
+    C2 = clone_contract(C0, 44),
+
+    T1 = aect_state_tree:insert_contract(C0, T0),
+    T2 = aect_state_tree:insert_contract(C1, T1),
+    T3 = aect_state_tree:insert_contract(C2, T2),
+    ?assertMatch({C0, Code0}, aect_state_tree:get_contract_with_code(aect_contracts:pubkey(C0), T3)),
+    ?assertMatch({C1, Code1}, aect_state_tree:get_contract_with_code(aect_contracts:pubkey(C1), T3)),
+    ?assertMatch({C2, Code0}, aect_state_tree:get_contract_with_code(aect_contracts:pubkey(C2), T3)).
+
+new_contract() ->
+    new_contract(#{}).
+
+new_contract(Override) ->
+    Map = #{ owner_id    => aeser_id:create(account, <<4711:32/unit:8>>)
+           , nonce       => 42
+           , code        => <<"THIS IS NOT ACTUALLY PROPER BYTE CODE">>
+           , vm_version  => ?VM_FATE_SOPHIA_2
+           , abi_version => ?ABI_FATE_SOPHIA_1
+           , fee         => 10
+           , ttl         => 100
+           , deposit     => 100
+           , amount      => 50
+           , gas         => 100
+           , gas_price   => 5
+           , call_data   => <<"NOT ENCODED ACCORDING TO ABI">>
+           },
+    Map1 = maps:merge(Map, Override),
+    {ok, Tx} = aect_create_tx:new(Map1),
+    {contract_create_tx, CTx} = aetx:specialize_type(Tx),
+    aect_contracts:new(CTx).
+
+clone_contract(Contract, Nonce) ->
+    aect_contracts:new_clone(
+        <<"_______________k1_______________">>,
+        Nonce,
+        aect_contracts:ct_version(Contract),
+        aect_contracts:pubkey(Contract),
+        0
+    ).

--- a/apps/aecore/src/aec_accounts.erl
+++ b/apps/aecore/src/aec_accounts.erl
@@ -224,19 +224,18 @@ serialize_for_client(#account{id      = Id,
                 %% This code is not defensive, we are guaranteed that contract and function hash exist
                 %% If not, just crash
                 {contract, ContractPK} = aeser_id:specialize(Account#account.ga_contract),
-                {ok, Contract} = aec_chain:get_contract(ContractPK),
+                {ok, Contract, Code} = aec_chain:get_contract_with_code(ContractPK),
                 AuthFunName =
                     case aect_contracts:abi_version(Contract) of
                         ?ABI_AEVM_SOPHIA_1 ->
-                            #{type_info := TypeInfo} = aect_sophia:deserialize(
-                                                         aect_contracts:code(Contract)),
+                            #{type_info := TypeInfo} = aect_sophia:deserialize(Code),
                             {ok, AuthFunName0} =
                                 aeb_aevm_abi:function_name_from_type_hash(
                                   Account#account.ga_auth_fun, TypeInfo),
                             AuthFunName0;
                         ?ABI_FATE_SOPHIA_1 ->
                             #{byte_code := ByteCode} =
-                                aect_sophia:deserialize(aect_contracts:code(Contract)),
+                                aect_sophia:deserialize(Code),
                             {ok, AuthFunName0} =
                                 aeb_fate_abi:get_function_name_from_function_hash(
                                     Account#account.ga_auth_fun, aeb_fate_code:deserialize(ByteCode)),

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -494,10 +494,9 @@ handle_request_('GetContractCode', Req, _Context) ->
     case aeser_api_encoder:safe_decode(contract_pubkey, maps:get(pubkey, Req)) of
         {error, _} -> {400, [], #{reason => <<"Invalid public key">>}};
         {ok, PubKey} ->
-            case aec_chain:get_contract(PubKey) of
+            case aec_chain:get_contract_with_code(PubKey) of
                 {error, _} -> {404, [], #{reason => <<"Contract not found">>}};
-                {ok, Contract} ->
-                    Code = aect_contracts:code(Contract),
+                {ok, _Contract, Code} ->
                     {200, [], #{ <<"bytecode">> => aeser_api_encoder:encode(contract_bytearray, Code) }}
             end
     end;

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -268,12 +268,12 @@ get_contract_code(ContractKey, CodeKey) ->
         TopBlockHash = aec_chain:top_block_hash(),
         {ok, Trees} = aec_chain:get_block_state(TopBlockHash),
         Tree = aec_trees:contracts(Trees),
-        case aect_state_tree:lookup_contract(ContractPubKey, Tree) of
+        case aect_state_tree:lookup_contract_with_code(ContractPubKey, Tree) of
             none ->
                 Msg = "Contract address for key " ++ atom_to_list(ContractKey) ++ " not found",
                 {error, {404, [], #{<<"reason">> => list_to_binary(Msg)}}};
-            {value, Contract} ->
-                {ok, maps:put(CodeKey, aect_contracts:code(Contract), State)}
+            {value, _Contract, Code} ->
+                {ok, maps:put(CodeKey, Code, State)}
         end
     end.
 

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -1599,7 +1599,16 @@ contract_call_fail(Call0, Fee, S) ->
 
 run_contract(CallerId, Contract, GasLimit, GasPrice, CallData, AllowInit,
              Origin, Amount, CallStack, Nonce, S) ->
-    run_contract(CallerId, aect_contracts:code(Contract), Contract, GasLimit,
+    Code =
+        case aect_contracts:code(Contract) of
+            {code, C} -> C;
+            {ref, Ref} ->
+                RefContractPK = aeser_id:specialize(Ref, contract),
+                {ok, RefContract} = get_contract_no_cache(RefContractPK, S),
+                {code, C} = aect_contracts:code(RefContract),
+                C
+        end,
+    run_contract(CallerId, Code, Contract, GasLimit,
                  GasPrice, CallData, AllowInit, Origin, Amount, CallStack, Nonce, S).
 
 run_contract(CallerId, Code, Contract, GasLimit, GasPrice, CallData, AllowInit,


### PR DESCRIPTION
In order for contract cloning to be efficient we do not want to store another copy of contract code after cloning. This PR introduces a way to store reference to contract containing actual code in contract tree structure.