### PR TITLE
New HTTP Endpoint: debug tx in mempool

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1912,6 +1912,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /debug/check-tx/pool/{hash}:
+    get:
+      tags:
+        - internal
+        - debug
+      operationId: GetCheckTxInPool
+      description: "Check if a transaction in the pool can be merged or it is blocked by something: not enough tokens, missing nonce or something else"
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
+        - $ref: '#/components/parameters/txHash'
+      responses:
+        "200":
+          description: The transaction can be included or is already included
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                required:
+                  - status
+        "400":
+          description: Transaction is blocked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Transaction is not in transaction pool
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/debug/token-supply/height/{height}":
     get:
       tags:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1918,7 +1918,7 @@ paths:
         - internal
         - debug
       operationId: GetCheckTxInPool
-      description: "Check if a transaction in the pool can be merged or it is blocked by something: not enough tokens, missing nonce or something else"
+      description: "Check if a transaction in the pool can be merged or if it is blocked by something: not enough tokens, missing nonce or something else"
       parameters:
         - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/txHash'

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1924,7 +1924,7 @@ paths:
         - $ref: '#/components/parameters/txHash'
       responses:
         "200":
-          description: The transaction can be included or is already included
+          description: The transaction status
           content:
             application/json:
               schema:
@@ -1934,12 +1934,6 @@ paths:
                     type: string
                 required:
                   - status
-        "400":
-          description: Transaction is blocked
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
         "404":
           description: Transaction is not in transaction pool
           content:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1918,7 +1918,7 @@ paths:
         - internal
         - debug
       operationId: GetCheckTxInPool
-      description: "Check if a transaction in the pool can be merged or if it is blocked by something: not enough tokens, missing nonce or something else"
+      description: "Check if a transaction in the pool can be included in a microblock or if it is blocked by something: not enough tokens, missing nonce or something else"
       parameters:
         - $ref: '#/components/parameters/intAsString'
         - $ref: '#/components/parameters/txHash'

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1800,6 +1800,40 @@ paths:
           description: Payer account not found
           schema:
             $ref: '#/definitions/Error'
+  /debug/check-tx/pool/{hash}:
+    get:
+      tags:
+        - internal
+        - debug
+      operationId: GetCheckTxInPool
+      description: "Check if a transaction in the pool can be merged or it is blocked by something: not enough tokens, missing nonce or something else"
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: hash
+          description: The hash of the transaction
+          required: true
+          # UInt64
+          type: string
+      responses:
+        '200':
+          description: The transaction can be included or is already included
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+            required:
+              - status
+        '400':
+          description: Transaction is blocked
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Transaction is not in transaction pool
+          schema:
+            $ref: '#/definitions/Error'
   /debug/token-supply/height/{height}:
     get:
       tags:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1818,7 +1818,7 @@ paths:
           type: string
       responses:
         '200':
-          description: The transaction can be included or is already included
+          description: The transaction status
           schema:
             type: object
             properties:
@@ -1826,10 +1826,6 @@ paths:
                 type: string
             required:
               - status
-        '400':
-          description: Transaction is blocked
-          schema:
-            $ref: '#/definitions/Error'
         '404':
           description: Transaction is not in transaction pool
           schema:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1806,7 +1806,7 @@ paths:
         - internal
         - debug
       operationId: GetCheckTxInPool
-      description: "Check if a transaction in the pool can be merged or it is blocked by something: not enough tokens, missing nonce or something else"
+      description: "Check if a transaction in the pool can be merged or if it is blocked by something: not enough tokens, missing nonce or something else"
       produces:
         - application/json
       parameters:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1806,7 +1806,7 @@ paths:
         - internal
         - debug
       operationId: GetCheckTxInPool
