### PR TITLE
Fix failure to sync past configured fork_management signalling_end

### DIFF
--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -213,7 +213,7 @@ accept_init(Ref, TcpSock, ranch_tcp, Opts) ->
                     %% ======  Exit critical section with Private keys in memory. ======
 
                     PingTimeout = first_ping_timeout(),
-                    epoch_sync:debug("Connection accepted from ~p", [RemotePub]),
+                    epoch_sync:debug("Connection accepted from ~p", [aec_peer:ppp(RemotePub)]),
                     %% Report this to aec_peers!? And possibly fail?
                     %% Or, we can't do this yet we don't know the port?!
                     TRef = erlang:start_timer(PingTimeout, self(), first_ping_timeout),

--- a/system_test/common/aest_community_fork_SUITE.erl
+++ b/system_test/common/aest_community_fork_SUITE.erl
@@ -10,7 +10,7 @@
 -export([end_per_suite/1]).
 
 % Test cases
--export([fork_chain/1]).
+-export([fork_chain/1, fork_sync/1]).
 
 -import(aest_nodes, [
     setup_nodes/2,
@@ -84,6 +84,7 @@
 %=== COMMON TEST FUNCTIONS =====================================================
 
 all() -> [
+    fork_sync,
     fork_chain
 ].
 
@@ -119,28 +120,27 @@ fork_chain(Cfg) ->
     %% protocol. If it was started from the beginning it could mine more blocks
     %% than node1 and node2 and they wouldn't switch to a new protocol.
 
-    wait_for_startup([name(?NODE1), name(?NODE2), name(?NODE3)], 1, Cfg),
+    %% node 3 is not guaranteed to even sync as far as block 1 from nodes running
+    %% the new protocol config (and block 1 is the definition of started here)
+    %% if the peer offers blocks after the fork for its sync pool.
+    %% Assume it's enough for this test case that nodes 3 and 4 get to the right state in the end.
+    wait_for_startup([name(?NODE1), name(?NODE2)], 1, Cfg),
     %% Check node picked user config
     #{network_id := <<"ae_system_test">>} = get_status(name(?NODE1)),
     #{network_id := <<"ae_system_test">>} = get_status(name(?NODE2)),
-    #{network_id := <<"ae_system_test">>} = get_status(name(?NODE3)),
 
     %% All the three node have the same chain until the last signalling
     %% block. One block after the signalling block the node3 stays with the
     %% current protocol and node1 and node2 switch to the new protocol.
     LastSigBlockHeight = ?SIGNALLING_END_HEIGHT - 1,
-    wait_for_value({height, LastSigBlockHeight}, [name(?NODE1), name(?NODE2), name(?NODE3)],
+    wait_for_value({height, LastSigBlockHeight}, [name(?NODE1), name(?NODE2)],
                    LastSigBlockHeight * ?MINING_TIMEOUT, Cfg),
 
     #{hash := LastSigBlockHash1, version := LastSigBlockVsn1} = get_block(name(?NODE1), LastSigBlockHeight),
-    #{hash := LastSigBlockHash2, version := LastSigBlockVsn2} = get_block(name(?NODE1), LastSigBlockHeight),
-    #{hash := LastSigBlockHash3, version := LastSigBlockVsn3} = get_block(name(?NODE1), LastSigBlockHeight),
+    #{hash := LastSigBlockHash2, version := LastSigBlockVsn2} = get_block(name(?NODE2), LastSigBlockHeight),
 
     ?assertEqual(LastSigBlockHash1, LastSigBlockHash2),
-    ?assertEqual(LastSigBlockHash1, LastSigBlockHash3),
-
     ?assertEqual(LastSigBlockVsn1, LastSigBlockVsn2),
-    ?assertEqual(LastSigBlockVsn1, LastSigBlockVsn3),
 
     %% node1 and node2 can switch to the new protocol and continue adding blocks
     %% to the chain. Since node3 is not mining and stays with the old protocol,
@@ -148,11 +148,11 @@ fork_chain(Cfg) ->
     %% (which is mining the old protocol blocks) to verify that node3 can still
     %% add old protocol blocks to the chain.
     start_node(name(?NODE4), Cfg),
-    wait_for_startup([name(?NODE4)], 1, Cfg),
+    wait_for_startup([name(?NODE3), name(?NODE4)], 1, Cfg),
     %% Check node picked user config
     #{network_id := <<"ae_system_test">>} = get_status(name(?NODE4)),
 
-    wait_for_value({height, LastSigBlockHeight}, [name(?NODE4)],
+    wait_for_value({height, LastSigBlockHeight}, [name(?NODE3), name(?NODE4)],
                    LastSigBlockHeight * ?MINING_TIMEOUT, Cfg),
 
     %% All the nodes are one block before the fork height. node1 and node2 will
@@ -187,6 +187,59 @@ fork_chain(Cfg) ->
     stop_node(name(?NODE2), 10000, Cfg),
     stop_node(name(?NODE3), 10000, Cfg),
     stop_node(name(?NODE4), 10000, Cfg),
+
+    ok.
+
+%% Test that a second mining node can sync to a node that has already mined
+%% past the new protocol
+%% This test is not absolutely deterministic, but node1 only needs to mine 5 more
+%% blocks before node2 has started and synced. This makes it many times more
+%% likely to pass than many of our other tests :)
+fork_sync(Cfg) ->
+    Node1 = maps:put(peers, [node2], ?NODE1),
+    Node2 = maps:put(peers, [node1], ?NODE2),
+    setup_nodes([Node1, Node2], Cfg),
+
+    %% Supports new protocol, mining.
+    start_node(name(?NODE1), Cfg),
+    %% Started, and mined almost up to the end of the signalling block
+    wait_for_startup([name(?NODE1)], 10, Cfg),
+    %% Check node picked user config
+    #{network_id := <<"ae_system_test">>} = get_status(name(?NODE1)),
+
+    %% Supports new protocol, mining. Started
+    start_node(name(?NODE2), Cfg),
+    wait_for_startup([name(?NODE2)], 1, Cfg),
+    #{network_id := <<"ae_system_test">>} = get_status(name(?NODE2)),
+
+    LastSigBlockHeight = ?SIGNALLING_END_HEIGHT - 1,
+    wait_for_value({height, LastSigBlockHeight}, [name(?NODE1), name(?NODE2)],
+                   LastSigBlockHeight * ?MINING_TIMEOUT, Cfg),
+
+    #{hash := LastSigBlockHash1, version := LastSigBlockVsn1} = get_block(name(?NODE1), LastSigBlockHeight),
+    #{hash := LastSigBlockHash2, version := LastSigBlockVsn2} = get_block(name(?NODE2), LastSigBlockHeight),
+
+    ?assertEqual(LastSigBlockHash1, LastSigBlockHash2),
+
+    ?assertEqual(LastSigBlockVsn1, LastSigBlockVsn2),
+
+    %% The nodes are at this point at least up to one block before the fork height and either will
+    %% soon or already have upgraded the protocol
+    AfterForkHeight = ?FORK_HEIGHT + 1,
+    wait_for_value({height, AfterForkHeight}, [name(?NODE1), name(?NODE2)],
+                   (AfterForkHeight - LastSigBlockHeight) * ?MINING_TIMEOUT, Cfg),
+
+    #{hash := ForkBlockHash1, version := ForkBlockVsn1} = get_block(name(?NODE1), ?FORK_HEIGHT),
+    #{hash := ForkBlockHash2, version := ForkBlockVsn2} = get_block(name(?NODE2), ?FORK_HEIGHT),
+
+    ?assertEqual(ForkBlockHash1, ForkBlockHash2),
+    ?assertEqual(ForkBlockVsn1, ForkBlockVsn2),
+
+    ?assert(has_status_new_protocol(name(?NODE1), {?VERSION, ?FORK_HEIGHT})),
+    ?assert(has_status_new_protocol(name(?NODE2), {?VERSION, ?FORK_HEIGHT})),
+
+    stop_node(name(?NODE1), 10000, Cfg),
+    stop_node(name(?NODE2), 10000, Cfg),
 
     ok.
 


### PR DESCRIPTION
Issue found during regular system-test runs reported in #3806

The issue prevented new nodes from syncing with an existing node which has fork_management enabled.

This change causes the syncing node to use of the protocol configured under `fork_management > fork > version` during the early parts of sync (fetching blocks out of order from another node) while keeping the original checks when storing blocks in the database.

Added new system-test case which always syncs past the fork point.

This PR is supported by the Æternity Crypto Foundation