### PR TITLE
HTTP API support for `paying_for_tx`

### DIFF
--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -66,6 +66,7 @@
         , co_sign_tx/2
         , substitute_innermost_tx/2
         , sign_tx/3
+        , sign_tx/4
         , sign_tx_hash/2
         , sign_pay_for_inner_tx/2
         , signed_spend_tx/1

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1843,6 +1843,42 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /debug/transactions/paying-for:
+    post:
+      tags:
+        - internal
+        - transaction
+        - debug
+      operationId: PostPayingFor
+      description: Get a paying for transaction object
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PayingForTx"
+        description: A paying for transaction
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnsignedTx"
+        "400":
+          description: Invalid transaction
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Sender account not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/debug/token-supply/height/{height}":
     get:
       tags:
@@ -2889,7 +2925,8 @@ components:
                       ContractCreateTx,
                       ContractCallTx,
                       GAAttachTx,
-                      GAMetaTx ]
+                      GAMetaTx,
+                      PayingForTx ]
           required:
             - version
             - type
@@ -2918,6 +2955,7 @@ components:
           - $ref: "#/components/schemas/ContractCallTx"
           - $ref: "#/components/schemas/GAAttachTx"
           - $ref: "#/components/schemas/GAMetaTx"
+          - $ref: "#/components/schemas/PayingForTx"
     TxInfoObject:
       type: object
       properties:
@@ -3456,6 +3494,21 @@ components:
         - gas_price
         - fee
         - auth_data
+        - tx
+    PayingForTx:
+      type: object
+      properties:
+        payer_id:
+          $ref: "#/components/schemas/EncodedPubkey"
+        fee:
+          $ref: "#/components/schemas/UInt"
+        nonce:
+          $ref: "#/components/schemas/UInt64"
+        tx:
+          $ref: "#/components/schemas/EncodedByteArray"
+      required:
+        - payer_id
+        - fee
         - tx
     Header:
       anyOf:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2884,6 +2884,7 @@ components:
           description: At least one signature is required unless for Generalized Account
             Meta transactions
           type: array
+          minItems: 0
           items:
             $ref: "#/components/schemas/EncodedValue"
       required:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2888,9 +2888,6 @@ components:
             $ref: "#/components/schemas/EncodedValue"
       required:
         - tx
-        - block_height
-        - block_hash
-        - hash
         - signatures
     Tx:
       allOf:
@@ -3505,7 +3502,7 @@ components:
         nonce:
           $ref: "#/components/schemas/UInt64"
         tx:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/SignedTx"
       required:
         - payer_id
         - fee

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1850,7 +1850,7 @@ paths:
         - transaction
         - debug
       operationId: PostPayingFor
-      description: Get a paying for transaction object
+      description: Get a paying-for transaction object
       parameters:
         - $ref: '#/components/parameters/intAsString'
       requestBody:
@@ -1858,7 +1858,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/PayingForTx"
-        description: A paying for transaction
+        description: A paying-for transaction
         required: true
       responses:
         "200":

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1874,7 +1874,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "404":
-          description: Sender account not found
+          description: Payer account not found
           content:
             application/json:
               schema:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1711,6 +1711,38 @@ paths:
           description: Invalid input
           schema:
             $ref: '#/definitions/Error'
+  /debug/transactions/paying-for:
+    post:
+      tags:
+        - internal
+        - transaction
+        - debug
+      operationId: 'PostPayingFor'
+      description: Get a paying for transaction object
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: transactions
+          required: true
+          schema:
+            $ref: '#/definitions/PayingForTx'
+      responses:
+        '200':
+          description: Successful operation
+          schema:
+            $ref: '#/definitions/UnsignedTx'
+        '400':
+          description: Invalid transaction
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Payer account not found
+          schema:
+            $ref: '#/definitions/Error'
   /debug/token-supply/height/{height}:
     get:
       tags:
@@ -2778,9 +2810,7 @@ definitions:
           $ref: '#/definitions/EncodedValue'
     required:
       - tx
