### PR TITLE
Fix two HTTP API bugs: missing CORS and crash in names

### DIFF
--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -85,6 +85,7 @@
          http_request/4,
          httpc_request/4,
          http_api_version/0,
+         http_api_prefix/0,
          process_http_return/1,
          internal_address/0,
          external_address/0
@@ -1351,6 +1352,9 @@ http_api_version() ->
        "/v2/" -> swagger2;
        "/v3/" -> oas3
     end.
+
+http_api_prefix() ->
+    get(api_prefix, "/v2/").
 
 http_request(Host, get, Path, Params) ->
     Prefix = get(api_prefix, "/v2/"),

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1986,6 +1986,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/debug/crash":
+    get:
+      tags:
+        - internal
+        - debug
+      operationId: GetCrashRequest
+      description: This is a sample URI to simulate a request crash. Shall be used only for test purposes only
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
+      responses:
+        "200":
+          description: This will never happen
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenSupply"
+        "500":
+          description: We always end up here
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/node/operator/mempool/hash/{hash}":
     delete:
       tags:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1992,7 +1992,7 @@ paths:
         - internal
         - debug
       operationId: GetCrashRequest
-      description: This is a sample URI to simulate a request crash. Shall be used only for test purposes only
+      description: This is a sample URI to simulate a request crash. Shall be used for test purposes only
       parameters:
         - $ref: '#/components/parameters/intAsString'
       responses:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1895,6 +1895,28 @@ paths:
           description: Height not available
           schema:
             $ref: '#/definitions/Error'
+  /debug/crash:
+    get:
+      tags:
+        - internal
+        - debug
+      operationId: GetCrashRequest
+      description: This is a sample URI to simulate a request crash. Shall be used only for test purposes only
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: This will never happen
+          schema:
+            type: object
+            properties:
+              next_nonce:
+                type: integer
+        '500':
+          description: We always end up here
+          schema:
+            $ref: "#/components/schemas/Error"
 
 
 ##

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1901,7 +1901,7 @@ paths:
         - internal
         - debug
       operationId: GetCrashRequest
-      description: This is a sample URI to simulate a request crash. Shall be used only for test purposes only
+      description: This is a sample URI to simulate a request crash. Shall be used for test purposes only
       produces:
         - application/json
       parameters: []

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -68,7 +68,10 @@ run(Queue, F) ->
         error:{rejected, _} ->
             {503, [], #{reason => <<"Temporary overload">>}};
         error:timeout ->
-            {503, [], #{reason => <<"Not yet started">>}}
+            {503, [], #{reason => <<"Not yet started">>}};
+        Class:Reason:Stacktrace ->
+            lager:error("CRASH ~p ~p, ~p", [Class, Reason, Stacktrace]),
+            {500, [], #{reason => <<"Internal server error">>}}
     end.
 
 %% read transactions

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -93,7 +93,7 @@ queue('GetGenerationByHeight')                  -> ?READ_Q;
 queue('GetAccountByPubkey')                     -> ?READ_Q;
 queue('GetAccountByPubkeyAndHeight')            -> ?READ_Q;
 queue('GetPendingAccountTransactionsByPubkey')  -> ?READ_Q;
-queue('GetAccountNextNonce')                     -> ?READ_Q;
+queue('GetAccountNextNonce')                    -> ?READ_Q;
 queue('GetTransactionByHash')                   -> ?READ_Q;
 queue('GetTransactionInfoByHash')               -> ?READ_Q;
 queue('GetContract')                            -> ?READ_Q;

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -74,7 +74,10 @@ handle_request(OperationID, Req, Context) ->
         error:{rejected, _} ->
             {503, [], #{reason => <<"Temporary overload">>}};
         error:timeout ->
-            {503, [], #{reason => <<"Not yet started">>}}
+            {503, [], #{reason => <<"Not yet started">>}};
+        Class:Reason:Stacktrace ->
+            lager:error("CRASH ~p ~p, ~p", [Class, Reason, Stacktrace]),
+            {500, [], #{reason => <<"Internal server error">>}}
     end.
 
 handle_request_('PostKeyBlock', #{'KeyBlock' := Data}, _Context) ->
@@ -215,6 +218,11 @@ handle_request_('GetTokenSupplyByHeight', Req, _Context) ->
         {error, chain_too_short} ->
             {400, [], #{reason => <<"Chain too short">>}}
     end;
+
+handle_request_('GetCrashRequest', Req, _Context) ->
+    1 = Req,
+    ok;
+
 
 handle_request_('DeleteTxFromMempool', Req, _Context) ->
     ParseFuns = [ parse_map_to_atom_keys(),

--- a/apps/aens/src/aens.erl
+++ b/apps/aens/src/aens.erl
@@ -85,11 +85,14 @@ get_name_hash(Name) when is_binary(Name) ->
 is_name(Bin) ->
     length(aens_utils:name_parts(Bin)) > 1.
 
+-spec name_to_name_hash(binary()) -> {ok, binary()} | {error, atom()}.
 name_to_name_hash(Name) ->
     case aens_utils:to_ascii(Name) of
         {ok, NameAscii} ->
             NameHash = aens_hash:name_hash(NameAscii),
             {ok, NameHash};
+        {error, {bad_label, _}} -> {error, invalid_name};
+        {error, {invalid_codepoint, _}} -> {error, invalid_name};
         {error, _Rsn} = Error ->
             Error
     end.

--- a/docs/release-notes/next/gh-3732.md
+++ b/docs/release-notes/next/gh-3732.md
@@ -1,0 +1,4 @@
+* Fixes a crash in HTTP endpoint `/<version prefix>/names/<name>` when the
+  name was invalid according to IDNA rules.
+* Fixes a bug: when an HTTP endpoint crashes, now appropriate CORS headers are
+  provided as well.


### PR DESCRIPTION
Fixes #3732.

There are two different bugs:
1. CORS not set when a request crashes
2. There is a crashing endpoint :)

The work on this PR had been supported by ACF.
