### PR TITLE
Cli peers

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -313,9 +313,11 @@ get_connection(PeerId) ->
 %--- UTILITY FUNCTIONS ---------------------------------------------------------
 
 %% @doc Parses a peer URI to a peer info map.
--spec parse_peer_address(binary() | string())
+-spec parse_peer_address(binary()| string())
     -> {ok, aec_peer:info()} | {error, term()}.
-parse_peer_address(PeerAddress) ->
+parse_peer_address(PeerAddress) when is_list(PeerAddress) ->
+    parse_peer_address(list_to_binary(PeerAddress));
+parse_peer_address(PeerAddress) when is_binary(PeerAddress) ->
     case uri_string:parse(PeerAddress) of
         #{scheme := <<"aenode">>, host := Host, userinfo := EncPubKey, port := Port} ->
             case aeser_api_encoder:safe_decode(peer_pubkey, to_binary(EncPubKey)) of

--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -313,7 +313,7 @@ get_connection(PeerId) ->
 %--- UTILITY FUNCTIONS ---------------------------------------------------------
 
 %% @doc Parses a peer URI to a peer info map.
--spec parse_peer_address(binary()| string())
+-spec parse_peer_address(binary() | string())
     -> {ok, aec_peer:info()} | {error, term()}.
 parse_peer_address(PeerAddress) when is_list(PeerAddress) ->
     parse_peer_address(list_to_binary(PeerAddress));

--- a/apps/aecore/test/aecore_admin_cli_SUITE.erl
+++ b/apps/aecore/test/aecore_admin_cli_SUITE.erl
@@ -91,7 +91,7 @@ init_per_suite(Config0) ->
         "admin: unrecognised argument: --help\n"
         "usage: admin  {peers|tx_pool}\n\n"
         "Subcommands:\n"
-        "  peers   Peer's pool commands\n"
+        "  peers   Peer pool commands\n"
         "  tx_pool Transaction pool commands\n",
     ExpectedRes = Res,
     %% mine keyblocks so the miner receives their first reward and have some

--- a/apps/aeutils/priv/admin
+++ b/apps/aeutils/priv/admin
@@ -93,7 +93,7 @@ tx_pool() ->
                 } }.
 
 peers() ->
-    #{ help => "Peer's pool commands"
+    #{ help => "Peer pool commands"
      , commands =>
         #{ "list" =>
             #{ help => "Inpsect peers"

--- a/apps/aeutils/priv/admin
+++ b/apps/aeutils/priv/admin
@@ -383,7 +383,7 @@ block_peer(Node, #{'address' := PeerAddress} = ArgsList) ->
             io:fwrite("Ok.~n", []),
             erlang:halt(0);
         {error, _E} ->
-            throw({decode_error, peer_id})
+            throw({decode_error, address})
     end.
 
 unblock_peer(Node, #{'peer_id' := EncPeerPubkey} = ArgsList) ->

--- a/apps/aeutils/priv/admin
+++ b/apps/aeutils/priv/admin
@@ -18,6 +18,7 @@
         , list_unverified_peers/2
         , list_blocked_peers/2
         , add_peer/2
+        , remove_peer/2
         ]).
 
 
@@ -122,11 +123,25 @@ peers() ->
                 }
             }
         , "add" =>
-            #{ help => "List connected peers"
+            #{ help => "Add a peer"
               , handler => {fun add_peer/2, not_used}
               , arguments => [#{ name => address
                                , type => string
-                               , help => "The address of the peer"
+                               , help => "The address of the peer: aenode://<peer pubkey>@<host>:<port>"
+                               },
+                              #{ name => trusted 
+                              , long => "-trusted"
+                              , type => boolean
+                              , help => "If the peer is trusted"
+                              , short => $c
+                              , default => false},
+                              timeout_arg()]}
+        , "remove" =>
+            #{ help => "Remove a peer"
+              , handler => {fun remove_peer/2, not_used}
+              , arguments => [#{ name => peer_id 
+                               , type => string
+                               , help => "The peer id"
                                },
                               timeout_arg()]}
         }
