### PR TITLE
Make it possible to parameterize community fork check

### DIFF
--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -86,8 +86,12 @@ force_community_fork() ->
     %% The common ancestor between the attacker and the community fork is
     %% 366181 - kh_jzsdZmVDgoG9QQ8zQBLE6sURzukcmpSbume1jyfcHEpT1DEQ2
     %% Check for the NEXT height
-    CommunityForkHeight = 366182,
-    {key_block_hash, CommunityForkHash} = aeser_api_encoder:decode(<<"kh_YGDYbJQL4TV84CSaEA4VgcppUkpVyxSWFyHbS3frKkPjHPw2m">>),
+    CommunityForkHeight = list_to_integer(os:getenv("AE_COMMUNITY_FORK_HEIGHT", "366182")),
+    {key_block_hash, CommunityForkHash} =
+        aeser_api_encoder:decode(
+          list_to_binary(os:getenv(
+                           "AE_COMMUNITY_FORK_HASH",
+                           "kh_YGDYbJQL4TV84CSaEA4VgcppUkpVyxSWFyHbS3frKkPjHPw2m"))),
     TopHash = aec_chain:top_block_hash(),
     {ok, TopHeader} = aec_chain:get_header(TopHash),
     TopHeight = aec_headers:height(TopHeader),


### PR DESCRIPTION
Make it possible to parameterize community fork check with AE_COMMUNITY_FORK_[HEIGHT|HASH]

E.g.
```
"AE_COMMUNITY_FORK_HEIGHT=366182 AE_COMMUNITY_FORK_HASH=kh_YGDYbJQL4TV84CSaEA4VgcppUkpVyxSWFyHbS3frKkPjHPw2m bin/aeternity daemon
```