### PR TITLE
Bump devmode plugin vsn to 0.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   aeplugin_devmode_version:
     type: string
-    default: "0.3.0"
+    default: "0.3.1"
 
 executors:
   infrastructure_container_unstable:


### PR DESCRIPTION
A bug fix in the dev_mode plugin motivates a bump in version to 0.3.1. See issue aeternity/aeplugin_dev_mode#7