### PR TITLE
New HTTP endpoint: dry-run

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -31,6 +31,8 @@ tags:
     description: Debug endpoints
   - name: obsolete
     description: Old endpoints that will be removed
+  - name: dry-run
+    description: External dry run endpoint.
 externalDocs:
   description: Find out more about Aeternity
   url: http://www.aeternity.com
@@ -541,6 +543,35 @@ paths:
           content:
             application/json:
               schema:
+  /dry-run:
+    post:
+      tags:
+        - external
+        - dry-run
+      operationId: ProtectedDryRunTxs
+      description: Dry-run transactions on top of a given block. Supports all TXs except GAMetaTx, PayingForTx and OffchainTx. The maximum gas limit of all calls is capped. The maximum gas limit per request is a global node setting. Since DryRunCallReq object do not have a mandatory gas field, if not set a default value of 1000000 is being used instead.
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DryRunInput"
+        description: transactions
+        required: true
+      responses:
+        "200":
+          description: Dry-run result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DryRunResults"
+        "403":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
                 $ref: "#/components/schemas/Error"
   "/transactions/{hash}":
     get:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -568,6 +568,33 @@ paths:
           description: 'Account not found'
           schema:
             $ref: '#/definitions/Error'
+  /dry-run:
+    post:
+      tags:
+        - external 
+        - dry-run
+      operationId: 'ProtectedDryRunTxs'
+      description: 'Dry-run transactions on top of a given block. Supports all TXs except GAMetaTx, PayingForTx and OffchainTx. The maximum gas limit of all calls is capped. The maximum gas limit per request is a global node setting. Since DryRunCallReq object do not have a mandatory gas field, if not set a default value of 1000000 is being used instead.'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: transactions
+          required: true
+          schema:
+            $ref: '#/definitions/DryRunInput'
+      responses:
+        '200':
+          description: Dry-run result
+          schema:
+            $ref: '#/definitions/DryRunResults'
+        '403':
+          description: Invalid input
+          schema:
+            $ref: '#/definitions/Error'
   /transactions/{hash}:
     get:
       tags:
@@ -1720,7 +1747,7 @@ paths:
         - internal
         - debug
       operationId: 'DryRunTxs'
-      description: 'Dry-run transactions on top of a given block. Supports all TXs except GAMetaTx, PayingForTx and OffchainTx'
+      description: 'Dry-run transactions on top of a given block. Supports all TXs except GAMetaTx, PayingForTx and OffchainTx.'
       consumes:
         - application/json
       produces:

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -61,7 +61,8 @@ check_env() ->
                       <<"channel">>      => true,
                       <<"node_info">>    => true,
                       <<"debug">>        => true,
-                      <<"obsolete">>     => true
+                      <<"obsolete">>     => true,
+                      <<"dry-run">>      => false
                       },
     EnabledGroups =
         lists:foldl(
@@ -77,7 +78,7 @@ check_env() ->
             end,
             [],
             maps:to_list(GroupDefaults)),
-        application:set_env(aehttp, enabled_endpoint_groups, EnabledGroups),
+    application:set_env(aehttp, enabled_endpoint_groups, EnabledGroups),
     ok.
 
 %%====================================================================

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -306,6 +306,11 @@
                             "description" : "Number of acceptors in external pool",
                             "type" : "integer",
                             "default" : 10
+                        },
+                        "gas_limit" : {
+                            "description" : "Maximum gas allowed to be available to a single dry-run call.",
+                            "type" : "integer",
+                            "default" : 1000000
                         }
                     }
                 },
@@ -366,6 +371,10 @@
                     },
                     "obsolete" : {
                         "description" : "Old endpoints that will be removed",
+                        "type" : "boolean"
+                    },
+                    "dry-run" : {
+                        "description" : "External protected dry run endpoint",
                         "type" : "boolean"
                     }
                 },

--- a/docs/release-notes/next/GH-3624_new_dryrun_api.md
+++ b/docs/release-notes/next/GH-3624_new_dryrun_api.md
@@ -1,0 +1,7 @@
+* Introduced a new HTTP endpoint: `/dry-run`. It is part of the `external`
+  interface and should be prefered over the existing `debug` endpoint. It
+  comes with some protections for the node: all transactions/calls provided
+  are limited to a total amount of `gas` that they can consume. There is a new
+  setting in the config where the node operator can change this according to
+  their needs, the default value is 6 000 000 gas. The new endpoint is
+  disabled by default and can be enabled via the new API group `dry-run`.


### PR DESCRIPTION
Fixes #3624

Introduce a new endpoint in the `external` interface. It is to slowly replace
the `internal` debug one. I've also made `aehttp_dryrun_SUITE` aware of the
two specs (oas3 and swagger2).

The work on this PR is being supported by ACF.
