### PR TITLE
Add trace_runner to production build to fix undef tr_ttb:event/1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -120,7 +120,7 @@
 {relx, [{release, { aeternity, "version value comes from VERSION" },
          % sasl is required for the command `aeternity versions` to work,
          % it is disabled in `sys.config` though.
-         [runtime_tools, sasl, lager, setup, sext, gproc, jobs, lz4,
+         [runtime_tools, sasl, lager, setup, sext, gproc, jobs, lz4, trace_runner,
           {rocksdb, load}, {mnesia_rocksdb, load}, {mnesia, load}, {leveled, load}, {mnesia_leveled, load},
           parse_trans, exometer_core, ranch, aeminer, aecore, aehttp, enacl, enoise,
           aebytecode, aeserialization, aevm, aechannel, aefate, aemon, aestratum, ecrecover]},


### PR DESCRIPTION
Fixes crash in sync:
`[error] Tx {aetx,contract_call_tx,aect_call_tx,217,{contract_call_tx,{id,account,<<11,180,237,121,39,249,123,81,225,188,181,225,52,13,18,51,91,42,43,18,200,188,82,33,214,60,75,203,57,212,30,97>>},291,{id,contract,<<199,178,40,54,108,93,81,46,186,177,234,171,176,101,81,181,82,125,183,187,230,119,141,202,15,39,108,250,189,19,54,57>>},1,500000,0,1,1000000,1,<<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32,121,206,44,26,74,251,90,24,201,127,197,102,127,211,222,241,196,236,17,63,54,128,63,46,182,129,30,223,82,36,221,109,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,96,247,58,5,27,65,190,45,235,125,230,107,35,136,111,74,208,34,43,196,183,71,239,254,34,213,168,244,121,28,57,234,189>>,[],<<11,180,237,121,39,249,123,81,225,188,181,225,52,13,18,51,91,42,43,18,200,188,82,33,214,60,75,203,57,212,30,97>>}} cannot be applied due to an error {error,undef}`

This PR was funded by the ACF.