@@ -316,10 +331,17 @@ format_peer_info(#{ pubkey  := Pubkey
     io_lib:format("aenode://~s@~s:~B", [aeser_api_encoder:encode(peer_pubkey, Pubkey),
                                Host, Port]).
 
-add_peer(Node, #{'address' := PeerAddress} = ArgsList) ->
+add_peer(Node, #{'address' := PeerAddress, 'trusted' := Trusted} = ArgsList) ->
     case aec_peers:parse_peer_address(PeerAddress) of
         {ok, PeerInfo} ->
-            ok = rpc(Node, aec_peers, add_peers, [undefined, PeerInfo], ArgsList),
+            case Trusted of
+                false ->
+                    ok = rpc(Node, aec_peers, add_peers, [undefined, PeerInfo],
+                             ArgsList);
+                true ->
+                    ok = rpc(Node, aec_peers, add_trusted, [PeerInfo],
+                             ArgsList)
+            end,
             io:fwrite("Ok.~n", []),
             erlang:halt(0);
         {error, _} ->
@@ -327,3 +349,13 @@ add_peer(Node, #{'address' := PeerAddress} = ArgsList) ->
     end,
     ok.
 
+remove_peer(Node, #{'peer_id' := EncPeerPubkey} = ArgsList) ->
+    case aeser_api_encoder:safe_decode(peer_pubkey, EncPeerPubkey) of
+        {ok, PeerPubkey} ->
+            ok = rpc(Node, aec_peers, del_peer, [PeerPubkey],
+                      ArgsList),
+            io:fwrite("Ok.~n", []),
+            erlang:halt(0);
+        {error, _} ->
+            throw({decode_error, peer_id})
+    end.

--- a/apps/aeutils/priv/admin
+++ b/apps/aeutils/priv/admin
@@ -117,7 +117,7 @@ peers() ->
                                     , timeout_arg()]}
                  , "blocked" =>
                     #{ help => "List blocked peers"
-                     , handler => {fun list_unverified_peers/2, not_used}
+                     , handler => {fun list_blocked_peers/2, not_used}
                      , arguments => [ count_arg()
                                     , timeout_arg()]}
                 }
@@ -350,12 +350,12 @@ add_peer(Node, #{'address' := PeerAddress, 'trusted' := Trusted} = ArgsList) ->
     ok.
 
 remove_peer(Node, #{'peer_id' := EncPeerPubkey} = ArgsList) ->
-    case aeser_api_encoder:safe_decode(peer_pubkey, EncPeerPubkey) of
+    case aeser_api_encoder:safe_decode(peer_pubkey, list_to_binary(EncPeerPubkey)) of
         {ok, PeerPubkey} ->
             ok = rpc(Node, aec_peers, del_peer, [PeerPubkey],
                       ArgsList),
             io:fwrite("Ok.~n", []),
             erlang:halt(0);
-        {error, _} ->
+        {error, _E} ->
             throw({decode_error, peer_id})
     end.

--- a/apps/aeutils/priv/admin
+++ b/apps/aeutils/priv/admin
@@ -12,6 +12,15 @@
         , set_tx_pool_miner_gas_price/2
         ]).
 
+%% peer pool interaction
+-export([ list_connected_peers/2
+        , list_verified_peers/2
+        , list_unverified_peers/2
+        , list_blocked_peers/2
+        , add_peer/2
+        ]).
+
+
 %% See https://hexdocs.pm/argparse/
 %% Argparse supports a hierarchical structure of commands and subcommands, each
 %% with its own arguments. This spec (no command specified) describes the top level.
@@ -23,6 +32,7 @@ spec() -> #{ commands => cmds()
 
 cmds() ->
     #{ "tx_pool" => tx_pool()
+     , "peers" => peers()
      }.
 
 tx_pool() ->
@@ -79,6 +89,49 @@ tx_pool() ->
                        }
                 } }.
 
+peers() ->
+    #{ help => "Peer's pool commands"
+     , commands =>
+        #{ "list" =>
+            #{ help => "Inpsect peers"
+             , commands =>
+                #{ "connected" =>
+                    #{ help => "List connected peers"
+                     , handler => {fun list_connected_peers/2, not_used}
+                     , arguments => [#{ name => show
+                                      , type => string
+                                      , long => "-show"
+                                      , help => "all | inbound | outbound"
+                                      , default => "all"},
+                                      count_arg(), timeout_arg()]}
+                 , "verified" =>
+                    #{ help => "List verified peers"
+                     , handler => {fun list_verified_peers/2, not_used}
+                     , arguments => [ count_arg()
+                                    , timeout_arg()]}
+                 , "unverified" =>
+                    #{ help => "List unverified peers"
+                     , handler => {fun list_unverified_peers/2, not_used}
+                     , arguments => [ count_arg()
+                                    , timeout_arg()]}
+                 , "blocked" =>
+                    #{ help => "List blocked peers"
+                     , handler => {fun list_unverified_peers/2, not_used}
+                     , arguments => [ count_arg()
+                                    , timeout_arg()]}
+                }
+            }
+        , "add" =>
+            #{ help => "List connected peers"
+              , handler => {fun add_peer/2, not_used}
+              , arguments => [#{ name => address
+                               , type => string
+                               , help => "The address of the peer"
+                               },
+                              timeout_arg()]}
+        }
+    }.
+
 tx_hash_arg() ->
     #{ name => tx_hash,
        type => string,
