### PR TITLE
Improve sync logs, use dirty read of top_header and fix sync chunk sizes

### DIFF
--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -39,6 +39,7 @@
         , top_key_block_hash/0
         , top_block_with_state/0
         , top_header/0
+        , dirty_top_header/0
         , top_header_hash_and_state/0
         , top_height/0
         ]).
@@ -402,6 +403,14 @@ top_header() ->
             undefined
     end.
 
+dirty_top_header() ->
+    case dirty_top_block_node() of
+        #{ header := Header } ->
+            Header;
+        undefined ->
+            undefined
+    end.
+
 -spec top_height() -> 'undefined' | non_neg_integer().
 top_height() ->
     case top_header() of
@@ -420,6 +429,9 @@ top_block() ->
                                          , header := aec_headers:header() }.
 top_block_node() ->
     aec_db:get_top_block_node().
+
+dirty_top_block_node() ->
+    aec_db:dirty_get_top_block_node().
 
 -spec top_block_hash() -> 'undefined' | binary().
 top_block_hash() ->

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1162,7 +1162,7 @@ handle_key_block_candidate_reply({{error, Reason}, _}, State) ->
 %%% In server context: A block was given to us from the outside world
 
 handle_synced_block(Block, State) ->
-    epoch_mining:info("synced_block: ~p", [Block]),
+    epoch_mining:debug("synced_block: ~p", [Block]),
     handle_add_block(Block, State, block_synced).
 
 handle_post_block(Block, State) ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -53,6 +53,7 @@
          dirty_get_signed_tx/1,
          get_top_block_hash/0,
          get_top_block_node/0,
+         dirty_get_top_block_node/0,
          get_finalized_height/0,
          dirty_get_finalized_height/0,
          get_block_state/1,
@@ -705,6 +706,9 @@ get_top_block_hash() ->
 
 get_top_block_node() ->
     get_chain_state_value(top_block_node).
+
+dirty_get_top_block_node() ->
+    dirty_get_chain_state_value(top_block_node).
 
 %% Some migration code: Ideally, top_block_node is there, and we're done.
 %% If not, we should find top_block_hash. Fetch the corresponding

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -1429,7 +1429,7 @@ validate_connected_to_chain(MicroHeader, _PrevHeader, _PrevKeyHeader) ->
 
 validate_delta_height(MicroHeader, _PrevHeader, _PrevKeyHeader) ->
     Height = aec_headers:height(MicroHeader),
-    case aec_chain:top_header() of
+    case aec_chain:dirty_top_header() of
         undefined -> ok;
         TopHeader ->
             MaxDelta = aec_chain_state:gossip_allowed_height_from_top(),

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -227,8 +227,8 @@ accept_init(Ref, TcpSock, ranch_tcp, Opts) ->
                     %% ======  Exit critical section with Private keys in memory. ======
 
                     %% What to do here? Close the socket and stop?
-                    epoch_sync:info("Connection accept failed - ~p was from ~p",
-                                    [Reason, maps:get(host, S)]),
+                    epoch_sync:debug("Connection accept failed - ~p was from ~p",
+                                     [Reason, maps:get(host, S)]),
                     gen_tcp:close(TcpSock)
             end
     end.
@@ -1074,7 +1074,7 @@ handle_light_micro_block(_S, Header, TxHashes, PoF) ->
             ok;
         E = {error, _} ->
             {ok, HH} = aec_headers:hash_header(Header),
-            epoch_sync:info("Dropping gossiped light micro_block (~s): ~p", [pp(HH), E]),
+            epoch_sync:debug("Dropping gossiped light micro_block (~s): ~p", [pp(HH), E]),
             case aec_chain:get_header(aec_headers:prev_key_hash(Header)) of
                 {ok, PrevHeader} ->
                     epoch_sync:debug("miner beneficiary: ~p", [aec_headers:beneficiary(PrevHeader)]),

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -864,7 +864,7 @@ do_work_on_sync_task(PeerId, Task, LastResult) ->
 
 agree_on_height(PeerId, #chain{ blocks = [#chain_block{ hash = TopHash, height = TopHeight } | _] }) ->
     try
-        LocalHeader = aec_chain:top_header(),
+        LocalHeader = aec_chain:dirty_top_header(),
         LocalHeight = aec_headers:height(LocalHeader),
         MinHeight   = min(TopHeight, LocalHeight),
         RemoteHash =
@@ -1187,7 +1187,7 @@ sync_progress(#state{sync_tasks = SyncTasks} = State) ->
                           [#chain_block{height = Height} | _] = Chain,
                           max(Height, MaxHeight)
                   end, 0, SyncTasks),
-            TopHeight = aec_headers:height(aec_chain:top_header()),
+            TopHeight = aec_headers:height(aec_chain:dirty_top_header()),
             SyncProgress0 = round(10000000 * TopHeight / TargetHeight) / 100000,
             %% It is possible to have TopHeight already higher than Height in sync task,
             %% e.g. when a block was mined and the sync task was not yet removed.

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -292,7 +292,7 @@ peek(MaxN, Account) when is_integer(MaxN), MaxN >= 0; MaxN =:= infinity ->
 delete(TxHash) ->
     gen_server:call(?SERVER, {delete, TxHash}).
 
--spec inspect(binary()) -> {ok, Failures :: non_neg_integer(), Visited :: boolean(), TTL :: non_neg_integer()} 
+-spec inspect(binary()) -> {ok, Failures :: non_neg_integer(), Visited :: boolean(), TTL :: non_neg_integer()}
                            | {error, not_found | already_accepted}.
 inspect(TxHash) ->
     case gen_server:call(?SERVER, {failures_cnt, TxHash}) of
@@ -672,7 +672,7 @@ revisit(#dbs{db = Db, visited_db = VDb}) ->
     ok.
 
 top_height() ->
-    case aec_chain:top_header() of
+    case aec_chain:dirty_top_header() of
         undefined -> 0;
         Header    -> aec_headers:height(Header)
     end.


### PR DESCRIPTION
- Reduce noisy logging + add more informative sync-logging
- Add dirty_top_header/0 and use it where appropriate
- Improve block-chunks organization during sync

This PR is supported by the Æternity Crypto Foundation