### PR TITLE
Fix OAS3 issues

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -763,6 +763,7 @@ paths:
           required: false
           schema:
             type: integer
+            default: 20
             minimum: 1
             maximum: 1000
             example: 1
@@ -772,6 +773,7 @@ paths:
           required: false
           schema:
             type: string
+            default: all
             enum:
               - open
               - closed
@@ -3467,8 +3469,9 @@ components:
       name: "int-as-string"
       description: 'If this flag is set to true, the response will have all integers set as strings'
       required: false
-      type: boolean
-      default: false
+      schema:
+        type: boolean
+        default: false
     blockHash:
       in: path
       name: hash

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1179,6 +1179,8 @@ paths:
         - debug
       operationId: PostNamePreclaim
       description: 'Get a name_preclaim transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1208,6 +1210,8 @@ paths:
         - debug
       operationId: PostNameClaim
       description: 'Get a name_claim transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1237,6 +1241,8 @@ paths:
         - debug
       operationId: PostNameUpdate
       description: 'Get a name_update transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1266,6 +1272,8 @@ paths:
         - debug
       operationId: PostNameTransfer
       description: 'Get a name_transfer transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1295,6 +1303,8 @@ paths:
         - debug
       operationId: PostNameRevoke
       description: 'Get a name_revoke transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1356,6 +1366,8 @@ paths:
         - debug
       operationId: PostChannelCreate
       description: 'Get a channel_create transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1385,6 +1397,8 @@ paths:
         - debug
       operationId: PostChannelDeposit
       description: 'Get a channel_deposit transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1410,6 +1424,8 @@ paths:
         - debug
       operationId: PostChannelWithdraw
       description: 'Get a channel_withdrawal transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1435,6 +1451,8 @@ paths:
         - debug
       operationId: PostChannelSnapshotSolo
       description: 'Get a channel_snapshot_solo transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1460,6 +1478,8 @@ paths:
         - debug
       operationId: PostChannelSetDelegates
       description: 'Get a channel_set_delegates_tx transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1485,6 +1505,8 @@ paths:
         - debug
       operationId: PostChannelCloseMutual
       description: 'Get a channel_close_mutual transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1510,6 +1532,8 @@ paths:
         - debug
       operationId: PostChannelCloseSolo
       description: 'Get a channel_close_solo transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1535,6 +1559,8 @@ paths:
         - debug
       operationId: PostChannelSlash
       description: 'Get a channel_slash transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:
@@ -1560,6 +1586,8 @@ paths:
         - debug
       operationId: PostChannelSettle
       description: 'Get a channel_settle transaction object'
+      consumes:
+        - application/json
       produces:
         - application/json
       parameters:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -803,6 +803,7 @@ paths:
           type: integer
           minimum: 1
           maximum: 1000
+          default: 20
         - in: query
           name: type
           description: 'The type of a query: open, closed or all'

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -528,10 +528,7 @@ handle_request_('GetOracleByPubkey', Params, _Context) ->
 handle_request_('GetOracleQueriesByPubkey', Params, _Context) ->
     case aeser_api_encoder:safe_decode(oracle_pubkey, maps:get(pubkey, Params)) of
         {ok, Pubkey} ->
-            Limit = case maps:get(limit, Params) of
-                        N when N =/= undefined -> N;
-                        undefined -> 20
-                    end,
+            Limit = maps:get(limit, Params),
             FromQueryId = case maps:get(from, Params) of
                               Id when Id =/= undefined ->
                                   {ok, OracleQueryId} = aeser_api_encoder:safe_decode(oracle_query_id, Id),


### PR DESCRIPTION
This fixes #3539 

While the initial bug report was regarding missing `consumes` section and in `OAS3` [specification](https://swagger.io/specification/) there is no such keyword (there is in `swagger 2`, the old version) - there was an unrelated bug. Addressed in this PR and now JS client can easily be built by:

```
$ curl -X POST \
  https://generator3.swagger.io/api/generate \
  -H 'content-type: application/json' \
  -d '{
  "specURL" : "https://raw.githubusercontent.com/aeternity/aeternity/09e3aa7348f17b66e92719d781345b16199ebd8a/apps/aehttp/priv/oas3.yaml",
  "lang" : "javascript",
  "type" : "CLIENT",
  "codegenVersion" : "V3"
}' -o js.zip
```

@davidyuk please confirm this resolves the issue on your end.