### PR TITLE
bump devmode_version to 0.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1108,7 +1108,7 @@ jobs:
                 name: Verify release artifacts
 parameters:
     aeplugin_devmode_version:
-        default: 0.3.1
+        default: 0.4.0
         type: string
     build_cache_version:
         default: v5


### PR DESCRIPTION
The latest devmode plugin release (v0.4.0) fixes rollback and adds a JSON REST API