@@ -90,6 +143,14 @@ timeout_arg() ->
      , help => "Timeout when waiting for response from the node"
      , type => {int, [{min, 0}]}
      , default => 10000 }.
+
+count_arg() ->
+    #{ name => count 
+     , long => "-count"
+     , type => boolean
+     , help => "Return only the total count"
+     , short => $c
+     , default => false}.
 
 main(Args) ->
     Opts = aeu_ext_scripts:parse_opts(Args, spec(), #{progname => admin}),
@@ -197,4 +258,72 @@ decode(transaction, EncTx) ->
         _Err ->
             throw({decode_error, transaction})
     end.
+
+list_connected_peers(Node, #{ 'show' := Show} = ArgsList)
+    when Show =:= "outbound";
+         Show =:= "inbound";
+         Show =:= "all" ->
+    ShowAtom = list_to_atom(Show),
+    Peers0 = rpc(Node, aec_peers, connected_peers, [ShowAtom], ArgsList),
+    Peers = format_peers(Peers0, ArgsList),
+    lists:foreach(
+        fun(P) ->
+            io:fwrite("~s\n", [P])
+        end,
+        Peers),
+    erlang:halt(0);
+list_connected_peers(_Node, _ArgsList) ->
+    io:fwrite("Not supported option for argument 'show': {all|inbound|outbound}\n", []),
+    erlang:halt(1).
+
+list_verified_peers(Node, ArgsList) ->
+    Peers0 = rpc(Node, aec_peers, available_peers, [verified], ArgsList),
+    Peers = format_peers(Peers0, ArgsList),
+    lists:foreach(
+        fun(P) ->
+            io:fwrite("~s\n", [P])
+        end,
+        Peers),
+    erlang:halt(0).
+
+list_unverified_peers(Node, ArgsList) ->
+    Peers0 = rpc(Node, aec_peers, available_peers, [unverified], ArgsList),
+    Peers = format_peers(Peers0, ArgsList),
+    io:fwrite("~s\n", [Peers]),
+    erlang:halt(0).
+
+list_blocked_peers(Node, ArgsList) ->
+    Peers0 = rpc(Node, aec_peers, blocked_peers, [], ArgsList),
+    Peers = format_peers(Peers0, ArgsList),
+    lists:foreach(
+        fun(P) ->
+            io:fwrite("~s\n", [P])
+        end,
+        Peers),
+    erlang:halt(0).
+
+
+format_peers(Peers, #{'count' := true}) ->
+    [io_lib:format("~B", [length(Peers)])];
+format_peers([_|_] = Peers0, #{'count' := false}) ->
+    [format_peer_info(PI) || PI <- Peers0];
+format_peers([], #{'count' := false}) ->
+    [""].
+
+format_peer_info(#{ pubkey  := Pubkey 
+                  , host    := Host
+                  , port    := Port}) ->
+    io_lib:format("aenode://~s@~s:~B", [aeser_api_encoder:encode(peer_pubkey, Pubkey),
+                               Host, Port]).
+
+add_peer(Node, #{'address' := PeerAddress} = ArgsList) ->
+    case aec_peers:parse_peer_address(PeerAddress) of
+        {ok, PeerInfo} ->
+            ok = rpc(Node, aec_peers, add_peers, [undefined, PeerInfo], ArgsList),
+            io:fwrite("Ok.~n", []),
+            erlang:halt(0);
+        {error, _} ->
+            throw({decode_error, address})
+    end,
+    ok.
 

--- a/apps/aeutils/priv/admin
+++ b/apps/aeutils/priv/admin
@@ -19,6 +19,8 @@
         , list_blocked_peers/2
         , add_peer/2
         , remove_peer/2
+        , block_peer/2
+        , unblock_peer/2
         ]).
 
 
@@ -125,10 +127,7 @@ peers() ->
         , "add" =>
             #{ help => "Add a peer"
               , handler => {fun add_peer/2, not_used}
-              , arguments => [#{ name => address
-                               , type => string
-                               , help => "The address of the peer: aenode://<peer pubkey>@<host>:<port>"
-                               },
+              , arguments => [peer_address_arg(),
                               #{ name => trusted 
                               , long => "-trusted"
                               , type => boolean
@@ -139,11 +138,15 @@ peers() ->
         , "remove" =>
             #{ help => "Remove a peer"
               , handler => {fun remove_peer/2, not_used}
-              , arguments => [#{ name => peer_id 
-                               , type => string
-                               , help => "The peer id"
-                               },
-                              timeout_arg()]}
+              , arguments => [ peer_id_arg(), timeout_arg()]}
+        , "block" =>
+            #{ help => "Block a peer"
+              , handler => {fun block_peer/2, not_used}
+              , arguments => [peer_address_arg(), timeout_arg()]}
+        , "unblock" =>
+            #{ help => "Unblock a peer"
+              , handler => {fun unblock_peer/2, not_used}
+              , arguments => [ peer_id_arg(), timeout_arg()]}
         }
     }.
 
