### PR TITLE
aesc_htlc_SUITE (HTLC-based State Channel market logic)

### DIFF
--- a/apps/aechannel/src/aesc_offchain_state.erl
+++ b/apps/aechannel/src/aesc_offchain_state.erl
@@ -187,8 +187,8 @@ check_update_tx(SignedTx, Updates, #state{signed_tx = OldSignedTx} = State,
 check_update_tx_(Mod, RefTx, Updates, #state{} = State,
                  ChannelPubkey,
                  Protocol, OnChainTrees, OnChainEnv, Reserve) ->
-    try Tx1 = make_update_tx(Updates, State, ChannelPubkey,
-                             Protocol, OnChainTrees, OnChainEnv, Reserve),
+    try {Tx1, _} = make_update_tx(Updates, State, ChannelPubkey,
+                                  Protocol, OnChainTrees, OnChainEnv, Reserve),
          {Mod1, Tx1I} = aetx:specialize_callback(Tx1),
          case Mod1:state_hash(Tx1I) =:= Mod:state_hash(RefTx) of
              true ->
@@ -217,7 +217,7 @@ prune_calls(State) ->
                      binary(),
                      aec_hard_forks:protocol_vsn(),
                      aec_trees:trees(), aetx_env:env(),
-                     non_neg_integer()) -> aetx:tx().
+                     non_neg_integer()) -> {aetx:tx(), list()}.
 make_update_tx(Updates, #state{signed_tx = LastSignedTx, trees=Trees},
                ChannelPubkey, Protocol,
                OnChainTrees, OnChainEnv, Reserve)
