### PR TITLE
Update aeternity/swagger_endpoints dep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,13 +149,13 @@ references:
     restore_cache:
       key: *build_nix_cache_key
 
-  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v14-{{ .Branch }}-{{ .Revision }}
+  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v15-{{ .Branch }}-{{ .Revision }}
   restore_machine_build_cache: &restore_machine_build_cache
     restore_cache:
       keys:
         - *machine_build_cache_key
-        - machine-build-cache-v14-{{ .Branch }}-
-        - machine-build-cache-v14-
+        - machine-build-cache-v15-{{ .Branch }}-
+        - machine-build-cache-v15-
 
   save_machine_build_cache: &save_machine_build_cache
     save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,13 +149,13 @@ references:
     restore_cache:
       key: *build_nix_cache_key
 
-  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v15-{{ .Branch }}-{{ .Revision }}
+  machine_build_cache_key: &machine_build_cache_key machine-build-cache-v16-{{ .Branch }}-{{ .Revision }}
   restore_machine_build_cache: &restore_machine_build_cache
     restore_cache:
       keys:
         - *machine_build_cache_key
-        - machine-build-cache-v15-{{ .Branch }}-
-        - machine-build-cache-v15-
+        - machine-build-cache-v16-{{ .Branch }}-
+        - machine-build-cache-v16-
 
   save_machine_build_cache: &save_machine_build_cache
     save_cache:

