### PR TITLE
Incr devmode version for docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   aeplugin_devmode_version:
     type: string
-    default: "0.2.0"
+    default: "0.3.0"
 
 executors:
   infrastructure_container_unstable:


### PR DESCRIPTION
See issue #3303 
The latest version of [aeternity/aeplugin_dev_mode](https://github.com/aeternity/aeplugin_dev_mode) is now "0.3.0"