### PR TITLE
Add mempool integration tests

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1040,7 +1040,7 @@ add_tx_hash_to_mempool(TxHash) when is_binary(TxHash) ->
       [{aec_tx_pool, TxHash}]).
 
 is_in_tx_pool(TxHash) ->
-    ?t(mnesia:read(aec_tx_pool, TxHash)) =/= ?TX_IN_MEMPOOL.
+    ?t(mnesia:read(aec_tx_pool, TxHash)) =:= ?TX_IN_MEMPOOL.
 
 remove_tx_from_mempool(TxHash) when is_binary(TxHash) ->
     ?t(mnesia:delete({aec_tx_pool, TxHash}),

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -512,7 +512,6 @@ valid_sync_tasks(#state{sync_tasks = STs}) ->
     [ST || #sync_task{suspect = false} = ST <- STs].
 
 update_top_target(TopTarget, State) ->
-    aec_tx_pool:new_sync_top_target(TopTarget),
     State#state{ top_target = TopTarget }.
 
 do_update_sync_task(State, STId, Update) ->

--- a/apps/aecore/src/aec_tx_pool_gc.erl
+++ b/apps/aecore/src/aec_tx_pool_gc.erl
@@ -70,6 +70,7 @@ adjust_ttl(Diff, Dbs) ->
     gen_server:cast(?SERVER, {adjust_ttl, Diff, Dbs}).
 
 delete_hash(MempoolGC, TxHash) ->
+    aec_db:remove_tx_from_mempool(TxHash),
     ets:delete(MempoolGC, TxHash).
 
 -spec gc(aec_blocks:height(), aec_tx_pool:dbs()) -> ok.
@@ -164,6 +165,7 @@ do_gc_([{TxHash, Key} | TxHashes], Dbs, GCDb) ->
     case aec_db:gc_tx(TxHash) of
         ok ->
             aec_tx_pool:raw_delete(Dbs, Key),
+            aec_db:remove_tx_from_mempool(TxHash),
             ets:delete(GCDb, TxHash),
             aec_metrics:try_update([ae,epoch,aecore,tx_pool,gced], 1),
             lager:debug("Garbage collected ~p", [pp(TxHash)]);

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -1339,6 +1339,13 @@ http_request(Host, post, Path, Params) ->
     %% lager:debug("Type = ~p; Body = ~p", [Type, Body]),
     ct:log("POST ~p, type ~p, Body ~p", [URL, Type, Body]),
     R = httpc_request(post, {URL, [], Type, Body}, [], []),
+    process_http_return(R);
+http_request(Host, delete, Path, Params) ->
+    Prefix = get(api_prefix, "/v2/"),
+    URL = binary_to_list(
+            iolist_to_binary([Host, Prefix, Path, encode_get_params(Params)])),
+    ct:log("DELETE ~p", [URL]),
+    R = httpc_request(delete, {URL, []}, [], []),
     process_http_return(R).
 
 httpc_request(Method, Request, HTTPOptions, Options) ->

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2019,7 +2019,7 @@ paths:
         - $ref: '#/components/parameters/txHash'
       responses:
         "200":
-          description: The transaction had been deleted from the pool or it is already inclued in a block
+          description: The transaction had been deleted from the pool
           content:
             application/json:
               schema:
@@ -2034,7 +2034,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         "404":
-          description: Transaction not found
+          description: Transaction not in mempool
           content:
             application/json:
               schema:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2019,7 +2019,7 @@ paths:
         - $ref: '#/components/parameters/txHash'
       responses:
         "200":
-          description: The transaction had been deleted from the pool
+          description: The transaction was deleted from the pool
           content:
             application/json:
               schema:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -33,6 +33,8 @@ tags:
     description: Old endpoints that will be removed
   - name: dry-run
     description: External dry run endpoint.
+  - name: node-operator
+    description: Endpoints to help the node oprator interract with the node
 externalDocs:
   description: Find out more about Aeternity
   url: http://www.aeternity.com
@@ -2002,6 +2004,37 @@ paths:
                 $ref: "#/components/schemas/TokenSupply"
         "400":
           description: Height not available
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  "/node/operator/mempool/hash/{hash}":
+    delete:
+      tags:
+        - internal
+        - node-operator
+      operationId: DeleteTxFromMempool
+      description: Delete a pending transaction from the mempool
+      parameters:
+        - $ref: '#/components/parameters/txHash'
+      responses:
+        "200":
+          description: The transaction had been deleted from the pool or it is already inclued in a block
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+        "400":
+          description: Invalid tx hash
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Transaction not found
           content:
             application/json:
               schema:

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -52,17 +52,18 @@ stop(_State) ->
 
 check_env() ->
     %TODO: we need to validate that all tags are present
-    GroupDefaults = #{<<"chain">>        => true,
-                      <<"transaction">>  => true,
-                      <<"account">>      => true,
-                      <<"contract">>     => true,
-                      <<"oracle">>       => true,
-                      <<"name_service">> => true,
-                      <<"channel">>      => true,
-                      <<"node_info">>    => true,
-                      <<"debug">>        => true,
-                      <<"obsolete">>     => true,
-                      <<"dry-run">>      => false
+    GroupDefaults = #{<<"chain">>         => true,
+                      <<"transaction">>   => true,
+                      <<"account">>       => true,
+                      <<"contract">>      => true,
+                      <<"oracle">>        => true,
+                      <<"name_service">>  => true,
+                      <<"channel">>       => true,
+                      <<"node_info">>     => true,
+                      <<"debug">>         => true,
+                      <<"obsolete">>      => true,
+                      <<"dry-run">>       => false,
+                      <<"node-operator">> => false
                       },
     EnabledGroups =
         lists:foldl(

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -218,7 +218,7 @@ handle_request_('DeleteTxFromMempool', Req, _Context) ->
                           ok ->
                               {ok, {200, [], #{<<"status">> => <<"deleted">>}}};
                           {error, already_accepted} ->
-                              {ok, {200, [], #{<<"status">> => <<"included">>}}};
+                              {ok, {404, [], #{<<"reason">> => <<"included">>}}};
                           {error, not_found} ->
                               {ok, {404, [], #{<<"reason">> => <<"not_found">>}}}
                       end

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -110,6 +110,7 @@ init_per_suite(Config0) ->
     DefCfg = #{<<"chain">> =>
                    #{<<"persist">> => false,
                      <<"hard_forks">> => Forks},
+               <<"mempool">> => #{<<"tx_ttl">> => 100},
               <<"http">> =>
                    #{<<"cache">> => #{<<"enabled">> => false}}},
     Config1 = [{instant_mining, true}, {symlink_name, "latest.http_ga"}, {test_module, ?MODULE}] ++ Config0,

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -38,6 +38,11 @@
    , wait_for_tx_hash_on_chain/1
    , sign_and_post_tx/2
    , end_per_testcase_all/1
+   , get_spend/1
+   , post_transactions_sut/1
+   , get_transactions_pending_sut/0
+   , delete_tx_from_mempool_sut/1
+   , get_key_blocks_current_height_sut/0
    ]).
 
 -export(
@@ -1435,6 +1440,16 @@ get_accounts_transactions_pending_by_pubkey_sut(Id) ->
     Host = external_address(),
     Id1 = binary_to_list(Id),
     http_request(Host, get, "accounts/" ++ http_uri:encode(Id1) ++ "/transactions/pending", []).
+
+get_transactions_pending_sut() ->
+    Host = internal_address(),
+    http_request(Host, get, "debug/transactions/pending", []).
+
+delete_tx_from_mempool_sut(Hash) when is_binary(Hash) ->
+    delete_tx_from_mempool_sut(binary_to_list(Hash));
+delete_tx_from_mempool_sut(Hash) when is_list(Hash) ->
+    Host = internal_address(),
+    http_request(Host, delete, "node/operator/mempool/hash/" ++ Hash, []).
 
 %% /transactions/*
 

--- a/apps/aehttp/test/aehttp_mempool_SUITE.erl
+++ b/apps/aehttp/test/aehttp_mempool_SUITE.erl
@@ -12,7 +12,7 @@
 %% use include_lib for aecontract to compile under system test
 -include_lib("aecontract/include/aecontract.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
--include("../../aecontract/test/include/aect_sophia_vsn.hrl").
+-include_lib("aecontract/test/include/aect_sophia_vsn.hrl").
 
 %% common_test exports
 -export([

--- a/apps/aehttp/test/aehttp_mempool_SUITE.erl
+++ b/apps/aehttp/test/aehttp_mempool_SUITE.erl
@@ -296,7 +296,7 @@ delete_tx_from_mempool(Config) ->
     %% those can be included
     {ok, _} = ?MINE_TXS([SpendTxHash1, SpendTxHash3]),
     [] = pending_txs(),
-    {ok, 200, #{<<"status">> := <<"included">>}} =
+    {ok, 404, #{<<"reason">> := <<"included">>}} =
         aehttp_integration_SUITE:delete_tx_from_mempool_sut(SpendTxHash1),
     MissingTxHash = aeser_api_encoder:encode(tx_hash, random_hash()),
     {ok, 404, #{<<"reason">> := <<"not_found">>}} =

--- a/apps/aehttp/test/aehttp_mempool_SUITE.erl
+++ b/apps/aehttp/test/aehttp_mempool_SUITE.erl
@@ -12,7 +12,7 @@
 %% use include_lib for aecontract to compile under system test
 -include_lib("aecontract/include/aecontract.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
--include_lib("aecontract/test/include/aect_sophia_vsn.hrl").
+-include("../../aecontract/test/include/aect_sophia_vsn.hrl").
 
 %% common_test exports
 -export([

--- a/apps/aehttp/test/aehttp_mempool_SUITE.erl
+++ b/apps/aehttp/test/aehttp_mempool_SUITE.erl
@@ -173,7 +173,7 @@ mine_5_txs_from_the_same_account(Config) ->
     %% the nonce offset for an account is 5
     5 = rpc:call(?NODENAME, aec_tx_pool, nonce_offset, []),
     %% posting a new tx with a higher nonce will fail:
-    SpendTx6= sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    SpendTx6 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
     {ok, 400, #{<<"reason">> := <<"Invalid tx">>}} = post_tx(SpendTx6),
     {ok, _} = ?MINE_TXS([SpendTxHash1, SpendTxHash2, SpendTxHash3,
                          SpendTxHash4, SpendTxHash5]),
@@ -201,7 +201,7 @@ txs_without_balance_are_not_mined(Config) ->
     {ok, 200, #{<<"tx_hash">> := SpendTxHash2}} = post_tx(SpendTx2),
     {ok, _} = ?MINE_TXS([SpendTxHash1]),
     %% we can not mine this tx
-    {error,max_reached} = ?MINE_TXS([SpendTxHash2]),
+    {error, max_reached} = ?MINE_TXS([SpendTxHash2]),
     SpendTx3 = sign_tx(spend_tx(Alice, EmptyAccPubkey, Fee + 1, Fee), AlicePrivkey),
     {ok, 200, #{<<"tx_hash">> := SpendTxHash3}} = post_tx(SpendTx3),
     {ok, _} = ?MINE_TXS([SpendTxHash2, SpendTxHash3]),
@@ -215,7 +215,7 @@ gc_txs(Config) ->
         ?config(accounts, Config),
     Fee = 20000 * ?DEFAULT_GAS_PRICE,
     ?TX_TTL = rpc:call(?NODENAME, aec_tx_pool, tx_ttl, []),
-    %% use a bigger nonce so the txs are not include
+    %% use a bigger nonce so the txs are not included
     Nonce = next_nonce(AccPubkey),
     SpendTx2 = sign_tx(spend_tx(AccPubkey, AccPubkey, 2, Fee, <<"blocked tx">>,
                                 Nonce + 1),
@@ -223,18 +223,18 @@ gc_txs(Config) ->
     PendingSpendTx2 = for_client_pending(SpendTx2),
     {ok, 200, #{<<"tx_hash">> := SpendTxHash2}} = post_tx(SpendTx2),
     %% assert a tx in pool
-    [PendingSpendTx2]  = pending_txs(),
+    [PendingSpendTx2] = pending_txs(),
     
     ?MINE_BLOCKS(?TX_TTL - 1),
     %% assert still a tx in pool
-    [PendingSpendTx2]  = pending_txs(),
+    [PendingSpendTx2] = pending_txs(),
 
     ?MINE_BLOCKS(1),
     timer:sleep(1000),
     %% assert pool is empty
     [] = pending_txs(),
     {ok, 200, #{<<"tx_hash">> := _SpendTxHash2}} = post_tx(SpendTx2),
-    [PendingSpendTx2]  = pending_txs(),
+    [PendingSpendTx2] = pending_txs(),
     %% add missing tx with nonce
     SpendTx1 = sign_tx(spend_tx(AccPubkey, AccPubkey, 2, Fee, <<"unblocking tx">>,
                                 Nonce),
@@ -286,7 +286,7 @@ delete_tx_from_mempool(Config) ->
     timer:sleep(1000),
     %% assert the tx has beed GCed
     [] = pending_txs(),
-    %% post the tx after it had been GCed
+    %% post the tx after it has been GCed
     {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
     [PendingSpendTx1]  = pending_txs(),
     %% post the ublocking tx with the correct nonce
@@ -333,12 +333,12 @@ spend_tx(FromPubkey, ToPubkey, Amount, Fee, Payload, Nonce) ->
     To = aeser_api_encoder:encode(account_pubkey, ToPubkey),
     {ok, 200, #{<<"tx">> := EncodedSpendTx}} =
         aehttp_integration_SUITE:get_spend(
-            #{sender_id => From,
-              nonce => Nonce,
+            #{sender_id    => From,
+              nonce        => Nonce,
               recipient_id => To, 
-              amount => Amount,
-              fee => Fee,
-              payload => Payload}),
+              amount       => Amount,
+              fee          => Fee,
+              payload      => Payload}),
     {ok, TxSer} = aeser_api_encoder:safe_decode(transaction, EncodedSpendTx),
     AeTx = aetx:deserialize_from_binary(TxSer),
     AeTx.

--- a/apps/aehttp/test/aehttp_mempool_SUITE.erl
+++ b/apps/aehttp/test/aehttp_mempool_SUITE.erl
@@ -1,0 +1,377 @@
+-module(aehttp_mempool_SUITE).
+
+%%
+%% Each test assumes that the chain is at least at the height where the latest
+%% consensus protocol applies hence each test reinitializing the chain should
+%% take care of that at the end of the test.
+%%
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%% use include_lib for aecontract to compile under system test
+-include_lib("aecontract/include/aecontract.hrl").
+-include_lib("aecontract/include/hard_forks.hrl").
+-include("../../aecontract/test/include/aect_sophia_vsn.hrl").
+
+%% common_test exports
+-export([
+         all/0, groups/0, suite/0,
+         init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2
+        ]).
+
+%% tests exports
+-export([
+          mine_2_txs/1
+        , mine_5_txs_from_the_same_account/1
+        , txs_without_balance_are_not_mined/1
+        , gc_txs/1
+        , delete_tx_from_mempool/1
+        ]).
+
+-define(NODE, dev1).
+-define(NODENAME, aecore_suite_utils:node_name(?NODE)).
+-define(DEFAULT_GAS_PRICE, aec_test_utils:min_gas_price()).
+-define(MAX_MINED_BLOCKS, 5).
+-define(TX_TTL, 11).
+-define(MINE_BLOCKS(N), aecore_suite_utils:mine_key_blocks(?NODENAME, N)).
+-define(MINE_TXS(Txs, MaxKeyBlocks), aecore_suite_utils:mine_blocks_until_txs_on_chain(?NODENAME, Txs, MaxKeyBlocks)).
+-define(MINE_TXS(Txs), ?MINE_TXS(Txs, ?MAX_MINED_BLOCKS)). 
+
+all() ->
+    [{group, oas3}
+    ].
+
+groups() ->
+    [{oas3, [sequence],
+      [{group, spend_txs_in_generation}]},
+     {spend_txs_in_generation, [sequence],
+      [ mine_2_txs
+      , mine_5_txs_from_the_same_account
+      , txs_without_balance_are_not_mined
+      , gc_txs
+      , delete_tx_from_mempool
+      ]}
+    ].
+
+suite() ->
+    [].
+
+init_per_suite(Config0) ->
+    Forks = aecore_suite_utils:forks(),
+    %% We want to run some suites with and some suites without client side cache
+    %% Arbitrary run this suite with cache disabled.
+    DefCfg = #{<<"chain">> =>
+                   #{<<"persist">> => false,
+                     <<"hard_forks">> => Forks},
+               <<"mempool">> =>
+                   #{<<"tx_ttl">> => ?TX_TTL},
+              <<"http">> =>
+                  #{<<"endpoints">> => #{<<"node-operator">> => true},
+                    <<"cache">> => #{<<"enabled">> => false}}},
+    Config1 = [{instant_mining, true}, {symlink_name, "latest.http_mempool"}, {test_module, ?MODULE}] ++ Config0,
+    Config2 = aecore_suite_utils:init_per_suite([?NODE], DefCfg, Config1),
+    NodeName = aecore_suite_utils:node_name(?NODE),
+    aecore_suite_utils:start_node(?NODE, Config2),
+    aecore_suite_utils:connect(NodeName, []),
+    [{node_name, NodeName}, {nodes, [aecore_suite_utils:node_tuple(?NODE)]}] ++ Config2.
+
+end_per_suite(Config) ->
+    aecore_suite_utils:stop_node(?NODE, Config),
+    ok.
+
+init_per_group(SwaggerVsn, Config0) when SwaggerVsn =:= oas3 ->
+    Config = [{swagger_version, SwaggerVsn} | Config0],
+    VM =
+        case aect_test_utils:latest_protocol_version() of
+            PreIris when PreIris < ?IRIS_PROTOCOL_VSN -> aevm; 
+            PostIris -> fate
+        end,
+    aect_test_utils:init_per_group(VM, Config);
+init_per_group(_GAGroup, Config) ->
+    aecore_suite_utils:reinit_with_ct_consensus(?NODE),
+    ToMine = max(0, aecore_suite_utils:latest_fork_height()),
+    ct:pal("ToMine ~p\n", [ToMine]),
+    [ ?MINE_BLOCKS(ToMine) || ToMine > 0 ],
+
+    %% Prepare accounts
+    StartAmt = 1000 * 1000 * 1000000 * ?DEFAULT_GAS_PRICE,
+    {APK, ASK, STx1} = new_account(StartAmt),
+    {BPK, BSK, STx2} = new_account(StartAmt),
+    {CPK, CSK, STx3} = new_account(1),
+
+    {ok, _} = ?MINE_TXS([STx1, STx2, STx3]),
+
+    %% Save account information
+    Accounts = #{acc_a => #{pub_key => APK, priv_key => ASK},
+                 acc_b => #{pub_key => BPK, priv_key => BSK},
+                 acc_empty => #{pub_key => CPK, priv_key => CSK}
+                },
+    [{accounts, Accounts} | Config].
+
+end_per_group(_VMGroup, _Config) ->
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    SwaggerVsn = proplists:get_value(swagger_version, Config),
+    aecore_suite_utils:use_swagger(SwaggerVsn),
+    put('$vm_version',     ?config(vm_version,     Config)),
+    put('$abi_version',    ?config(abi_version,    Config)),
+    put('$sophia_version', ?config(sophia_version, Config)),
+    [{tc_start, os:timestamp()}|Config].
+
+end_per_testcase(_Case, Config) ->
+    Ts0 = ?config(tc_start, Config),
+    ct:log("Events during TC: ~p", [[{N, aecore_suite_utils:all_events_since(N, Ts0)}
+                                     || {_, N} <- ?config(nodes, Config)]]),
+    ok.
+
+%% ============================================================
+%% Test cases
+%% ============================================================
+
+mine_2_txs(Config) ->
+    %% precondition - no txs in the pool
+    [] = pending_txs(),
+    #{acc_a := #{pub_key := Alice, priv_key := AlicePrivkey},
+      acc_b := #{pub_key := Bob, priv_key := BobPrivkey} } =
+        ?config(accounts, Config),
+    Fee = 20000 * ?DEFAULT_GAS_PRICE,
+    SpendTx1 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    SpendTx2 = sign_tx(spend_tx(Bob, Bob, 1, Fee), BobPrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash2}} = post_tx(SpendTx2),
+    PendingTxs = pending_txs(),
+    %% assert 2 txs in pool
+    2 = length(PendingTxs),
+    {ok, _} = ?MINE_TXS([SpendTxHash1, SpendTxHash2]),
+    %% assert pool is empty
+    [] = pending_txs(),
+    ok.
+
+mine_5_txs_from_the_same_account(Config) ->
+    %% precondition - no txs in the pool
+    [] = pending_txs(),
+    #{acc_a := #{pub_key := Alice, priv_key := AlicePrivkey}} =
+        ?config(accounts, Config),
+    Fee = 20000 * ?DEFAULT_GAS_PRICE,
+    SpendTx1 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
+    SpendTx2 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash2}} = post_tx(SpendTx2),
+    SpendTx3 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash3}} = post_tx(SpendTx3),
+    SpendTx4 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash4}} = post_tx(SpendTx4),
+    SpendTx5 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash5}} = post_tx(SpendTx5),
+    PendingTxs = pending_txs(),
+    %% assert 5 txs in pool
+    5 = length(PendingTxs),
+    %% the nonce offset for an account is 5
+    5 = rpc:call(?NODENAME, aec_tx_pool, nonce_offset, []),
+    %% posting a new tx with a higher nonce will fail:
+    SpendTx6= sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    {ok, 400, #{<<"reason">> := <<"Invalid tx">>}} = post_tx(SpendTx6),
+    {ok, _} = ?MINE_TXS([SpendTxHash1, SpendTxHash2, SpendTxHash3,
+                         SpendTxHash4, SpendTxHash5]),
+    %% assert pool is empty
+    [] = pending_txs(),
+    %% now the tx makes the node to accept it:
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash6}} = post_tx(SpendTx6),
+    [_] = pending_txs(),
+    {ok, _} = ?MINE_TXS([SpendTxHash6]),
+    [] = pending_txs(),
+    ok.
+
+    
+txs_without_balance_are_not_mined(Config) ->
+    %% precondition - no txs in the pool
+    [] = pending_txs(),
+    #{acc_a := #{pub_key := Alice, priv_key := AlicePrivkey},
+      acc_empty := #{pub_key := EmptyAccPubkey, priv_key := EmptyAccPrivkey} } =
+        ?config(accounts, Config),
+    Fee = 20000 * ?DEFAULT_GAS_PRICE,
+    SpendTx1 = sign_tx(spend_tx(Alice, Alice, 1, Fee), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
+    SpendTx2 = sign_tx(spend_tx(EmptyAccPubkey, EmptyAccPubkey, 1, Fee),
+                       EmptyAccPrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash2}} = post_tx(SpendTx2),
+    {ok, _} = ?MINE_TXS([SpendTxHash1]),
+    %% we can not mine this tx
+    {error,max_reached} = ?MINE_TXS([SpendTxHash2]),
+    SpendTx3 = sign_tx(spend_tx(Alice, EmptyAccPubkey, Fee + 1, Fee), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash3}} = post_tx(SpendTx3),
+    {ok, _} = ?MINE_TXS([SpendTxHash2, SpendTxHash3]),
+    [] = pending_txs(),
+    ok.
+
+gc_txs(Config) ->
+    %% precondition - no txs in the pool
+    [] = pending_txs(),
+    #{acc_a := #{pub_key := AccPubkey, priv_key := AccPrivkey} } =
+        ?config(accounts, Config),
+    Fee = 20000 * ?DEFAULT_GAS_PRICE,
+    ?TX_TTL = rpc:call(?NODENAME, aec_tx_pool, tx_ttl, []),
+    %% use a bigger nonce so the txs are not include
+    Nonce = next_nonce(AccPubkey),
+    SpendTx2 = sign_tx(spend_tx(AccPubkey, AccPubkey, 2, Fee, <<"blocked tx">>,
+                                Nonce + 1),
+                       AccPrivkey),
+    PendingSpendTx2 = for_client_pending(SpendTx2),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash2}} = post_tx(SpendTx2),
+    %% assert a tx in pool
+    [PendingSpendTx2]  = pending_txs(),
+    
+    ?MINE_BLOCKS(?TX_TTL - 1),
+    %% assert still a tx in pool
+    [PendingSpendTx2]  = pending_txs(),
+
+    ?MINE_BLOCKS(1),
+    timer:sleep(1000),
+    %% assert pool is empty
+    [] = pending_txs(),
+    {ok, 200, #{<<"tx_hash">> := _SpendTxHash2}} = post_tx(SpendTx2),
+    [PendingSpendTx2]  = pending_txs(),
+    %% add missing tx with nonce
+    SpendTx1 = sign_tx(spend_tx(AccPubkey, AccPubkey, 2, Fee, <<"unblocking tx">>,
+                                Nonce),
+                       AccPrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
+    PendingTxs = pending_txs(),
+    %% assert 2 txs in pool
+    2 = length(PendingTxs),
+    {ok, _} = ?MINE_TXS([SpendTxHash1, SpendTxHash2]),
+    [] = pending_txs(),
+    ok.
+
+delete_tx_from_mempool(Config) ->
+    %% precondition - no txs in the pool
+    [] = pending_txs(),
+    #{acc_a := #{pub_key := Alice, priv_key := AlicePrivkey},
+      acc_b := #{pub_key := Bob, priv_key := BobPrivkey} } =
+        ?config(accounts, Config),
+    Fee = 20000 * ?DEFAULT_GAS_PRICE,
+    Nonce = next_nonce(Alice),
+    SpendTx1 = sign_tx(spend_tx(Alice, Alice, 1, Fee, <<"to be deleted from pool">>,
+                                Nonce + 1), AlicePrivkey),
+    PendingSpendTx1 = for_client_pending(SpendTx1),
+    SpendTx2 = sign_tx(spend_tx(Bob, Bob, 1, Fee), BobPrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash2}} = post_tx(SpendTx2),
+    PendingTxs = pending_txs(),
+    %% assert 2 txs in pool
+    2 = length(PendingTxs),
+    {ok, 200, #{<<"status">> := <<"deleted">>}} =
+        aehttp_integration_SUITE:delete_tx_from_mempool_sut(SpendTxHash1),
+    [_] = pending_txs(),
+    {ok, _} = ?MINE_TXS([SpendTxHash2]),
+    [] = pending_txs(),
+    %% we will repost and GC the tx. In case there is a hanging reference to
+    %% it in the GC, it will be GCed sooner than expected. In order to do so,
+    %% we mine a few blocks
+    ?MINE_BLOCKS(3),
+    %% assert pool is empty
+    [] = pending_txs(),
+    %% tx can still be posted
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
+    %% tx can be GCed
+    [PendingSpendTx1]  = pending_txs(),
+    ?MINE_BLOCKS(?TX_TTL - 1),
+    %% assert still in the pool
+    [PendingSpendTx1]  = pending_txs(),
+    ?MINE_BLOCKS(1),
+    timer:sleep(1000),
+    %% assert the tx has beed GCed
+    [] = pending_txs(),
+    %% post the tx after it had been GCed
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash1}} = post_tx(SpendTx1),
+    [PendingSpendTx1]  = pending_txs(),
+    %% post the ublocking tx with the correct nonce
+    SpendTx3 = sign_tx(spend_tx(Alice, Alice, 1, Fee, <<"">>,
+                                Nonce), AlicePrivkey),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash3}} = post_tx(SpendTx3),
+    %% those can be included
+    {ok, _} = ?MINE_TXS([SpendTxHash1, SpendTxHash3]),
+    [] = pending_txs(),
+    {ok, 200, #{<<"status">> := <<"included">>}} =
+        aehttp_integration_SUITE:delete_tx_from_mempool_sut(SpendTxHash1),
+    MissingTxHash = aeser_api_encoder:encode(tx_hash, random_hash()),
+    {ok, 404, #{<<"reason">> := <<"not_found">>}} =
+        aehttp_integration_SUITE:delete_tx_from_mempool_sut(MissingTxHash),
+    ok.
+
+
+%% ============================================================
+%% private functions
+%% ============================================================
+new_account(Amount) ->
+    {Pubkey, Privkey} = aecore_suite_utils:generate_key_pair(),
+    Fee = 20000 * ?DEFAULT_GAS_PRICE,
+    SpendTx = spend_tx(patron_pubkey(), Pubkey, Amount, Fee),
+    SignedSpendTx = sign_tx(SpendTx, patron_privkey()),
+    {ok, 200, #{<<"tx_hash">> := SpendTxHash}} = post_tx(SignedSpendTx),
+    {Pubkey, Privkey, SpendTxHash}.
+
+next_nonce(Pubkey) ->
+    ID = aeser_api_encoder:encode(account_pubkey, Pubkey),
+    %% fetch what would be the next nonce
+    {ok, 200, #{<<"next_nonce">> := Nonce}} = aehttp_integration_SUITE:get_accounts_next_nonce_sut(ID),
+    Nonce.
+
+spend_tx(FromPubkey, ToPubkey, Amount, Fee) ->
+    spend_tx(FromPubkey, ToPubkey, Amount, Fee, <<>>).
+
+spend_tx(FromPubkey, ToPubkey, Amount, Fee, Payload) ->
+    Nonce = next_nonce(FromPubkey),
+    spend_tx(FromPubkey, ToPubkey, Amount, Fee, Payload, Nonce).
+
+spend_tx(FromPubkey, ToPubkey, Amount, Fee, Payload, Nonce) ->
+    From = aeser_api_encoder:encode(account_pubkey, FromPubkey),
+    To = aeser_api_encoder:encode(account_pubkey, ToPubkey),
+    {ok, 200, #{<<"tx">> := EncodedSpendTx}} =
+        aehttp_integration_SUITE:get_spend(
+            #{sender_id => From,
+              nonce => Nonce,
+              recipient_id => To, 
+              amount => Amount,
+              fee => Fee,
+              payload => Payload}),
+    {ok, TxSer} = aeser_api_encoder:safe_decode(transaction, EncodedSpendTx),
+    AeTx = aetx:deserialize_from_binary(TxSer),
+    AeTx.
+
+sign_tx(Tx, Privkey) ->
+    STx = aec_test_utils:sign_tx(Tx, [Privkey]),
+    aeser_api_encoder:encode(transaction, aetx_sign:serialize_to_binary(STx)).
+
+
+patron_pubkey() ->
+    maps:get(pubkey, aecore_suite_utils:patron()).
+
+patron_privkey() ->
+    maps:get(privkey, aecore_suite_utils:patron()).
+
+post_tx(Tx) ->
+    aehttp_integration_SUITE:post_transactions_sut(Tx).
+
+pending_txs() ->
+    {ok, 200, #{<<"transactions">> := Txs}} =
+        aehttp_integration_SUITE:get_transactions_pending_sut(),
+    Txs.
+
+for_client_pending(<<"tx_", _/binary>> = EncodedTx) ->
+    {ok, TxSer} = aeser_api_encoder:safe_decode(transaction, EncodedTx),
+    SignedTx = aetx_sign:deserialize_from_binary(TxSer),
+    for_client_pending(SignedTx);
+for_client_pending(SignedTx) ->
+    aetx_sign:serialize_for_client_pending(SignedTx).
+
+random_hash() ->
+    HList =
+        lists:map(
+            fun(_) -> rand:uniform(255) end,
+            lists:seq(1, 32)),
+    list_to_binary(HList).

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -359,7 +359,8 @@
                     },
                     "node_operator" : {
                         "description" : "Node operator endpoints",
-                        "type" : "boolean"
+                        "type" : "boolean",
+                        "default" : false
                     },
                     "dev" : {
                         "description" : "Development only API - for validation of client implementations. Should not be used in real life scenarios",

--- a/docs/release-notes/next/http_endpoint_delete_tx_from_pool.md
+++ b/docs/release-notes/next/http_endpoint_delete_tx_from_pool.md
@@ -1,5 +1,5 @@
 * Adds new a group of HTTP endpoints: `node-operator`. It is to hold endpoints
-  that are meant to provide functionality for thinkering of the node and
+  that are meant to provide functionality for tinkering with the node and
   diving into its internals. Those should be only `internal` and the group is
   disabled by default. The new group will be present only in the new `OAS3`
   API and will not be present in the old `swagger2` API.
@@ -12,4 +12,3 @@
   blocks. It was not triggered when the node mined the transaction. This is
   being refactored to be using internal events system and now GC is being
   triggered when on a top change.
-

--- a/docs/release-notes/next/http_endpoint_delete_tx_from_pool.md
+++ b/docs/release-notes/next/http_endpoint_delete_tx_from_pool.md
@@ -1,0 +1,15 @@
+* Adds new a group of HTTP endpoints: `node-operator`. It is to hold endpoints
+  that are meant to provide functionality for thinkering of the node and
+  diving into its internals. Those should be only `internal` and the group is
+  disabled by default. The new group will be present only in the new `OAS3`
+  API and will not be present in the old `swagger2` API.
+* Adds a new HTTP endpoint: `DELETE /node/operator/mempool/hash/{hash}`. It
+  deletes a transaction currently present in the mempool. It is a part of the
+  internal `node-operator` API.
+* Fixes a bug in the transaction pool: transactions with a TTL of 0 were not
+  subject for GC of the transaction pool.
+* Fixes a bug in transaction pool: GC was triggered on syncing incoming
+  blocks. It was not triggered when the node mined the transaction. This is
+  being refactored to be using internal events system and now GC is being
+  triggered when on a top change.
+


### PR DESCRIPTION
Introduce a new endpoint: `DELETE /node/operator/mempool/hash/{hash}` and a lot of tests. Tests detected 2 unrelated bugs that are also fixed. For details please consult the release notes line.

The work on this PR has been supported by ACF.