-      description: "Check if a transaction in the pool can be merged or if it is blocked by something: not enough tokens, missing nonce or something else"
+      description: "Check if a transaction in the pool is valid in the current state of the chain and can be included in a microblock or if it is blocked by something: not enough tokens, missing nonce or something else"
       produces:
         - application/json
       parameters:

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -234,12 +234,12 @@ handle_request_('GetCheckTxInPool', Req, _Context) ->
                                   {ok, _Trees1, _Env20} ->
                                       {ok, {200, [], #{<<"status">> => <<"includable">>}}};
                                   {error, Reason} ->
-                                      {error, {200, [], #{<<"status">> => atom_to_binary(Reason, utf8)}}}
+                                      {ok, {200, [], #{<<"status">> => atom_to_binary(Reason, utf8)}}}
                               catch
                                   Type:What ->
                                       Reason = {Type, What},
                                       lager:error("HTTP API: tx ~p cannot be applied due to an error ~p", [Tx, Reason]),
-                                      {error, {200, [], #{<<"status">> => <<"unhandled">>}}}
+                                      {ok, {200, [], #{<<"status">> => <<"unhandled">>}}}
                               end
                       end
                   end

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -234,12 +234,12 @@ handle_request_('GetCheckTxInPool', Req, _Context) ->
                                   {ok, _Trees1, _Env20} ->
                                       {ok, {200, [], #{<<"status">> => <<"includable">>}}};
                                   {error, Reason} ->
-                                      {error, {400, [], #{<<"reason">> => atom_to_binary(Reason, utf8)}}}
+                                      {error, {200, [], #{<<"status">> => atom_to_binary(Reason, utf8)}}}
                               catch
                                   Type:What ->
                                       Reason = {Type, What},
                                       lager:error("HTTP API: tx ~p cannot be applied due to an error ~p", [Tx, Reason]),
-                                      {error, {400, [], #{<<"reason">> => <<"unhandled">>}}}
+                                      {error, {200, [], #{<<"status">> => <<"unhandled">>}}}
                               end
                       end
                   end

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -3079,7 +3079,7 @@ check_transaction_in_pool(_Config) ->
     Nonce2 = NextNonceFun(),
     Tx3 = PostSpendTxFun(Nonce2 + 1), %% there is a gap in the nonce
     Tx3Hash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(Tx3)),
-    {ok, 400, #{<<"reason">> := <<"tx_nonce_too_high_for_account">>}} = check_transaction_in_pool_sut(Tx3Hash),
+    {ok, 200, #{<<"status">> := <<"tx_nonce_too_high_for_account">>}} = check_transaction_in_pool_sut(Tx3Hash),
     Tx2 = PostSpendTxFun(Nonce2),
     Tx2Hash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(Tx2)),
     MineTxFun([Tx2, Tx3]),

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -29,6 +29,7 @@
    , get_accounts_by_pubkey_sut/1
    , get_accounts_by_pubkey_and_height_sut/2
    , get_transactions_by_hash_sut/1
+   , check_transaction_in_pool_sut/1
    , get_contract_call_object/1
    , get_top_block/1
    , get_top_header/1
@@ -135,6 +136,7 @@
     unknown_atom_in_spend_tx/1,
 
     get_transaction/1,
+    check_transaction_in_pool/1,
 
     % sync gossip
     pending_transactions/1,
@@ -449,6 +451,7 @@ groups() ->
         unknown_atom_in_spend_tx,
 
         get_transaction,
+        check_transaction_in_pool,
 
         % sync gossip
         pending_transactions,
@@ -1564,6 +1567,10 @@ post_contract_and_call_tx(_Config) ->
 get_transactions_by_hash_sut(Hash) ->
     Host = external_address(),
     http_request(Host, get, "transactions/" ++ http_uri:encode(Hash), []).
+
+check_transaction_in_pool_sut(Hash) ->
+    Host = internal_address(),
+    http_request(Host, get, "debug/check-tx/pool/" ++ http_uri:encode(Hash), []).
 
 get_transaction_info_by_hash_sut(Hash) ->
     Host = external_address(),
@@ -3024,6 +3031,63 @@ get_transaction(_Config) ->
     Expected = PendingTx,
 
     aecore_suite_utils:mine_key_blocks(aecore_suite_utils:node_name(?NODE), 2),
+    ok.
+
+check_transaction_in_pool(_Config) ->
+    Node = aecore_suite_utils:node_name(?NODE),
+    MineTxFun =
+        fun(PendingTxs) ->
+            PendingTxHashes =
+                [aeser_api_encoder:encode(tx_hash, aetx_sign:hash(Tx))
+                    || Tx <- PendingTxs],
+            ct:log("Pending txs: ~p", [PendingTxs]),
+            ct:log("Pending tx hashes: ~p", [PendingTxHashes]),
+            aecore_suite_utils:mine_blocks_until_txs_on_chain(Node, PendingTxHashes, ?MAX_MINED_BLOCKS)
+        end,
+    {ok, HangingOldTxs} = rpc(aec_tx_pool, peek, [infinity]),
+    MineTxFun(HangingOldTxs),
+    {ok, []} = rpc(aec_tx_pool, peek, [infinity]), % empty
+    MinerAddress = get_miner_address(),
+    {ok, MinerPubkey} = aeser_api_encoder:safe_decode(account_pubkey, MinerAddress),
+    RandAddress = random_hash(),
+    NextNonceFun =
+        fun() ->
+            {ok, N} = rpc(aec_next_nonce, pick_for_account, [MinerPubkey]),
+            N
+        end,
+    PostSpendTxFun =
+        fun(Nonce) ->
+            Opts = #{ sender_id => aeser_id:create(account, MinerPubkey),
+                      recipient_id => aeser_id:create(account, RandAddress),
+                      amount => 2,
+                      fee => 100000 * aec_test_utils:min_gas_price(),
+                      nonce => Nonce,
+                      ttl => 43,
+                      payload => <<>>
+                      },
+            {ok, S} = aec_spend_tx:new(Opts),
+            {ok, SignedSpendTx} = aecore_suite_utils:sign_on_node(?NODE, S),
+            SerializedSpendTx = aetx_sign:serialize_to_binary(SignedSpendTx),
+            {ok, 200, _} = post_transactions_sut(aeser_api_encoder:encode(transaction, SerializedSpendTx)),
+            SignedSpendTx
+        end,
+    Tx1 = PostSpendTxFun(NextNonceFun()),
+    Tx1Hash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(Tx1)),
+    {ok, 200, #{<<"status">> := <<"includable">>}} = check_transaction_in_pool_sut(Tx1Hash),
+    MineTxFun([Tx1]),
+    {ok, 200, #{<<"status">> := <<"included">>}} = check_transaction_in_pool_sut(Tx1Hash),
+    Nonce2 = NextNonceFun(),
+    Tx3 = PostSpendTxFun(Nonce2 + 1), %% there is a gap in the nonce
+    Tx3Hash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(Tx3)),
+    {ok, 400, #{<<"reason">> := <<"tx_nonce_too_high_for_account">>}} = check_transaction_in_pool_sut(Tx3Hash),
+    Tx2 = PostSpendTxFun(Nonce2),
+    Tx2Hash = aeser_api_encoder:encode(tx_hash, aetx_sign:hash(Tx2)),
+    MineTxFun([Tx2, Tx3]),
+    {ok, 200, #{<<"status">> := <<"included">>}} = check_transaction_in_pool_sut(Tx1Hash),
+    {ok, 200, #{<<"status">> := <<"included">>}} = check_transaction_in_pool_sut(Tx2Hash),
+    {ok, 200, #{<<"status">> := <<"included">>}} = check_transaction_in_pool_sut(Tx3Hash),
+    MissingHash = aeser_api_encoder:encode(tx_hash, random_hash()),
+    {ok, 404, #{<<"reason">> := <<"tx_not_found">>}} = check_transaction_in_pool_sut(MissingHash),
     ok.
 
 %% Maybe this test should be broken into a couple of smaller tests

--- a/docs/release-notes/next/why_did_my_tx_did_not_pass.md
+++ b/docs/release-notes/next/why_did_my_tx_did_not_pass.md
@@ -1,0 +1,5 @@
+* Introduces a new endpoint for checking a transaction currently residing in
+  the mempool: if it can be included by miners or it is blocked by something:
+  not enough tokens, skipped nonce or something else. The endpoint is
+  `/debug/check-tx/pool/{transaction-hash}`. It is a debug endpoint and should
+  not be used in production.

--- a/docs/release-notes/next/why_did_my_tx_did_not_pass.md
+++ b/docs/release-notes/next/why_did_my_tx_did_not_pass.md
@@ -1,5 +1,5 @@
 * Introduces a new endpoint for checking a transaction currently residing in
-  the mempool: if it can be included by miners or it is blocked by something:
+  the mempool: if it can be included by miners or if it is blocked by something:
   not enough tokens, skipped nonce or something else. The endpoint is
   `/debug/check-tx/pool/{transaction-hash}`. It is a debug endpoint and should
   not be used in production.


### PR DESCRIPTION
Introduce a new endpoint for some easier debugging: currently if a transaction
appears to be stuck in the mempool - the only way to inspect why a it seems
stuck is to attack to a running node. This PR address this issue exactly.
