### PR TITLE
Refine on_demand consensus client requests

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -25,6 +25,7 @@
                 "plugins" : {
                     "description" : "List of application names of plugins to load",
                     "type" : "array",
+                    "default" : [],
                     "items" : {
                         "type" : "object",
                         "description" : "Plugin name and properties",


### PR DESCRIPTION
See issue #3722 and PR #3733
This PR changes the on-demand consensus mode so that it will not produce empty microblocks.
This also slightly changes the interpretation of `client_request({mine_blocks, N, micro})`, such that _up to N_ microblocks will be generated, but only up to the point when the mempool is empty.