@@ -166,6 +169,18 @@ count_arg() ->
      , help => "Return only the total count"
      , short => $c
      , default => false}.
+
+peer_id_arg() ->
+    #{ name => peer_id 
+     , type => string
+     , help => "The peer id"
+     }.
+
+peer_address_arg() ->
+    #{ name => address
+     , type => string
+     , help => "The address of the peer: aenode://<peer pubkey>@<host>:<port>"
+     }.
 
 main(Args) ->
     Opts = aeu_ext_scripts:parse_opts(Args, spec(), #{progname => admin}),
@@ -359,3 +374,26 @@ remove_peer(Node, #{'peer_id' := EncPeerPubkey} = ArgsList) ->
         {error, _E} ->
             throw({decode_error, peer_id})
     end.
+
+block_peer(Node, #{'address' := PeerAddress} = ArgsList) ->
+    case aec_peers:parse_peer_address(PeerAddress) of
+        {ok, PeerPubkey} ->
+            ok = rpc(Node, aec_peers, block_peer, [PeerPubkey],
+                      ArgsList),
+            io:fwrite("Ok.~n", []),
+            erlang:halt(0);
+        {error, _E} ->
+            throw({decode_error, peer_id})
+    end.
+
+unblock_peer(Node, #{'peer_id' := EncPeerPubkey} = ArgsList) ->
+    case aeser_api_encoder:safe_decode(peer_pubkey, list_to_binary(EncPeerPubkey)) of
+        {ok, PeerPubkey} ->
+            ok = rpc(Node, aec_peers, unblock_peer, [PeerPubkey],
+                      ArgsList),
+            io:fwrite("Ok.~n", []),
+            erlang:halt(0);
+        {error, _E} ->
+            throw({decode_error, peer_id})
+    end.
+

--- a/docs/release-notes/next/cli.md
+++ b/docs/release-notes/next/cli.md
@@ -3,8 +3,8 @@
   ```
   ./bin/aeternity admin <command>
   ```
-  The initial commit allows interacting with the transaction pool.
-  It currently supports:
+  It allows interacting with the transaction pool and network peers.
+  It currently supports the following pool functionalities:
   * Push of a new transaction to the pool. It has a force option in order to
     skip the checks if the transaction had already been deleted in the past
   * Delete a transaction from the pool.
@@ -16,3 +16,17 @@
   * A getter and a setter for the minumum gas required from this node in
     particular. This allows scripting node behaviour with varying gas price
     expectations. 
+  It also supports the following peers functionalities:
+  * Inspect peers - currently `connected`, `verified`, `unverified` and
+    `blocked`.  They are returned in a list but there is also an optional
+    argument to return their count instead.
+  * Add a new peer - add a new peer to the unverified list. This new peer
+    will follow the same verification process as if received by other peer.
+    There is also the option of adding a trusted peer - those are a special
+    set of peers that are always kept in the `verified` bucket and are never
+    degraded to `unverified` even if they are offline.
+  * Remove a peer by their peer id.
+  * Block and unblock peers - `blocked` peers are considered malicious entities
+    and the node will not attempt connecting to them. It will also refuse
+    incoming connections from `blocked` peers.
+


### PR DESCRIPTION
Provide a CLI interface for interaction of the local set of peers. Please consult the release notes for further details.

The work on this PR had been supported by ACF.