### PR TITLE
Add pseudo-index for key headers by height

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1373,7 +1373,7 @@ ensure_key_headers_height_store() ->
     end.
 
 start_key_headers_height_store_migration() ->
-    lager:info("[Key headers migrations scan] Retriving all key blocks"),
+    lager:info("[Key headers migrations scan] Retriving all key headers"),
     spawn(fun() -> %% Don't use spawn_link here - we can't be killed by the setup process
         %% An error here should bring down the entire node with it!
         try
@@ -1409,7 +1409,7 @@ key_headers_height_store_migration_step(Time, N, {TimeRead, {Headers, Cont}}) ->
         aec_db:ensure_transaction(fun() ->
             lists:foldl(
                 fun({Hash, Header, Height}, Count) ->
-                    mnesia:write(#aec_chain_state{key = {key_block, Height, Hash}, value = Header}),
+                    mnesia:write(#aec_chain_state{key = {key_header, Height, Hash}, value = Header}),
                     Count+1
                 end,
                 0,

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -90,6 +90,7 @@
         , get_fork_result/2
         , get_info_field/2
         , ensure_chain_ends/0
+        , ensure_key_headers_height_store/0
         ]).
 
 -import(aetx_env, [no_events/0]).
@@ -125,6 +126,7 @@
 
 -include("aec_block_insertion.hrl").
 -include("blocks.hrl").
+-include("aec_db.hrl").
 
 -type events() :: aetx_env:events().
 
@@ -1011,9 +1013,9 @@ db_get_header(Hash) when is_binary(Hash) ->
 %% The usual result of this function call is one header, sometimes two headers. On heavy generations on a good SSD
 %% using the rocksdb backend this right now takes 13-14ms which is bad in the hot path... This should take at most 100us -.-
 db_find_key_nodes_at_height(Height) when is_integer(Height) ->
-    case aec_db:find_headers_and_hash_at_height(Height) of
+    case aec_db:find_key_headers_and_hash_at_height(Height) of
         [_|_] = Headers ->
-            case [wrap_header(H, Hash) || {Hash, H} <- Headers, aec_headers:type(H) =:= key] of
+            case [wrap_header(H, Hash) || {Hash, H} <- Headers] of
                 [] -> error;
                 List -> {ok, List}
             end;
@@ -1268,11 +1270,11 @@ ensure_chain_ends() ->
     case aec_db:get_top_block_hash() of
         undefined -> ok; %% Fresh DB
         _ -> %% Ok this is not a fresh DB
-            case aec_db:chain_end_migration_status() of
+            case aec_db:chain_migration_status(chain_ends) of
                 done -> %% No migration is in progress
                     case aec_db:find_chain_end_hashes() of
                         [] -> %% Ok this is an old DB - migration required
-                            aec_db:start_chain_end_migration(),
+                            aec_db:start_chain_migration(chain_ends),
                             start_chain_ends_migration();
                         _ -> %% No migration required
                             ok
@@ -1326,7 +1328,7 @@ chain_ends_finish_migration(OldTops0) ->
     ok = aec_db:ensure_transaction(fun() ->
         NewTops = aec_db:find_chain_end_hashes(),
         chain_ends_maybe_apply(OldTops, NewTops, NewTops),
-        aec_db:finish_chain_end_migration(),
+        aec_db:finish_chain_migration(chain_ends),
         ok
       end).
 
@@ -1346,3 +1348,78 @@ chain_ends_maybe_apply([H1|T1] = OldTops, [H2|T2], NewTops) -> %% Check if H1 is
             lager:info("[Orphan key blocks scan] ignoring deleted header: find_common_ancestor(~p, ~p)", [EH1, EH2]),
             chain_ends_maybe_apply(T1, NewTops, NewTops)
     end.
+
+
+% We use aec_chain_state to store all key block headers with heights.
+% This allows for cheap retrieval of key header by height.
+-spec ensure_key_headers_height_store() -> ok | pid().
+ensure_key_headers_height_store() ->
+    case aec_db:get_top_block_hash() of
+        undefined -> ok; %% Fresh DB
+        _ -> %% Ok this is not a fresh DB
+            case aec_db:chain_migration_status(key_headers) of
+                done -> %% No migration is in progress
+                    case aec_db:find_key_headers_and_hash_at_height(1) of
+                        [] -> %% Ok this is an old DB - migration required
+                            aec_db:start_chain_migration(key_headers),
+                            start_key_headers_height_store_migration();
+                        _ -> %% No migration required
+                            ok
+                    end;
+                in_progress -> %% The migration was interrupted and not finished yet
+                    lager:info("[Orphan key blocks scan] Resuming interrupted scan"),
+                    start_key_headers_height_store_migration()
+            end
+    end.
+
+start_key_headers_height_store_migration() ->
+    lager:info("[Key headers migrations scan] Retriving all key blocks"),
+    spawn(fun() -> %% Don't use spawn_link here - we can't be killed by the setup process
+        %% An error here should bring down the entire node with it!
+        try
+            mnesia:activity(async_dirty, fun () ->
+                Res = timer:tc(fun() ->
+                    mnesia:select(aec_headers,
+                                  [{ {aec_headers, '$1', '$2', '$3'}
+                                  , [{'=:=', {element, 1, '$2'}, key_header}]
+                                  , [{{'$1', '$2', '$3'}}]
+                                  }],
+                                  10000,
+                                  read)
+                end),
+                {TotalTime, TotalCount} = key_headers_height_store_migration_step(Res),
+                lager:info("[Key headers migrations scan] DONE: In total migrated ~p headers in ~p microseconds", [TotalCount, TotalTime])
+            end),
+            aec_db:finish_chain_migration(key_headers)
+        catch
+            E:R:Stack ->
+                (catch io:format(user, "[Orphan key blocks scan] Terminating node: ~p ~p ~p", [E, R, Stack])),
+                (catch lager:error("[Orphan key blocks scan] Terminating node: ~p ~p ~p", [E, R, Stack])),
+                init:stop("[Orphan key blocks scan] Encountered a fatal error during the migration. Terminating the node")
+        end
+    end).
+
+key_headers_height_store_migration_step(First) ->
+    key_headers_height_store_migration_step(0, 0, First).
+key_headers_height_store_migration_step(Time, N, {TimeAdd, '$end_of_table'}) ->
+    {Time + TimeAdd, N};
+key_headers_height_store_migration_step(Time, N, {TimeRead, {Headers, Cont}}) ->
+    lager:info("[Key headers migrations scan] Read headers in ~p microseconds", [TimeRead]),
+    {TimeWrite, Count} = timer:tc(fun() ->
+        aec_db:ensure_transaction(fun() ->
+            lists:foldl(
+                fun({Hash, Header, Height}, Count) ->
+                    mnesia:write(#aec_chain_state{key = {key_block, Height, Hash}, value = Header}),
+                    Count+1
+                end,
+                0,
+                Headers
+            )
+        end)
+    end),
+    lager:info("[Key headers migrations scan] Wrote ~p headers in ~p microseconds", [Count, TimeWrite]),
+    key_headers_height_store_migration_step(
+        Time + TimeRead + TimeWrite,
+        N + Count,
+        timer:tc(fun() -> mnesia:select(Cont) end)
+    ).

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -123,9 +123,9 @@
 -export([ find_chain_end_hashes/0
         , mark_chain_end_hash/1
         , unmark_chain_end_hash/1
-        , start_chain_end_migration/0
-        , finish_chain_end_migration/0
-        , chain_end_migration_status/0
+        , start_chain_migration/1
+        , finish_chain_migration/1
+        , chain_migration_status/1
         ]).
 
 %%
@@ -351,7 +351,10 @@ write_block(Block, Hash) ->
             Headers = #aec_headers{ key = Hash
                                   , value = Header
                                   , height = Height },
-            ?t(mnesia:write(Headers),
+            ?t(begin
+                   mnesia:write(Headers),
+                   mnesia:write(#aec_chain_state{key = {key_block, Height, Hash}, value = Header})
+               end,
                [{aec_headers, Hash}]);
         micro ->
             Txs = aec_blocks:txs(Block),
@@ -508,11 +511,24 @@ find_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
 %% When benchmarked on an cloud SSD it is faster then mnesia:index_read followed by filter
 -spec find_key_headers_and_hash_at_height(pos_integer()) -> [{binary(), aec_headers:key_header()}].
 find_key_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
-    R = mnesia:dirty_select(aec_headers, [{ #aec_headers{key = '_', value = '$1', height = Height}
-                                          , [{'=:=', {element, 1, '$1'}, key_header}]
-                                          , ['$_']
-                                          }]),
-    [{Hash, aec_headers:from_db_header(Header)} || #aec_headers{key = Hash, value = Header} <- R].
+    case persistent_term:get({?MODULE, chain_migration, key_headers}, done) of
+        in_progress ->
+            R = mnesia:dirty_select(aec_headers, [{ #aec_headers{key = '_',
+                                                                 value = '$1',
+                                                                 height = Height}
+                                                  , [{'=:=', {element, 1, '$1'}, key_header}]
+                                                  , ['$_']}]),
+            [{Hash, aec_headers:from_db_header(Header)}
+             || #aec_headers{key = Hash, value = Header} <- R];
+        done ->
+            R = mnesia:dirty_select(aec_chain_state, [{#aec_chain_state{key = {key_block, Height, '_'},
+                                                                        value = '_'}
+                                                        , []
+                                                        , ['$_']
+                                                          }]),
+            [{Hash, aec_headers:from_db_header(Header)}
+             || #aec_chain_state{key = {key_block, Height, Hash}, value = Header} <- R]
+    end.
 
 find_discovered_pof(Hash) ->
     case ?t(read(aec_discovered_pof, Hash)) of
@@ -600,17 +616,19 @@ unmark_chain_end_hash(Hash) when is_binary(Hash) ->
 find_chain_end_hashes() ->
     mnesia:dirty_select(aec_chain_state, [{ #aec_chain_state{key = {end_block_hash, '$1'}, _ = '_'}, [], ['$1'] }]).
 
-start_chain_end_migration() ->
+start_chain_migration(Key) ->
     %% Writes occur before the error store is initialized - if error keys are present then this will crash
     %% Fortunately this write will be correctly handled by the rocksdb bypass logic
-    ?t(mnesia:write(#aec_chain_state{key = chain_end_migration_lock, value = chain_end_migration_lock})).
+    ?t(mnesia:write(#aec_chain_state{key = {chain_migration_lock, Key}, value = lock})),
+    persistent_term:put({?MODULE, chain_migration, Key}, in_progress).
 
-finish_chain_end_migration() ->
-    ?t(mnesia:delete(aec_chain_state, chain_end_migration_lock, write)).
+finish_chain_migration(Key) ->
+    ?t(mnesia:delete(aec_chain_state, {chain_migration_lock, Key}, write)),
+    persistent_term:erase({?MODULE, chain_migration, Key}).
 
--spec chain_end_migration_status() -> in_progress | done.
-chain_end_migration_status() ->
-    case ?t(mnesia:read(aec_chain_state, chain_end_migration_lock)) of
+-spec chain_migration_status(atom()) -> in_progress | done.
+chain_migration_status(Key) ->
+    case ?t(mnesia:read(aec_chain_state, {chain_migration_lock, Key})) of
         [#aec_chain_state{}] -> in_progress;
         _ -> done
     end.

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -353,7 +353,7 @@ write_block(Block, Hash) ->
                                   , height = Height },
             ?t(begin
                    mnesia:write(Headers),
-                   mnesia:write(#aec_chain_state{key = {key_block, Height, Hash}, value = Header})
+                   mnesia:write(#aec_chain_state{key = {key_header, Height, Hash}, value = Header})
                end,
                [{aec_headers, Hash}]);
         micro ->
@@ -521,13 +521,13 @@ find_key_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0
             [{Hash, aec_headers:from_db_header(Header)}
              || #aec_headers{key = Hash, value = Header} <- R];
         done ->
-            R = mnesia:dirty_select(aec_chain_state, [{#aec_chain_state{key = {key_block, Height, '_'},
+            R = mnesia:dirty_select(aec_chain_state, [{#aec_chain_state{key = {key_header, Height, '_'},
                                                                         value = '_'}
                                                         , []
                                                         , ['$_']
                                                           }]),
             [{Hash, aec_headers:from_db_header(Header)}
-             || #aec_chain_state{key = {key_block, _, Hash}, value = Header} <- R]
+             || #aec_chain_state{key = {key_header, _, Hash}, value = Header} <- R]
     end.
 
 find_discovered_pof(Hash) ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -527,7 +527,7 @@ find_key_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0
                                                         , ['$_']
                                                           }]),
             [{Hash, aec_headers:from_db_header(Header)}
-             || #aec_chain_state{key = {key_block, Height, Hash}, value = Header} <- R]
+             || #aec_chain_state{key = {key_block, _, Hash}, value = Header} <- R]
     end.
 
 find_discovered_pof(Hash) ->

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -21,6 +21,7 @@ start(_StartType, _StartArgs) ->
     case aec_db:persisted_valid_genesis_block() of
         true ->
             aec_chain_state:ensure_chain_ends(),
+            aec_chain_state:ensure_key_headers_height_store(),
             aecore_sup:start_link();
         false ->
             lager:error("Persisted chain has a different genesis block than "

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -723,14 +723,14 @@ fork_test_chain_ends_and_migration(ExpectedTops, ExpectedBlocks) ->
     F(),
     MaxHeight = lists:max([aec_headers:height(aec_db:get_header(H)) || H <- ExpectedTops]),
     aec_db:ensure_transaction(fun() ->
-        [[mnesia:delete({aec_chain_state, {key_block, H, Hash}})
+        [[mnesia:delete({aec_chain_state, {key_header, H, Hash}})
         || {Hash, _Header} <- aec_db:find_key_headers_and_hash_at_height(H)]
         || H  <- lists:seq(0, MaxHeight)]
     end),
     aec_db:ensure_transaction(fun() ->
         ?assertEqual(
             [],
-            mnesia:dirty_select(aec_chain_state, [{{aec_chain_state, {key_block, '_', '_'}, '_'}
+            mnesia:dirty_select(aec_chain_state, [{{aec_chain_state, {key_header, '_', '_'}, '_'}
                                                   , []
                                                   , ['$_']
                                                   }])

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -698,34 +698,58 @@ fork_common_block(EasyChain, TopHashEasy, HardChain, TopHashHard) ->
     %% The second chain should take over
     ok = write_blocks_to_chain(EasyChain),
     ?assertEqual(TopHashEasy, top_block_hash()),
-    fork_test_chain_ends_and_migration([TopHashEasy]),
+    fork_test_chain_ends_and_migration([TopHashEasy], EasyChain),
     ok = write_blocks_to_chain(HardChain),
     ?assertEqual(TopHashHard, top_block_hash()),
-    fork_test_chain_ends_and_migration([TopHashEasy, TopHashHard]),
+    fork_test_chain_ends_and_migration([TopHashEasy, TopHashHard], HardChain),
 
     restart_chain_db(),
     %% The second chain should not take over
     ok = write_blocks_to_chain(HardChain),
     ?assertEqual(TopHashHard, top_block_hash()),
-    fork_test_chain_ends_and_migration([TopHashHard]),
+    fork_test_chain_ends_and_migration([TopHashHard], HardChain),
     ok = write_blocks_to_chain(EasyChain),
     ?assertEqual(TopHashHard, top_block_hash()),
-    fork_test_chain_ends_and_migration([TopHashEasy, TopHashHard]),
+    fork_test_chain_ends_and_migration([TopHashEasy, TopHashHard], HardChain),
     ok.
 
-fork_test_chain_ends_and_migration(Expected) ->
-    F = fun() -> ?assertEqual( lists:usort(Expected)
-                             , lists:usort(aec_db:find_chain_end_hashes())) end,
+fork_test_chain_ends_and_migration(ExpectedTops, ExpectedBlocks) ->
+    F = fun() -> ?assertEqual( lists:usort(ExpectedTops)
+                             , lists:usort(aec_db:find_chain_end_hashes())),
+                 ?assertEqual( [ aec_blocks:to_header(Block) || Block <- ExpectedBlocks]
+                             , [ header_by_height(H) ||
+                                 H <- lists:seq(0, aec_blocks:height(lists:last(ExpectedBlocks)))])
+        end,
     F(),
-    [aec_db:unmark_chain_end_hash(H) || H <- Expected],
-    case aec_chain_state:ensure_chain_ends() of
-        ok -> error("Migration did not trigger!");
-        Pid ->
-            MRef = erlang:monitor(process, Pid),
-            receive {'DOWN', MRef, process, _, _} -> ok end,
-            F(),
-            ok = aec_chain_state:ensure_chain_ends() %% Already migrated
-    end.
+    MaxHeight = lists:max([aec_headers:height(aec_db:get_header(H)) || H <- ExpectedTops]),
+    aec_db:ensure_transaction(fun() ->
+        [[mnesia:delete({aec_chain_state, {key_block, H, Hash}})
+        || {Hash, _Header} <- aec_db:find_key_headers_and_hash_at_height(H)]
+        || H  <- lists:seq(0, MaxHeight)]
+    end),
+    aec_db:ensure_transaction(fun() ->
+        ?assertEqual(
+            [],
+            mnesia:dirty_select(aec_chain_state, [{{aec_chain_state, {key_block, '_', '_'}, '_'}
+                                                  , []
+                                                  , ['$_']
+                                                  }])
+        )
+    end),
+    [aec_db:unmark_chain_end_hash(H) || H <- ExpectedTops],
+    PidEnds = aec_chain_state:ensure_chain_ends(),
+    ?assertNotEqual(ok, PidEnds),
+    PidHeight = aec_chain_state:ensure_key_headers_height_store(),
+    ?assertNotEqual(ok, PidHeight),
+    await_pid(PidEnds),
+    await_pid(PidHeight),
+    F(),
+    ok = aec_chain_state:ensure_chain_ends(), %% Already migrated
+    ok = aec_chain_state:ensure_key_headers_height_store().
+
+await_pid(Pid) ->
+    MRef = erlang:monitor(process, Pid),
+    receive {'DOWN', MRef, process, _, _} -> ok end.
 
 fork_get_by_height() ->
     CommonChain = gen_block_chain_with_state_by_target([?GENESIS_TARGET, ?GENESIS_TARGET, 1, 1], 111),
@@ -852,7 +876,7 @@ fork_on_micro_block() ->
 
     {ok, KB2ForkHash} = aec_blocks:hash_internal_representation(KB2Fork),
     ?assertEqual(KB2ForkHash, aec_chain:top_block_hash()),
-    fork_test_chain_ends_and_migration([KB2ForkHash]),
+    fork_test_chain_ends_and_migration([KB2ForkHash], [KB0, KB1, KB2Fork]),
 
     %% Insert main chain
     ok = insert_block(MB2),
@@ -862,7 +886,7 @@ fork_on_micro_block() ->
     %% Check main chain took over
     {ok, KB3Hash} = aec_blocks:hash_internal_representation(KB3),
     ?assertEqual(KB3Hash, aec_chain:top_block_hash()),
-    fork_test_chain_ends_and_migration([KB2ForkHash, KB3Hash]),
+    fork_test_chain_ends_and_migration([KB2ForkHash, KB3Hash], [KB0, KB1, KB2, KB3]),
     ok.
 
 fork_on_old_fork_point() ->
@@ -1891,6 +1915,10 @@ extend_chain_with_state(Base, Targets, Nonce, TxsFun) ->
 
 block_hash(Block) ->
     {ok, H} = aec_blocks:hash_internal_representation(Block),
+    H.
+
+header_by_height(Height) ->
+    {ok, H} = aec_chain:get_key_header_by_height(Height),
     H.
 
 make_spend_tx(Sender, SenderNonce, Recipient) ->

--- a/apps/aecore/test/aecore_app_tests.erl
+++ b/apps/aecore/test/aecore_app_tests.erl
@@ -17,6 +17,7 @@ persisted_valid_gen_block_test_() ->
              meck:expect(aec_jobs_queues, start, 0, ok),
              meck:new(aec_chain_state, [passthrough]),
              meck:expect(aec_chain_state, ensure_chain_ends, 0, ok),
+             meck:expect(aec_chain_state, ensure_key_headers_height_store, 0, ok),
              ok = lager:start(),
              InitialApps
      end,


### PR DESCRIPTION
- Add {key_header, Height, Hash} -> Header to aec_chain_state database
- Proper migration
- Use new fast find key header by height when migration done

TODO:
- [ ] performance tests