### PR TITLE
Make try expr catch pattern match failure

### DIFF
--- a/apps/aecore/src/aec_chain_metrics_probe.erl
+++ b/apps/aecore/src/aec_chain_metrics_probe.erl
@@ -127,8 +127,8 @@ sample_(_, Acc) ->
     Acc.
 
 total_difficulty() ->
-    try aec_chain:difficulty_at_top_block() of
-        {ok, V} -> V
+    try {ok, V} = aec_chain:difficulty_at_top_block(),
+         V
     catch
         error:_ -> 0
     end.


### PR DESCRIPTION
Closes issue #3096

The pattern `try Expr of {ok, V} -> V catch ... end` doesn't actually catch `{error, Reason}`, since that results in a `try_clause` error.

Verified through visual inspection of test suite metrics logs that the change didn't actually break the metric, and double-checking that the new pattern actually does catch the error return.

```erlang
2> O = fun() -> try {ok, Fd} = file:open("foo", [read]), Fd catch error:_ -> nooo end end.          
#Fun<erl_eval.21.126501267>
3> O().
nooo
```