### PR TITLE
Fix oas3 definition for GA

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2480,8 +2480,6 @@ components:
           $ref: "#/components/schemas/EncodedPubkey"
         responder_amount:
           $ref: "#/components/schemas/UInt"
-        push_amount:
-          $ref: "#/components/schemas/UInt"
         channel_reserve:
           $ref: "#/components/schemas/UInt"
         lock_period:
@@ -2501,7 +2499,6 @@ components:
         - initiator_amount
         - responder_id
         - responder_amount
-        - push_amount
         - channel_reserve
         - lock_period
         - fee
@@ -2891,7 +2888,6 @@ components:
             $ref: "#/components/schemas/EncodedValue"
       required:
         - tx
-        - signatures
     Tx:
       allOf:
         - type: object

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3457,7 +3457,7 @@ components:
         auth_fun:
           description: Contract authorization function hash (hex encoded)
           type: string
-          pattern: ^(0x|0X)?[a-fA-F0-9]+$'
+          pattern: "^(0x|0X)?[a-fA-F0-9]+$"
       required:
         - owner_id
         - code

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -2412,8 +2412,6 @@ definitions:
         $ref: '#/definitions/EncodedPubkey'
       responder_amount:
         $ref: '#/definitions/UInt'
-      push_amount:
-        $ref: '#/definitions/UInt'
       channel_reserve:
         $ref: '#/definitions/UInt'
       lock_period:
@@ -3503,7 +3501,7 @@ definitions:
       auth_fun:
         description: Contract authorization function hash (hex encoded)
         type: string
-        pattern: ^(0x|0X)?[a-fA-F0-9]+$'
+        pattern: "^(0x|0X)?[a-fA-F0-9]+$"
     required:
       - owner_id
       - code

