### PR TITLE
Improve HTTP API with handling missing value

### DIFF
--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -239,7 +239,12 @@ prepare_param_({"schema", [{"type",  _} = _Type | _] = Schema}, Value, Name, Val
 prepare_param_({"enum", Values0}, Value0, Name, _, _) ->
     try
         Values = [ to_atom(Acc) || Acc <- Values0 ],
-        Value = to_existing_atom(Value0),
+        Value = 
+            case Value0 of
+                undefined -> %% maybe a missing default value?
+                    undefined;
+                _ -> to_existing_atom(Value0)
+            end,
         case lists:member(Value, Values) of
             true -> {ok, Value};
             false -> param_error({enum, Value0}, Name)


### PR DESCRIPTION
Further improves API: while reading params, if the params is an `enum` in the
OAS definition, it is being parsed to an atom. If no value is being provided,
the `default` from the schema is being used. If there is no `default` - we
used to crash.

The only place where this could happen is fixed in #3611, so this is a
protection for future cases.

