### PR TITLE
Fix HTTP API issue for /v2/

### DIFF
--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -808,6 +808,7 @@ paths:
           name: type
           description: 'The type of a query: open, closed or all'
           required: false
+          default: all
           type: string
           enum: [open, closed, all]
       responses:

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -572,7 +572,6 @@ groups() ->
        get_generation_by_hash,
        get_generation_by_height
       ]},
-     %% /oracles/*
      {paying_for_tx, [sequence],
       [post_paying_for_tx]}
     ].
@@ -1665,6 +1664,10 @@ post_oracle_register(Config) ->
     ok = post_tx(TxHash, Tx),
     ok = wait_for_tx_hash_on_chain(TxHash),
     {ok, 200, Resp} = get_oracles_by_pubkey_sut(OracleId),
+    {ok, 200, #{<<"oracle_queries">> := []}} = get_oracles_queries_by_pubkey_sut(OracleId, #{type => "all"}),
+    {ok, 200, #{<<"oracle_queries">> := []}} = get_oracles_queries_by_pubkey_sut(OracleId, #{}),
+    {ok, 200, #{<<"oracle_queries">> := []}} = get_oracles_queries_by_pubkey_sut(OracleId, #{type => "open"}),
+    {ok, 200, #{<<"oracle_queries">> := []}} = get_oracles_queries_by_pubkey_sut(OracleId, #{type => "closed"}),
     ?assertEqual(OracleId, maps:get(<<"id">>, Resp)),
     {save_config, save_config([account_id, oracle_id, oracle_ttl_value], Config)}.
 

--- a/docs/release-notes/next/GH-3594_fix_swagger2_for_oracle_queries.md
+++ b/docs/release-notes/next/GH-3594_fix_swagger2_for_oracle_queries.md
@@ -1,0 +1,5 @@
+* Fixed a HTTP API issue: in `/v2/` when fetching oracle queries, the client
+  can specify if they want currently `open`, already `closed` or simply `all`
+  queries for that oracle. If no parameter was provided, the endpoint crashed.
+  Now if nothing is specified, `all` queries are returned as this is the
+  default behaviour for `/v3/`.


### PR DESCRIPTION
Fixes #3594

A default value was missing, now `all` are returned by default. For more info - 
please consult the release notes line.

The work on this PR had been supported by ACF.
