### PR TITLE
Add a release notes line for tx-pool strict mode

### DIFF
--- a/docs/release-notes/next/GH-3675_tx_pool_strict_mode.md
+++ b/docs/release-notes/next/GH-3675_tx_pool_strict_mode.md
@@ -1,0 +1,6 @@
+* Introduces a new `strict` mode in the tx-pool. It allows the node operator
+  to specify different maximum attempts per error type of a transaction, thus
+  allowing a higher grace period for some transactions to become valid while
+  limiting other errors. All error types can be specified in the config but
+  some come with sensible defaults. This feature can also be turned off in the
+  config.


### PR DESCRIPTION
Somehow we missed the release notes line in #3719.

The work on this PR had been supported by ACF.
