### PR TITLE
Fully remove txs during rollback

### DIFF
--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -130,6 +130,7 @@ do_rollback(ForkPoint, Height, TopHeight) ->
     do_rollback_(ForkPoint, Height, TopHeight).
 
 do_rollback_(ForkPoint, Height, TopHeight) ->
+    lager:debug("Perform rollback from ~p to ~p", [TopHeight, Height]),
     ensure_gc_disabled(),
     {value, FPHeader} = aec_db:find_header(ForkPoint),
     SafetyMargin = 1000, %% Why not?
@@ -152,9 +153,12 @@ remove_tx_locations(Hash) ->
         none ->
             ok;
         {value, TxHashes} ->
-            [aec_db:remove_tx_location(TxHash) || TxHash <- TxHashes],
+            lists:foreach(fun remove_tx/1, TxHashes),
             ok
     end.
+
+remove_tx(TxHash) ->
+    aec_db:remove_tx(TxHash).
 
 ensure_gc_disabled() ->
     case aec_db_gc:config() of

--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -55,7 +55,8 @@
         , key_header_difficulty/1 ]).
 
 -export([ get_whitelist/0
-        , rollback/1 ]).
+        , rollback/1
+        , rollback_to_hash/1 ]).
 
 -ifdef(TEST).
 -export([load_whitelist/0]).
@@ -121,32 +122,69 @@ rollback(Height) ->
     F = fun() ->
                 TopHeight = aec_chain:top_height(),
                 {ok, ForkPoint} = aec_chain_state:get_key_block_hash_at_height(Height),
-                do_rollback_(ForkPoint, Height, TopHeight)
+                do_rollback_(ForkPoint, key, Height, TopHeight)
+        end,
+    aec_db:ensure_activity(sync_dirty, F).
+
+rollback_to_hash(Hash) ->
+    F = fun() ->
+                TopHeight = aec_chain:top_height(),
+                case aec_chain:get_header(Hash) of
+                    none ->
+                        {error, hash_not_found};
+                    {ok, Hdr} ->
+                        Type = aec_headers:type(Hdr),
+                        Height = aec_headers:height(Hdr),
+                        do_rollback_(Hash, Type, Height, TopHeight)
+                end
         end,
     aec_db:ensure_activity(sync_dirty, F).
 
 do_rollback(ForkPoint, Height, TopHeight) ->
     lager:info("Jumping to the community fork", []),
-    do_rollback_(ForkPoint, Height, TopHeight).
+    aec_db:ensure_activity(sync_dirty,
+                           fun() ->
+                                   do_rollback_(ForkPoint, key, Height, TopHeight)
+                           end).
 
-do_rollback_(ForkPoint, Height, TopHeight) ->
+do_rollback_(ForkPoint, Type, Height, TopHeight) ->
     lager:debug("Perform rollback from ~p to ~p", [TopHeight, Height]),
     ensure_gc_disabled(),
     {value, FPHeader} = aec_db:find_header(ForkPoint),
     SafetyMargin = 1000, %% Why not?
-    aec_db:ensure_activity(sync_dirty, fun() ->
-        [begin
-             [begin
-                  Del = element(2, T),
-                  ok = remove_tx_locations(Del),
-                  ok = mnesia:delete(aec_headers, Del, write),
-                  ok = mnesia:delete(aec_blocks, Del, write),
-                  ok = mnesia:delete(aec_block_state, Del, write)
-              end || T <- mnesia:index_read(aec_headers, H, height)]
-         end || H <- lists:seq(Height+1, TopHeight+SafetyMargin)],
-        aec_db:write_top_block_node(ForkPoint, FPHeader)
-      end),
+    FromHeight = case Type of
+                     micro -> Height;
+                     key   -> Height + 1
+                 end,
+    lists:foreach(
+      fun(H) ->
+              roll_back_height_(H, Height, ForkPoint, Type)
+      end, lists:seq(FromHeight, TopHeight+SafetyMargin)),
+      aec_db:write_top_block_node(ForkPoint, FPHeader),
     ok.
