### PR TITLE
Latest aestratum_client version with m1 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -111,14 +111,7 @@
 
         % for hyperchains and the testing suite
         {aesophia_aci_encoder, {git, "https://github.com/aeternity/aesophia_aci_encoder",
-          {ref, "27f48de"}}},
-
-        % Dependencies needed for the test profile, but kept here to allow us to lock
-        % versions and prevent "downgrades" of common deps during test runs
-        {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"e3e35aa"}}},
-        {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {ref,"5f03a89"}}},
-        {aestratum_client, {git, "git://github.com/aeternity/aestratum_client", {ref, "4160401"}}}
-        % End of test profile only deps
+          {ref, "27f48de"}}}
 
        ]}.
 
@@ -234,6 +227,9 @@
                     {dist_node, [{setcookie, 'aeternity_cookie'},
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"e3e35aa"}}},
+                            {aesophia_cli, {git, "git://github.com/aeternity/aesophia_cli", {ref,"5f03a89"}}},
+                            {aestratum_client, {git, "git://github.com/aeternity/aestratum_client", {ref, "adb0993"}}},
                             {websocket_client, {git, "git://github.com/aeternity/websocket_client", {ref, "95ef9de"}}}
                            ]}
                    ]},


### PR DESCRIPTION
This PR ensures latest libs are used during common test runs.

This PR is sponsored by the ACF 