### PR TITLE
Introduce transaction pool strict mode

### DIFF
--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -117,7 +117,7 @@ int_create_block(PrevBlockHash, PrevBlock, KeyBlock, Trees, Txs) ->
     Env = aetx_env:tx_env_from_key_header(KeyHeader, PrevKeyHash,
                                           Time, PrevBlockHash),
     {ok, Txs1, InvalidTxs, Trees2, Events} = int_apply_block_txs(Txs, Trees, Env, false),
-    case length(InvalidTxs) > 0 of
+    case InvalidTxs =/= [] of
         true ->
             ok = aec_tx_pool:failed_txs(InvalidTxs);
         false -> pass

--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -172,9 +172,8 @@ get_pof(KeyBlock, PrevBlockHash, PrevBlock) ->
 
 %% Non-strict
 int_apply_block_txs(Txs, Trees, Env, false) ->
-    {ok, Txs1, InvalidTxs, Trees1, Events} =
-        aec_trees:apply_txs_on_state_trees(Txs, Trees, Env),
-    {ok, Txs1, InvalidTxs, Trees1, Events};
+    {ok, _Txs1, _InvalidTxs, _Trees1, _Events} =
+        aec_trees:apply_txs_on_state_trees(Txs, Trees, Env);
 %% strict
 int_apply_block_txs(Txs, Trees, Env, true) ->
     case aec_trees:apply_txs_on_state_trees_strict(Txs, Trees, Env) of

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -395,7 +395,7 @@ handle_call_({failed_txs, FailedTxs}, _From, #state{dbs = Dbs} = State) ->
                                           FailReason,
                                           Failures) of
                         true ->
-                            lager:debug("Tx reached ~p failures and had failed with ~p", [Failures, FailReason]),
+                            lager:debug("Tx reached ~p failures (failed with: ~p)", [Failures, FailReason]),
                             pool_db_raw_delete(Dbs, Key),
                             updated;
                         false ->

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -48,6 +48,7 @@
         , top_change/4
         , dbs/0
         , delete/1
+        , failed_txs/1
         ]).
 
 %% exports used by GC (should perhaps be in a common lib module)
@@ -117,6 +118,10 @@
 -type negated_fee() :: non_pos_integer().
 -type non_pos_integer() :: neg_integer() | 0.
 -type tx_hash() :: binary().
+
+-record(tx, { hash          :: binary(),
+              signed_tx     :: aetx_sign:signed_tx(),
+              failures  = 0 :: non_neg_integer() }).
 
 -type pool_db_key() :: ?KEY(negated_fee(), aect_contracts:amount(),
                             aec_keys:pubkey(), non_neg_integer(), binary()).
@@ -228,11 +233,11 @@ restore_mempool() ->
 
 peek_db() ->
     #dbs{db = Db} = dbs(),