+
+roll_back_height_(H, H, Hash, micro) ->
+    {ok, #{micro_blocks := MBs}} = aec_chain:get_generation_by_height(H, forward),
+    MBHashes = [ok(aec_blocks:hash_internal_representation(B)) || B <- MBs],
+    MBs1 = micros_after_hash(MBHashes, Hash),
+    lists:foreach(fun remove_block/1, MBs1);
+roll_back_height_(CurH, _Height, _ForkPoint, _Type) ->
+    lists:foreach(fun remove_block/1,
+                  [element(2,T) ||
+                      T <- mnesia:index_read(aec_headers, CurH, height)]).
+
+ok({ok, Res}) -> Res.
+
+micros_after_hash([H|T], H) ->
+    T;
+micros_after_hash([_|T], H) ->
+    micros_after_hash(T, H).
+
+remove_block(Hash) ->
+    ok = remove_tx_locations(Hash),
+    ok = mnesia:delete(aec_headers, Hash, write),
+    ok = mnesia:delete(aec_blocks, Hash, write),
+    ok = mnesia:delete(aec_block_state, Hash, write).
 
 remove_tx_locations(Hash) ->
     case aec_db:find_block_tx_hashes(Hash) of

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -64,6 +64,7 @@
 %% Location of chain transactions
 -export([ add_tx_location/2
         , add_tx/1
+        , remove_tx/1
         , add_tx_hash_to_mempool/1
         , is_in_tx_pool/1
         , find_tx_location/1
@@ -983,8 +984,7 @@ add_tx_location(STxHash, BlockHash) when is_binary(STxHash),
        [{aec_tx_location, STxHash}]).
 
 remove_tx_location(TxHash) when is_binary(TxHash) ->
-    ?t(mnesia:delete({aec_tx_location, TxHash}),
-       [{aec_tx_location, TxHash}]).
+    ?t(mnesia:delete({aec_tx_location, TxHash})).
 
 find_tx_location(STxHash) ->
     ?t(case mnesia:read(aec_tx_location, STxHash) of
@@ -1016,6 +1016,13 @@ find_tx_with_location(STxHash) ->
                        {BlockHash, aetx_sign:from_db_format(DBSTx)}
                end;
            [] -> none
+       end).
+
+remove_tx(TxHash) ->
+    ?t(begin
+           remove_tx_from_mempool(TxHash),
+           remove_tx_location(TxHash),
+           mnesia:delete({aec_signed_tx, TxHash})
        end).
 
 add_tx(STx) ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1020,7 +1020,6 @@ find_tx_with_location(STxHash) ->
 
 remove_tx(TxHash) ->
     ?t(begin
-           remove_tx_from_mempool(TxHash),
            remove_tx_location(TxHash),
            mnesia:delete({aec_signed_tx, TxHash})
        end).

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -491,7 +491,6 @@ tx_pool_test_() ->
                PK = new_pubkey(),
                MaxGas = aec_governance:block_gas_limit(),
                TopBlockHash = aec_chain:top_block_hash(),
-               TopHeight = aec_chain:top_height(),
                STx1 = a_signed_tx(PK, me, Nonce1=1, _Fee1=20000),
                ?assertEqual(ok, aec_tx_pool:push(STx1)),
                ?assertEqual([], aec_tx_pool:peek_visited()),

--- a/apps/aecore/test/aecore_txs_SUITE.erl
+++ b/apps/aecore/test/aecore_txs_SUITE.erl
@@ -343,7 +343,7 @@ rollback_releases_tx(Config) ->
            "~s~n"
            "=========================================", [N1RBCmdRes]),
     TopHeight = rpc:call(N1, aec_chain, top_height, []),
-    none = rpc:call(N1, aec_db, find_tx_location, [TxHash]),
+    not_found = rpc:call(N1, aec_db, find_tx_location, [TxHash]),
     {ok,_,_} = aecore_suite_utils:start_node(dev2, Config),
     aecore_suite_utils:connect(N2),
     ok.

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -879,7 +879,7 @@ init_per_testcase(_Case, Config) ->
 init_per_testcase_all(Config) ->
     [{_, Node} | _] = ?config(nodes, Config),
     aecore_suite_utils:mock_mempool_nonce_offset(Node, 100),
-    SwaggerVsn = proplists:get_value(swagger_version, Config),
+    SwaggerVsn = proplists:get_value(swagger_version, Config, oas3),
     aecore_suite_utils:use_swagger(SwaggerVsn),
     [{tc_start, os:timestamp()} | Config].
 

--- a/apps/aeutils/priv/db_rollback
+++ b/apps/aeutils/priv/db_rollback
@@ -92,7 +92,7 @@ check_block_hash(Hash, Node, St) ->
                       end,
             HdrType = aec_headers:type(Hdr),
             St#{ from => #{ height  => HdrHeight
-                          , type    => Type
+                          , type    => HdrType
                           , hash    => DecHash
                           , header  => Hdr }};
         error ->
