### PR TITLE
Improve the release process

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -12,8 +12,6 @@
 -define(KEY_HEADER_MIN_BYTES, 364).
 -define(MIC_HEADER_MIN_BYTES, 216).
 
--define(KEY_HEADER_INFO_LIMA_POINT_RELEASE, 591).
-
 -type(txs_hash() :: <<_:(?TXS_HASH_BYTES*8)>>).
 -type(state_hash() :: <<_:(?STATE_HASH_BYTES*8)>>).
 -type(miner_pubkey() :: <<_:(?MINER_PUB_BYTES*8)>>).

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -302,7 +302,8 @@ new_key_header(Height, PrevHash, PrevKeyHash, RootHash, Miner, Beneficiary,
 make_info(Version, Info) when (Version >= ?MINERVA_PROTOCOL_VSN), ?IS_INT_INFO(Info) ->
     <<Info:?OPTIONAL_INFO_BYTES/unit:8>>;
 make_info(Version, default) when Version >= ?MINERVA_PROTOCOL_VSN ->
-    <<?KEY_HEADER_INFO_LIMA_POINT_RELEASE:?OPTIONAL_INFO_BYTES/unit:8>>;
+    PointReleaseInfo = aeu_info:block_info(),
+    <<PointReleaseInfo:?OPTIONAL_INFO_BYTES/unit:8>>;
 make_info(_Version, default) ->
     <<>>.
 

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -16,6 +16,7 @@ start(_StartType, _StartArgs) ->
     ok = lager:info("Starting aecore node"),
     ok = aec_jobs_queues:start(),
     ok = application:ensure_started(mnesia),
+    _ = aeu_info:block_info(), %% init the cache so this process is the owner of the table
     aec_db:load_database(),
     case aec_db:persisted_valid_genesis_block() of
         true ->

--- a/apps/aecore/test/aec_eunit_SUITE.erl
+++ b/apps/aecore/test/aec_eunit_SUITE.erl
@@ -130,10 +130,13 @@ application_test(Config) ->
     meck:expect(aec_fork_block_settings, lima_extra_accounts, 0, []),
     meck:expect(aec_fork_block_settings, lima_contracts, 0, []),
     meck:expect(aec_fork_block_settings, block_whitelist, 0, #{}),
+    meck:new(aeu_info, []),
+    meck:expect(aeu_info, block_info, 0, 591),
     {ok,_} = application:ensure_all_started(aecore),
     timer:sleep(100),
     ok = application:stop(aecore),
     meck:unload(aec_fork_block_settings),
+    meck:unload(aeu_info),
 
     app_stop(StartedApps -- ?TO_BE_STOPPED_APPS_BLACKLIST, TempDir).
 

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -185,7 +185,7 @@ info_test_() ->
                              ?TEST_MODULE:time_in_msecs(RawKey),
                              default,
                              ?MINERVA_PROTOCOL_VSN),
-               Info = ?KEY_HEADER_INFO_LIMA_POINT_RELEASE,
+               Info = aeu_info:block_info(),
                ?assertEqual(Info, ?TEST_MODULE:info(WithInfo))
        end},
       {"Default value of the info field in the pre release of Fortuna: Roma protocol",
@@ -223,7 +223,7 @@ info_test_() ->
                              ?TEST_MODULE:time_in_msecs(RawKey),
                              default,
                              ?FORTUNA_PROTOCOL_VSN),
-               Info = ?KEY_HEADER_INFO_LIMA_POINT_RELEASE,
+               Info = aeu_info:block_info(),
                ?assertEqual(Info, ?TEST_MODULE:info(WithInfo))
        end}
      ]}.

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -46,7 +46,8 @@ mine_block_test_() ->
                              ?IRIS_PROTOCOL_VSN    -> 9446698485151902999 
                          end,
                  {BlockCandidate,_} = aec_test_utils:create_keyblock_with_state(
-                                        [{TopBlock, aec_trees:new()}], ?TEST_PUB),
+                                        [{TopBlock, aec_trees:new()}],
+                                        ?TEST_PUB, ?TEST_PUB, #{info => 591}),
 
                  HeaderBin = aec_headers:serialize_to_binary(aec_blocks:to_header(BlockCandidate)),
 

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -45,9 +45,14 @@ mine_block_test_() ->
                              ?LIMA_PROTOCOL_VSN    -> 2331533446344578375;
                              ?IRIS_PROTOCOL_VSN    -> 9446698485151902999 
                          end,
+                 Info =
+                    case aec_hard_forks:protocol_effective_at_height(Height + 1) of
+                        ?ROMA_PROTOCOL_VSN -> default;
+                        _ -> 591
+                    end,
                  {BlockCandidate,_} = aec_test_utils:create_keyblock_with_state(
                                         [{TopBlock, aec_trees:new()}],
-                                        ?TEST_PUB, ?TEST_PUB, #{info => 591}),
+                                        ?TEST_PUB, ?TEST_PUB, #{info => Info}),
 
                  HeaderBin = aec_headers:serialize_to_binary(aec_blocks:to_header(BlockCandidate)),
 

--- a/apps/aeutils/src/aeu_info.erl
+++ b/apps/aeutils/src/aeu_info.erl
@@ -3,7 +3,8 @@
 -export([get_version/0,
          get_revision/0,
          get_os/0,
-         vendor/0]).
+         vendor/0,
+         block_info/0]).
 
 -define(VERSION_FILE, <<"VERSION">>).
 -define(REVISION_FILE, <<"REVISION">>).
@@ -15,6 +16,14 @@ get_version() ->
 
 get_revision() ->
     cached_file(?REVISION_FILE).
+
+block_info() ->
+    cached_file(block_info,
+                fun(block_info) ->
+                    binary_to_integer(re:replace(cached_file(?VERSION_FILE), "\\.", "",
+                                                 [{return, binary}, global]))
+
+                end).
 
 get_os() ->
     Bin = fun(A) when is_atom(A)    -> atom_to_binary(A, utf8)
@@ -41,6 +50,9 @@ trim_ending_whitespace(Binary) ->
     re:replace(Binary, "\\s+$", "", [{return, binary}, global]).
 
 cached_file(Filename) ->
+    cached_file(Filename, fun read_trimmed_file/1).
+
+cached_file(Filename, ReadFun) ->
     EtsKey = {file, Filename},
     try
         [{EtsKey, Data}] = ets:lookup(?ETS_TABLE, EtsKey),
@@ -52,7 +64,7 @@ cached_file(Filename) ->
                     ets:new(?ETS_TABLE, [named_table, {read_concurrency, true}, public]);
                 _ -> pass
             end,
-            ReadData = read_trimmed_file(Filename),
+            ReadData = ReadFun(Filename),
             ets:insert(?ETS_TABLE, {EtsKey, ReadData}),
             ReadData
     end.


### PR DESCRIPTION
This automates the block info field in the keyblock. It also provides caching
capabilities for the revision and version. Mining tests nonces do not have to
be updated on every new info as well.

A tribute to @dincho for pushing for this :)