@@ -227,8 +227,9 @@ make_update_tx(Updates, #state{signed_tx = LastSignedTx, trees=Trees},
 
     NextRound = Mod:round(TxI) + 1,
 
-    Trees1 = apply_updates(Updates, NextRound, Trees, OnChainTrees,
-                           OnChainEnv, Reserve),
+    {Results, Trees1} = apply_updates(Updates, NextRound, Trees, OnChainTrees,
+                                      OnChainEnv, Reserve),
+    lager:debug("Results = ~p", [Results]),
     StateHash = aec_trees:hash(Trees1),
     Props0 =
         #{channel_id => aeser_id:create(channel, ChannelPubkey),
@@ -241,11 +242,11 @@ make_update_tx(Updates, #state{signed_tx = LastSignedTx, trees=Trees},
             _                     -> Props0
         end,
     {ok, OffchainTx} = aesc_offchain_tx:new(Props),
-    OffchainTx.
+    {OffchainTx, Results}.
 
 apply_updates(Updates, Round, Trees0, OnChainTrees, OnChainEnv, Reserve) ->
     Trees = aect_call_state_tree:prune_without_backend(Trees0),
-    lists:foldl(
+    lists:mapfoldl(
         fun(U, AccumTrees) ->
             aesc_offchain_update:apply_on_trees(U, AccumTrees, OnChainTrees,
                                                 OnChainEnv, Round, Reserve)
@@ -280,12 +281,12 @@ set_signed_tx(SignedTx, Updates, #state{}=State, OnChainTrees,
             {Trees, Calls} =
                 lists:foldl(
                     fun(Update, {TrAccum, CallsAccum}) ->
-                        TrAccum1 = aesc_offchain_update:apply_on_trees(Update,
-                                                                       TrAccum,
-                                                                       OnChainTrees,
-                                                                       OnChainEnv,
-                                                                       Mod:round(TxI),
-                                                                       Reserve),
+                        {_Res, TrAccum1} = aesc_offchain_update:apply_on_trees(Update,
+                                                                               TrAccum,
+                                                                               OnChainTrees,
+                                                                               OnChainEnv,
+                                                                               Mod:round(TxI),
+                                                                               Reserve),
                         IsCall = aesc_offchain_update:is_call(Update),
                         IsNewContract = aesc_offchain_update:is_contract_create(Update),
                         case IsNewContract orelse IsCall of

--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -948,7 +948,7 @@ process_force_progress(Tx, OffChainTrees, Payload, TxHash, Height, Trees, Env) -
     %% use in gas payment
     Reserve = aesc_channels:channel_reserve(Channel),
     PrunedOffChainTrees = aect_call_state_tree:prune_without_backend(OffChainTrees),
-    NewOffChainTrees =
+    {_, NewOffChainTrees} =
         try aesc_offchain_update:apply_on_trees(Update,
                                                 PrunedOffChainTrees,
                                                 Trees, Env,

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -5212,9 +5212,12 @@ load_contract(CreateArgs, #{ fsm := FsmC, pub := Owner} = Creator, Acknowledger,
     {Creator2, Acknowledger2, ContractPubkey}.
 
 prepare_contract_create_args(ContractName, InitArgs, Deposit) ->
-    ct:log("SophiaVsn = ~p, IrisFate = ~p", [aect_test_utils:sophia_version(), ?SOPHIA_IRIS_FATE]),
-    {ok, BinCode} = aect_test_utils:compile_contract(aect_test_utils:sophia_version(), ContractName),
-    {ok, BinSrc} = aect_test_utils:read_contract(aect_test_utils:sophia_version(), ContractName),
+    ct:log("SophiaVsn = ~p, IrisFate = ~p",
+           [aect_test_utils:sophia_version(), ?SOPHIA_IRIS_FATE]),
+    {ok, BinCode} = aect_test_utils:compile_contract(
+                      aect_test_utils:sophia_version(), ContractName),
+    {ok, BinSrc} = aect_test_utils:read_contract(
+                     aect_test_utils:sophia_version(), ContractName),
     {ok, CallData} =
         aect_test_utils:encode_call_data(aect_test_utils:sophia_version(), BinSrc,
                                          "init", InitArgs),
@@ -5229,11 +5232,10 @@ call_contract(ContractId, ContractName, FunName, FunArgs,
     call_contract(ContractId, ContractName, FunName, FunArgs, Amount,
                   Caller, Acknowledger, Cfg, false).
 
-call_contract(ContractId,
-              ContractName, FunName, FunArgs, Amount,
-              #{fsm := FsmC} = Caller, Acknowledger, Cfg, ReturnResult) ->
-    Debug = get_debug(Cfg),
-    {ok, BinSrc} = aect_test_utils:read_contract(aect_test_utils:sophia_version(), ContractName),
+call_contract(ContractId, ContractName, FunName, FunArgs, Amount,
+              Caller, Acknowledger, Cfg, ReturnResult) ->
+    {ok, BinSrc} = aect_test_utils:read_contract(
+                     aect_test_utils:sophia_version(), ContractName),
     {ok, CallData} =
         aect_test_utils:encode_call_data(aect_test_utils:sophia_version(), BinSrc,
                                          FunName, FunArgs),
@@ -5247,8 +5249,8 @@ call_contract(ContractId,
 
 upd_call_contract(#{fsm := FsmC} = Caller, Acknowledger, CallArgs, Cfg) ->
     Debug = get_debug(Cfg),
-    {ok, CallRes} = aesc_fsm:upd_call_contract(FsmC, CallArgs),
-    ?LOG(Debug, "CallRes = ~p", [CallRes]),
+    UpdCallRes = aesc_fsm:upd_call_contract(FsmC, CallArgs),
+    ?LOG(Debug, "UpdCallRes = ~p", [UpdCallRes]),
     {Caller1, _} = await_signing_request(update, Caller, Cfg),
     await_update_incoming_report(Acknowledger, ?TIMEOUT, Debug),
     {Acknowledger1, _} = await_signing_request(update_ack, Acknowledger, Cfg),
@@ -5257,15 +5259,18 @@ upd_call_contract(#{fsm := FsmC} = Caller, Acknowledger, CallArgs, Cfg) ->
     assert_empty_msgq(Debug),
     case maps:get(return_result, CallArgs, false) of
         true ->
+            {ok, CallRes} = UpdCallRes,
             {Caller2, Acknowledger2, CallRes};
         false ->
+            ok = UpdCallRes,
             {Caller2, Acknowledger2}
     end.
 
 trigger_force_progress(ContractPubkey,
                        ContractName, FunName, FunArgs, Amount,
                        #{ fsm := FsmC}) ->
-    {ok, BinSrc} = aect_test_utils:read_contract(aect_test_utils:sophia_version(), ContractName),
+    {ok, BinSrc} = aect_test_utils:read_contract(
+                     aect_test_utils:sophia_version(), ContractName),
     {ok, CallData} =
         aect_test_utils:encode_call_data(aect_test_utils:sophia_version(), BinSrc,
                                          FunName, FunArgs),

--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -149,8 +149,6 @@
 -define(BOGUS_BLOCKHASH, <<42:32/unit:8>>).
 
 -define(PEEK_MSGQ(_D), peek_message_queue(?LINE, _D)).
-%% -define(LOG(_Fmt, _Args), log(_Fmt, _Args, ?LINE, true)).
-%% -define(LOG(_D, _Fmt, _Args), log(_Fmt, _Args, ?LINE, _D)).
 
 %% Default configuration values
 -define(MINIMUM_DEPTH, 5).
@@ -605,7 +603,7 @@ responder_accept_timeout(Cfg) ->
                      #{noise => NOpts1}
              end,
     create_channel_([ ?SLOGAN
-                   , {spawn_interval, 500}
+                    , {spawn_interval, 500}
                     , {responder_opts, ROptsF} | Cfg]).
 
 -record(miner, { parent
@@ -3630,8 +3628,6 @@ new_config_table() ->
 load_idx(Cfg) ->
     Roles = proplists:get_value(roles, Cfg, [initiator, responder]),
     lists:foldl(fun load_last_idx/2, Cfg, Roles).
-    %% Cfg1 = load_last_idx(initiator, Cfg),
-    %% load_last_idx(responder, Cfg1).
 
 load_last_idx(Role, Cfg) ->
     OldValue =
@@ -4271,13 +4267,6 @@ lock_period(plain, Depth) ->
 lock_period(_, _) ->
     %% Was hard-coded before
     10.
-
-%% log(Fmt, Args, L, #{debug := true}) ->
-%%     log(Fmt, Args, L, true);
-%% log(Fmt, Args, L, true) ->
-%%     ct:log("~p at ~p: " ++ Fmt, [self(), L | Args]);
-%% log(_, _, _, _) ->
-%%     ok.
 
 config() ->
     Cfg = get(config),
@@ -5212,8 +5201,6 @@ load_contract(CreateArgs, #{ fsm := FsmC, pub := Owner} = Creator, Acknowledger,
     {Creator2, Acknowledger2, ContractPubkey}.
 
 prepare_contract_create_args(ContractName, InitArgs, Deposit) ->
-    ct:log("SophiaVsn = ~p, IrisFate = ~p",
-           [aect_test_utils:sophia_version(), ?SOPHIA_IRIS_FATE]),
     {ok, BinCode} = aect_test_utils:compile_contract(
                       aect_test_utils:sophia_version(), ContractName),
     {ok, BinSrc} = aect_test_utils:read_contract(

--- a/apps/aechannel/test/aesc_htlc_SUITE.erl
+++ b/apps/aechannel/test/aesc_htlc_SUITE.erl
@@ -1,0 +1,365 @@
+%%%=============================================================================
+%%% @copyright (C) 2018, Aeternity Anstalt
+%%% @doc
+%%%    Test utils for State Channel markets, using HTLC contracts
+%%% @end
+%%%=============================================================================
+-module(aesc_htlc_SUITE).
+
+-export([
+          all/0
+        , groups/0
+        , suite/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_group/2
+        , end_per_group/2
+        , init_per_testcase/2
+        , end_per_testcase/2
+        ]).
+
+%% test case exports
+-export([
+          create_3_party/1
+        , alice_pays_bob/1
+        , shutdown/1
+        ]).
+
+%%% ========================================================================
+%%% Strategy
+%%% We reuse as much as we can from the aesc_fsm_SUITE.
+%%% One quirk of the fsm_SUITE is that it spawns proxy processes which are
+%%% linked to the testcase process, and here we want to use test sequences
+%%% which begin with a market setup that remains throughout the sequence.
+%%% To achieve this, we create yet another proxy process in `init_per_group/2`.
+%%% This proxy evaluates funs provided by the testcase process, and forwards
+%%% all received messages to it (the testcase process 'registers' with the
+%%% proxy in `init_per_testcase/2`, etc.)
+%%% ========================================================================
+
+-import(aesc_fsm_SUITE, [ create_channel_/3
+                        , channel_shutdown/3
+                        , prepare_contract_create_args/3
+                        , load_contract/4
+                        , call_contract/8
+                        , receive_log/2
+                        , get_debug/1
+                        , set_configs/2
+                        , log/4
+                        , peek_message_queue/2
+                        , prepare_patron/1
+                        , prep_initiator/2
+                        , prep_responder/2
+                        , rpc/4
+                        , receive_from_fsm/4
+                        ]).
+
+-include_lib("common_test/include/ct.hrl").
+-include("../../aecontract/test/include/aect_sophia_vsn.hrl").
+-include_lib("aecontract/include/aecontract.hrl").
+-include_lib("aecontract/include/hard_forks.hrl").
+
+-define(MINIMUM_FEE, 100).
+
+-define(TIMEOUT, 3000).
+-define(SLIGHTLY_LONGER_TIMEOUT, 2000).
+-define(LONG_TIMEOUT, 60000).
+-define(PORT, 9325).
+
+-define(PEEK_MSGQ(_D), peek_message_queue(?LINE, _D)).
+-define(LOG(_Fmt, _Args), log(_Fmt, _Args, ?LINE, true)).
+-define(LOG(_D, _Fmt, _Args), log(_Fmt, _Args, ?LINE, _D)).
+
+-define(MINIMUM_DEPTH, 5).
+-define(MINIMUM_DEPTH_FACTOR, 10).
+-define(MINIMUM_DEPTH_STRATEGY, txfee).
+-define(INITIATOR_AMOUNT, (10000000 * aec_test_utils:min_gas_price())).
+-define(RESPONDER_AMOUNT, (10000000 * aec_test_utils:min_gas_price())).
+-define(ACCOUNT_BALANCE, max(?INITIATOR_AMOUNT, ?RESPONDER_AMOUNT) * 1000).
+
+-define(SLOGAN, {slogan, {?FUNCTION_NAME, ?LINE}}).
+-define(SLOGAN(I), {slogan, {?FUNCTION_NAME, ?LINE, I}}).
+
+
+all() ->
+    [{group, all_tests}].
+
+groups() ->
+    [ {all_tests, [sequence], [ {group, happy_path}
+                              ]}
+    , {happy_path, [sequence],
+       [ create_3_party
+       , alice_pays_bob
+       , shutdown ]}
+    ].
+
+suite() ->
+    [].
+
+init_per_suite(Config) ->
+    aesc_fsm_SUITE:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    aesc_fsm_SUITE:end_per_suite([{symlink, "latest.aesc_htlc"} | Config]).
+
+init_per_group(_, Config) ->
+    init_per_group_(Config).
+
+init_per_group_(Config) ->
+    Node = dev1,
+    aecore_suite_utils:reinit_with_ct_consensus(Node),
+    prepare_patron(Node),
+    Alice = prep_client(?ACCOUNT_BALANCE, Node),
+    Bob = prep_client(?ACCOUNT_BALANCE, Node),
+    #{alice := Ah, bob := Bh} = prep_hub(?ACCOUNT_BALANCE, ?ACCOUNT_BALANCE, Node),
+    set_configs([ {alice, Alice}
+                , {bob, Bob}
+                , {hub_alice, Ah}
+                , {hub_bob, Bh}
+                , {roles, [alice, bob, hub_alice, hub_bob]}
+                , {port, ?PORT}
+                , {proxy, spawn_proxy()}
+                ], Config).
+
+end_per_group(_Grp, Config) ->
+    proxy_stop(Config),
+    ok.
+
+init_per_testcase(TC, Config) ->
+    Config1 = case ?config(saved_config, Config) of
+                  undefined ->
+                      Config;
+                  {_Saver, SavedConf} ->
+                      ?LOG("SavedConf = ~p", [SavedConf]),
+                      SavedConf ++ Config
+              end,
+    proxy_register(Config1),
+    aesc_fsm_SUITE:init_per_testcase(TC, Config1).
+
+end_per_testcase(_Case, Config) ->
+    proxy_unregister(Config),
+    ok.
+
+%%%===================================================================
+%%% Test state
+%%%
+%%% Note that all testcases need to return {save_config, Config}, in
+%%% order for the market data structure to carry forward through the
+%%% sequence.
+%%%===================================================================
+
+create_3_party(Cfg) ->
+    Debug = get_debug(Cfg),
+    [Alice, Bob, Ah, Bh] = [?config(R, Cfg) || R <- [alice, bob,
+                                                     hub_alice, hub_bob]],
+    %%
+    %% Alice side of the market (Variables: Cx = Client, Hx = Hub)
+    CfgA = set_configs([{responder, Ah}, {initiator, Alice}], Cfg),
+    
+    #{i := Ca, r := Ha} = _ChannelA =
+        proxy_do(fun() -> create_channel_(CfgA, #{}, Debug) end, CfgA),
+    %%
+    %% Bob side of the market
+    CfgB = set_configs([{responder, Bh}, {initiator, Bob}], Cfg),
+    #{i := Cb, r := Hb} = _ChannelB =
+        proxy_do(fun() -> create_channel_(CfgB, #{}, Debug) end, CfgB),
+    ?LOG("3-way Channel Market set up (no contract yet).", []),
+    %%
+    %% Contract for Alice
+    CreateArgsA = prepare_contract_create_args(
+                    channel_htlc, htlc_init_args(Alice), 10),
+    {Ha1, Ca1, ContractPubKeyA} =
+        proxy_do(fun() -> load_contract(CreateArgsA, Ha, Ca, CfgA) end, CfgA),
+    ?LOG("HTLC contract loaded on Alice's channel", []),
+    %%
+    %% Contract for Bob
+    CreateArgsB = prepare_contract_create_args(
+                    channel_htlc, htlc_init_args(Bob), 10),
+    {Hb1, Cb1, ContractPubKeyB} =
+        proxy_do(fun() -> load_contract(CreateArgsB, Hb, Cb, CfgB) end, CfgB),
+    ?LOG("HTLC contract loaded on Bob's channel", []),
+    {save_config, [{market, #{ encpub(Alice) => #{ client   => Ca1
+                                                 , hub      => Ha1
+                                                 , contract => ContractPubKeyA }
+                             , encpub(Bob)   => #{ client   => Cb1
+                                                 , hub      => Hb1
+                                                 , contract => ContractPubKeyB } }}
+                  ]}.
+
+alice_pays_bob(Cfg) ->
+    #{encoded_pub := AlicePub} = ?config(alice, Cfg),
+    #{encoded_pub := BobPub} = ?config(bob, Cfg),
+    Amount = 1000,
+    Fee = 100,
+    HashLock = request_hashlock(AlicePub, BobPub, Amount, Cfg),
+    ?LOG("Hashlock Res = ~p", [HashLock]),
+    SendRes = new_send(AlicePub, BobPub, Amount, Fee, HashLock, Cfg),
+    ?LOG("SendRes = ~p", [SendRes]),
+    {save_config, Cfg}.
+
+shutdown(Config) ->
+    Debug = get_debug(Config),
+    Market = ?config(market, Config),
+    ?LOG("Market = ~p", [Market]),
+    maps:fold(
+      fun(_ClientPub, #{client := C, hub := H}, ok) ->
+              ConfigX = set_configs([{responder, H}, {initiator, C}], Config),
+              proxy_do(fun() ->
+                               shutdown(C, H, ConfigX, Debug)
+                       end, ConfigX),
+              ok
+      end, ok, Market),
+    ok.
+
+htlc_init_args(Client) ->
+    ClientPub = encode_pub(Client),
+    MinimumFee = integer_to_list(?MINIMUM_FEE),
+    [ClientPub, MinimumFee].
+
+encpub(#{encoded_pub := P}) ->
+    P.
+
+%%%===================================================================
+%%% Market operations
+%%%===================================================================
+
+request_hashlock(A, B, Amount, Cfg) ->
+    #{A := ChA, B := ChB} = _Market = ?config(market, Cfg),
+    SeqBin = integer_to_binary(erlang:unique_integer([positive, monotonic])),
+    AmtBin = integer_to_binary(Amount),
+    Req = << "SND REQ ", SeqBin/binary, "\n",
+             A/binary, "\n",
+             B/binary, "\n",
+             AmtBin/binary >>,
+    ok = inband_msg_via_hub(Req, ChA, ChB, Cfg),
+    ?LOG("Inband msg send request:~n~s", [Req]),
+    %%
+    Secret = crypto:strong_rand_bytes(32),
+    HashLock = crypto:hash(sha256, Secret),
+    Rep = << "SND OK ", SeqBin/binary, "\n",
+             HashLock/binary >>,
+    ok = inband_msg_via_hub(Rep, ChB, ChA, Cfg),
+    ?LOG("Inband msg OK:~n~s", [Rep]),
+    HashLock.
+
+new_send(A, B, Amount, Fee, HashLock, Cfg) ->
+    #{A := ChA, B := ChB} = ?config(market, Cfg),
+    #{contract := ContractA, client := Ca, hub := Ha} = ChA,
+    Args = [integer_to_list(Amount), B, integer_to_list(Fee), HashLock],
+    call_contract(ContractA, channel_htlc, "new_send", Args, Amount + Fee,
+                  Ca, Ha, Cfg).
+
+inband_msg_via_hub(Msg, ChA, ChB, Cfg) ->
+    #{ client := #{fsm := FsmC}, hub := #{pub := HubPub} = Ah } = ChA,
+    #{ hub := #{fsm := FsmH}, client := #{pub := BPub} = Bc } = ChB,
+    ok = send_inband(FsmC, HubPub, Msg, Cfg),
+    ok = receive_inband(Msg, Ah),
+    ok = send_inband(FsmH, BPub, Msg, Cfg),
+    ok = receive_inband(Msg, Bc).
+
+send_inband(Fsm, Pub, Msg, Cfg) ->
+    ok = proxy_do(fun() ->
+                          rpc(dev1, aesc_fsm, inband_msg,
+                              [Fsm, Pub, Msg])
+                  end, Cfg),
+    ok.
+
+receive_inband(Msg, R) ->
+    {ok, _} = 
+        receive_from_fsm(
+          message, R, fun(#{info := #{info := M}}) when M == Msg ->
+                              ok
+                      end, 1000),
+    ok.
+    
+
+%%%===================================================================
+%%% Account preparation
+%%%===================================================================
+
+prep_client(Amount, Node) ->
+    I = prep_initiator(Amount, Node),
+    I#{encoded_pub => encode_pub(I)}.
+
+encode_pub(#{pub := Pub}) ->
+    aeser_api_encoder:encode(account_pubkey, Pub).
+
+prep_hub(AmountI, AmountR, Node) ->
+    Alice = prep_responder(AmountI, Node),
+    Bob   = prep_responder(AmountR, Node),
+    #{alice => Alice,
+      bob   => Bob}.
+
+
+shutdown(I, R, Cfg, Debug) ->
+    channel_shutdown(I, R, Cfg),
+    {ok, _} = receive_log(I, Debug),
+    {ok, _} = receive_log(R, Debug),
+    ok.
+
+%%%===================================================================
+%%% Proxy process
+%%%===================================================================
+    
+spawn_proxy() ->
+    Parent = self(),
+    spawn(fun() ->
+                  proxy_loop(#{parent => Parent})
+          end).
+
+proxy_register(Config) ->
+    Proxy = ?config(proxy, Config),
+    link(Proxy),
+    call_proxy({register, self()}, Config).
+
+proxy_unregister(Config) ->
+    Proxy = ?config(proxy, Config),
+    call_proxy({register, undefined}, Config),
+    unlink(Proxy),
+    ok.
+
+proxy_stop(Config) ->
+    Proxy = ?config(proxy, Config),
+    proxy_do(fun() -> ok end, Config),  % just checking
+    exit(Proxy, kill).
+
+proxy_do(F, Config) ->
+    call_proxy({do, F}, Config).
+
+call_proxy(Req, Config) ->
+    Proxy = ?config(proxy, Config),
+    MRef = erlang:monitor(process, Proxy),
+    Proxy ! {'$proxy_call', {self(), MRef}, Req},
+    receive
+        {MRef, Result} ->
+            erlang:demonitor(MRef),
+            Result;
+        {'DOWN', MRef, _, _, Reason} ->
+            error(Reason)
+    after 10000 ->
+            error(timeout)
+    end.
+
+proxy_loop(#{parent := Parent} = St) ->
+    receive
+        {'$proxy_call', {From, Ref}, Req} ->
+            {Reply, St1} = proxy_handle_call(Req, From, St),
+            From ! {Ref, Reply},
+            proxy_loop(St1);
+        Msg ->
+            case Parent of
+                undefined ->
+                    ct:pal("PROXY (no parent): ~p", [Msg]);
+                _ when is_pid(Parent) ->
+                    Parent ! Msg
+            end,
+            proxy_loop(St)
+    end.
+
+proxy_handle_call(Req, _From, St) ->
+    case Req of
+        {register, Pid} ->
+            {ok, St#{parent := Pid}};
+        {do, F} ->
+            {F(), St}
+    end.

--- a/apps/aechannel/test/aesc_txs_SUITE.erl
+++ b/apps/aechannel/test/aesc_txs_SUITE.erl
@@ -4773,9 +4773,11 @@ create_contract_call_payload_with_calldata(Key, ContractId, CallData, Amount) ->
         {UpdatedTrees, StateHash} =
             case maps:get(fake_solo_state_hash, Props, none) of
                 none ->
-                    Trees1 = aesc_offchain_update:apply_on_trees(Update,
-                                                                 aect_call_state_tree:prune_without_backend(Trees0),
-                                                                 OnChainTrees, Env, Round, Reserve),
+                    {_, Trees1} =
+                        aesc_offchain_update:apply_on_trees(
+                          Update,
+                          aect_call_state_tree:prune_without_backend(Trees0),
+                          OnChainTrees, Env, Round, Reserve),
                     StateHash1 = aec_trees:hash(Trees1),
                     {Trees1, StateHash1};
                 SH ->
@@ -4855,8 +4857,8 @@ apply_offchain_update(Props, Round, Update) ->
     OnChainTrees = aesc_test_utils:trees(State),
     Env = tx_env(Props),
     Reserve = maps:get(channel_reserve, Props, 0),
-    Trees = aesc_offchain_update:apply_on_trees(Update, Trees0, OnChainTrees,
-                                                Env, Round, Reserve),
+    {_, Trees} = aesc_offchain_update:apply_on_trees(Update, Trees0, OnChainTrees,
+                                                     Env, Round, Reserve),
     Props#{trees => Trees}.
 
 

--- a/apps/aecore/test/aec_test_utils.hrl
+++ b/apps/aecore/test/aec_test_utils.hrl
@@ -1,0 +1,3 @@
+-define(LOG(D, Fmt, Args), aec_test_utils:log(Fmt, Args, ?LINE, D)).
+-define(LOG(Fmt, Args), aec_test_utils:log(Fmt, Args, ?LINE, true)).
+              

--- a/apps/aefate/src/aefa_fate_code.erl
+++ b/apps/aefate/src/aefa_fate_code.erl
@@ -1,9 +1,12 @@
 -module(aefa_fate_code).
 
 -export([ encode_calldata/3
+        , encode_arg/1
         , decode_result/3 ]).
 
 -define(FD, aeb_fate_data).
+
+-include_lib("aebytecode/include/aeb_fate_data.hrl").
 
 encode_calldata(FCode, Fun, Args) when is_binary(Fun), is_list(Args) ->
     {InTypes, _} = type_sig(Fun, FCode),
@@ -26,18 +29,36 @@ encode_args(TypeArgs) ->
 %% TODO: Go through aefa_test_utils:encode/1, and include all variants
 %% that are reasonable to support here. Special-case the others in
 %% aefa_test_utils, then have it call this for the rest.
-encode_arg({Type, Val}) ->
-    case Type of
-        integer    when is_integer(Val)      -> aeb_fate_data:make_integer(Val);
-        string     when is_binary(Val)       -> aeb_fate_data:make_string(Val);
-        {bytes,S}  when byte_size(Val) =:= S -> aeb_fate_data:make_bytes(Val);
-        bits       when is_integer(Val)      -> aeb_fate_data:make_bits(Val);
-        hash       when is_binary(Val)       -> aeb_fate_data:make_hash(Val);
-        bool       when is_boolean(Val)      -> aeb_fate_data:make_boolean(Val);
-        {tuple,Es} when is_tuple(Val) -> make_tuple(Es, Val);
-        address   -> make_address(Val);
-        contract  -> make_contract(Val)
-    end.
+encode_arg(none)      -> aeb_fate_data:make_variant([0, 1], 0, {});
+encode_arg({some, X}) -> aeb_fate_data:make_variant([0, 1], 1, {encode_arg(X)});
+encode_arg({integer, Val})    when is_integer(Val) -> aeb_fate_data:make_integer(Val);
+encode_arg({string, Val})     when is_binary(Val)  -> aeb_fate_data:make_string(Val);
+encode_arg({{bytes,S}, Val})  when byte_size(Val) =:= S -> aeb_fate_data:make_bytes(Val);
+encode_arg({bytes, Val})      when is_binary(Val)       -> aeb_fate_data:make_bytes(Val);
+encode_arg({bits, Val})       when is_integer(Val)      -> aeb_fate_data:make_bits(Val);
+encode_arg({hash, Val})       when is_binary(Val)       -> aeb_fate_data:make_hash(Val);
+encode_arg({bool, Val})       when is_boolean(Val)      -> aeb_fate_data:make_boolean(Val);
+encode_arg({{tuple,Es}, Val}) when is_tuple(Val)        -> make_tuple(Es, Val);
+encode_arg({address, Val})      -> make_address(Val);
+encode_arg({contract, Val})     -> make_contract(Val);
+encode_arg({signature, Val})    -> make_signature(Val);
+encode_arg({oracle, Val})       -> make_oracle(Val);
+encode_arg({oracle_query, Val}) -> make_oracle_query(Val);
+encode_arg({channel, Val})      -> make_channel(Val);
+encode_arg({variant, Arities, Tag, Values}) ->
+    aeb_fate_data:make_variant(Arities, Tag,
+                               list_to_tuple([encode_arg(V)
+                                              || V <- tuple_to_list(Values)]));
+encode_arg(Term) when is_integer(Term) -> aeb_fate_data:make_integer(Term);
+encode_arg(Term) when is_boolean(Term) -> aeb_fate_data:make_boolean(Term);
+encode_arg(Term) when is_list(Term) -> aeb_fate_data:make_list([encode_arg(E) || E <- Term]);
+encode_arg(Term) when is_tuple(Term) ->
+    aeb_fate_data:make_tuple(list_to_tuple([encode_arg(E)
+                                            || E <- erlang:tuple_to_list(Term)]));
+encode_arg(Term) when is_map(Term) ->
+    aeb_fate_data:make_map(maps:from_list([{encode_arg(K), encode_arg(V)}
+                                           || {K,V} <- maps:to_list(Term)]));
+encode_arg(Term) when is_binary(Term) -> aeb_fate_data:make_string(Term).
 
 make_address(<<"ak_", _/binary>> = A) ->
     aeb_fate_data:make_address(aeser_api_decode(account_pubkey, A));
@@ -64,6 +85,37 @@ make_signature("sg_" ++ _ = S) ->
     aeb_fate_data:make_signature(encode_address(signature, S));
 make_signature(B) when bit_size(B) =:= 256 ->
     aeb_fate_data:make_signature(B).
+
+make_oracle(<<"ok_", _/binary>> = O) ->
+    aeb_fate_data:make_oracle(encode_address(oracle_pubkey, O));
+make_oracle("ok_" ++ _ = O) ->
+    aeb_fate_data:make_oracle(encode_address(oracle_pubkey, O));
+make_oracle(O) when is_binary(O) ->
+    aeb_fate_data:make_oracle(O);
+make_oracle(I) when is_integer(I) ->
+    aeb_fate_data:make_oracle(<<I:256>>);
+make_oracle(B) when bit_size(B) =:= 256 ->
+    aeb_fate_data:make_oracle(B);
+make_oracle(Id) when element(1, Id) =:= id ->
+    aeb_fate_data:make_oracle(encode_id(oracle, Id)).
+
+make_oracle_query(<<"ov_", _/binary>> = Q) ->
+    aeb_fate_data:make_oracle_query(encode_address(oracle_query, Q));
+make_oracle_query("ov_" ++ _ = Q) ->
+    aeb_fate_data:make_oracle_query(encode_address(oracle_query, Q));
+make_oracle_query(I) when is_integer(I) ->
+    aeb_fate_data:make_oracle_query(<<I:256>>);
+make_oracle_query(B) when bit_size(B) =:= 256 ->
+    aeb_fate_data:make_oracle_query(B).
+
+make_channel(<<"ch_", _/binary>> = C) ->
+    aeb_fate_data:make_channel(C);
+make_channel("ch_" ++ _ = C) ->
+    aeb_fate_data:make_channel(C);
+make_channel(I) when is_integer(I) ->
+    aeb_fate_data:make_channel(<<I:256>>);
+make_channel(Id) when element(1, Id) =:= id ->
+    aeb_fate_data:make_channel(encode_id(channel, Id)).
 
 encode_address(Type, S) when is_list(S); is_binary(S) ->
     B = iolist_to_binary(S),

--- a/apps/aefate/src/aefa_fate_code.erl
+++ b/apps/aefate/src/aefa_fate_code.erl
@@ -1,0 +1,93 @@
+-module(aefa_fate_code).
+
+-export([ encode_calldata/3
+        , decode_result/3 ]).
+
+-define(FD, aeb_fate_data).
+
+encode_calldata(FCode, Fun, Args) when is_binary(Fun), is_list(Args) ->
+    {InTypes, _} = type_sig(Fun, FCode),
+    aeb_fate_abi:create_calldata(binary_to_list(Fun),
+                                 encode_args(lists:zip(InTypes, Args))).
+
+decode_result(FCode, Fun, Result) ->
+    {_, RetType} = type_sig(Fun, FCode),
+    {RetType, aeb_fate_encoding:deserialize(Result)}.
+
+type_sig(Fun, FCode) ->
+    Id = aeb_fate_code:symbol_identifier(Fun),
+    Funs = aeb_fate_code:functions(FCode),
+    {_, {_, _} = Types, _} = maps:get(Id, Funs),
+    Types.
+
+encode_args(TypeArgs) ->
+    lists:map(fun encode_arg/1, TypeArgs).
+
+%% TODO: Go through aefa_test_utils:encode/1, and include all variants
+%% that are reasonable to support here. Special-case the others in
+%% aefa_test_utils, then have it call this for the rest.
+encode_arg({Type, Val}) ->
+    case Type of
+        integer    when is_integer(Val)      -> aeb_fate_data:make_integer(Val);
+        string     when is_binary(Val)       -> aeb_fate_data:make_string(Val);
+        {bytes,S}  when byte_size(Val) =:= S -> aeb_fate_data:make_bytes(Val);
+        bits       when is_integer(Val)      -> aeb_fate_data:make_bits(Val);
+        hash       when is_binary(Val)       -> aeb_fate_data:make_hash(Val);
+        bool       when is_boolean(Val)      -> aeb_fate_data:make_boolean(Val);
+        {tuple,Es} when is_tuple(Val) -> make_tuple(Es, Val);
+        address   -> make_address(Val);
+        contract  -> make_contract(Val)
+    end.
+
+make_address(<<"ak_", _/binary>> = A) ->
+    aeb_fate_data:make_address(aeser_api_decode(account_pubkey, A));
+make_address(I) when is_integer(I) ->
+    B = <<I:256>>,
+    aeb_fate_data:make_address(B);
+make_address(B) when bit_size(B) == 256 ->
+    aeb_fate_data:make_address(B);
+make_address(Id) when element(1, Id) =:= id ->
+    aeb_fate_data:make_address(encode_id(account, Id)).
+
+make_contract(<<"ct_", _/binary>> = C) ->
+    aeb_fate_data:make_contract(encode_address(contract_pubkey, C));
+make_contract("ct_" ++ _ = C) ->
+    aeb_fate_data:make_contract(encode_address(contract_pubkey, C));
+make_contract(C) when bit_size(C) == 256 ->
+    aeb_fate_data:make_contract(C);
+make_contract(I) when is_integer(I) ->
+    aeb_fate_data:make_contract(<<I:256>>).
+
+make_signature(<<"sg_", _/binary>> = S) ->
+    aeb_fate_data:make_signature(encode_address(signature, S));
+make_signature("sg_" ++ _ = S) ->
+    aeb_fate_data:make_signature(encode_address(signature, S));
+make_signature(B) when bit_size(B) =:= 256 ->
+    aeb_fate_data:make_signature(B).
+
+encode_address(Type, S) when is_list(S); is_binary(S) ->
+    B = iolist_to_binary(S),
+    try aeser_api_encoder:decode(B) of
+        {Type, Encoding} ->
+            Encoding;
+        _ -> erlang:error({bad_address_encoding, Type, S})
+    catch _:_ ->
+            erlang:error({bad_address_encoding, Type, S})
+    end.
+
+encode_id(Type, Id) ->
+    case aeser_id:specialize(Id) of
+        {Type, K}  -> K;
+        {Other, Val} ->
+            erlang:error({bad_id_type, Other, Val})
+    end.
+
+
+make_tuple(Es, Val) ->
+    aeb_fate_data:make_tuple(list_to_tuple(
+                               encode_args(lists:zip(Es, tuple_to_list(Val)))
+                               )).
+
+aeser_api_decode(Type, K) ->
+    {Type, Res} = aeser_api_encoder:decode(K),
+    Res.

--- a/apps/aefate/test/aefa_test_utils.erl
+++ b/apps/aefate/test/aefa_test_utils.erl
@@ -32,44 +32,26 @@ make_calldata(Fun, Args) ->
 %% to a Fate term, but it can not distinguish between e.g. 32-byte strings
 %% and addresses. Therfore an extra tuple layer on the erlang side for
 %% addresses and bits.
-encode({bits, Term}) when is_integer(Term) -> aeb_fate_data:make_bits(Term);
-%% TODO: check that each byte is in base58
-encode({address, B}) when is_binary(B)  -> aeb_fate_data:make_address(B);
-encode({address, I}) when is_integer(I)  -> B = <<I:256>>, aeb_fate_data:make_address(B);
 encode({address, S}) when is_list(S)  ->
+    %% The test code treats lists and binaries as semantically different
     aeb_fate_data:make_address(encode_address(account_pubkey, S));
-encode({hash, H}) when is_binary(H)  -> aeb_fate_data:make_hash(H);
+encode({address, B}) when is_binary(B) ->
+    %% This is what aefate_engine_test expects, but differs from the aefa_fate_code
+    %% implementation.
+    aeb_fate_data:make_address(B);
 encode({hash, H}) when is_list(H)  -> aeb_fate_data:make_hash(base64:decode(H));
-encode({signature, S}) when is_binary(S)  -> aeb_fate_data:make_signature(S);
 encode({signature, S}) when is_list(S)  ->
     aeb_fate_data:make_signature(encode_address(signature, S));
-encode({bytes, B}) when is_binary(B) -> aeb_fate_data:make_bytes(B);
-encode({contract, B}) when is_binary(B)  -> aeb_fate_data:make_contract(B);
-encode({contract, I}) when is_integer(I)  -> B = <<I:256>>, aeb_fate_data:make_contract(B);
 encode({contract, S}) when is_list(S)  ->
     aeb_fate_data:make_contract(encode_address(contract_pubkey, S));
-encode({oracle, B}) when is_binary(B)  -> aeb_fate_data:make_oracle(B);
-encode({oracle, I}) when is_integer(I)  -> B = <<I:256>>, aeb_fate_data:make_oracle(B);
-encode({oracle_query, B}) when is_binary(B)  -> aeb_fate_data:make_oracle_query(B);
-encode({oracle_query, I}) when is_integer(I)  -> B = <<I:256>>, aeb_fate_data:make_oracle_query(B);
 encode({oracle, S}) when is_list(S)  ->
    aeb_fate_data:make_oracle(encode_address(oracle_pubkey, S));
-encode({channel, B}) when is_binary(B)  -> aeb_fate_data:make_channel(B);
-encode({channel, I}) when is_integer(I)  -> B = <<I:256>>, aeb_fate_data:make_channel(B);
 encode({channel, S}) when is_list(S)  ->
     aeb_fate_data:make_channel(encode_address(channel, S));
 encode({variant, Arities, Tag, Values}) ->
     aeb_fate_data:make_variant(Arities, Tag, list_to_tuple([encode(V) || V <- tuple_to_list(Values)]));
-encode(none)      -> aeb_fate_data:make_variant([0, 1], 0, {});
-encode({some, X}) -> aeb_fate_data:make_variant([0, 1], 1, {encode(X)});
-encode(Term) when is_integer(Term) -> aeb_fate_data:make_integer(Term);
-encode(Term) when is_boolean(Term) -> aeb_fate_data:make_boolean(Term);
-encode(Term) when is_list(Term) -> aeb_fate_data:make_list([encode(E) || E <- Term]);
-encode(Term) when is_tuple(Term) ->
-    aeb_fate_data:make_tuple(list_to_tuple([encode(E) || E <- erlang:tuple_to_list(Term)]));
-encode(Term) when is_map(Term) ->
-    aeb_fate_data:make_map(maps:from_list([{encode(K), encode(V)} || {K,V} <- maps:to_list(Term)]));
-encode(Term) when is_binary(Term) -> aeb_fate_data:make_string(Term).
+encode(Term) ->
+    aefa_fate_code:encode_arg(Term).
 
 encode_address(Type, S) when is_list(S) ->
     B = list_to_binary(S),

--- a/test/contracts/channel_htlc.aes
+++ b/test/contracts/channel_htlc.aes
@@ -7,59 +7,64 @@ include "String.aes"
 
 contract ChannelHTLC = 
 
-  record state = { sends       : map(hash, send),
-                   receives    : map(hash, recv),
-                   client      : address,
-                   hub         : address,
-                   minimum_fee : int }
+  record state = { sends           : map(hash, send),
+                   receives        : map(hash, recv),
+                   client          : address,
+                   hub             : address,
+                   minimum_fee     : int,
+                   default_timeout : int }
 
-  datatype status = INVALID | ACTIVE | REFUNDED | COLLECTED | EXPIRED 
+  datatype status = INVALID | ACTIVE | REFUNDED | COLLECTED | EXPIRED
 
   record recv = {
     amount : int,
     hash_lock : hash,
     status    : status,
-    sender    : address }
+    sender    : address,
+    timeout   : int }
 
   record send = {
     amount    : int,
     fee       : int,
     hash_lock : hash,
     status    : status,
-    receiver  : address }
-
-  datatype event =
-    Withdraw(hash, address, address, string)
-    | Refund(hash, address, address, string)
-    | NewSwap(hash, address, address, string)
+    receiver  : address,
+    timeout   : int }
 
   entrypoint init(
-      client : address,
-      minimum_fee : int ) : state =
+      client'        : address,
+      minimum_fee'   : int,
+      default_timeout' : int ) : state =
 
-    { client      = client,
-      hub         = Call.caller,
-      minimum_fee = minimum_fee,
-      sends       = {},
-      receives    = {}
+    { client          = client',
+      hub             = Call.caller,
+      minimum_fee     = minimum_fee',
+      default_timeout = default_timeout',
+      sends           = {},
+      receives        = {}
       }
 
   // Called by the client in order to initiate a new send.
   // Before doing this, the receiver must have provided a hashed secret
   // (passed as `hash_lock`)
+  // Note that timeout' is the relative timeout
   payable stateful entrypoint new_send(
       amount' : int,
       receiver' : address,
       fee' : int,
-      hash_lock' : hash ) =
+      timeout' : int,
+      hash_lock' : hash ) : int =
 
     require( Call.caller == state.client, "Not client" )
     require( fee' >= state.minimum_fee, "Fee too low" )
     require( amount' > 0, "Invalid amount")
     require( Call.value == (amount' + fee'), "Wrong value (should be amount + fee)" )
+    require( timeout' >= 0, "Invalid timeout")
 
     // Do not include fee in id calculation
     let id : hash = generate_id(state.client, receiver', amount', hash_lock')
+
+    let abs_timeout : int = abs_timeout(timeout', state.default_timeout, Chain.block_height)
 
     require(!send_exists(id), "Send entry already exists")
 
@@ -68,19 +73,23 @@ contract ChannelHTLC =
       fee = fee',
       hash_lock = hash_lock',
       status = ACTIVE,
-      receiver = receiver' }
+      receiver = receiver',
+      timeout = abs_timeout }
 
     put(state{ sends[id] = _send })
-    generate_new_send_message(_send)
+    abs_timeout
 
   // Called by the hub on the receiver channel in order to forward
   // the send request. The `hash_lock` is the one provided by the reciever earlier
   // There is no fee here, since the fee is paid by the sender and collected by
   // the hub.
+  //
+  // Note that timeout' here is the absolute timeout
   payable stateful entrypoint new_receive(
       amount' : int,
       sender' : address,
-      hash_lock' : hash ) =
+      timeout' : int,
+      hash_lock' : hash ) : unit =
     require( Call.caller == state.hub, "Not hub" )
     require( amount' > 0, "Invalid amount" )
     require( Call.value == amount', "Wrong value (should be amount)")
@@ -93,10 +102,9 @@ contract ChannelHTLC =
             amount = amount',
             hash_lock = hash_lock',
             status = ACTIVE,
-            sender = sender' }
+            sender = sender',
+            timeout = timeout' }
     put(state{receives[id] = _recv})
-    generate_new_recv_message(_recv)
-
 
   // Called by the hub to collect the collateral + the fee
   // To be safe, the withdraw should be performed before 
@@ -104,32 +112,33 @@ contract ChannelHTLC =
            receiver'  : address,
            amount'    : int,
            hash_lock' : hash,
-           secret'    : hash ) =
+           secret'    : hash ) : unit =
     require( Call.caller == state.hub, "Unauthorized")
     let id : hash = generate_id(state.client, receiver', amount', hash_lock')
     let _send : send = state.sends[id]
     collectable(_send, secret')
     Chain.spend(state.hub, _send.amount + _send.fee)
     put(state{sends[id].status = COLLECTED})
-    generate_collect_message(secret', _send.hash_lock)
 
-  stateful payable entrypoint receive(
+  payable stateful entrypoint receive(
         sender'  : address,
         amount'  : int,
         hash_lock' : hash,
-        secret'    : hash ) =
+        secret'    : hash ) : unit =
     require( Call.caller == state.client, "Unauthorized")
     let id : hash = generate_id(sender', state.client, amount', hash_lock')
     let _recv : recv = state.receives[id]
     receivable(_recv, secret')
     Chain.spend(state.client, _recv.amount)
-    generate_receive_message(secret', _recv.hash_lock)
 
   // Called by client in order to get a refund. This will only be allowed
   // under certain circumstances.
-  stateful entrypoint refund(id : hash) =
-    require(Call.caller == state.client, "Not client")
-
+  payable stateful entrypoint refund(
+        receiver'  : address,
+        amount'    : int,
+        hash_lock' : hash ) : unit =
+    require(Call.caller == state.client, "Unauthorized")
+    let id : hash = generate_id(Call.caller, receiver', amount', hash_lock')
     let _send : send = state.sends[id]
     refundable(_send)
     
@@ -161,35 +170,26 @@ contract ChannelHTLC =
     require(send_exists(id), "SEND_NOT_FOUND")
     state.sends[id]
 
+  function abs_timeout(timeout' : int, default' : int, height' : int) : int =
+    if (timeout' == 0)
+      height' + default'
+    else
+      height' + timeout'
+
   function collectable(_send : send, secret : hash) =
-    require(is_active(_send.status), "SEND_NOT_ACTIVE")
+    require(is_active(_send.status), "NOT_ACTIVE")
     require(_send.hash_lock == Crypto.sha256(secret), "INVALID_SECRET")
+    require(Chain.block_height < _send.timeout + 1, "COLLECT_TIMEOUT")
 
   function receivable(_recv : recv, secret : hash) =
-    require(is_active(_recv.status), "RECV_NOT_ACTIVE")
+    require(is_active(_recv.status), "NOT_ACTIVE")
     require(_recv.hash_lock == Crypto.sha256(secret), "INVALID_SECRET")
+    require(Chain.block_height < _recv.timeout, "RECEIVE_TIMEOUT")
 
   function refundable(_send: send) =
-    require(is_active(_send.status), "SWAP_NOT_ACTIVE")
+    require(is_active(_send.status), "NOT_ACTIVE")
     require(state.client == Call.caller, "INVALID_SENDER")
-
-  function generate_collect_message(secret : hash, hash_lock : hash) : string =
-    concat([Bytes.to_str(secret), Bytes.to_str(hash_lock)])
-
-  function generate_receive_message(secret : hash, hash_lock : hash) : string =
-    concat([Bytes.to_str(secret), Bytes.to_str(hash_lock)])
-
-  function generate_new_send_message(_send : send) : string =
-    concat([
-      Address.to_str(_send.receiver),
-      Int.to_str(_send.amount),
-      Bytes.to_str(_send.hash_lock)])
-  
-  function generate_new_recv_message(_recv : recv) : string =
-    concat([
-      Address.to_str(_recv.sender),
-      Int.to_str(_recv.amount),
-      Bytes.to_str(_recv.hash_lock)])
+    require(Chain.block_height >= _send.timeout + 3, "NOT_YET_REFUNDABLE")
 
   function is_active(x : status) : bool =
     x == ACTIVE

--- a/test/contracts/channel_htlc.aes
+++ b/test/contracts/channel_htlc.aes
@@ -215,9 +215,8 @@ contract ChannelHTLC =
   function recieve_exists(id : hash) : bool =
     Map.member(id, state.receives)
 
-  function cc(ss : list(string)) : string =
-   switch(ss)
-    s :: ss => List.foldl(String.concat, s, ss)
+  function cc(s :: ss : list(string)) : string =
+    List.foldl(String.concat, s, ss)
 
   function concat(ss : list(string)) : string =
    cc(List.intersperse(",", ss))

--- a/test/contracts/channel_htlc.aes
+++ b/test/contracts/channel_htlc.aes
@@ -100,21 +100,30 @@ contract ChannelHTLC =
 
   // Called by the hub to collect the collateral + the fee
   // To be safe, the withdraw should be performed before 
-  stateful entrypoint collect(id : hash, secret : hash) =
+  payable stateful entrypoint collect(
+           receiver'  : address,
+           amount'    : int,
+           hash_lock' : hash,
+           secret'    : hash ) =
     require( Call.caller == state.hub, "Unauthorized")
+    let id : hash = generate_id(state.client, receiver', amount', hash_lock')
     let _send : send = state.sends[id]
-    collectable(_send, secret)
+    collectable(_send, secret')
     Chain.spend(state.hub, _send.amount + _send.fee)
     put(state{sends[id].status = COLLECTED})
-    generate_collect_message(secret, _send.hash_lock)
+    generate_collect_message(secret', _send.hash_lock)
 
   stateful payable entrypoint receive(
-        id : hash, secret : hash ) =
+        sender'  : address,
+        amount'  : int,
+        hash_lock' : hash,
+        secret'    : hash ) =
     require( Call.caller == state.client, "Unauthorized")
+    let id : hash = generate_id(sender', state.client, amount', hash_lock')
     let _recv : recv = state.receives[id]
-    receivable(_recv, secret)
+    receivable(_recv, secret')
     Chain.spend(state.client, _recv.amount)
-    generate_receive_message(secret, _recv.hash_lock)
+    generate_receive_message(secret', _recv.hash_lock)
 
   // Called by client in order to get a refund. This will only be allowed
   // under certain circumstances.

--- a/test/contracts/channel_htlc.aes
+++ b/test/contracts/channel_htlc.aes
@@ -1,0 +1,199 @@
+
+@compiler >= 6
+
+// Adapted from JellySwap's JellyHTLC for State Channel markets
+include "List.aes"
+include "String.aes"
+
+contract ChannelHTLC = 
+
+  record state = { sends       : map(hash, send),
+                   receives    : map(hash, recv),
+                   client      : address,
+                   hub         : address,
+                   minimum_fee : int }
+
+  datatype status = INVALID | ACTIVE | REFUNDED | COLLECTED | EXPIRED 
+
+  record recv = {
+    amount : int,
+    hash_lock : hash,
+    status    : status,
+    sender    : address }
+
+  record send = {
+    amount    : int,
+    fee       : int,
+    hash_lock : hash,
+    status    : status,
+    receiver  : address }
+
+  datatype event =
+    Withdraw(hash, address, address, string)
+    | Refund(hash, address, address, string)
+    | NewSwap(hash, address, address, string)
+
+  entrypoint init(
+      client : address,
+      minimum_fee : int ) : state =
+
+    { client      = client,
+      hub         = Call.caller,
+      minimum_fee = minimum_fee,
+      sends       = {},
+      receives    = {}
+      }
+
+  // Called by the client in order to initiate a new send.
+  // Before doing this, the receiver must have provided a hashed secret
+  // (passed as `hash_lock`)
+  payable stateful entrypoint new_send(
+      amount' : int,
+      receiver' : address,
+      fee' : int,
+      hash_lock' : hash ) =
+
+    require( Call.caller == state.client, "Not client" )
+    require( fee' >= state.minimum_fee, "Fee too low" )
+    require( amount' > 0, "Invalid amount")
+    require( Call.value == (amount' + fee'), "Wrong value (should be amount + fee)" )
+
+    // Do not include fee in id calculation
+    let id : hash = generate_id(state.client, receiver', amount', hash_lock')
+
+    require(!send_exists(id), "Send entry already exists")
+
+    let _send : send = { 
+      amount = amount',
+      fee = fee',
+      hash_lock = hash_lock',
+      status = ACTIVE,
+      receiver = receiver' }
+
+    put(state{ sends[id] = _send })
+    generate_new_send_message(_send)
+
+  // Called by the hub on the receiver channel in order to forward
+  // the send request. The `hash_lock` is the one provided by the reciever earlier
+  // There is no fee here, since the fee is paid by the sender and collected by
+  // the hub.
+  payable stateful entrypoint new_receive(
+      amount' : int,
+      sender' : address,
+      hash_lock' : hash ) =
+    require( Call.caller == state.hub, "Not hub" )
+    require( amount' > 0, "Invalid amount" )
+    require( Call.value == amount', "Wrong value (should be amount)")
+
+    let id : hash = generate_id(sender', state.client, amount', hash_lock')
+
+    require(!recieve_exists(id), "Recieve entry already exists")
+
+    let _recv : recv = {
+            amount = amount',
+            hash_lock = hash_lock',
+            status = ACTIVE,
+            sender = sender' }
+    put(state{receives[id] = _recv})
+    generate_new_recv_message(_recv)
+
+
+  // Called by the hub to collect the collateral + the fee
+  // To be safe, the withdraw should be performed before 
+  stateful entrypoint collect(id : hash, secret : hash) =
+    require( Call.caller == state.hub, "Unauthorized")
+    let _send : send = state.sends[id]
+    collectable(_send, secret)
+    Chain.spend(state.hub, _send.amount + _send.fee)
+    put(state{sends[id].status = COLLECTED})
+    generate_collect_message(secret, _send.hash_lock)
+
+  stateful payable entrypoint receive(
+        id : hash, secret : hash ) =
+    require( Call.caller == state.client, "Unauthorized")
+    let _recv : recv = state.receives[id]
+    receivable(_recv, secret)
+    Chain.spend(state.client, _recv.amount)
+    generate_receive_message(secret, _recv.hash_lock)
+
+  // Called by client in order to get a refund. This will only be allowed
+  // under certain circumstances.
+  stateful entrypoint refund(id : hash) =
+    require(Call.caller == state.client, "Not client")
+
+    let _send : send = state.sends[id]
+    refundable(_send)
+    
+    Chain.spend(state.client, _send.amount)
+    Chain.spend(state.hub, _send.fee)
+
+    put(state{ sends[id].status = REFUNDED })
+
+
+  entrypoint get_send_status(id : hash) : status =
+    let _send : send = state.sends[id]
+    _send.status
+
+  entrypoint get_many_send_status(ids : list(hash)) : list(status) =
+    List.map((id) => get_send_status(id), ids)
+
+  entrypoint generate_id(sender : address, receiver : address,
+   amount : int, hash_lock : hash) : hash =
+    let packed_string : string = 
+     cc([
+       Address.to_str(sender),
+       Address.to_str(receiver),
+       Int.to_str(amount),
+       Bytes.to_str(hash_lock)])
+    
+    Crypto.sha256(packed_string)
+
+  entrypoint get_send(id : hash) : send =
+    require(send_exists(id), "SEND_NOT_FOUND")
+    state.sends[id]
+
+  function collectable(_send : send, secret : hash) =
+    require(is_active(_send.status), "SEND_NOT_ACTIVE")
+    require(_send.hash_lock == Crypto.sha256(secret), "INVALID_SECRET")
+
+  function receivable(_recv : recv, secret : hash) =
+    require(is_active(_recv.status), "RECV_NOT_ACTIVE")
+    require(_recv.hash_lock == Crypto.sha256(secret), "INVALID_SECRET")
+
+  function refundable(_send: send) =
+    require(is_active(_send.status), "SWAP_NOT_ACTIVE")
+    require(state.client == Call.caller, "INVALID_SENDER")
+
+  function generate_collect_message(secret : hash, hash_lock : hash) : string =
+    concat([Bytes.to_str(secret), Bytes.to_str(hash_lock)])
+
+  function generate_receive_message(secret : hash, hash_lock : hash) : string =
+    concat([Bytes.to_str(secret), Bytes.to_str(hash_lock)])
+
+  function generate_new_send_message(_send : send) : string =
+    concat([
+      Address.to_str(_send.receiver),
+      Int.to_str(_send.amount),
+      Bytes.to_str(_send.hash_lock)])
+  
+  function generate_new_recv_message(_recv : recv) : string =
+    concat([
+      Address.to_str(_recv.sender),
+      Int.to_str(_recv.amount),
+      Bytes.to_str(_recv.hash_lock)])
+
+  function is_active(x : status) : bool =
+    x == ACTIVE
+
+  function send_exists(id : hash) : bool =
+    Map.member(id, state.sends)
+
+  function recieve_exists(id : hash) : bool =
+    Map.member(id, state.receives)
+
+  function cc(ss : list(string)) : string =
+   switch(ss)
+    s :: ss => List.foldl(String.concat, s, ss)
+
+  function concat(ss : list(string)) : string =
+   cc(List.intersperse(",", ss))

--- a/test/contracts/channel_htlc.aes
+++ b/test/contracts/channel_htlc.aes
@@ -14,7 +14,7 @@ contract ChannelHTLC =
                    minimum_fee     : int,
                    default_timeout : int }
 
-  datatype status = INVALID | ACTIVE | REFUNDED | COLLECTED | EXPIRED
+  datatype status = INVALID | ACTIVE | REFUNDED | COLLECTED
 
   record recv = {
     amount : int,
@@ -89,7 +89,7 @@ contract ChannelHTLC =
       amount' : int,
       sender' : address,
       timeout' : int,
-      hash_lock' : hash ) : unit =
+      hash_lock' : hash ) : hash =
     require( Call.caller == state.hub, "Not hub" )
     require( amount' > 0, "Invalid amount" )
     require( Call.value == amount', "Wrong value (should be amount)")
@@ -105,6 +105,7 @@ contract ChannelHTLC =
             sender = sender',
             timeout = timeout' }
     put(state{receives[id] = _recv})
+    id
 
   // Called by the hub to collect the collateral + the fee
   // To be safe, the withdraw should be performed before 
@@ -130,6 +131,7 @@ contract ChannelHTLC =
     let _recv : recv = state.receives[id]
     receivable(_recv, secret')
     Chain.spend(state.client, _recv.amount)
+    put(state{ receives[id].status = COLLECTED })
 
   // Called by client in order to get a refund. This will only be allowed
   // under certain circumstances.
@@ -147,6 +149,14 @@ contract ChannelHTLC =
 
     put(state{ sends[id].status = REFUNDED })
 
+  // Called by the hub in order to get a refund on the collateral.
+  // This will only be allowed after Timeout + 3 blocks
+  payable stateful entrypoint refund_receive(
+        id' : hash ) : unit =
+    let _recv: recv = state.receives[id']
+    refundable_receive(_recv)
+    Chain.spend(state.hub, _recv.amount)
+    put(state{ receives[id'].status = REFUNDED })
 
   entrypoint get_send_status(id : hash) : status =
     let _send : send = state.sends[id]
@@ -188,8 +198,13 @@ contract ChannelHTLC =
 
   function refundable(_send: send) =
     require(is_active(_send.status), "NOT_ACTIVE")
-    require(state.client == Call.caller, "INVALID_SENDER")
+    require(state.client == Call.caller, "UNAUTHORIZED")
     require(Chain.block_height >= _send.timeout + 3, "NOT_YET_REFUNDABLE")
+
+  function refundable_receive(_recv: recv) =
+    require(is_active(_recv.status), "NOT_ACTIVE")
+    require(state.hub == Call.caller, "UNAUTHORIZED")
+    require(Chain.block_height >= _recv.timeout + 3, "NOT_YET_REFUNDABLE")
 
   function is_active(x : status) : bool =
     x == ACTIVE


### PR DESCRIPTION
See issue #3745 

This PR implements a State Channel HTLC contract and a test suite that runs through some scenarios.

The setup looks something like this:
```
                         +---------------------------------------------+                
                         |   Hub                                       |                
                         |                                             |                
                         |       +-+                         +-+       |                
                         |       |-+                         +|+       |                
                         +-------/----------------------------\--------+                
                                |                              |                        
                                /                              |                        
                               |                               \                        
                               /                                |                       
                              |                                 \                       
       +----------------------/--+                           +---|---------------------+
       | Alice              +|+  |                           | +-|                Bob  |
       |                    +-+  |                           | +-+                     |
       |                         |                           |                         |
       +-------------------------+                           +-------------------------+
```
When `Alice` wants to send tokens to `Bob`, she first sends a request via a generic message on the `Alice-Hub` channel. The request is forwarded by the `Hub` to `Bob` on the `Bob-Hub` channel. `Bob` generates a random secret, pairs it with the specifics of the transfer request, then hashes the result, producing a `hash_lock` value. This is passed back to `Alice` via generic message, forwarded by the `Hub`.

`Alice` then calls `new_send()` method of the HTLC contract. The `Hub` is automatically notified, as it is asked to co-sign. The `Hub` then performas a corresponding `new_receive()` call on the `Bob-Hub` channel. `Bob` retrieves the amount by passing the secret as a contract call argument to `receive()`. The `Hub` gets the secret in the co-signing request, and can then get its collateral back via a `collect()` call on the `Alice-Hub` channel.

A `timeout` parameter gives a window in which `Bob` can collect the amount. After `timeout + 3`, `Alice` (and `Hub`) can reclaim the amount (`Hub` will still get the specified fee from `Alice`). The timeout limits are staggered in order to avoid exploits via race conditions.

All contract calls are force-progressable on-chain, so for example, the `Hub` cannot deny a refund to `Alice` if the timeout has expired and the amount hasn't been collected. Likewise, `Alice` cannot keep `Hub` from collecting the amount.