### PR TITLE
ensure gproc running before apply_os_env()

### DIFF
--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -286,6 +286,7 @@ read_config(Mode) when Mode =:= silent; Mode =:= report ->
     end.
 
 apply_os_env() ->
+    ok = application:ensure_started(gproc),
     try
     Pfx = "AE",  %% TODO: make configurable
     %% We sort on variable names to allow specific values to override object


### PR DESCRIPTION
See issue #3612 

The fix ensures that `gproc` is running before OS env settings are applied (any updates are published using `aec_events`, which uses `gproc`).