--- a/apps/aehttp/src/aehttp_api_router.erl
+++ b/apps/aehttp/src/aehttp_api_router.erl
@@ -29,8 +29,7 @@ get_paths(Target, LogicHandler) ->
                 end,
             [{path(Path), aehttp_api_handler,
                 {SpecVsn, OperationId, method(Method), LogicHandler}}
-                || {OperationId, Spec} <- maps:to_list(Endpoints:operations()),
-                    {Method, #{path := Path, tags := Tags}} <- maps:to_list(Spec),
+                || {OperationId, #{path := Path, tags := Tags, method := Method}} <- maps:to_list(Endpoints:operations()),
                     is_enabled(Target, Tags, EnabledGroups)
             ]
         end,
@@ -44,8 +43,8 @@ path(Path0) ->
     Path1 = binary:replace(Path0, <<"}">>, <<"">>, [global]),
     binary:replace(Path1, <<"{">>, <<":">>, [global]).
 
-method(Atom) ->
-    list_to_binary(string:uppercase(atom_to_list(Atom))).
+method(Method) ->
+    list_to_binary(string:uppercase(Method)).
 
 is_enabled(Target, Tags, EnabledGroups) when is_atom(Target) ->
     TargetBin = atom_to_binary(Target, utf8),

--- a/apps/aehttp/src/aehttp_api_validate.erl
+++ b/apps/aehttp/src/aehttp_api_validate.erl
@@ -64,7 +64,7 @@ response_(_OperationId, _Method0, Code, _Response, _Validator, _EndpointsMod) wh
     ok;
 response_(OperationId, Method0, Code, Response, Validator, EndpointsMod) ->
     Method = to_method(Method0),
-    #{responses := Resps} = maps:get(Method, EndpointsMod:operation(OperationId)),
+    #{responses := Resps} = EndpointsMod:operation(OperationId),
     case maps:get(Code, Resps, not_found) of
         undefined -> ok;
         not_found -> throw({error, {Code, unspecified_response_code}});
@@ -109,7 +109,7 @@ fix_def_refs(_, X) ->
 
 request(OperationId, Method0, Req, Validator, EndpointsMod) ->
     Method = to_method(Method0),
-    #{parameters := Params} = maps:get(Method, EndpointsMod:operation(OperationId)),
+    #{parameters := Params} = EndpointsMod:operation(OperationId),
     params(Params, #{}, Req, Validator, EndpointsMod).
 
 params([], Model, Req, _, _) -> {ok, Model, Req};

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -47,7 +47,7 @@ patterns() ->
 -spec forbidden( Mod :: module(), OperationID :: atom() ) -> boolean().
 forbidden(Mod, OpId) ->
     OpSpec = Mod:operation(OpId),
-    [ #{ tags := Tags } | _ ] = maps:values(OpSpec),
+    Tags = maps:get(tags, OpSpec),
     case lists:member(<<"debug">>, Tags) of
         true -> not aehttp_app:enable_internal_debug_endpoints();
         false -> false

--- a/apps/aehttp/test/aehttp_client.erl
+++ b/apps/aehttp/test/aehttp_client.erl
@@ -9,13 +9,13 @@
 %% Required config values: int_http, ext_http
 %% Optional config values: ct_log (true by default)
 request(OpId, Params, Cfg) ->
-    Op = endpoints:operation(OpId),
-    {Method, Interface} = operation_spec(Op),
+    #{method := Method} = Op = endpoints:operation(OpId),
+    {MethodAtom, Interface} = operation_spec(Op),
     BaseUrl = string:trim(proplists:get_value(Interface, Cfg), trailing, "/"),
     Path = endpoints:path(Method, OpId, Params),
     Query = endpoints:query(Method, OpId, Params),
     {ok, _} = application:ensure_all_started(inets),
-    request(Method, BaseUrl, Path, Query, Params, [], [{timeout, 15000}], [{socket_opts, [{reuseaddr, true}]}], default, Cfg).
+    request(MethodAtom, BaseUrl, Path, Query, Params, [], [{timeout, 15000}], [{socket_opts, [{reuseaddr, true}]}], default, Cfg).
 
 request(get, BaseUrl, Path, Query, _Params, Headers, HttpOpts, Opts, Profile, Cfg) ->
     Url = binary_to_list(iolist_to_binary([BaseUrl, Path, Query])),
@@ -58,10 +58,18 @@ log(Fmt, Params, Cfg) ->
         false -> ok
     end.
 
-operation_spec(#{get := GetSpec}) ->
-    {get, operation_interface(GetSpec)};
-operation_spec(#{post := PostSpec}) ->
-    {post, operation_interface(PostSpec)}.
+operation_spec(#{method := Method0} = Spec) ->
+    Method =
+        case Method0 of
+            "get" -> get;
+            "post" -> post;
+            "put" -> put;
+            "patch" -> patch;
+            "delete" -> delete;
+            "head" -> head;
+            "options" -> options
+        end,
+    {Method, operation_interface(Spec)}.
 
 operation_interface(#{tags := Tags}) ->
     IsExt = lists:member(<<"external">>, Tags),

--- a/apps/aeutils/test/endpoints_tests.erl
+++ b/apps/aeutils/test/endpoints_tests.erl
@@ -5,18 +5,18 @@
 -include_lib("eunit/include/eunit.hrl").
 
 operation_method_test() ->
-   ?assertEqual([get], maps:keys(endpoints:operation('GetTopBlock'))).
+   ?assertEqual("get", maps:get(method, endpoints:operation('GetTopBlock'))).
 
 path_without_test() ->
-   ?assertEqual(<<"/v2/blocks/top">>, endpoints:path(get, 'GetTopBlock', #{})),
-   ?assertEqual(<<"/v2/debug/peers">>, endpoints:path(get, 'GetPeers', #{})).
+   ?assertEqual(<<"/v2/blocks/top">>, endpoints:path("get", 'GetTopBlock', #{})),
+   ?assertEqual(<<"/v2/debug/peers">>, endpoints:path("get", 'GetPeers', #{})).
 
 path_with_params_test() ->
    ?assertEqual(<<"/v2/key-blocks/height/3">>,
-      iolist_to_binary(endpoints:path(get, 'GetKeyBlockByHeight',
+      iolist_to_binary(endpoints:path("get", 'GetKeyBlockByHeight',
                                       #{"height" => 3}))),
    ?assertThrow({error, _},
-      iolist_to_binary(endpoints:path(get, 'GetKeyBlockByHeight',
+      iolist_to_binary(endpoints:path("get", 'GetKeyBlockByHeight',
                                       #{}))).
 
 -endif.

--- a/docs/release-notes/next/update_endpoints_generator.md
+++ b/docs/release-notes/next/update_endpoints_generator.md
@@ -1,0 +1,2 @@
+* Updates the `aeternity/swagger_endpoints` dep. This allows the node to have
+  RESTfull APIs.

--- a/rebar.config
+++ b/rebar.config
@@ -111,7 +111,7 @@
        ]}.
 
 {plugins, [
-        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "88838a2"}}},
+        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "d7222b8"}}},
         {aesophia_rebar_plugin, {git, "https://github.com/aeternity/aesophia_rebar_plugin", {ref, "df113cc"}}}
     ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -111,7 +111,7 @@
        ]}.
 
 {plugins, [
-        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "d7222b8"}}},
+        {swagger_endpoints, {git, "https://github.com/aeternity/swagger_endpoints", {ref, "47f1b7a"}}},
         {aesophia_rebar_plugin, {git, "https://github.com/aeternity/aesophia_rebar_plugin", {ref, "df113cc"}}}
     ]}.
 


### PR DESCRIPTION
Update the dep so other methods than `GET` and `POST` are allowed. This is
required for the endpoint to delete a specific transaction from the mempool
(where we need a `DELETE` method) but probably for other REST APIs as well.

The work on this PR had been supported by ACF.
