### PR TITLE
Bump devmode plugin version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1108,7 +1108,7 @@ jobs:
                 name: Verify release artifacts
 parameters:
     aeplugin_devmode_version:
-        default: 0.4.0
+        default: 0.4.1
         type: string
     build_cache_version:
         default: v5


### PR DESCRIPTION
This PR bumps the devmode_plugin version to [0.4.1](https://github.com/aeternity/aeplugin_dev_mode/releases/tag/v0.4.1)