-      - block_height
-      - block_hash
-      - hash
+      - signatures
   GenericTx:
     type: object
     discriminator: type
@@ -2884,6 +2914,10 @@ definitions:
     allOf:
       - $ref: '#/definitions/GenericTx'
       - $ref: '#/definitions/GAMetaTx'
+  PayingForTxJSON:
+    allOf:
+      - $ref: '#/definitions/GenericTx'
+      - $ref: '#/definitions/PayingForTx'
   TxInfoObject:
      type: object
      properties:
@@ -3465,6 +3499,21 @@ definitions:
       - gas_price
       - fee
       - auth_data
+      - tx
+  PayingForTx:
+    type: object
+    properties:
+      payer_id:
+        $ref: '#/definitions/EncodedPubkey'
+      fee:
+        $ref: '#/definitions/UInt'
+      nonce:
+        $ref: '#/definitions/UInt64'
+      tx:
+        $ref: '#/definitions/GenericSignedTx'
+    required:
+      - payer_id
+      - fee
       - tx
   DelegatesList:
     type: array

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1718,7 +1718,7 @@ paths:
         - transaction
         - debug
       operationId: 'PostPayingFor'
-      description: Get a paying for transaction object
+      description: Get a paying-for transaction object
       consumes:
         - application/json
       produces:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -2810,6 +2810,22 @@ definitions:
           $ref: '#/definitions/EncodedValue'
     required:
       - tx
+      - block_height
+      - block_hash
+      - hash
+  SignedTx:
+    type: object
+    properties:
+      tx:
+        $ref: '#/definitions/GenericTx'
+      signatures:
+        description: 'At least one signature is required unless for Generalized Account Meta transactions'
+        type: array
+        minItems: 0
+        items:
+          $ref: '#/definitions/EncodedValue'
+    required:
+      - tx
       - signatures
   GenericTx:
     type: object
@@ -3510,7 +3526,7 @@ definitions:
       nonce:
         $ref: '#/definitions/UInt64'
       tx:
-        $ref: '#/definitions/GenericSignedTx'
+        $ref: '#/definitions/SignedTx'
     required:
       - payer_id
       - fee

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -46,9 +46,10 @@ allowed_methods(Req, State = #state{ allowed_method = Method }) ->
 
 forbidden(Req, State = #state{
         operation_id = OperationId,
-        logic_handler = LogicHandler
+        logic_handler = LogicHandler,
+        endpoints = Mod
     }) ->
