### PR TITLE
Add read cache for contract store

### DIFF
--- a/apps/aecontract/src/aect_contracts_store.erl
+++ b/apps/aecontract/src/aect_contracts_store.erl
@@ -41,7 +41,7 @@ new() ->
 
 -spec new(aeu_mtrees:mtree()) -> store().
 new(Tree) ->
-    #store{ cache = #{}, mtree = Tree }.
+    #store{ cache = #{}, mtree = aeu_mp_trees:tree_no_cache(Tree) }.
 
 %% Returns empty binary if key is not in the store.
 -spec get(key(), store()) -> val().

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -80,6 +80,7 @@
         , push_return_type_check/4
         , spend_gas/2
         , spend_gas_for_new_cells/2
+        , spend_gas_for_store_values/2
         , spend_gas_for_traversal/3
         , spend_gas_for_traversal/4
         , update_for_remote_call/5
@@ -507,6 +508,11 @@ spend_gas_for_new_cells1(NewCells, #es{ created_cells = Cells } = ES) ->
     CellCost = 1 + (TotalCells bsr 10),
     spend_gas(NewCells * CellCost, ES#es{ created_cells = TotalCells }).
 
+spend_gas_for_store_values(StoreValues, ES) ->
+    case consensus_version(ES) < ?CERES_PROTOCOL_VSN of
+        true  -> ES;
+        false -> spend_gas(StoreValues * 20000, ES)
+    end.
 
 -define(GAS_DENOMINATOR, 1000).
 

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -1264,7 +1264,7 @@ paysplit_contract(Config) ->
 
     ECheck = fun([_]) -> ok end,
 
-    call_func(APub, APriv, EncCPub, Paysplit, "payAndSplit", [], #{<<"amount">> => 100000}, {log, ECheck}),
+    call_func(APub, APriv, EncCPub, Paysplit, "payAndSplit", [], #{<<"amount">> => 100000, <<"gas">> => 1000000}, {log, ECheck}),
     call_func(APub, APriv, EncCPub, Paysplit, "payAndSplit", [], #{}, revert),
     call_func(APub, APriv, EncCPub, Paysplit, "payAndSplit", [], #{<<"amount">> => 100000, <<"gas">> => 1000}, error),
 

--- a/test/contracts/maps_benchmark.aes
+++ b/test/contracts/maps_benchmark.aes
@@ -22,6 +22,9 @@ contract Benchmark =
   entrypoint get(k) = state.map[k]
   entrypoint noop() = ()
 
+  entrypoint get1() = state.map
+  entrypoint get2() = Map.to_list(state.map)
+
   stateful entrypoint benchmark(k, v) =
     let m = state.updater.update_map(k, v, state.map)
     put(state{ map = m })

--- a/test/contracts/sophia_2/maps_benchmark.aes
+++ b/test/contracts/sophia_2/maps_benchmark.aes
@@ -22,6 +22,9 @@ contract Benchmark =
   function get(k) = state.map[k]
   function noop() = ()
 
+  function get1() = state.map
+  function get2() = Map.to_list(state.map)
+
   stateful function benchmark(k, v) =
     let m = state.updater.update_map(k, v, state.map)
     put(state{ map = m })

--- a/test/contracts/sophia_4/maps_benchmark.aes
+++ b/test/contracts/sophia_4/maps_benchmark.aes
@@ -22,6 +22,9 @@ contract Benchmark =
   entrypoint get(k) = state.map[k]
   entrypoint noop() = ()
 
+  entrypoint get1() = state.map
+  entrypoint get2() = Map.to_list(state.map)
+
   stateful entrypoint benchmark(k, v) =
     let m = state.updater.update_map(k, v, state.map)
     put(state{ map = m })


### PR DESCRIPTION
Reading from the Merkle-Patricia Tree is rather expensive, reading a full subtree is even more expensive - by adding a read cache the iterators used to fetch the subtree will become (much) more efficient. 

This PR is supported by the Æternity Crypto Foundation