### PR TITLE
Allow dev-mode on all protocols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ edoc: VERSION
 $(CT_TARGETS):
 	@KIND=test \
 	SYSCONFIG=config/test-$(patsubst ct-%,%,$@).config \
+	PROTOCOL=$(patsubst ct-%,%,$@) \
 	AETERNITY_TESTCONFIG_DB_BACKEND=mnesia \
 	$(MAKE) internal-ct
 

--- a/apps/aecore/src/aec_consensus_on_demand.erl
+++ b/apps/aecore/src/aec_consensus_on_demand.erl
@@ -192,7 +192,7 @@ genesis_raw_header() ->
         0,
         0,
         default,
-        ?IRIS_PROTOCOL_VSN).
+        ?ROMA_PROTOCOL_VSN).
 genesis_difficulty() -> 0.
 
 key_header_for_sealing(Header) ->

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -160,7 +160,15 @@ protocols_from_network_id(<<"local_ceres_testnet">>) ->
      , ?CERES_PROTOCOL_VSN     => 1
      };
 protocols_from_network_id(<<"ae_dev">>) ->
-    #{ ?IRIS_PROTOCOL_VSN => 0 };
+    case aeu_env:user_map_or_env([<<"chain">>, <<"hard_forks">>], aecore, hard_forks, undefined) of
+        undefined ->
+            #{ ?ROMA_PROTOCOL_VSN => 0
+             , ?IRIS_PROTOCOL_VSN => 1 };
+        M when is_map(M) ->
+            maps:fold(fun(K, V, Acc) ->
+                              Acc#{binary_to_integer(K) => V}
+                      end, #{}, M)
+    end;
 protocols_from_network_id(_ID) ->
     case aeu_env:user_map_or_env([<<"chain">>, <<"hard_forks">>], aecore, hard_forks, undefined) of
         undefined ->

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -591,8 +591,15 @@ sign_on_node(Id, Tx, SignHash) ->
     sign_on_node(node_tuple(Id), Tx, SignHash).
 
 forks() ->
-    Protocol = list_to_binary(os:getenv("PROTOCOL")),
-    NetworkId = <<"local_", Protocol/binary, "_testnet">>,
+    NetworkId =
+        case os:getenv("PROTOCOL") of
+            false ->
+                {ok, NId} = application:get_env(aecore, network_id),
+                NId;
+            P ->
+                Protocol = list_to_binary(P),
+                <<"local_", Protocol/binary, "_testnet">>
+        end,
     aec_hard_forks:protocols_from_network_id(NetworkId).
 
 latest_fork_height() ->

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -185,6 +185,7 @@ create_config(Node, CTConfig, CustomConfig, Options) ->
         Backend ->
             #{<<"chain">> => #{<<"db_backend">> => binary:list_to_bin(Backend)}}
     end,
+    Forks = #{ <<"chain">> => #{<<"hard_forks">> => forks()}},
     NodeCfgPath = node_config_dir(Node, CTConfig),
     ok = filelib:ensure_dir(NodeCfgPath),
     MergedCfg = maps_merge(default_config(Node, CTConfig), CustomConfig),
@@ -208,7 +209,8 @@ create_config(Node, CTConfig, CustomConfig, Options) ->
                                  }
                               })
                  end,
-    Config = config_apply_options(Node, MergedCfg3, Options),
+    MergedCfg4 = maps_merge(MergedCfg3, Forks),
+    Config = config_apply_options(Node, MergedCfg4, Options),
     write_keys(Node, Config),
     write_config(NodeCfgPath, Config).
 
@@ -589,9 +591,9 @@ sign_on_node(Id, Tx, SignHash) ->
     sign_on_node(node_tuple(Id), Tx, SignHash).
 
 forks() ->
-    Vs = aec_hard_forks:sorted_protocol_versions(),
-    Hs = lists:seq(0, (length(Vs) - 1)),
-    maps:from_list(lists:zip(Vs, Hs)).
+    Protocol = list_to_binary(os:getenv("PROTOCOL")),
+    NetworkId = <<"local_", Protocol/binary, "_testnet">>,
+    aec_hard_forks:protocols_from_network_id(NetworkId).
 
 latest_fork_height() ->
     lists:max(maps:values(forks())).

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -591,10 +591,8 @@ suite() ->
     [].
 
 init_per_suite(Config) ->
-    Forks = aecore_suite_utils:forks(),
     DefCfg = #{<<"chain">> =>
-                   #{<<"persist">> => false,
-                     <<"hard_forks">> => Forks},
+                   #{<<"persist">> => false},
                <<"mining">> =>
                    #{<<"micro_block_cycle">> => 1,
                      <<"name_claim_bid_timeout">> => 0 %% NO name auctions

--- a/docs/release-notes/next/dev_mode_on_different_protocols.md
+++ b/docs/release-notes/next/dev_mode_on_different_protocols.md
@@ -1,0 +1,3 @@
+* Improve dev-mode to allow running it on protocols beyond `iris`. `iris` is
+  still the default one but if the user wants to, they can define different
+  hard fork heights.


### PR DESCRIPTION
`dev-mode` used to work only on `iris` hard fork.

From this PR - if there is a hard forks set in the config - this is being used; otherwise it uses height 0 for `roma` and then automatically jumps to `iris` on height 1.

Some small cleanup happened along the way.