-    IsForbidden = LogicHandler:forbidden(OperationId),
+    IsForbidden = LogicHandler:forbidden(Mod, OperationId),
     {IsForbidden, Req, State}.
 
 content_types_accepted(Req, State) ->

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -468,7 +468,8 @@ handle_request_('PostTransaction', #{<<"tx">> := Tx}, _Context) ->
                         ok ->
                             Hash = aetx_sign:hash(SignedTx),
                             {200, [], #{<<"tx_hash">> => aeser_api_encoder:encode(tx_hash, Hash)}};
-                        {error, _} ->
+                        {error, E} ->
+                            lager:debug("Transaciton ~p failed to be pushed in pool because: ~p", [SignedTx, E]),
                             {400, [], #{reason => <<"Invalid tx">>}}
                     end;
                 {error, broken_tx} ->

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -469,7 +469,7 @@ handle_request_('PostTransaction', #{<<"tx">> := Tx}, _Context) ->
                             Hash = aetx_sign:hash(SignedTx),
                             {200, [], #{<<"tx_hash">> => aeser_api_encoder:encode(tx_hash, Hash)}};
                         {error, E} ->
-                            lager:debug("Transaciton ~p failed to be pushed in pool because: ~p", [SignedTx, E]),
+                            lager:debug("Transaciton ~p failed to be pushed to pool because: ~p", [SignedTx, E]),
                             {400, [], #{reason => <<"Invalid tx">>}}
                     end;
                 {error, broken_tx} ->
@@ -702,4 +702,3 @@ deserialize_transaction(Tx) ->
     catch
         _:_ -> {error, broken_tx}
     end.
-

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -1,6 +1,6 @@
 -module(aehttp_dispatch_ext).
 
--export([forbidden/1]).
+-export([forbidden/2]).
 -export([handle_request/3]).
 
 -import(aeu_debug, [pp/1]).
@@ -38,8 +38,8 @@
 
 -define(TC(Expr, Msg), begin {Time, Res} = timer:tc(fun() -> Expr end), lager:debug("[~p] Msg = ~p", [Time, Msg]), Res end).
 
--spec forbidden( OperationID :: atom() ) -> boolean().
-forbidden(_OpId) -> false.
+-spec forbidden( Mod :: module(), OperationID :: atom() ) -> boolean().
+forbidden(_Mod, _OpId) -> false.
 
 -spec handle_request(
         OperationID :: atom(),

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -88,7 +88,6 @@ handle_request_(OperationId, Req, _Context)
     when  OperationId =:= 'PostSpend';
           OperationId =:= 'PostContractCreate';
           OperationId =:= 'PostContractCall';
-          OperationId =:= 'DryRunTxs';
           OperationId =:= 'PostNamePreclaim';
           OperationId =:= 'PostNameUpdate';
           OperationId =:= 'PostNameClaim';

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -861,7 +861,8 @@ get_poi(Type, KeyName, PutKey) when Type =:= account
         end
     end.
 
--spec safe_binary_to_atom(binary()) -> {ok, atom()} | {error, non_existing}.
+-spec safe_binary_to_atom(atom() | binary()) -> {ok, atom()} | {error, non_existing}.
+safe_binary_to_atom(A) when is_atom(A) -> {ok, A};
 safe_binary_to_atom(Binary) when is_binary(Binary) ->
     try binary_to_existing_atom(Binary, utf8) of
         Atom -> {ok, Atom}

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -775,6 +775,11 @@ init_per_group(external_endpoints, Config) ->
     true = aec_blocks:is_key_block(KeyBlock),
     Config;
 
+init_per_group(paying_for_tx, Config) ->
+    case aect_test_utils:latest_protocol_version() >= ?IRIS_PROTOCOL_VSN of
+        true -> Config;
+        false -> {skip, requires_iris_or_newer}
+    end;
 init_per_group(_Group, Config) ->
     Config.
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -268,9 +268,8 @@ groups() ->
        {group, debug_endpoints},
        {group, swagger_validation},
        {group, wrong_http_method_endpoints},
-       %% TODO: handle swagger2
-       %%{group, paying_for_tx}
-       {group, naming}
+       {group, naming},
+       {group, paying_for_tx}
       ]},
 
      %% /key-blocks/* /micro-blocks/* /generations/*

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -35,6 +35,7 @@
         , update_tx/2
         , valid_at_protocol/2
         , check_protocol/2
+        , swagger_name_to_type/1
         ]).
 
 -ifdef(TEST).
@@ -608,6 +609,35 @@ type_to_swagger_name(channel_snapshot_solo_tx)    -> <<"ChannelSnapshotSoloTx">>
 type_to_swagger_name(channel_set_delegates_tx)    -> <<"ChannelSetDelegatesTx">>;
 %% not exposed in HTTP API:
 type_to_swagger_name(channel_offchain_tx)         -> <<"ChannelOffchainTx">>.
+
+-spec swagger_name_to_type(binary()) -> tx_type().
+swagger_name_to_type(<<"SpendTx">>)                   -> spend_tx;
+swagger_name_to_type(<<"OracleRegisterTx">>)          -> oracle_register_tx;
+swagger_name_to_type(<<"OracleExtendTx">>)            -> oracle_extend_tx;
+swagger_name_to_type(<<"OracleQueryTx">>)             -> oracle_query_tx;
+swagger_name_to_type(<<"OracleRespondTx">>)           -> oracle_response_tx;
+swagger_name_to_type(<<"NamePreclaimTx">>)            -> name_preclaim_tx;
+swagger_name_to_type(<<"NameClaimTx">>)               -> name_claim_tx;
+swagger_name_to_type(<<"NameTransferTx">>)            -> name_transfer_tx;
+swagger_name_to_type(<<"NameUpdateTx">>)              -> name_update_tx;
+swagger_name_to_type(<<"NameRevokeTx">>)              -> name_revoke_tx;
+swagger_name_to_type(<<"ContractCallTx">>)            -> contract_call_tx;
+swagger_name_to_type(<<"ContractCreateTx">>)          -> contract_create_tx;
+swagger_name_to_type(<<"GAAttachTx">>)                -> ga_attach_tx;
+swagger_name_to_type(<<"GAMetaTx">>)                  -> ga_meta_tx;
+swagger_name_to_type(<<"PayingForTx">>)               -> paying_for_tx;
+swagger_name_to_type(<<"ChannelCreateTx">>)           -> channel_create_tx;
+swagger_name_to_type(<<"ChannelDepositTx">>)          -> channel_deposit_tx;
+swagger_name_to_type(<<"ChannelWithdrawTx">>)         -> channel_withdraw_tx;
+swagger_name_to_type(<<"ChannelForceProgressTx">>)    -> channel_force_progress_tx;
+swagger_name_to_type(<<"ChannelCloseSoloTx">>)        -> channel_close_solo_tx;
+swagger_name_to_type(<<"ChannelCloseMutualTx">>)      -> channel_close_mutual_tx;
+swagger_name_to_type(<<"ChannelSlashTx">>)            -> channel_slash_tx;
+swagger_name_to_type(<<"ChannelSettleTx">>)           -> channel_settle_tx;
+swagger_name_to_type(<<"ChannelSnapshotSoloTx">>)     -> channel_snapshot_solo_tx;
+swagger_name_to_type(<<"ChannelSetDelegatesTx">>)     -> channel_set_delegates_tx;
+%% not exposed in HTTP API:
+swagger_name_to_type(<<"ChannelOffchainTx">>)         -> channel_offchain_tx.
 
 -spec specialize_type(Tx :: tx()) -> {tx_type(), tx_instance()}.
 specialize_type(#aetx{ type = Type, tx = Tx }) -> {Type, Tx}.

--- a/docs/release-notes/next/GH-3566_paying_for_http_api
+++ b/docs/release-notes/next/GH-3566_paying_for_http_api
@@ -1,0 +1,6 @@
+* Introduces a new HTTP API for asking the node to provide a correct
+  `paying_for_tx`. It is marked as `debug` and it is intended to be used while
+  developing tools that produce that transaction. This API must not be used in
+  real-life scenarios. Since the inner transaction has a specific
+  `network_id`, a proper check had been added to the API so attempts to create
+  an erronous `paying_for_tx` would fail.

--- a/docs/release-notes/next/GH-3566_paying_for_http_api
+++ b/docs/release-notes/next/GH-3566_paying_for_http_api
@@ -2,5 +2,5 @@
   `paying_for_tx`. It is marked as `debug` and it is intended to be used while
   developing tools that produce that transaction. This API must not be used in
   real-life scenarios. Since the inner transaction has a specific
-  `network_id`, a proper check had been added to the API so attempts to create
-  an erronous `paying_for_tx` would fail.
+  `network_id`, a proper check has been added to the API so attempts to create
+  an erronous `paying_for_tx` will fail.


### PR DESCRIPTION
Fixes #3566

This PR introduces `paying_for_tx` to both old `swagger2` and `oas3`. It enchances the internal HTTP API with a new endpoint: `/debug/transactions/paying-for` that produces a valid `paying_for_tx` for the client. It has some additional checks that the inner tx had been correclty autenticated.

The work on this PR had been supported by the ACF.