--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -45,7 +45,7 @@ validator(SpecVsn) ->
 
 -spec response(
     OperationId :: atom(),
-    Methohd :: binary(),
+    Method :: binary(),
     Code :: 200..599,
     Response :: jesse:json_term(),
     Validator :: jesse_state:state(),

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -428,7 +428,9 @@ handle_request_('GetTransactionByHash', Params, _Config) ->
                     {200, [], SerializedTx};
                 {BlockHash, Tx} ->
                     {ok, Header} = aec_chain:get_header(BlockHash),
-                    {200, [], aetx_sign:serialize_for_client(Header, Tx)}
+                    Response = aetx_sign:serialize_for_client(Header, Tx),
+                    lager:debug("ASDF ~p", [Response]),
+                    {200, [], Response}
             end;
         {error, _} ->
             {400, [], #{reason => <<"Invalid hash">>}}

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -429,7 +429,6 @@ handle_request_('GetTransactionByHash', Params, _Config) ->
                 {BlockHash, Tx} ->
                     {ok, Header} = aec_chain:get_header(BlockHash),
                     Response = aetx_sign:serialize_for_client(Header, Tx),
-                    lager:debug("ASDF ~p", [Response]),
                     {200, [], Response}
             end;
         {error, _} ->

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -227,9 +227,6 @@
 
 -export([post_paying_for_tx/1]).
 
--export([attach_ga/1,
-         meta_ga/1]).
-
 -include_lib("common_test/include/ct.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
 
@@ -239,16 +236,6 @@
 -define(SPEND_FEE, 20000 * aec_test_utils:min_gas_price()).
 
 -define(MAX_MINED_BLOCKS, 20).
-
--define(SECP256K1_PRIV, <<61,194,116,40,192,100,75,189,11,148,242,211,52,100,55,
-                          188,165,162,142,65,19,181,89,25,9,228,120,175,152,249,
-                          83,234>>).
-
--define(SECP256K1_PUB,  <<80,118,213,110,10,210,229,6,53,195,79,174,91,179,150,
-                          239,241,145,147,201,2,48,7,221,141,221,250,110,105,29,
-                          90,39,75,16,175,218,92,200,158,78,172,106,64,159,90,180,
-                          147,171,9,70,251,21,150,252,90,63,233,252,123,104,198,
-                          103,79,255>>).
 
 all() ->
     [
@@ -287,8 +274,7 @@ groups() ->
        {group, swagger_validation},
        {group, wrong_http_method_endpoints},
        {group, naming},
-       {group, paying_for_tx},
-       {group, generalized_accounts}
+       {group, paying_for_tx}
       ]},
 
      %% /key-blocks/* /micro-blocks/* /generations/*
@@ -558,8 +544,7 @@ groups() ->
        {group, swagger_validation},
        {group, wrong_http_method_endpoints},
        {group, naming},
-       {group, paying_for_tx},
-       {group, generalized_accounts}
+       {group, paying_for_tx}
       ]},
      {oas_block_endpoints, [sequence],
       [
@@ -587,11 +572,9 @@ groups() ->
        get_generation_by_hash,
        get_generation_by_height
       ]},
+     %% /oracles/*
      {paying_for_tx, [sequence],
-      [post_paying_for_tx]},
-     {generalized_accounts, [sequence],
-      [attach_ga,
-       meta_ga]}
+      [post_paying_for_tx]}
     ].
 
 suite() ->
@@ -802,11 +785,6 @@ init_per_group(paying_for_tx, Config) ->
     case aect_test_utils:latest_protocol_version() >= ?IRIS_PROTOCOL_VSN of
         true -> Config;
         false -> {skip, requires_iris_or_newer}
-    end;
-init_per_group(generalized_accounts, Config) ->
-    case aect_test_utils:latest_protocol_version() >= ?FORTUNA_PROTOCOL_VSN of
-        true -> Config;
-        false -> {skip, requires_fortuna_or_newer}
     end;
 init_per_group(_Group, Config) ->
     Config.
@@ -4353,109 +4331,3 @@ mine_tx(Node, SignedTx) ->
                                                                       [TxHash],
                                                                       10), %% max keyblocks
     TxHash.
-
-attach_ga(Config) ->
-    %% create a new account
-    {PubKey, PrivKey} = initialize_account(100000000 * aec_test_utils:min_gas_price()),
-    EncodedPubKey = aeser_api_encoder:encode(account_pubkey, PubKey),
-    GAContract = "bitcoin_auth",
-    GAAuthFun = "authorize",
-    GAParams = [aega_test_utils:to_hex_lit(64, ?SECP256K1_PUB)],
-    EncTxHash = attach(Config, {PubKey, PrivKey}, GAContract, GAAuthFun, GAParams),
-    {ok, 200, _AttachTx} = get_transactions_by_hash_sut(EncTxHash),
-    %% ensure that the account is available through the API
-    {ok, 200, _ } = get_accounts_by_pubkey_sut(EncodedPubKey),
-    ok.
-
-meta_ga(Config) ->
-    %% create a new account
-    [ {NodeId, _Node} | _ ] = ?config(nodes, Config),
-    {PubKey, PrivKey} = initialize_account(100000000 * aec_test_utils:min_gas_price()),
-    GAContract = "bitcoin_auth",
-    GAAuthFun = "authorize",
-    GAParams = [aega_test_utils:to_hex_lit(64, ?SECP256K1_PUB)],
-    _EncTxHash = attach(Config, {PubKey, PrivKey}, GAContract, GAAuthFun, GAParams),
-
-    SpendProps = #{ sender_id    => aeser_id:create(account, PubKey)
-                  , recipient_id => aeser_id:create(account, PubKey)
-                  , amount       => 1
-                  , fee          => 20000 * aec_test_utils:min_gas_price()
-                  , nonce        => 0
-                  , payload      => <<>>
-                  },
-    {ok, SpendAetx} = aec_spend_tx:new(SpendProps),
-    SignedTx = meta(PubKey, GAContract, aetx_sign:new(SpendAetx, [])),
-    {ok, 200, #{<<"tx_hash">> := EncTxHash}} =
-        post_transactions_sut(aeser_api_encoder:encode(transaction,
-                                                       aetx_sign:serialize_to_binary(SignedTx))),
-    _TxHash = mine_tx(NodeId, SignedTx),
-    {ok, 200, _MetaTx} = get_transactions_by_hash_sut(EncTxHash),
-    ok.
-
-attach(Config, {Owner, OwnerPrivkey}, Contract, AuthFun, Args) ->
-    attach(Config, {Owner, OwnerPrivkey}, Contract, AuthFun, Args, #{}).
-attach(Config, {Owner, OwnerPrivkey}, Contract, AuthFun, Args, Opts) ->
-    case get_contract_(Contract) of
-        {ok, #{src := Src, bytecode := C, map := #{type_info := TI}}} ->
-            attach_(Config, {Owner, OwnerPrivkey}, Src, C, TI, AuthFun, Args, Opts);
-        _ ->
-            error(bad_contract)
-    end.
-
-attach_(Config, {Owner, OwnerPrivkey}, Src, ByteCode, TypeInfo, AuthFun, Args, Opts) ->
-    [ {NodeId, _Node} | _ ] = ?config(nodes, Config),
-    {ok, Nonce} = rpc(dev1, aec_next_nonce, pick_for_account, [Owner]),
-    Calldata = aega_test_utils:make_calldata(Src, "init", Args),
-    {ok, AuthFunHash} = aeb_aevm_abi:type_hash_from_function_name(list_to_binary(AuthFun),
-                                                                  TypeInfo),
-    Options1 = maps:merge(#{nonce => Nonce, code => ByteCode,
-                            auth_fun => AuthFunHash, call_data => Calldata},
-                          Opts),
-    AttachTx = aega_test_utils:ga_attach_tx(Owner, Options1),
-
-    SignedTx = aec_test_utils:sign_tx(AttachTx, [OwnerPrivkey]),
-    {ok, 200, #{<<"tx_hash">> := EncTxHash}} =
-        post_transactions_sut(aeser_api_encoder:encode(transaction,
-                                                       aetx_sign:serialize_to_binary(SignedTx))),
-    _TxHash =
-      mine_tx(NodeId, SignedTx),
-    EncTxHash.
-
-get_contract_(Name) ->
-    aega_test_utils:get_contract(aect_test_utils:latest_sophia_version(), Name).
-
-btc_auth(TxHash, Nonce, PrivKey) ->
-    Val = <<32:256, TxHash/binary, (list_to_integer(Nonce)):256>>,
-    Sig0 = crypto:sign(ecdsa, sha256, {digest, aec_hash:hash(tx, Val)},
-                       [PrivKey, secp256k1]),
-    Sig  = aega_test_utils:to_hex_lit(64, aeu_crypto:ecdsa_from_der_sig(Sig0)),
-    aega_test_utils:make_calldata("bitcoin_auth", "authorize", [Nonce, Sig]).
-
-meta(Owner, Contract, SignedTx) ->
-    %% authenticate the inner tx, that could be a transaction instance or yet
-    %% another meta
-    AuthData =
-        case Contract of
-            "bitcoin_auth" ->
-                Nonce = get_btc_auth_nonce(Owner),
-                TxBin = aec_governance:add_network_id(aetx:serialize_to_binary(aetx_sign:tx(SignedTx))),
-                btc_auth(aec_hash:hash(tx, TxBin), integer_to_list(Nonce), ?SECP256K1_PRIV)
-        end,
-    %% produce the new layer of meta authenticating the inner tx and not the
-    %% innermost one, but include the inner tx
-    aecore_suite_utils:meta_tx(Owner, #{}, AuthData, SignedTx).
-
-get_btc_auth_nonce(PubKey) ->
-    {value, Account} = rpc(dev1, aec_chain, get_account, [PubKey]),
-    ContractPubkey = aeser_id:specialize(aec_accounts:ga_contract(Account),
-                                         contract),
-    {ok, Contract} = rpc(dev1, aec_chain, get_contract, [ContractPubkey]),
-    extract_nonce_from_btc_auth_store(aect_contracts:state(Contract)).
-
-
-extract_nonce_from_btc_auth_store(Store) ->
-    #{<<0>> := Encoded0} = rpc(dev1, aect_contracts_store, contents, [Store]),
-    {ok, {Nonce, _}} = aeb_heap:from_binary({tuple, [word, {tuple, [word, word]}]},
-                                Encoded0),
-    Nonce.
-

--- a/apps/aehttp/test/aehttp_validation_SUITE.erl
+++ b/apps/aehttp/test/aehttp_validation_SUITE.erl
@@ -2,6 +2,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include("../../aeoracle/include/oracle_txs.hrl").
 
 %% common_test exports
 -export([
@@ -24,8 +25,21 @@
           channel_close_solo_tx/1,
           channel_slash_tx/1,
           channel_settle_tx/1,
-          channel_snapshot_solo/1,
-          channel_set_delegates_tx/1
+          channel_snapshot_solo_tx/1,
+          channel_set_delegates_tx/1,
+          oracle_register_tx/1,
+          oracle_extend_tx/1,
+          oracle_query_tx/1,
+          oracle_response_tx/1,
+          name_preclaim_tx/1,
+          name_claim_tx/1,
+          name_update_tx/1,
+          name_transfer_tx/1,
+          name_revoke_tx/1,
+          contract_create_tx/1,
+          contract_call_tx/1,
+          generalized_accounts_attach_tx/1,
+          paying_for_tx/1
         ]).
 
 -define(PUBKEY, <<40:32/unit:8>>).
@@ -45,7 +59,8 @@ groups() ->
      {oas3, [sequence], [{group, transactions}]},
      {transactions, [sequence],
       [ spend_tx,
-        %% channel txs
+
+        %% channels
         channel_create_tx,
         channel_deposit_tx,
         channel_withdraw_tx,
@@ -54,25 +69,34 @@ groups() ->
         channel_close_solo_tx,
         channel_slash_tx,
         channel_settle_tx,
-        channel_snapshot_solo,
-        channel_set_delegates_tx
+        channel_snapshot_solo_tx,
+        channel_set_delegates_tx,
+
+        %% oracles
+        oracle_register_tx,
+        oracle_extend_tx,
+        oracle_query_tx,
+        oracle_response_tx,
+
+        %% names
+        name_preclaim_tx,
+        name_claim_tx,
+        name_update_tx,
+        name_transfer_tx,
+        name_revoke_tx,
+
+        %% contracts
+        contract_create_tx,
+        contract_call_tx,
+
+        %% generalized_accounts
+        generalized_accounts_attach_tx,
+        %% all tx types are tested to be wrapped in a meta tx, so no need for
+        %% an explicit test
+
+        paying_for_tx
       ]}
     ].
-
-%% TODO tx types:
-%% OracleRegisterTx,
-%% OracleExtendTx,
-%% OracleQueryTx,
-%% OracleRespondTx,
-%% NamePreclaimTx,
-%% NameClaimTx,
-%% NameUpdateTx,
-%% NameTransferTx,
-%% NameRevokeTx,
-%% ContractCreateTx,
-%% ContractCallTx,
-%% GAAttachTx,
-%% PayingForTx
 
 suite() ->
     [].
@@ -108,75 +132,68 @@ end_per_testcase(_Testcase, _Config) ->
     ok.
 
 spend_tx(Config) ->
-    Opts =
-        #{sender_id => aeser_id:create(account, ?PUBKEY),
-          recipient_id => aeser_id:create(account, ?PUBKEY),
-          amount => 1,
-          fee => ?FEE,
-          nonce => 1,
-          payload => <<"">>},
+    Opts = spend_tx_opts(),
     test_transaction_validation(Config, aec_spend_tx, Opts),
     test_transaction_validation(Config, aec_spend_tx, Opts#{payload => <<"something longer">>}),
     ok.
 
+spend_tx_opts() ->
+    #{sender_id => aeser_id:create(account, ?PUBKEY),
+      recipient_id => aeser_id:create(account, ?PUBKEY),
+      amount => 1,
+      fee => ?FEE,
+      nonce => 1,
+      payload => <<"">>}.
+
 channel_create_tx(Config) ->
-    Opts =
-        #{initiator_id => aeser_id:create(account, ?PUBKEY),
-          responder_id => aeser_id:create(account, ?PUBKEY),
-          initiator_amount => 1,
-          responder_amount => 1,
-          channel_reserve => 1,
-          lock_period => 1,
-          fee => ?FEE,
-          nonce => 1,
-          state_hash => ?STATE_HASH,
-          delegate_ids => {[],[]}},
+    Opts = channel_create_tx_opts(),
     test_transaction_validation(Config, aesc_create_tx, Opts),
     %% old style delegates
     test_transaction_validation(Config, aesc_create_tx, Opts#{delegate_ids => []}),
     ok.
 
+channel_create_tx_opts() ->
+    #{initiator_id => aeser_id:create(account, ?PUBKEY),
+      responder_id => aeser_id:create(account, ?PUBKEY),
+      initiator_amount => 1,
+      responder_amount => 1,
+      channel_reserve => 1,
+      lock_period => 1,
+      fee => ?FEE,
+      nonce => 1,
+      state_hash => ?STATE_HASH,
+      delegate_ids => {[],[]}}.
+
 channel_deposit_tx(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          from_id => aeser_id:create(account, ?PUBKEY),
-          amount => 1,
-          fee => ?FEE,
-          nonce => 1,
-          state_hash => ?STATE_HASH,
-          round => 2},
+    Opts = channel_deposit_tx_opts(),
     test_transaction_validation(Config, aesc_deposit_tx, Opts),
     ok.
 
+channel_deposit_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      from_id => aeser_id:create(account, ?PUBKEY),
+      amount => 1,
+      fee => ?FEE,
+      nonce => 1,
+      state_hash => ?STATE_HASH,
+      round => 2}.
+
 channel_withdraw_tx(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          to_id => aeser_id:create(account, ?PUBKEY),
-          amount => 1,
-          fee => ?FEE,
-          nonce => 1,
-          state_hash => ?STATE_HASH,
-          round => 2},
+    Opts = channel_withdraw_tx_opts(),
     test_transaction_validation(Config, aesc_withdraw_tx, Opts),
     ok.
 
+channel_withdraw_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      to_id => aeser_id:create(account, ?PUBKEY),
+      amount => 1,
+      fee => ?FEE,
+      nonce => 1,
+      state_hash => ?STATE_HASH,
+      round => 2}.
+
 channel_force_progress_tx(Config) ->
-    OffChainCall =
-        aesc_offchain_update:op_call_contract(aeser_id:create(account, ?PUBKEY),
-                                              aeser_id:create(contract, ?PUBKEY),
-                                              1,
-                                              1,
-                                              <<>>, [], 1, 1),
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          from_id => aeser_id:create(account, ?PUBKEY),
-          payload => <<>>, %% empty payload
-          update => OffChainCall,
-          offchain_trees => aec_trees:new_without_backend(),
-          fee => ?FEE,
-          nonce => 1,
-          state_hash => ?STATE_HASH,
-          round => 2},
+    Opts = channel_force_progress_tx_opts(),
     test_transaction_validation(Config, aesc_force_progress_tx, Opts),
     %% use a payload
     test_transaction_validation(Config, aesc_force_progress_tx,
@@ -186,25 +203,38 @@ channel_force_progress_tx(Config) ->
         Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
     ok.
 
+channel_force_progress_tx_opts() ->
+    OffChainCall =
+        aesc_offchain_update:op_call_contract(aeser_id:create(account, ?PUBKEY),
+                                              aeser_id:create(contract, ?PUBKEY),
+                                              1,
+                                              1,
+                                              <<>>, [], 1, 1),
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      from_id => aeser_id:create(account, ?PUBKEY),
+      payload => <<>>, %% empty payload
+      update => OffChainCall,
+      offchain_trees => aec_trees:new_without_backend(),
+      fee => ?FEE,
+      nonce => 1,
+      state_hash => ?STATE_HASH,
+      round => 2}.
+
 channel_close_mutual_tx(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          from_id => aeser_id:create(account, ?PUBKEY),
-          initiator_amount_final => 1,
-          responder_amount_final => 1, 
-          fee => ?FEE,
-          nonce => 1},
+    Opts = channel_close_mutual_tx_opts(),
     test_transaction_validation(Config, aesc_close_mutual_tx, Opts),
     ok.
 
+channel_close_mutual_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      from_id => aeser_id:create(account, ?PUBKEY),
+      initiator_amount_final => 1,
+      responder_amount_final => 1, 
+      fee => ?FEE,
+      nonce => 1}.
+
 channel_close_solo_tx(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          from_id => aeser_id:create(account, ?PUBKEY),
-          payload => <<>>, %% empty payload
-          poi => aec_trees:new_poi(aec_trees:new_without_backend()),
-          fee => ?FEE,
-          nonce => 1},
+    Opts = channel_close_solo_tx_opts(),
     test_transaction_validation(Config, aesc_close_solo_tx, Opts),
     test_transaction_validation(Config, aesc_close_solo_tx,
         Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
@@ -212,14 +242,16 @@ channel_close_solo_tx(Config) ->
         Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
     ok.
 
+channel_close_solo_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      from_id => aeser_id:create(account, ?PUBKEY),
+      payload => <<>>, %% empty payload
+      poi => aec_trees:new_poi(aec_trees:new_without_backend()),
+      fee => ?FEE,
+      nonce => 1}.
+
 channel_slash_tx(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          from_id => aeser_id:create(account, ?PUBKEY),
-          payload => <<>>, %% empty payload, not really possible
-          poi => aec_trees:new_poi(aec_trees:new_without_backend()),
-          fee => ?FEE,
-          nonce => 1},
+    Opts = channel_slash_tx_opts(),
     test_transaction_validation(Config, aesc_slash_tx, Opts),
     test_transaction_validation(Config, aesc_slash_tx,
         Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
@@ -227,24 +259,30 @@ channel_slash_tx(Config) ->
         Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
     ok.
 
+
+channel_slash_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      from_id => aeser_id:create(account, ?PUBKEY),
+      payload => <<>>, %% empty payload, not really possible
+      poi => aec_trees:new_poi(aec_trees:new_without_backend()),
+      fee => ?FEE,
+      nonce => 1}.
+
 channel_settle_tx(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          from_id => aeser_id:create(account, ?PUBKEY),
-          initiator_amount_final => 1,
-          responder_amount_final => 1,
-          fee => ?FEE,
-          nonce => 1},
+    Opts = channel_settle_tx_opts(),
     test_transaction_validation(Config, aesc_settle_tx, Opts),
     ok.
 
-channel_snapshot_solo(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          from_id => aeser_id:create(account, ?PUBKEY),
-          payload => <<>>, %% empty payload, not really possible
-          fee => ?FEE,
-          nonce => 1},
+channel_settle_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      from_id => aeser_id:create(account, ?PUBKEY),
+      initiator_amount_final => 1,
+      responder_amount_final => 1,
+      fee => ?FEE,
+      nonce => 1}.
+
+channel_snapshot_solo_tx(Config) ->
+    Opts = channel_snapshot_solo_tx_opts(),
     test_transaction_validation(Config, aesc_snapshot_solo_tx, Opts),
     test_transaction_validation(Config, aesc_snapshot_solo_tx,
         Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
@@ -252,17 +290,15 @@ channel_snapshot_solo(Config) ->
         Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
     ok.
 
+channel_snapshot_solo_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      from_id => aeser_id:create(account, ?PUBKEY),
+      payload => <<>>, %% empty payload, not really possible
+      fee => ?FEE,
+      nonce => 1}.
+
 channel_set_delegates_tx(Config) ->
-    Opts =
-        #{channel_id => aeser_id:create(channel, ?PUBKEY),
-          initiator_delegate_ids => [], %% no delegates
-          responder_delegate_ids => [], %% no delegates
-          from_id => aeser_id:create(account, ?PUBKEY),
-          payload => <<>>, %% empty payload, not really possible
-          state_hash => ?STATE_HASH,
-          round => 1,
-          fee => ?FEE,
-          nonce => 1},
+    Opts = channel_set_delegates_tx_opts(),
     test_transaction_validation(Config, aesc_set_delegates_tx, Opts),
     test_transaction_validation(Config, aesc_set_delegates_tx,
         Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
@@ -274,16 +310,277 @@ channel_set_delegates_tx(Config) ->
         Opts#{responder_delegate_ids => [aeser_id:create(channel, ?PUBKEY)]}),
     ok.
 
+channel_set_delegates_tx_opts() ->
+    #{channel_id => aeser_id:create(channel, ?PUBKEY),
+      initiator_delegate_ids => [], %% no delegates
+      responder_delegate_ids => [], %% no delegates
+      from_id => aeser_id:create(account, ?PUBKEY),
+      payload => <<>>, %% empty payload, not really possible
+      state_hash => ?STATE_HASH,
+      round => 1,
+      fee => ?FEE,
+      nonce => 1}.
+
+oracle_register_tx(Config) ->
+    Opts = oracle_register_tx_opts(),
+    test_transaction_validation(Config, aeo_register_tx, Opts),
+    test_transaction_validation(Config, aeo_register_tx,
+                                Opts#{oracle_ttl => {?ttl_block_atom, 1}}),
+    ok.
+
+oracle_register_tx_opts() ->
+    #{account_id => aeser_id:create(account, ?PUBKEY),
+      query_format => <<>>,
+      abi_version => 1,
+      response_format => <<>>,
+      query_fee => 1,
+      oracle_ttl => {?ttl_delta_atom, 1},
+      fee => ?FEE,
+      nonce => 1}.
+
+oracle_extend_tx(Config) ->
+    Opts = oracle_extend_tx_opts(),
+    test_transaction_validation(Config, aeo_extend_tx, Opts),
+    ok.
+
+oracle_extend_tx_opts() ->
+    #{oracle_id => aeser_id:create(oracle, ?PUBKEY),
+      oracle_ttl => {?ttl_delta_atom, 1},
+      fee => ?FEE,
+      nonce => 1}.
+
+oracle_query_tx(Config) ->
+    Opts = oracle_query_tx_opts(),
+    test_transaction_validation(Config, aeo_query_tx, Opts),
+    test_transaction_validation(Config, aeo_query_tx,
+                                Opts#{query_ttl => {?ttl_block_atom, 1}}),
+    test_transaction_validation(Config, aeo_query_tx,
+                                Opts#{oracle_id => aeser_id:create(name, ?PUBKEY)}),
+    ok.
+
+oracle_query_tx_opts() ->
+        #{sender_id => aeser_id:create(account, ?PUBKEY),
+          oracle_id => aeser_id:create(oracle, ?PUBKEY),
+          query => <<>>,
+          query_fee => 1,
+          query_ttl => {?ttl_delta_atom, 1},
+          response_ttl => {?ttl_delta_atom, 1},
+          fee => ?FEE,
+          nonce => 1}.
+
+oracle_response_tx(Config) ->
+    Opts = oracle_response_tx_opts(),
+    test_transaction_validation(Config, aeo_response_tx, Opts),
+    ok.
+
+oracle_response_tx_opts() ->
+    #{oracle_id => aeser_id:create(oracle, ?PUBKEY),
+      query_id => <<>>,
+      response => <<>>,
+      response_ttl => {?ttl_delta_atom, 1},
+      fee => ?FEE,
+      nonce => 1}.
+
+name_preclaim_tx(Config) ->
+    Opts = name_preclaim_tx_opts(),
+    test_transaction_validation(Config, aens_preclaim_tx, Opts),
+    ok.
+
+name_preclaim_tx_opts() ->
+    #{account_id => aeser_id:create(account, ?PUBKEY),
+      commitment_id => aeser_id:create(commitment, ?PUBKEY),
+      fee => ?FEE,
+      nonce => 1}.
+
+name_claim_tx(Config) ->
+    Opts = name_claim_tx_opts(),
+    test_transaction_validation(Config, aens_claim_tx, Opts),
+    test_transaction_validation(Config, aens_claim_tx,
+                                Opts#{name => <<"asdf.ghj">>}),
+    ok.
+
+name_claim_tx_opts() ->
+    #{account_id => aeser_id:create(account, ?PUBKEY),
+      name => <<>>,
+      name_salt => 1,
+      fee => ?FEE,
+      nonce => 1}.
+
+name_update_tx(Config) ->
+    Opts = name_update_tx_opts(),
+    test_transaction_validation(Config, aens_update_tx, Opts),
+    AccountPointer = aens_pointer:new(<<"account_pubkey">>, aeser_id:create(account, ?PUBKEY)),
+    ChannelPointer = aens_pointer:new(<<"channel_pubkey">>, aeser_id:create(channel, ?PUBKEY)),
+    ContractPointer = aens_pointer:new(<<"contract_pubkey">>, aeser_id:create(contract, ?PUBKEY)),
+    OraclePointer = aens_pointer:new(<<"oracle_pubkey">>, aeser_id:create(oracle, ?PUBKEY)),
+    CustomPointer = aens_pointer:new(<<"my custom account">>, aeser_id:create(account, ?PUBKEY)),
+    test_transaction_validation(Config, aens_update_tx,
+                                Opts#{pointers => [AccountPointer,
+                                                   ChannelPointer,
+                                                   ContractPointer,
+                                                   OraclePointer,
+                                                   CustomPointer ]}),
+    ok.
+
+name_update_tx_opts() ->
+    #{account_id => aeser_id:create(account, ?PUBKEY),
+      name_id => aeser_id:create(name, ?PUBKEY),
+      name_ttl => 1,
+      client_ttl => 1,
+      pointers => [], %% no pointers
+      fee => ?FEE,
+      nonce => 1}.
+
+name_transfer_tx(Config) ->
+    Opts = name_transfer_tx_opts(),
+    test_transaction_validation(Config, aens_transfer_tx, Opts),
+    %% send to another name
+    test_transaction_validation(Config, aens_transfer_tx,
+                                Opts#{recipient_id => aeser_id:create(name, ?PUBKEY)}),
+    ok.
+
+name_transfer_tx_opts() ->
+    #{account_id => aeser_id:create(account, ?PUBKEY),
+      name_id => aeser_id:create(name, ?PUBKEY),
+      recipient_id => aeser_id:create(account, ?PUBKEY),
+      fee => ?FEE,
+      nonce => 1}.
+
+name_revoke_tx(Config) ->
+    Opts = name_revoke_tx_opts(),
+    test_transaction_validation(Config, aens_revoke_tx, Opts),
+    ok.
+
+name_revoke_tx_opts() ->
+    #{account_id => aeser_id:create(account, ?PUBKEY),
+      name_id => aeser_id:create(name, ?PUBKEY),
+      fee => ?FEE,
+      nonce => 1}.
+
+contract_create_tx(Config) ->
+    Opts = contract_create_tx_opts(),
+    test_transaction_validation(Config, aect_create_tx, Opts),
+    ok.
+
+contract_create_tx_opts() ->
+        #{owner_id => aeser_id:create(account, ?PUBKEY),
+          code => <<>>,
+          vm_version => 1,
+          abi_version => 1,
+          deposit => 1,
+          amount => 1,
+          gas => 1,
+          gas_price => 1,
+          fee => ?FEE,
+          call_data => <<>>,
+          nonce => 1}.
+
+contract_call_tx(Config) ->
+    Opts = contract_call_tx_opts(),
+    test_transaction_validation(Config, aect_call_tx, Opts),
+    ok.
+
+contract_call_tx_opts() ->
+    #{caller_id => aeser_id:create(account, ?PUBKEY),
+      contract_id => aeser_id:create(contract, ?PUBKEY),
+      abi_version => 1,
+      amount => 1,
+      gas => 1,
+      gas_price => 1,
+      fee => ?FEE,
+      call_data => <<>>,
+      nonce => 1}.
+
+generalized_accounts_attach_tx(Config) ->
+    Opts = generalized_accounts_attach_tx_opts(),
+    test_transaction_validation(Config, aega_attach_tx, Opts),
+    ok.
+
+generalized_accounts_attach_tx_opts() ->
+    #{owner_id => aeser_id:create(account, ?PUBKEY),
+      code => <<>>,
+      auth_fun => <<"0xabcd">>,
+      vm_version => 1,
+      abi_version => 1,
+      deposit => 1,
+      gas => 1,
+      gas_price => 1,
+      fee => ?FEE,
+      call_data => <<>>,
+      nonce => 1}.
+
+paying_for_tx(Config) ->
+    Opts0 =
+        #{payer_id => aeser_id:create(account, ?PUBKEY),
+          %% must set tx
+          fee => ?FEE,
+          nonce => 1},
+    MakeTx =
+        fun(Mod, Opts) ->
+            {ok, Aetx} = Mod:new(Opts),
+            case lists:member(Mod, mutual_auth_modules()) of
+                false ->
+                    [ sign(Aetx),
+                      meta(Aetx) ];
+                true ->
+                    [ sign(Aetx),
+                      meta(Aetx),
+                      meta(aetx_sign:tx(meta(Aetx))) ]
+            end
+        end,
+        
+    lists:foreach(
+      fun(Tx) ->
+          test_transaction_validation(Config, aec_paying_for_tx, Opts0#{tx => Tx})
+      end,
+      lists:flatten(
+          [MakeTx(aec_spend_tx, spend_tx_opts()),
+          MakeTx(aesc_create_tx, channel_create_tx_opts()),
+          MakeTx(aesc_deposit_tx, channel_deposit_tx_opts()),
+          MakeTx(aesc_withdraw_tx, channel_withdraw_tx_opts()),
+          MakeTx(aesc_force_progress_tx, channel_force_progress_tx_opts()),
+          MakeTx(aesc_close_mutual_tx, channel_close_mutual_tx_opts()),
+          MakeTx(aesc_close_solo_tx, channel_close_solo_tx_opts()),
+          MakeTx(aesc_slash_tx, channel_slash_tx_opts()),
+          MakeTx(aesc_settle_tx, channel_settle_tx_opts()),
+          MakeTx(aesc_snapshot_solo_tx, channel_snapshot_solo_tx_opts()),
+          MakeTx(aesc_set_delegates_tx, channel_set_delegates_tx_opts()),
+          MakeTx(aeo_register_tx, oracle_register_tx_opts()),
+          MakeTx(aeo_extend_tx, oracle_extend_tx_opts()),
+          MakeTx(aeo_query_tx, oracle_query_tx_opts()),
+          MakeTx(aeo_response_tx, oracle_response_tx_opts()),
+          MakeTx(aens_preclaim_tx, name_preclaim_tx_opts()),
+          MakeTx(aens_claim_tx, name_claim_tx_opts()),
+          MakeTx(aens_update_tx, name_update_tx_opts()),
+          MakeTx(aens_transfer_tx, name_transfer_tx_opts()),
+          MakeTx(aens_revoke_tx, name_revoke_tx_opts()),
+          MakeTx(aect_create_tx, contract_create_tx_opts()),
+          MakeTx(aect_call_tx, contract_call_tx_opts()),
+          MakeTx(aega_attach_tx, generalized_accounts_attach_tx_opts())
+          ])),
+    ok.
+
 test_transaction_validation(Config, TxModule, Opts) ->
-    validate_response(Config, get_transaction_by_hash_operation(), 200,
-                      mk_transaction_response(TxModule, Opts, mempool, fun sign/1)),
-    validate_response(Config, get_transaction_by_hash_operation(), 200,
-                      mk_transaction_response(TxModule, Opts, mempool, fun meta/1)),
-    validate_response(Config, get_transaction_by_hash_operation(), 200,
-                      mk_transaction_response(TxModule, Opts, included_in_block, fun sign/1)),
-    validate_response(Config, get_transaction_by_hash_operation(), 200,
-                      mk_transaction_response(TxModule, Opts, included_in_block, fun meta/1)).
+    Test =
+        fun(AuthFun) ->
+            validate_response(Config, get_transaction_by_hash_operation(), 200,
+                              mk_transaction_response(TxModule, Opts, mempool, AuthFun)),
+            validate_response(Config, get_transaction_by_hash_operation(), 200,
+                              mk_transaction_response(TxModule, Opts, included_in_block, AuthFun)),
+            ok
+        end,
+    case lists:member(TxModule, mutual_auth_modules()) of
+        false ->
+            lists:foreach(Test, [fun sign/1, fun meta/1]);
+        true ->
+            lists:foreach(Test, [fun sign/1, fun meta/1,
+                                 fun(Tx) -> meta(aetx_sign:tx(meta(Tx))) end])
+    end.
     
+mutual_auth_modules() ->
+    [ aesc_create_tx, aesc_deposit_tx, aesc_withdraw_tx,
+      aesc_close_mutual_tx, aesc_set_delegates_tx].
+
 get_transaction_by_hash_operation() -> operation('GetTransactionByHash', "get").
 
 operation(OperationId, Method) -> {OperationId, Method}.

--- a/apps/aehttp/test/aehttp_validation_SUITE.erl
+++ b/apps/aehttp/test/aehttp_validation_SUITE.erl
@@ -1,0 +1,327 @@
+-module(aehttp_validation_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%% common_test exports
+-export([
+         all/0, groups/0, suite/0,
+         init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2
+        ]).
+
+-import(aecore_suite_utils, [http_request/4]).
+
+%% test case exports
+%% external endpoints
+-export([ spend_tx/1,
+          channel_create_tx/1,
+          channel_deposit_tx/1,
+          channel_withdraw_tx/1,
+          channel_force_progress_tx/1,
+          channel_close_mutual_tx/1,
+          channel_close_solo_tx/1,
+          channel_slash_tx/1,
+          channel_settle_tx/1,
+          channel_snapshot_solo/1,
+          channel_set_delegates_tx/1
+        ]).
+
+-define(PUBKEY, <<40:32/unit:8>>).
+-define(BLOCK_HASH, <<41:32/unit:8>>).
+-define(BLOCK_HEIGHT, 42).
+-define(STATE_HASH, <<42:32/unit:8>>).
+-define(TX_HASH, <<43:32/unit:8>>).
+-define(FEE, 20000 * aec_test_utils:min_gas_price()).
+
+all() ->
+    [{group, swagger2},
+     {group, oas3}
+    ].
+
+groups() ->
+    [{swagger2, [sequence], [{group, transactions}]},
+     {oas3, [sequence], [{group, transactions}]},
+     {transactions, [sequence],
+      [ spend_tx,
+        %% channel txs
+        channel_create_tx,
+        channel_deposit_tx,
+        channel_withdraw_tx,
+        channel_force_progress_tx,
+        channel_close_mutual_tx,
+        channel_close_solo_tx,
+        channel_slash_tx,
+        channel_settle_tx,
+        channel_snapshot_solo,
+        channel_set_delegates_tx
+      ]}
+    ].
+
+%% TODO tx types:
+%% OracleRegisterTx,
+%% OracleExtendTx,
+%% OracleQueryTx,
+%% OracleRespondTx,
+%% NamePreclaimTx,
+%% NameClaimTx,
+%% NameUpdateTx,
+%% NameTransferTx,
+%% NameRevokeTx,
+%% ContractCreateTx,
+%% ContractCallTx,
+%% GAAttachTx,
+%% PayingForTx
+
+suite() ->
+    [].
+
+init_per_suite(Config0) ->
+    Config0.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(SwaggerVsn, Config) when SwaggerVsn =:= swagger2;
+                                        SwaggerVsn =:= oas3 ->
+    Json = aehttp_spec:json(SwaggerVsn),
+    R = jsx:decode(Json),
+    Validator = jesse_state:new(R, [{default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}]),
+    EndpointsMod =
+        case SwaggerVsn of
+            swagger2 -> endpoints;
+            oas3     -> oas_endpoints
+        end,
+    [{swagger_version, SwaggerVsn}, {validator, Validator}, {endpoints_mod, EndpointsMod}
+     | Config];
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_VMGroup, _Config) ->
+    ok.
+
+init_per_testcase(_Testcase, Config) ->
+    Config.
+
+end_per_testcase(_Testcase, _Config) ->
+    ok.
+
+spend_tx(Config) ->
+    Opts =
+        #{sender_id => aeser_id:create(account, ?PUBKEY),
+          recipient_id => aeser_id:create(account, ?PUBKEY),
+          amount => 1,
+          fee => ?FEE,
+          nonce => 1,
+          payload => <<"">>},
+    test_transaction_validation(Config, aec_spend_tx, Opts),
+    test_transaction_validation(Config, aec_spend_tx, Opts#{payload => <<"something longer">>}),
+    ok.
+
+channel_create_tx(Config) ->
+    Opts =
+        #{initiator_id => aeser_id:create(account, ?PUBKEY),
+          responder_id => aeser_id:create(account, ?PUBKEY),
+          initiator_amount => 1,
+          responder_amount => 1,
+          channel_reserve => 1,
+          lock_period => 1,
+          fee => ?FEE,
+          nonce => 1,
+          state_hash => ?STATE_HASH,
+          delegate_ids => {[],[]}},
+    test_transaction_validation(Config, aesc_create_tx, Opts),
+    %% old style delegates
+    test_transaction_validation(Config, aesc_create_tx, Opts#{delegate_ids => []}),
+    ok.
+
+channel_deposit_tx(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          from_id => aeser_id:create(account, ?PUBKEY),
+          amount => 1,
+          fee => ?FEE,
+          nonce => 1,
+          state_hash => ?STATE_HASH,
+          round => 2},
+    test_transaction_validation(Config, aesc_deposit_tx, Opts),
+    ok.
+
+channel_withdraw_tx(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          to_id => aeser_id:create(account, ?PUBKEY),
+          amount => 1,
+          fee => ?FEE,
+          nonce => 1,
+          state_hash => ?STATE_HASH,
+          round => 2},
+    test_transaction_validation(Config, aesc_withdraw_tx, Opts),
+    ok.
+
+channel_force_progress_tx(Config) ->
+    OffChainCall =
+        aesc_offchain_update:op_call_contract(aeser_id:create(account, ?PUBKEY),
+                                              aeser_id:create(contract, ?PUBKEY),
+                                              1,
+                                              1,
+                                              <<>>, [], 1, 1),
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          from_id => aeser_id:create(account, ?PUBKEY),
+          payload => <<>>, %% empty payload
+          update => OffChainCall,
+          offchain_trees => aec_trees:new_without_backend(),
+          fee => ?FEE,
+          nonce => 1,
+          state_hash => ?STATE_HASH,
+          round => 2},
+    test_transaction_validation(Config, aesc_force_progress_tx, Opts),
+    %% use a payload
+    test_transaction_validation(Config, aesc_force_progress_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
+    %% GA authenticated payload
+    test_transaction_validation(Config, aesc_force_progress_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
+    ok.
+
+channel_close_mutual_tx(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          from_id => aeser_id:create(account, ?PUBKEY),
+          initiator_amount_final => 1,
+          responder_amount_final => 1, 
+          fee => ?FEE,
+          nonce => 1},
+    test_transaction_validation(Config, aesc_close_mutual_tx, Opts),
+    ok.
+
+channel_close_solo_tx(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          from_id => aeser_id:create(account, ?PUBKEY),
+          payload => <<>>, %% empty payload
+          poi => aec_trees:new_poi(aec_trees:new_without_backend()),
+          fee => ?FEE,
+          nonce => 1},
+    test_transaction_validation(Config, aesc_close_solo_tx, Opts),
+    test_transaction_validation(Config, aesc_close_solo_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
+    test_transaction_validation(Config, aesc_close_solo_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
+    ok.
+
+channel_slash_tx(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          from_id => aeser_id:create(account, ?PUBKEY),
+          payload => <<>>, %% empty payload, not really possible
+          poi => aec_trees:new_poi(aec_trees:new_without_backend()),
+          fee => ?FEE,
+          nonce => 1},
+    test_transaction_validation(Config, aesc_slash_tx, Opts),
+    test_transaction_validation(Config, aesc_slash_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
+    test_transaction_validation(Config, aesc_slash_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
+    ok.
+
+channel_settle_tx(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          from_id => aeser_id:create(account, ?PUBKEY),
+          initiator_amount_final => 1,
+          responder_amount_final => 1,
+          fee => ?FEE,
+          nonce => 1},
+    test_transaction_validation(Config, aesc_settle_tx, Opts),
+    ok.
+
+channel_snapshot_solo(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          from_id => aeser_id:create(account, ?PUBKEY),
+          payload => <<>>, %% empty payload, not really possible
+          fee => ?FEE,
+          nonce => 1},
+    test_transaction_validation(Config, aesc_snapshot_solo_tx, Opts),
+    test_transaction_validation(Config, aesc_snapshot_solo_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
+    test_transaction_validation(Config, aesc_snapshot_solo_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
+    ok.
+
+channel_set_delegates_tx(Config) ->
+    Opts =
+        #{channel_id => aeser_id:create(channel, ?PUBKEY),
+          initiator_delegate_ids => [], %% no delegates
+          responder_delegate_ids => [], %% no delegates
+          from_id => aeser_id:create(account, ?PUBKEY),
+          payload => <<>>, %% empty payload, not really possible
+          state_hash => ?STATE_HASH,
+          round => 1,
+          fee => ?FEE,
+          nonce => 1},
+    test_transaction_validation(Config, aesc_set_delegates_tx, Opts),
+    test_transaction_validation(Config, aesc_set_delegates_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(sign(off_chain_tx()))}),
+    test_transaction_validation(Config, aesc_set_delegates_tx,
+        Opts#{payload => aetx_sign:serialize_to_binary(meta(off_chain_tx()))}),
+    test_transaction_validation(Config, aesc_set_delegates_tx,
+        Opts#{initiator_delegate_ids => [aeser_id:create(channel, ?PUBKEY)]}),
+    test_transaction_validation(Config, aesc_set_delegates_tx,
+        Opts#{responder_delegate_ids => [aeser_id:create(channel, ?PUBKEY)]}),
+    ok.
+
+test_transaction_validation(Config, TxModule, Opts) ->
+    validate_response(Config, get_transaction_by_hash_operation(), 200,
+                      mk_transaction_response(TxModule, Opts, mempool, fun sign/1)),
+    validate_response(Config, get_transaction_by_hash_operation(), 200,
+                      mk_transaction_response(TxModule, Opts, mempool, fun meta/1)),
+    validate_response(Config, get_transaction_by_hash_operation(), 200,
+                      mk_transaction_response(TxModule, Opts, included_in_block, fun sign/1)),
+    validate_response(Config, get_transaction_by_hash_operation(), 200,
+                      mk_transaction_response(TxModule, Opts, included_in_block, fun meta/1)).
+    
+get_transaction_by_hash_operation() -> operation('GetTransactionByHash', "get").
+
+operation(OperationId, Method) -> {OperationId, Method}.
+
+mk_transaction_response(Mod, Opts, Location, Auth) ->
+    {ok, Aetx} = Mod:new(Opts),
+    case Location of
+        mempool ->
+            aetx_sign:serialize_for_client_pending(sign(Aetx));
+        included_in_block ->
+            aetx_sign:serialize_for_client(Auth(Aetx),
+                                           ?BLOCK_HEIGHT, ?BLOCK_HASH,
+                                           ?TX_HASH)
+    end.
+
+sign(Aetx) -> aetx_sign:new(Aetx, []).
+
+meta(Aetx) ->
+    {ok, Meta} = aega_meta_tx:new(
+        #{ga_id => aeser_id:create(account, ?PUBKEY),
+          auth_data => <<>>,
+          abi_version => 1,
+          gas => 1,
+          gas_price => 1,
+          fee => 1,
+          tx => aetx_sign:new(Aetx, [])}),
+    aetx_sign:new(Meta, []).
+
+validate_response(Config, {OperationId, Method}, Code, Response) ->
+    EndpointsMod = ?config(endpoints_mod, Config),
+    Validator = ?config(validator, Config),
+    aehttp_api_validate:response(OperationId, Method, Code, Response,
+                                 Validator, EndpointsMod).
+
+off_chain_tx() ->
+    {ok, Aetx} =
+        aesc_offchain_tx:new(
+            #{channel_id => aeser_id:create(channel, ?PUBKEY),
+              state_hash => ?STATE_HASH,
+              round => 2}),
+    Aetx.

--- a/apps/aehttp/test/aehttp_validation_SUITE.erl
+++ b/apps/aehttp/test/aehttp_validation_SUITE.erl
@@ -2,7 +2,6 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
--include("../../aeoracle/include/oracle_txs.hrl").
 
 %% common_test exports
 -export([
@@ -325,7 +324,7 @@ oracle_register_tx(Config) ->
     Opts = oracle_register_tx_opts(),
     test_transaction_validation(Config, aeo_register_tx, Opts),
     test_transaction_validation(Config, aeo_register_tx,
-                                Opts#{oracle_ttl => {?ttl_block_atom, 1}}),
+                                Opts#{oracle_ttl => {block, 1}}),
     ok.
 
 oracle_register_tx_opts() ->
@@ -334,7 +333,7 @@ oracle_register_tx_opts() ->
       abi_version => 1,
       response_format => <<>>,
       query_fee => 1,
-      oracle_ttl => {?ttl_delta_atom, 1},
+      oracle_ttl => {delta, 1},
       fee => ?FEE,
       nonce => 1}.
 
@@ -345,7 +344,7 @@ oracle_extend_tx(Config) ->
 
 oracle_extend_tx_opts() ->
     #{oracle_id => aeser_id:create(oracle, ?PUBKEY),
-      oracle_ttl => {?ttl_delta_atom, 1},
+      oracle_ttl => {delta, 1},
       fee => ?FEE,
       nonce => 1}.
 
@@ -353,7 +352,7 @@ oracle_query_tx(Config) ->
     Opts = oracle_query_tx_opts(),
     test_transaction_validation(Config, aeo_query_tx, Opts),
     test_transaction_validation(Config, aeo_query_tx,
-                                Opts#{query_ttl => {?ttl_block_atom, 1}}),
+                                Opts#{query_ttl => {block, 1}}),
     test_transaction_validation(Config, aeo_query_tx,
                                 Opts#{oracle_id => aeser_id:create(name, ?PUBKEY)}),
     ok.
@@ -363,8 +362,8 @@ oracle_query_tx_opts() ->
           oracle_id => aeser_id:create(oracle, ?PUBKEY),
           query => <<>>,
           query_fee => 1,
-          query_ttl => {?ttl_delta_atom, 1},
-          response_ttl => {?ttl_delta_atom, 1},
+          query_ttl => {delta, 1},
+          response_ttl => {delta, 1},
           fee => ?FEE,
           nonce => 1}.
 
@@ -377,7 +376,7 @@ oracle_response_tx_opts() ->
     #{oracle_id => aeser_id:create(oracle, ?PUBKEY),
       query_id => <<>>,
       response => <<>>,
-      response_ttl => {?ttl_delta_atom, 1},
+      response_ttl => {delta, 1},
       fee => ?FEE,
       nonce => 1}.
 

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -40,7 +40,8 @@
          deserialize_from_binary/1]).
 
 -ifdef(TEST).
--export([set_tx/2]).
+-export([set_tx/2,
+         serialize_for_client/4]).
 -endif.
 
 -export_type([signed_tx/0,

--- a/docs/release-notes/next/GH-3596_fix_oas3_for_GA.md
+++ b/docs/release-notes/next/GH-3596_fix_oas3_for_GA.md
@@ -1,0 +1,2 @@
+* Fixed a HTTP API issue: in `/v3/` when fetching a transaction by hash, if
+  the transaction is `ga_attach_tx`, the API crashed.

--- a/docs/release-notes/next/GH-3596_fix_oas3_for_GA.md
+++ b/docs/release-notes/next/GH-3596_fix_oas3_for_GA.md
@@ -1,2 +1,4 @@
 * Fixed a HTTP API issue: in `/v3/` when fetching a transaction by hash, if
   the transaction is `ga_attach_tx`, the API crashed.
+* Fixed a HTTP API issue: in `/v3/` when fetching a `channel_create_tx`, the
+  API crashed.


### PR DESCRIPTION
Fixes #3596

The issue was that with the new `oas3` we do check the pattern of the auth
function for `ga_attach_tx`. We don't do that for `swagger2` API. Since we didn't have integration tests coverage, this slipped in. Now we have tests to cover attach and meta transactions.

The work on this PR had been supported by the ACF.
