### PR TITLE
Fix a race condition in the tx-pool

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -594,9 +594,13 @@ move_to_visited(VDb, #dbs{visited_db = VDb}, _) ->
     %% already in visited
     ignore;
 move_to_visited(Db, #dbs{visited_db = VDb}, Key) ->
-    [{Key, TxRec}] = ets:lookup(Db, Key), 
-    ets:insert(VDb, {Key, TxRec}),
-    ets:delete(Db, Key),
+    case ets:lookup(Db, Key) of
+        [{Key, TxRec}] ->
+            ets:insert(VDb, {Key, TxRec}),
+            ets:delete(Db, Key);
+        [] -> %% GCed
+            pass
+    end,
     ok.
 
 revisit(#dbs{db = Db, visited_db = VDb}) ->


### PR DESCRIPTION
Fix a IF in the tx-pool: when the GC kicks in and deletes txs while a micro block candidate is being computed. The symptom is:
```
*** User 2021-09-23 13:04:54.709 ***
Node net1_node1's crash logs is not empty:
2021-09-23 13:03:26 =ERROR REPORT====
Error in process <0.4537.0> on node aeternity@localhost with exit value:
{{badmatch,[]},[{aec_tx_pool,move_to_visited,3,[{file,"/app/apps/aecore/src/aec_tx_pool.erl"},{line,597}]},{aec_tx_pool,'-int_get_candidate/3-lc$^0/1-0-',2,[{file,"/app/apps/aecore/src/aec_tx_pool.erl"},{line,509}]},{aec_tx_pool,int_get_candidate,3,[{file,"/app/apps/aecore/src/aec_tx_pool.erl"},{line,511}]},{timer,tc,1,[{file,"timer.erl"},{line,166}]},{aec_tx_pool,get_candidate,2,[{file,"/app/apps/aecore/src/aec_tx_pool.erl"},{line,277}]},{aec_block_micro_candidate,int_create,4,[{file,"/app/apps/aecore/src/aec_block_micro_candidate.erl"},{line,102}]},{aec_block_generator,create_block_candidate,1,[{file,"/app/apps/aecore/src/aec_block_generator.erl"},{line,218}]}]}
```