### PR TITLE
tx_pool understands rollback; stricter rollback check in forking_SUITE

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -367,7 +367,7 @@ new_state_from_persistence() ->
 persist_state(OldState, NewState) ->
     case {get_top_block_hash(OldState), get_top_block_hash(NewState)} of
         {TH, TH} -> false;
-        {_, TopBlockHash} ->
+        {_, _TopBlockHash} ->
             Node = get_top_block_node(NewState),
             db_write_top_block_node(Node),
             maybe_set_finalized_height(NewState),

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -45,6 +45,7 @@
                 mining_opts             = #{}     :: mining_opts(),
                 top_block_hash                    :: binary() | 'undefined',
                 top_key_block_hash                :: binary() | 'undefined',
+                top_height                        :: aec_blocks:height(),
                 workers                 = []      :: workers(),
                 miner_instances         = []      :: miner_instances(),
                 consensus                         :: #consensus{},

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -351,8 +351,7 @@ get_mpt(Height) ->
     try get_mpt_from_hash(Hash) of
         MPT -> MPT
     catch
-        error:{hash_not_present_in_db, MissingHash} ->
-            Stacktrace = erlang:get_stacktrace(),
+        error:{hash_not_present_in_db, MissingHash}:Stacktrace ->
             error({hash_not_present_in_db_at_height, Height, MissingHash, Stacktrace})
     end.
 


### PR DESCRIPTION
See issue #3749 
This PR makes the tx_pool check if the chain has retreated, and (1) doesn't crash, (2) treats it the same way as when the top jumps backwards due to sync (i.e. adjusting the tx TTLs for GC).

It also ensures that the location objects of txs in deleted blocks are deleted.

Lastly, the `aecore_forking_SUITE` checks more thoroughly that the rollback performed actually succeeds and results in the expected new top height.

This PR is supported by the Æternity Crypto Foundation