### PR TITLE
Rollback: release txs before deleting block

### DIFF
--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -137,10 +137,10 @@ do_rollback_(ForkPoint, Height, TopHeight) ->
         [begin
              [begin
                   Del = element(2, T),
+                  ok = remove_tx_locations(Del),
                   ok = mnesia:delete(aec_headers, Del, write),
                   ok = mnesia:delete(aec_blocks, Del, write),
-                  ok = mnesia:delete(aec_block_state, Del, write),
-                  ok = remove_tx_locations(Del)
+                  ok = mnesia:delete(aec_block_state, Del, write)
               end || T <- mnesia:index_read(aec_headers, H, height)]
          end || H <- lists:seq(Height+1, TopHeight+SafetyMargin)],
         aec_db:write_top_block_node(ForkPoint, FPHeader)


### PR DESCRIPTION
See issue #3749 - last fix (PR #3750) did things in the wrong order, causing the tx locations to be untouched.

Also added a test case in `aecore_txs_SUITE`, verifying first that it failed before the bugfix.