### PR TITLE
Bump app_ctrl dep + add app_ctrl to application deps

### DIFF
--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -11,7 +11,6 @@
   {applications,
    [kernel,
     stdlib,
-    app_ctrl,
     crypto,
     sext,
     parse_trans,
@@ -47,6 +46,7 @@
     aeserialization,
     ranch
   ]},
+  {runtime_dependencies, ["app_ctrl-0.1.0"]},
   {env, [
          {'$app_ctrl',
           [

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -11,6 +11,7 @@
   {applications,
    [kernel,
     stdlib,
+    app_ctrl,
     crypto,
     sext,
     parse_trans,

--- a/apps/aeutils/src/aeutils.app.src
+++ b/apps/aeutils/src/aeutils.app.src
@@ -5,7 +5,6 @@
   {applications,
    [kernel,
     stdlib,
-    app_ctrl,
     lager,
     gproc,
     jobs,
@@ -13,6 +12,7 @@
     exometer_core,
     yamerl
    ]},
+  {runtime_dependencies, ["app_ctrl-0.1.0"]},
   {mod, {aeutils_app, []}},
   {env,[
         {'$setup_hooks',

--- a/apps/aeutils/src/aeutils.app.src
+++ b/apps/aeutils/src/aeutils.app.src
@@ -5,6 +5,7 @@
   {applications,
    [kernel,
     stdlib,
+    app_ctrl,
     lager,
     gproc,
     jobs,

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,7 @@
         %% lager version with trace-based msg suppression (merged upstream)
         {lager, {git, "https://github.com/erlang-lager/lager.git",
                 {ref, "fae5339"}}},
-        {app_ctrl, {git, "https://github.com/aeternity/app_ctrl.git", {ref, "41c3c57"}}},
+        {app_ctrl, {git, "https://github.com/aeternity/app_ctrl.git", {ref, "f0d3c54"}}},
 
         {cowboy, {git, "https://github.com/ninenines/cowboy.git",
                  {ref, "04ca4c5"}}}, % tag: 2.9.0"

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,7 @@
         %% lager version with trace-based msg suppression (merged upstream)
         {lager, {git, "https://github.com/erlang-lager/lager.git",
                 {ref, "fae5339"}}},
-        {app_ctrl, {git, "https://github.com/aeternity/app_ctrl.git", {ref, "f0d3c54"}}},
+        {app_ctrl, {git, "https://github.com/aeternity/app_ctrl.git", {ref, "92b8ae6"}}},
 
         {cowboy, {git, "https://github.com/ninenines/cowboy.git",
                  {ref, "04ca4c5"}}}, % tag: 2.9.0"

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,7 @@
         %% lager version with trace-based msg suppression (merged upstream)
         {lager, {git, "https://github.com/erlang-lager/lager.git",
                 {ref, "fae5339"}}},
-        {app_ctrl, {git, "https://github.com/aeternity/app_ctrl.git", {ref, "c887ef6"}}},
+        {app_ctrl, {git, "https://github.com/aeternity/app_ctrl.git", {ref, "41c3c57"}}},
 
         {cowboy, {git, "https://github.com/ninenines/cowboy.git",
                  {ref, "04ca4c5"}}}, % tag: 2.9.0"

--- a/rebar.lock
+++ b/rebar.lock
@@ -42,7 +42,7 @@
   0},
  {<<"app_ctrl">>,
   {git,"https://github.com/aeternity/app_ctrl.git",
-      {ref,"f0d3c542b692f9e08acfd780530a1ac3ffc36f8b"}},
+      {ref,"92b8ae60e3b4995385edcefc23d261bbab572bb8"}},
   0},
  {<<"argparse">>,{pkg,<<"argparse">>,<<"1.1.4">>},0},
  {<<"base58">>,

--- a/rebar.lock
+++ b/rebar.lock
@@ -42,7 +42,7 @@
   0},
  {<<"app_ctrl">>,
   {git,"https://github.com/aeternity/app_ctrl.git",
-      {ref,"c887ef63322acdee126d81274921806bd611ba18"}},
+      {ref,"41c3c5799345eca2b01a0352768ce01743cd656f"}},
   0},
  {<<"argparse">>,{pkg,<<"argparse">>,<<"1.1.4">>},0},
  {<<"base58">>,

--- a/rebar.lock
+++ b/rebar.lock
@@ -42,7 +42,7 @@
   0},
  {<<"app_ctrl">>,
   {git,"https://github.com/aeternity/app_ctrl.git",
-      {ref,"41c3c5799345eca2b01a0352768ce01743cd656f"}},
+      {ref,"f0d3c542b692f9e08acfd780530a1ac3ffc36f8b"}},
   0},
  {<<"argparse">>,{pkg,<<"argparse">>,<<"1.1.4">>},0},
  {<<"base58">>,


### PR DESCRIPTION
See #3786 

In order to manually bootstrap an aeternity node, this might work as a start:
```
application:ensure_all_started(app_ctrl)
application:ensure_all_started(aecore)
```

(This won't enable sync. `application:ensure_all_started(aesync)` would do that.)