@@ -105,8 +105,9 @@ do_rollback(Spec, Node, _Opts) ->
     PrevMode = rpc:call(Node, aeu_ext_scripts, ensure_mode, [maintenance]),
     try
         Res= case Spec of
-                 #{mode := hash, from := #{ hash := Hash }} ->
-                     rpc:call(Node, aec_consensus_bitcoin_ng, rollback_to_hash, [Hash]);
+                 #{mode := hash, from := #{ type := Type, hash := Hash }} ->
+                     rpc:call(Node, aec_consensus_bitcoin_ng, rollback_to_hash,
+                              [Type, Hash]);
                  _ ->
                      rpc:call(Node, aec_consensus_bitcoin_ng, rollback, [Height])
              end,

--- a/apps/aeutils/priv/db_rollback
+++ b/apps/aeutils/priv/db_rollback
@@ -15,7 +15,7 @@ args() ->
     [ #{ name => height, short => $h, long => "-height"   , required => false,
          type => int   , help => "Chain height, from which to start deleting"}
     , #{ name => hash  , short => $b, long => "-blockhash", required => false,
-         type => string, help => "Keyblock hash, from which to start deleting"}
+         type => string, help => "Block hash, from which to start deleting"}
     , #{ name => whitelist, short => $w, long => "-whitelist", required => false,
          type => boolean, help => "Roll back based on contents of whitelist",
          default => false }
@@ -48,49 +48,83 @@ rollback(Node, #{opts := Opts}) ->
                         undefined ->
                             abort("Could not rollback from whitelist", []);
                         {H, Hdr} ->
-                            do_rollback(St#{from => #{ height => H
-                                                     , header => Hdr }}, Node, Opts)
+                            do_rollback(St#{ mode => height
+                                           , from => #{ height => H
+                                                      , header => Hdr }}, Node, Opts)
                     end
             end;
