### PR TITLE
HTTP endpoint for peer stats

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2039,6 +2039,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  "/node/operator/peers/count":
+    get:
+      tags:
+        - internal
+        - node-operator
+      operationId: GetPeerCount
+      description: Get the number of peers in the different pools. This is to be used to catch if a node loses connectivity 
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
+      responses:
+        "200":
+          description: The different count of peers in the respective pools
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PeerCount"
 components:
   schemas:
     UInt:
@@ -3333,6 +3349,29 @@ components:
             $ref: "#/components/schemas/Peer"
       required:
         - peers
+        - blocked
+    PeerCount:
+      type: object
+      properties:
+        connected:
+          type: object
+          properties:
+            inbound:
+              $ref: "#/components/schemas/UInt64"
+            outbound:
+              $ref: "#/components/schemas/UInt64"
+        available:
+          type: object
+          properties:
+            verified:
+              $ref: "#/components/schemas/UInt64"
+            unverified:
+              $ref: "#/components/schemas/UInt64"
+        blocked:
+          $ref: "#/components/schemas/UInt64"
+      required:
+        - connected
+        - available
         - blocked
     ContractCreateTx:
       type: object

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -238,7 +238,22 @@ handle_request_('DeleteTxFromMempool', Req, _Context) ->
                               {ok, {404, [], #{<<"reason">> => <<"not_found">>}}}
                       end
                   end],
-
+    process_request(ParseFuns, Req);
+handle_request_('GetPeerCount', Req, _Context) ->
+    ParseFuns = [
+                  fun(_Req, #{}) ->
+                      ConnectedInbound = length(aec_peers:connected_peers(inbound)),
+                      ConnectedOutbound = length(aec_peers:connected_peers(outbound)),
+                      AvailableVerified = length(aec_peers:available_peers(verified)),
+                      AvailableUnverified = length(aec_peers:available_peers(unverified)),
+                      Blocked = length(aec_peers:blocked_peers()),
+                      {ok, {200, [], #{<<"connected">> => #{<<"inbound">> => ConnectedInbound,
+                                                            <<"outbound">> => ConnectedOutbound},
+                                       <<"available">> => #{<<"verified">> => AvailableVerified,
+                                                            <<"unverified">> => AvailableUnverified},
+                                       <<"blocked">> => Blocked
+                                      }}}
+                  end],
     process_request(ParseFuns, Req);
 
 handle_request_('GetNetworkStatus', _Req, _Context) ->

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -42,6 +42,7 @@
    , post_transactions_sut/1
    , get_transactions_pending_sut/0
    , delete_tx_from_mempool_sut/1
+   , get_peer_count_sut/0
    , get_key_blocks_current_height_sut/0
    ]).
 
@@ -1461,6 +1462,10 @@ delete_tx_from_mempool_sut(Hash) when is_binary(Hash) ->
 delete_tx_from_mempool_sut(Hash) when is_list(Hash) ->
     Host = internal_address(),
     http_request(Host, delete, "node/operator/mempool/hash/" ++ Hash, []).
+
+get_peer_count_sut() ->
+    Host = internal_address(),
+    http_request(Host, get, "node/operator/peers/count", []).
 
 %% /transactions/*
 

--- a/docs/release-notes/next/peers_node_operator_api.md
+++ b/docs/release-notes/next/peers_node_operator_api.md
@@ -1,0 +1,6 @@
+* Introduces a new HTTP endpoint for fetching peer pool stats: connected
+  (inbound and outbound), available for a new connection (verified and not yet
+  verified) and blocked peers. This is part of the `node-operator` group that
+  is bound to the internal interface and disabled by default. This new
+  endpoint is intended for the node operator to be monitoring its node's
+  connectivity.


### PR DESCRIPTION
Introduces a new endpoint that provides stats for the current peer pool state.

The work on this PR had been supported by ACF.
