### PR TITLE
Remove build_uml_diagrams from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1397,20 +1397,6 @@ jobs:
           command: |
             /infrastructure/scripts/check_release_artifacts.sh ${CIRCLE_TAG}
 
-  build_uml_diagrams:
-    docker:
-      - image: circleci/openjdk:11-jdk-stretch
-    steps:
-      - fixed_checkout
-      - run:
-          name: Install PlantUML dependencies
-          command: |
-            sudo apt-get -qq -y update && sudo apt-get -qq -y install graphviz librsvg2-bin
-      - run: make build-uml
-      - store_artifacts:
-          path: docs/state-channels
-      - *fail_notification
-
 # CircleCI skips a job for a tag by default.
 # A job must have a filters tags section to run as a part of a tag push
 # and all its transitively dependent jobs must also have a filters tags section.
@@ -1786,7 +1772,6 @@ workflows:
             - static_analysis
             - rebar_lock_check
             - linux_package
-            - build_uml_diagrams
           filters:
             branches:
               only: master
@@ -1882,16 +1867,6 @@ workflows:
           filters:
             branches:
               only: env/dev2
-
-      - build_uml_diagrams:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - env/dev1
-                - env/dev2
-                - system-tests
 
   release:
     jobs:


### PR DESCRIPTION
Since SourceForge (download source for plantuml.jar) hasn't renewed their certificates, our CI pipeline fails on this build step.

The UML diagram - we have only one - changes very seldomly, and we can easily get away with updating it manually on the [wiki page](https://github.com/aeternity/aeternity/wiki/State-Channels) - or removing it entirely.