+        #{height := H, hash := Hash} ->
+            case check_block_hash(Hash, Node, St#{ mode => height }) of
+                #{from := #{height := H1}} when H1 =/= H ->
+                    abort("Blockhash height and given height do not match");
+                St1 ->
+                    do_rollback(St1, Node, Opts)
+            end;
         #{height := H} ->
-            do_rollback(state_at_height(Node, H, St), Node, Opts);
+            do_rollback(state_at_height(Node, H, St#{mode => height}), Node, Opts);
         #{hash := Hash} ->
-            case aeser_api_encoder:safe_decode(key_block_hash, Hash) of
-                {error, _} ->
-                    abort("Specified hash is not a valid keyblock hash");
-                {ok, DecHash} ->
-                    case rpc:call(Node, aec_chain, get_header, [DecHash]) of
-                        {ok, Hdr} ->
-                            HdrHeight = aec_headers:height(Hdr),
-                            Type = aec_headers:type(Hdr),
-                            case Type of
-                                key ->
-                                    St1 = St#{ from => #{ height  => HdrHeight
-                                                        , header  => Hdr }},
-                                    do_rollback(St1, Node, Opts);
-                                micro ->
-                                    abort("Cannot roll back to a microblock")
-                            end;
-                        error ->
-                            abort("Cannot find specified hash")
-                    end
-            end
+            St1 = check_block_hash(Hash, Node, St#{ mode => hash }),
+            do_rollback(St1, Node, Opts)
+    end.
+
+
+check_block_hash(Hash, Node, St) ->
+    NotValidHash = fun() -> abort("Specified hash is not a valid block hash") end,
+    {Type, DecHash} =
+        try aeser_api_encoder:decode(list_to_binary(Hash)) of
+            {T, H} when T == key_block_hash;
+                        T == micro_block_hash ->
+                {T, H};
+            Other ->
+                abort("Decode result: ~p", [Other]),
+                NotValidHash()
+        catch
+            error:DecErr ->
+                abort("Decode failed with ~p (Hash=~p)", [DecErr, Hash]),
+                NotValidHash()
+        end,
+    case rpc:call(Node, aec_chain, get_header, [DecHash]) of
+        {ok, Hdr} ->
+            HdrHeight = aec_headers:height(Hdr),
+            HdrType = case Type of
+                          micro_block_hash -> micro;
+                          key_block_hash   -> key
+                      end,
+            HdrType = aec_headers:type(Hdr),
+            St#{ from => #{ height  => HdrHeight
+                          , type    => Type
+                          , hash    => DecHash
+                          , header  => Hdr }};
+        error ->
+            abort("Cannot find specified hash")
     end.
 
 do_rollback(Spec, Node, _Opts) ->
     #{ from := #{ height := Height }} = Spec,
     io:fwrite("Will rollback: ~p~n", [Spec]),
     PrevMode = rpc:call(Node, aeu_ext_scripts, ensure_mode, [maintenance]),
-    Res = rpc:call(Node, aec_consensus_bitcoin_ng, rollback, [Height]),
-    io:fwrite(standard_io, "Rollback to height ~p complete: ~p~n", [Height, Res]),
-    ok = rpc:call(Node, aeu_ext_scripts, restore_mode, [PrevMode]),
+    try
+        Res= case Spec of
+                 #{mode := hash, from := #{ hash := Hash }} ->
+                     rpc:call(Node, aec_consensus_bitcoin_ng, rollback_to_hash, [Hash]);
+                 _ ->
+                     rpc:call(Node, aec_consensus_bitcoin_ng, rollback, [Height])
+             end,
+        io:fwrite(standard_io, "Rollback complete. Height: ~p, Res: ~p~n", [Height, Res])
+    after
+        ok = rpc:call(Node, aeu_ext_scripts, restore_mode, [PrevMode])
+    end,
     ok.
 
 state_at_height(_Node, H, #{ top_height := TopHeight }) when H > TopHeight ->
     abort("Rollback height (~p) exceeds current top height (~p)", [H, TopHeight]);
 state_at_height(Node, H, St) ->
+    Hdr = header_by_height(Node, H),
+    Hash = aec_headers:hash_header(Hdr),
     St#{ from => #{ height => H
-                  , header => header_by_height(Node, H) }}.
+                  , hash   => Hash
+                  , type   => key
+                  , header => Hdr }}.
 
 abort(Str) ->
     abort(Str, []).


### PR DESCRIPTION
See issue #3749 - this is another attempt at solving the issue.

The transactions need to be fully removed. Otherwise, the tx_pool will detect that the tx was present before, and may deny re-entry (configurable).

Also note that if an action should be completely reverted by rollback (e.g. in dev mode), it's not enough to save the current height, perform the action and then roll back to the saved height. If the generation at the saved height is still open, the action may well remain on-chain even after the rollback. Currently, the rollback takes only whole generations.

So, save the current height, then make sure to post a new keyblock to ensure that the reversible actions are posted at `height + 1`.