-    [Tx || {_, Tx} <- ets:tab2list(Db)].
+    [Tx#tx.signed_tx || {_, Tx} <- ets:tab2list(Db)].
 
 peek_visited() ->
     #dbs{visited_db = VDb} = dbs(),
-    [Tx || {_, Tx} <- ets:tab2list(VDb)].
+    [Tx#tx.signed_tx || {_, Tx} <- ets:tab2list(VDb)].
 
 peek_nonces() ->
     #dbs{nonce_db = NDb} = dbs(),
@@ -261,6 +266,10 @@ peek(MaxN, Account) when is_integer(MaxN), MaxN >= 0; MaxN =:= infinity ->
 -spec delete(binary()) -> ok | {error, not_found | already_accepted}.
 delete(TxHash) ->
     gen_server:call(?SERVER, {delete, TxHash}).
+
+-spec failed_txs([{aetx_sign:signed_tx(), atom()}]) -> ok.
+failed_txs(FailedTxs) ->
+    gen_server:call(?SERVER, {failed_txs, FailedTxs}).
     
 -spec get_candidate(pos_integer(), binary()) -> {ok, [aetx_sign:signed_tx()]}.
 get_candidate(MaxGas, BlockHash) when is_integer(MaxGas), MaxGas > 0,
@@ -323,7 +332,7 @@ init([]) ->
     {ok, _NonceDb} = pool_db_open(pool_db_nonce()),
     %% The gc db should be owned by this process to ensure that the gc state
     %% is consistent with the actual mempool if any of the servers restart.
-    {ok, _GCDb} = pool_db_open(pool_db_gc(), [{keypos, #tx.hash}]),
+    {ok, _GCDb} = pool_db_open(pool_db_gc(), [{keypos, #gc_tx.hash}]),
     origins_cache_open(origins_cache()),
     GCHeight = top_height(),
     Handled  = ets:new(init_tx_pool, [private]),
@@ -375,6 +384,38 @@ handle_call_({delete, TxHash}, _From, #state{dbs = Dbs} = State) ->
             none -> {error, not_found}
         end,
     {reply, Res, State};
+handle_call_({failed_txs, FailedTxs}, _From, #state{dbs = Dbs} = State) ->
+    #dbs{db = Db, visited_db = VisitedDb} = Dbs,
+    TryUpdating =
+        fun(DBHandle, Key, SignedTx, FailReason) ->
+            case ets:lookup(DBHandle, Key) of
+                [{Key, #tx{failures = Failures0} = TxRec0}] ->
+                    Failures = Failures0 + 1,
+                    case should_delete_tx(SignedTx,
+                                          FailReason,
+                                          Failures) of
+                        true ->
+                            lager:debug("Tx reached ~p failures and had failed with ~p", [Failures, FailReason]),
+                            pool_db_raw_delete(Dbs, Key),
+                            updated;
+                        false ->
+                            lager:debug("Tx failed with reason ~p, this attempt ~p", [FailReason, Failures]),
+                            TxRec = TxRec0#tx{failures = Failures},
+                            ets:insert(DBHandle, {Key, TxRec}),
+                            updated
+                    end;
+                [] -> not_found
+            end
+        end,
+    lists:foreach(fun({SignedTx, FailReason}) ->
+                      Key = pool_db_key(SignedTx),
+                      case TryUpdating(VisitedDb, Key, SignedTx, FailReason) of
+                          updated -> pass;
+                          not_found -> TryUpdating(Db, Key, SignedTx, FailReason)
+                      end
+                  end,
+                  FailedTxs),
+    {reply, ok, State};
 handle_call_(dbs, _From, #state{dbs = Dbs} = State) ->
     {reply, Dbs, State};
 handle_call_(Request, From, State) ->
@@ -410,7 +451,7 @@ handle_info_({gproc_ps_event, top_changed, #{info := #{block_type := key,
             State) ->
     {noreply, do_update_sync_top_target(Height, State)};
 handle_info_({gproc_ps_event, top_changed, #{info := #{block_type := micro,
-                                                      height := Height}}},
+                                                      height := _Height}}},
             State) ->
     {noreply, State};
 handle_info_(Info, State) ->
@@ -461,7 +502,7 @@ int_get_candidate(MaxGas, BlockHash, #dbs{db = Db} = DBs) ->
     %% Move Txs to visited *after* revisiting visited!
     AllVisited = gb_trees:values(AccTree) ++ lists:reverse(AccTxs) ++ lists:reverse(AccBadTxs),
     Txs = [ begin
-                move_to_visited(DbX, DBs, KeyX, TxX),
+                move_to_visited(DbX, DBs, KeyX),
                 TxX
             end || {DbX, KeyX, TxX} <- AllVisited ],
 
@@ -502,9 +543,10 @@ fold_txs([Tx|Txs], Gas, MinTxGas, MinMinerGasPrice, Db, Dbs, AccountsTree, Heigh
 fold_txs([], Gas, _, _, _, _, _, _, _, Acc) ->
     {Gas, Acc}.
 
-int_get_candidate_({?KEY(_, _, Account, Nonce, _) = Key, Tx},
+int_get_candidate_({?KEY(_, _, Account, Nonce, _) = Key, TxRec},
                    Gas, MinMinerGasPrice, Db, Dbs, AccountsTree, Height, Protocol,
                    Acc = #{ tree := AccTree }) ->
+    Tx = TxRec#tx.signed_tx,
     case gb_trees:is_defined({Account, Nonce}, AccTree) of
         true when Nonce > 0 ->
             %% The earlier non-meta Tx must have had higher fee. Skip this tx.
@@ -544,11 +586,12 @@ check_candidate(Db, #dbs{gc_db = GCDb} = _Dbs,
             {Gas, Acc#{ bad_txs := [{Db, Key, Tx} | maps:get(bad_txs, Acc)] }}
     end.
 
-move_to_visited(VDb, #dbs{visited_db = VDb}, _, _) ->
+move_to_visited(VDb, #dbs{visited_db = VDb}, _) ->
     %% already in visited
     ignore;
-move_to_visited(Db, #dbs{visited_db = VDb}, Key, Tx) ->
-    ets:insert(VDb, {Key, Tx}),
+move_to_visited(Db, #dbs{visited_db = VDb}, Key) ->
+    [{Key, TxRec}] = ets:lookup(Db, Key), 
+    ets:insert(VDb, {Key, TxRec}),
     ets:delete(Db, Key),
     ok.
 
@@ -654,9 +697,9 @@ pool_db_peek(#dbs{db = Db, visited_db = VDb}, Max, Account, MaxNonce) ->
 pool_db_peek_(VDb, Db, Pat, Max) ->
     case sel_return(ets_select(VDb, Pat, Max)) of
         [] ->
-            [Tx || {_, Tx} <- sel_return(ets_select(Db, Pat, Max))];
+            [Tx#tx.signed_tx || {_, Tx} <- sel_return(ets_select(Db, Pat, Max))];
         Vs ->
-            pool_db_merge(Vs, sel_return(ets_select(Db, Pat, Max)), Max)
+            [Tx#tx.signed_tx || Tx <- pool_db_merge(Vs, sel_return(ets_select(Db, Pat, Max)), Max)]
     end.
 
 pool_db_merge(L1, L2, infinity) ->
@@ -825,7 +868,7 @@ pool_db_raw_delete(#dbs{db = Db, visited_db = VDb, nonce_db = NDb}, Key) ->
 
 pool_db_raw_put(#dbs{db = Db, nonce_db = NDb, gc_db = GCDb},
                 GCHeight0, Key, Tx, TxHash) ->
-    ets:insert(Db, {Key, Tx}),
+    ets:insert(Db, {Key, #tx{hash = TxHash, signed_tx = Tx}}), %% this resets any failed attempts
     insert_nonce(NDb, Key),
     GCHeight =
         case aetx:ttl(aetx_sign:tx(Tx)) of
@@ -1001,3 +1044,11 @@ minimum_miner_gas_price() ->
 maximum_auth_fun_gas() ->
     aeu_env:user_config_or_env([<<"mining">>, <<"max_auth_fun_gas">>],
                                aecore, mining_max_auth_fun_gas, ?DEFAULT_MAX_AUTH_FUN_GAS).
+
+should_delete_tx(SignedTx, FailReason, Failures) ->
+    case aec_tx_pool_failures:limit(SignedTx, FailReason) of
+        no_limit -> false;
+        {ok, MaxFailures} when MaxFailures > Failures -> false;
+        {ok, _} -> true
+    end.
+

--- a/apps/aecore/src/aec_tx_pool.hrl
+++ b/apps/aecore/src/aec_tx_pool.hrl
@@ -1,5 +1,5 @@
 %% Shared between aec_tx_pool and aec_tx_pool_gc.
 %% Really an internal format that shouldn't be included by anyone else
--record(tx, { hash :: aec_tx_pool:tx_hash()     | atom()
-            , ttl  :: aetx:tx_ttl()             | atom()
-            , key  :: aec_tx_pool:pool_db_key() | atom()}).
+-record(gc_tx, { hash :: aec_tx_pool:tx_hash()     | atom()
+               , ttl  :: aetx:tx_ttl()             | atom()
+               , key  :: aec_tx_pool:pool_db_key() | atom()}).

--- a/apps/aecore/src/aec_tx_pool_failures.erl
+++ b/apps/aecore/src/aec_tx_pool_failures.erl
@@ -1,0 +1,102 @@
+-module(aec_tx_pool_failures).
+
+-export([limit/2,
+         settings/0]).
+
+-ifdef(TEST).
+-export([set/1]).
+-endif.
+
+-define(ENABLED, <<"enabled">>).
+-define(COMMON, <<"common">>).
+-define(DEFAULT, <<"fallback">>).
+-define(DEFAULT_DEFAULT_VALUE, 20).
+
+-define(ETS_TABLE, ?MODULE).
+-define(ETS_KEY, settings).
+
+-spec limit(aetx_sign:signed_tx(), atom()) -> {ok, non_neg_integer()} | no_limit.
+limit(SignedTx, Error) ->
+    {Type, _Tx} = aetx:specialize_type(aetx_sign:tx(SignedTx)),
+    Settings = settings(),
+    IsEnabled = maps:get(?ENABLED, Settings, true),
+    case IsEnabled of
+        false -> no_limit;
+        true ->
+            ErrorName = error_to_setting_name(Error),
+            TxType = tx_type_to_setting_name(Type),
+            GeneralSettings = maps:get(?COMMON, Settings, #{}),
+            TxSettings = maps:merge(GeneralSettings, maps:get(TxType, Settings, #{})),
+            {ok, _R} = lookup_setting(TxSettings, ErrorName)
+    end.
+
+settings() ->
+    try
+        [{?ETS_KEY, Settings}] = ets:lookup(?ETS_TABLE, ?ETS_KEY),
+        Settings
+    catch
+        _:_ ->
+            ensure_table(),
+            S = load_settings(),
+            true = ets:insert(?ETS_TABLE, {?ETS_KEY, S}),
+            S
+    end.
+
+lookup_setting(Map, Key) ->
+    case maps:find(Key, Map) of
+        {ok, Val} -> {ok, Val};
+        error -> maps:find(?DEFAULT, Map)
+    end.
+
+tx_type_to_setting_name(TxNameAtom) -> atom_to_binary(TxNameAtom, utf8).
+
+error_to_setting_name(Event) when is_atom(Event) -> atom_to_binary(Event, utf8).
+
+load_settings() ->
+    Settings0 =
+        case aeu_env:find_config([<<"mempool">>, <<"tx_failures">>],
+                                          [user_config]) of
+            {ok, S} -> S;
+            undefined -> #{}
+        end,
+    {ok, Defaults} = aeu_env:schema_default_values([<<"mempool">>, <<"tx_failures">>]),
+    MapFold =
+        fun(MergeFun, M1, M2) ->
+            maps:fold(
+                fun(K, V1, Acc) ->
+                    Val =
+                        case maps:find(K, Acc) of
+                            {ok, V2} -> MergeFun(V1, V2);
+                            error -> V1
+                        end,
+                    maps:put(K, Val, Acc)
+                end,
+                M2, M1) %% M2 overwrites M1
+        end,
+    DeepMerge =
+        fun Merge(V1, V2) when is_map(V2) ->
+                  MapFold(Merge, V1, V2);
+            Merge(_V1, V2) -> V2
+        end,
+    Settings = MapFold(DeepMerge, Defaults, Settings0),
+    %% ensure there is a default
+    case lookup_setting(maps:get(?COMMON, Settings, #{}), ?DEFAULT) of
+        error ->
+            maps:put(?COMMON,
+                     maps:put(?DEFAULT, ?DEFAULT_DEFAULT_VALUE, maps:get(?COMMON, Settings, #{})),
+                     Settings);
+        {ok, _} -> Settings
+    end.
+
+ensure_table() ->
+    case ets:whereis(?ETS_TABLE) of
+        undefined ->
+            ets:new(?ETS_TABLE, [set, named_table, {read_concurrency, false}, public]);
+        _ -> pass
+    end.
+
+-ifdef(TEST).
+set(S) ->
+    ensure_table(),
+    true = ets:insert(?ETS_TABLE, {?ETS_KEY, S}).
+-endif.

--- a/apps/aecore/src/aec_tx_pool_gc.erl
+++ b/apps/aecore/src/aec_tx_pool_gc.erl
@@ -62,8 +62,8 @@
 add_hash(MempoolGC, TxHash, Key, TTL) ->
     %% Use update_counter with a threshold to do the compare and maybe update
     %% efficiently.
-    ets:update_counter(MempoolGC, TxHash, {#tx.ttl, 0, TTL, TTL},
-                       #tx{hash = TxHash, ttl = TTL, key = Key}).
+    ets:update_counter(MempoolGC, TxHash, {#gc_tx.ttl, 0, TTL, TTL},
+                       #gc_tx{hash = TxHash, ttl = TTL, key = Key}).
 
 -spec adjust_ttl(integer(), aec_tx_pool:dbs()) -> ok.
 adjust_ttl(Diff, Dbs) ->
@@ -148,13 +148,13 @@ do_adjust_ttl(GCDb, Diff) ->
 do_adjust_ttl(_GCDb, '$end_of_table', _Diff) ->
     ok;
 do_adjust_ttl(GCDb, TxHash, Diff) ->
-    ets:update_counter(GCDb, TxHash, {#tx.ttl, -Diff}),
+    ets:update_counter(GCDb, TxHash, {#gc_tx.ttl, -Diff}),
     do_adjust_ttl(GCDb, ets:next(GCDb, TxHash), Diff).
 
 do_gc(Height, Dbs) ->
     GCDb = aec_tx_pool:gc_db(Dbs),
     GCTxs = ets:select(
-              GCDb, [{ #tx{hash = '$1', ttl = '$2', key = '$3', _ = '_'},
+              GCDb, [{ #gc_tx{hash = '$1', ttl = '$2', key = '$3', _ = '_'},
                        [{'=<', '$2', Height}],
                        [{{'$1', '$3'}}] }]),
     do_gc_(GCTxs, Dbs, GCDb).

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -111,6 +111,7 @@ tx_pool_test_() ->
        end},
       {"ensure nonce limit",
        fun() ->
+            persistent_term:put({aec_consensus_bitcoin_ng, whitelist}, #{}),
             aec_test_utils:stop_chain_db(),
             PK = new_pubkey(),
             meck:expect(aec_fork_block_settings, genesis_accounts, 0, [{PK, 100000}]),

--- a/apps/aecore/test/aecore_forking_SUITE.erl
+++ b/apps/aecore/test/aecore_forking_SUITE.erl
@@ -219,6 +219,7 @@ dev3_failed_attack(Config) ->
     {ok, BlocksN3} = mine_key_blocks(N3, 20),
     N3Top = lists:last(BlocksN3),
     ct:log("top of fork dev3 (N3Top): ~p", [ N3Top ]),
+    ct:log("dev3 difficulty: ~p", [ aec_blocks:difficulty(N3Top) ]),
     ok = stop_and_check([dev3], Config),
     %%
     %% restart N1 (dev1), N2 (dev2), sync, mine some blocks and set fork resilience
@@ -233,6 +234,7 @@ dev3_failed_attack(Config) ->
     NewTop = rpc:call(N1, aec_chain, top_block, [], 5000),
     NewTopHeight = aec_blocks:height(NewTop),
     ct:log("top of fork dev1 (NewTop): ~p", [ NewTop ]),
+    ct:log("dev1 difficulty: ~p", [ aec_blocks:difficulty(NewTop) ]),
     aec_test_utils:wait_for_it(
       fun() -> rpc:call(N2, aec_chain, top_block, [], 5000) end,
       NewTop),

--- a/apps/aecore/test/aecore_mempool_SUITE.erl
+++ b/apps/aecore/test/aecore_mempool_SUITE.erl
@@ -310,7 +310,7 @@ push_tx_skipped_nonce(Config) ->
     {ok, []} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
     {ok, NextNonce} = rpc:call(NodeName, aec_next_nonce, pick_for_account, [Pub]),
     ct:log("NextNonce: ~p", [NextNonce]),
-    SpendTx = prepare_spend_tx(Node, #{nonce => NextNonce + 1}),
+    SpendTx = prepare_spend_tx(Node, #{nonce => NextNonce + 1, payload => <<"skiped nonce">>}),
     ct:log("Spend tx: ~p", [SpendTx]),
     ok = push(NodeName, SpendTx, Config),
     {ok, [_SpendTx]} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]).
@@ -318,10 +318,12 @@ push_tx_skipped_nonce(Config) ->
 repush_tx_skipped_nonce_is_stopped_by_cache(Config) ->
     Node = dev1,
     NodeName = aecore_suite_utils:node_name(Node),
+    %% test requirement: empty pool
+    {ok, []} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
     {_, Pub} = aecore_suite_utils:sign_keys(Node),
     {ok, NextNonce} = rpc:call(NodeName, aec_next_nonce, pick_for_account, [Pub]),
     ct:log("NextNonce: ~p", [NextNonce]),
-    SpendTx = prepare_spend_tx(Node, #{nonce => NextNonce + 1}),
+    SpendTx = prepare_spend_tx(Node, #{nonce => NextNonce + 1, payload => <<"skiped nonce">>}),
     ct:log("Spend tx: ~p", [SpendTx]),
     ok = push(NodeName, SpendTx, Config),
     {ok, []} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),

--- a/apps/aecore/test/aecore_mempool_SUITE.erl
+++ b/apps/aecore/test/aecore_mempool_SUITE.erl
@@ -454,8 +454,6 @@ skipped_nonce_specific_cleanup(Config) ->
     timer:sleep(100), %% provide some time for the tx pool to process the message
     {ok, []} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
     %% the tx can reenter the pool:
-    timer:sleep(4000), %% provide some time for the tx pool to process the message
-    ct:log("Pushing again the tx", []),
     ok = push(NodeName, SkippedNonceTx, Config),
     {ok, [SkippedNonceTx]} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
     make_microblock_attempts(CleanupTTL, Config),

--- a/apps/aecore/test/aecore_mempool_SUITE.erl
+++ b/apps/aecore/test/aecore_mempool_SUITE.erl
@@ -612,9 +612,5 @@ test_disabled(Config) ->
 
 
 random_hash() ->
-    HList =
-        lists:map(
-            fun(_) -> rand:uniform(255) end,
-            lists:seq(1, 32)),
-    list_to_binary(HList).
+    crypto:strong_rand_bytes(32).
 

--- a/apps/aecore/test/aecore_mempool_SUITE.erl
+++ b/apps/aecore/test/aecore_mempool_SUITE.erl
@@ -23,7 +23,7 @@
     repush_tx_skipped_nonce_is_stopped_by_cache/1,
     skipped_nonce_specific_cleanup/1,
     insufficient_funds_specific_cleanup/1,
-    name_claim_to_unknown_commitement_cleanup/1,
+    name_claim_to_unknown_commitment_cleanup/1,
     test_defaults/1,
     test_disabled/1,
     stop_node/1
@@ -121,7 +121,7 @@ groups() ->
       [
        skipped_nonce_specific_cleanup,
        insufficient_funds_specific_cleanup,
-       name_claim_to_unknown_commitement_cleanup,
+       name_claim_to_unknown_commitment_cleanup,
        test_defaults,
        test_disabled
       ]}
@@ -450,7 +450,6 @@ skipped_nonce_specific_cleanup(Config) ->
     {ok, [SkippedNonceTx]} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
     %% it should be cleaned up at the next height
     make_microblock_attempts(1, Config),
-    %%{ok, _} = aecore_suite_utils:mine_blocks(NodeName, 1, ?MINE_RATE, key, #{}),
     timer:sleep(100), %% provide some time for the tx pool to process the message
     {ok, []} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
     %% the tx can reenter the pool:
@@ -483,7 +482,7 @@ insufficient_funds_specific_cleanup(Config) ->
     ok.
 
 %% this tests the fallback to the defaults in the schema
-name_claim_to_unknown_commitement_cleanup(Config) ->
+name_claim_to_unknown_commitment_cleanup(Config) ->
     Node = dev1,
     NodeName = aecore_suite_utils:node_name(Node),
     {Priv, Pub} = aecore_suite_utils:sign_keys(Node),
@@ -595,7 +594,7 @@ test_disabled(Config) ->
     DefaultSettings = rpc:call(NodeName, aec_tx_pool_failures, settings, []),
     Settings = #{<<"enabled">> => false},
     true = rpc:call(NodeName, aec_tx_pool_failures, set, [Settings]),
-    %% ensure new settings are into effect:
+    %% ensure new settings are in effect:
     Settings = rpc:call(NodeName, aec_tx_pool_failures, settings, []),
     %% ensure an account for Carol
     seed_account(pubkey(?CAROL), 1, Config),

--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -47,7 +47,9 @@ init_per_suite(Config) ->
             <<"micro_block_cycle">> => MicroBlockCycle
         },
         <<"mempool">> => #{ <<"invalid_tx_ttl">> => 2
-                          , <<"nonce_baseline">> => 10 }
+                          , <<"nonce_baseline">> => 10
+                          , <<"tx_failures">> => #{ <<"enabled">> => false}
+                          }
     },
     Config1 = aecore_suite_utils:init_per_suite([dev1, dev2], DefCfg,
                                                 [{add_peers, true}],

--- a/apps/aehttp/test/aehttp_ga_SUITE.erl
+++ b/apps/aehttp/test/aehttp_ga_SUITE.erl
@@ -110,7 +110,9 @@ init_per_suite(Config0) ->
     DefCfg = #{<<"chain">> =>
                    #{<<"persist">> => false,
                      <<"hard_forks">> => Forks},
-               <<"mempool">> => #{<<"tx_ttl">> => 100},
+               <<"mempool">> => #{<<"tx_ttl">> => 100,
+                                  <<"tx_failures">> => #{ <<"enabled">> => false}
+                                  },
               <<"http">> =>
                    #{<<"cache">> => #{<<"enabled">> => false}}},
     Config1 = [{instant_mining, true}, {symlink_name, "latest.http_ga"}, {test_module, ?MODULE}] ++ Config0,

--- a/apps/aehttp/test/aehttp_sc_SUITE.erl
+++ b/apps/aehttp/test/aehttp_sc_SUITE.erl
@@ -364,6 +364,8 @@ init_per_suite(Config) ->
     DefCfg = #{<<"chain">> =>
                    #{<<"persist">> => false,
                      <<"hard_forks">> => Forks},
+                     <<"mempool">> =>
+                        #{<<"tx_failures">> => #{ <<"enabled">> => false}},
                <<"mining">> =>
                    #{<<"micro_block_cycle">> => 1,
                      %% disable name claim auction

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -192,6 +192,11 @@
                                     "type" : "integer",
                                     "default" : 1
                                 },
+                                "name_not_preclaimed" : {
+                                    "description" : "If the origin of the transaction does not have ownership to the commitment. Legacy. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
                                 "commitment_not_owned" : {
                                     "description" : "If the origin of the transaction does not have ownership to the commitment. Clean up.",
                                     "type" : "integer",

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -95,6 +95,890 @@
                 "cache_size" : {
                     "description" : "Maximum number of recently received cached transactions",
                     "type" : "integer"
+                },
+                "tx_failures" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "enabled" : {
+                            "description" : "If true, the following error codes will have specific failures.",
+                            "type" : "boolean",
+                            "default" : true
+                        },
+                        "common" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "crash" : {
+                                    "description" : "Something went really wrong, clean up.",
+                                    "type" : "integer",
+                                    "default" : 1 
+                                },
+                                "not_a_generalized_account" : {
+                                    "description" : "If the transaction is being authenticated as a GA but the account is still basic. We provide a grace period in a number of generations for the account to be upgraded.",
+                                    "type" : "integer",
+                                    "default" : 15
+                                },
+                                "tx_nonce_already_used_for_account" : {
+                                    "description" : "If the transaction nonce is already used, the transaction can not be applied. Clean it up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "tx_nonce_too_high_for_account" : {
+                                    "description" : "If the transaction nonce is set somewhere in the future it can get included once the transaction with the missing nonce is being included. Provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 30
+                                }
+                            }
+                        },
+                        "spend_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : false,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                }
+                            }
+                        },
+                        "name_preclaim_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                }
+                            }
+                        },
+                        "name_claim_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "bad_transaction" : {
+                                    "description" : "If there is something unexpected about the transaciton. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "commitment_not_owned" : {
+                                    "description" : "If the origin of the transaction does not have ownership to the commitment. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "commitment_delta_too_small" : {
+                                    "description" : "If the commitment had not yet matured, provide a grace period for it.",
+                                    "type" : "integer",
+                                    "default" : 50
+                                },
+                                "name_already_taken" : {
+                                    "description" : "If the name is already registered. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "invalid_registrar" : {
+                                    "description" : "If the registrar is not available, if there is an upcoming fork to allow new registrars - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "invalid_name_fee" : {
+                                    "description" : "If the fee is insufficient for the name. If there is an upcoming fork that changes pricing - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "name_revoke_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "name_not_owned" : {
+                                    "description" : "If the name is not owned by the origin of the transaction. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "name_revoked" : {
+                                    "description" : "If the the name is already revoked. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "name_transfer_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "name_not_owned" : {
+                                    "description" : "If the name is not owned by the origin of the transaction. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "name_revoked" : {
+                                    "description" : "If the the name is already revoked. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "name_update_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "ttl_too_high" : {
+                                    "description" : "If the provided TTL is too far away in the future. If there is an upcoming fork that changes pricing - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "ttl_too_low" : {
+                                    "description" : "If the provided TTL is too soon. If there is an upcoming fork that changes pricing - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "ttl_invalid" : {
+                                    "description" : "If the provided TTL is using unknown format. If there is an upcoming fork that changes pricing - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "name_not_owned" : {
+                                    "description" : "If the name is not owned by the origin of the transaction. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "name_revoked" : {
+                                    "description" : "If the name is already revoked. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "invalid_pointers" : {
+                                    "description" : "If the provided pointers fail the required checks. If there is an upcoming fork that changes pricing - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "channel_create_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                }
+                            }
+                        },
+                        "channel_close_mutual_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be closed is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "account_not_peer" : {
+                                    "description" : "If the origin of the transaction is not a channel peer. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "channel_not_active" : {
+                                    "description" : "If the channel is already closing. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "wrong_amounts" : {
+                                    "description" : "If the channel closing amounts exceed the channel balance. There could be a hanging channel_deposit_tx, provide a grace period.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                }
+                            }
+                        },
+                        "channel_deposit_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be deposited is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "channel_not_active" : {
+                                    "description" : "If the channel is already closing. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "old_round" : {
+                                    "description" : "If the channel deposit is based on a round older than the on-chain stored one. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "same_round" : {
+                                    "description" : "If the channel deposit is trying to replace current state hash. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "channel_withdraw_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be withdrawn from is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "channel_not_active" : {
+                                    "description" : "If the channel is already closing. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "old_round" : {
+                                    "description" : "If the channel withdrawal is based on a round older than the on-chain stored one. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "same_round" : {
+                                    "description" : "If the channel withdrawal is trying to replace current state hash. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "not_enough_channel_funds" : {
+                                    "description" : "If the channel withdrawal is trying to withdraw more tokens than the current channels balance allows it to.  There could be a hanging channel_deposit_tx, provide a grace period.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                }
+                            }
+                        },
+                        "channel_settle_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be settled is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "account_not_peer" : {
+                                    "description" : "If the origin of the transaction is not a channel peer. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "channel_not_closed" : {
+                                    "description" : "If the channel dispute time interval is still active. Provide a grace period.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "wrong_amt" : {
+                                    "description" : "If the channel final amounts do not match the closing amounts. There could be a hanging channel_slash_tx, provide a grace period.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "insufficient_channel_funds" : {
+                                    "description" : "If the channel final amounts exceedthe channel balance. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "channel_close_solo_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be closed is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "account_not_peer" : {
+                                    "description" : "If the origin of the transaction is not a channel peer. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "channel_not_active" : {
+                                    "description" : "If the channel is already closing. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "payload_deserialization_failed" : {
+                                    "description" : "If the payload is from an unknown format, if there is an upcoming fork to allow new serializations - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_offchain_state_type" : {
+                                    "description" : "If the offhchain state is from an unknown off-chain transaction type, if there is an upcoming fork to allow new off-chain transaction types - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "account_not_found" : {
+                                    "description" : "If the origin of the transaction is not in the state tree. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "invalid_poi_hash_in_channel" : {
+                                    "description" : "If the root of the proof of inclusion for the off-chain state does not match the provided hash. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_state_channel_pubkey" : {
+                                    "description" : "If the channel id of the payload off-chain transaction does not match the transaction channel id. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "old_round" : {
+                                    "description" : "If the transaction is based on a round older than the on-chain stored one. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "same_round" : {
+                                    "description" : "If the transaction is trying to replace current state hash. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "signature_check_failed" : {
+                                    "description" : "If the payload authentication failed. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "wrong_channel_peers" : {
+                                    "description" : "If the accounts provided in the PoI are not of the channel participants. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "poi_amounts_change_channel_funds" : {
+                                    "description" : "If the amounts of accounts provided in the PoI exceed the total channel balance. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "channel_slash_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be slashed is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "account_not_peer" : {
+                                    "description" : "If the origin of the transaction is not a channel peer. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "channel_not_closing" : {
+                                    "description" : "If the channel is not yet closing. There might be a close solo hanging in the pool, provide a grace period.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "payload_deserialization_failed" : {
+                                    "description" : "If the payload is from an unknown format, if there is an upcoming fork to allow new serializations - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_offchain_state_type" : {
+                                    "description" : "If the offhchain state is from an unknown off-chain transaction type, if there is an upcoming fork to allow new off-chain transaction types - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "account_not_found" : {
+                                    "description" : "If the origin of the transaction is not in the state tree. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "invalid_poi_hash_in_channel" : {
+                                    "description" : "If the root of the proof of inclusion for the off-chain state does not match the provided hash. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_state_channel_pubkey" : {
+                                    "description" : "If the channel id of the payload off-chain transaction does not match the transaction channel id. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "old_round" : {
+                                    "description" : "If the transaction is based on a round older than the on-chain stored one. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "same_round" : {
+                                    "description" : "If the transaction is trying to replace current state hash. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "signature_check_failed" : {
+                                    "description" : "If the payload authentication failed. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "wrong_channel_peers" : {
+                                    "description" : "If the accounts provided in the PoI are not of the channel participants. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "poi_amounts_change_channel_funds" : {
+                                    "description" : "If the amounts of accounts provided in the PoI exceed the total channel balance. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "slash_must_have_payload" : {
+                                    "description" : "If the slash transaction comes with an empty payload. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "channel_snapshot_solo_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "payload_deserialization_failed" : {
+                                    "description" : "If the payload is from an unknown format, if there is an upcoming fork to allow new serializations - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "snapshot_must_have_payload" : {
+                                    "description" : "If the snapshot transaction comes with an empty payload. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_offchain_state_type" : {
+                                    "description" : "If the offhchain state is from an unknown off-chain transaction type, if there is an upcoming fork to allow new off-chain transaction types - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be snapshot is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "account_not_found" : {
+                                    "description" : "If the origin of the transaction is not in the state tree. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "account_not_peer" : {
+                                    "description" : "If the origin of the transaction is not a channel peer. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "channel_not_active" : {
+                                    "description" : "If the channel is already closing. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "old_round" : {
+                                    "description" : "If the channel deposit is based on a round older than the on-chain stored one. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "same_round" : {
+                                    "description" : "If the channel deposit is trying to replace current state hash. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "signature_check_failed" : {
+                                    "description" : "If the payload authentication failed. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "channel_set_delegates_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "channel_does_not_exist" : {
+                                    "description" : "If the channel to be set is not present. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "bad_offchain_state_type" : {
+                                    "description" : "If the offhchain state is from an unknown off-chain transaction type, if there is an upcoming fork to allow new off-chain transaction types - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "payload_deserialization_failed" : {
+                                    "description" : "If the payload is from an unknown format, if there is an upcoming fork to allow new serializations - provide a grace period for it, otherwise clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "account_not_found" : {
+                                    "description" : "If the origin of the transaction is not in the state tree. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "account_not_peer" : {
+                                    "description" : "If the origin of the transaction is not a channel peer. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "channel_not_active" : {
+                                    "description" : "If the channel is already closing. Clean up.",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "unexpected_state_hash" : {
+                                    "description" : "If the set delegates is based on the latest state hash which is different. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "unexpected_state_hash" : {
+                                    "description" : "If the set delegates is based on the latest round which is different. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                }
+                            }
+                        },
+                        "contract_create_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "illegal_vm_version" : {
+                                    "description" : "If the VM version is not supported. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "illegal_contract_compiler_version" : {
+                                    "description" : "If the compiler version is not supported. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_sophia_code" : {
+                                    "description" : "If the sophia code does not parse. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_init_function" : {
+                                    "description" : "If the init function fails. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "contract_call_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "illegal_vm_version" : {
+                                    "description" : "If the VM version is not supported. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "ga_attach_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "illegal_vm_version" : {
+                                    "description" : "If the VM version is not supported. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "oracle_register_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "account_is_already_an_oracle" : {
+                                    "description" : "If account is already an oracle. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_abi_version" : {
+                                    "description" : "If the ABI version is not supported. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_query_format" : {
+                                    "description" : "If the query format is not supported. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_response_format" : {
+                                    "description" : "If the response format is not supported. If there is an upcoming hard fork - provide a grace period, otherwise - clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "oracle_extend_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "account_is_not_an_active_oracle" : {
+                                    "description" : "If account is not an oracle. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "oracle_query_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "oracle_does_not_exist" : {
+                                    "description" : "If oracle does not exist. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_format" : {
+                                    "description" : "If the query format does not match up. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "query_fee_too_low" : {
+                                    "description" : "If the fee provided does not match expectations. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "too_long_ttl" : {
+                                    "description" : "If the ttl provided does not match expectations. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                }
+                            }
+                        },
+                        "oracle_response_tx" : {
+                            "type" : "object",
+                            "additionalProperties" : true,
+                            "properties" : {
+                                "fallback" : {
+                                    "description" : "Default value if the failed reason is not set.",
+                                    "type" : "integer",
+                                    "default" : 5
+                                },
+                                "insufficient_funds" : {
+                                    "description" : "If the origin of the transaction does not have enough tokens to spend. We provide a grace period in a number of generations.",
+                                    "type" : "integer",
+                                    "default" : 20
+                                },
+                                "oracle_does_not_exist" : {
+                                    "description" : "If oracle does not exist. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "bad_format" : {
+                                    "description" : "If the query format does not match up. Clean up",
+                                    "type" : "integer",
+                                    "default" : 1
+                                },
+                                "no_matching_oracle_query" : {
+                                    "description" : "If there is no matching query id. Provide a grace period",
+                                    "type" : "integer",
+                                    "default" : 20
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -143,7 +143,7 @@
                         },
                         "spend_tx" : {
                             "type" : "object",
-                            "additionalProperties" : false,
+                            "additionalProperties" : true,
                             "properties" : {
                                 "fallback" : {
                                     "description" : "Default value if the failed reason is not set.",

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -253,7 +253,7 @@ schema_default_values(Path) ->
             RecoursiveDefault =
                 fun R(_PName,
                       #{<<"type">> := <<"object">>, <<"properties">> := Props}) ->
-                          maps:map(fun(_PN, #{<<"type">> := <<"object">>} = PP) -> R(PN, PP);
+                          maps:map(fun(PN, #{<<"type">> := <<"object">>} = PP) -> R(PN, PP);
                                       (_PN, #{<<"default">> := Def}) -> Def
                                     end, Props);
                     R(_PName, #{<<"default">> := Def}) ->

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -250,7 +250,7 @@ schema_default_values(Path) ->
     case schema(Path) of
         undefined -> undefined;
         {ok, Tree} ->
-            RecoursiveDefault =
+            RecursiveDefault =
                 fun R(_PName,
                       #{<<"type">> := <<"object">>, <<"properties">> := Props}) ->
                           maps:map(fun(PN, #{<<"type">> := <<"object">>} = PP) -> R(PN, PP);
@@ -259,7 +259,7 @@ schema_default_values(Path) ->
                     R(_PName, #{<<"default">> := Def}) ->
                         Def
                 end,
-            Res = RecoursiveDefault(<<"root">>, Tree),
+            Res = RecursiveDefault(<<"root">>, Tree),
             {ok, Res}
       end.
 

--- a/apps/aeutils/src/aeutils_app.erl
+++ b/apps/aeutils/src/aeutils_app.erl
@@ -8,6 +8,7 @@
 
 start(_StartType, _StartArgs) ->
     _ = aeu_info:block_info(), %% init the cache so this process is the owner of the table
+    _ = aec_tx_pool_failures:settings(), %% init the cache so this process is the owner of the table
     aeutils_sup:start_link().
 
 start_phase(_Phase, _Type, _Args) ->


### PR DESCRIPTION
Fixes #3675

Once entering the tx pool, transactions are being kept and broadcasted until
they are included in a microblock or they had stayed there for whatever is the
tx pool GC setting.

This means that transactions are being tested if they are valid on every
microblock generation attempt. Those that are currently invalid are postponed
for the next generation, when they are tried again.

This PR adds the functionality for providing a soft maximmum attempts based on
specific error that is preventing the transaction to be included. Once the
threshold is reached, the transaction is GCed. This will allow faster purging
of transactions that do not seem to get valid anytime soon.

The PR comes with sensible default values for some of the errors. The node
operator can overwrite those in their config. The schema allows configuring
the less likely errors if needed.

The work on this PR is being supported by ACF.
