### PR TITLE
Integrate Slack notifications into CI

### DIFF
--- a/.circleci/config/@main.yml
+++ b/.circleci/config/@main.yml
@@ -1,0 +1,4 @@
+version: 2.1
+
+orbs:
+  slack: circleci/slack@4.6.2

--- a/.circleci/config/@version.yml
+++ b/.circleci/config/@version.yml
@@ -1,4 +1,0 @@
-version: 2.1
-
-orbs:
-  slack: circleci/slack@4.6.1

--- a/.circleci/config/@version.yml
+++ b/.circleci/config/@version.yml
@@ -1,1 +1,4 @@
 version: 2.1
+
+orbs:
+  slack: circleci/slack@4.0

--- a/.circleci/config/@version.yml
+++ b/.circleci/config/@version.yml
@@ -1,4 +1,4 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.0
+  slack: circleci/slack@4.6.1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,12 +1,6 @@
 fail_notification:
   steps:
     - slack/notify:
-        branch_pattern: << pipeline.parameters.master_branch >>
-        channel: << pipeline.parameters.slack_notification_channel >>
-        event: fail
-        template: basic_fail_1
-    - slack/notify:
-        tag_pattern: << pipeline.parameters.tag_regex >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
@@ -14,7 +8,6 @@ fail_notification:
 deploy_notification:
   steps:
     - slack/notify:
-        tag_pattern: << pipeline.parameters.tag_regex >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: pass
         template: success_tagged_deploy_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,7 +1,11 @@
 fail_notification:
   steps:
+    - run:
+        name: artificial fail
+        command: |
+          false
     - slack/notify:
-        branch_pattern: << pipeline.parameters.master_branch >>
+        branch_pattern: slack_notifications
         event: fail
         template: basic_fail_1
     - slack/notify:

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,23 +1,15 @@
 fail_notification:
   steps:
-    - run:
-        name: artificial fail
-        command: |
-          false
     - slack/notify:
         branch_pattern: << pipeline.parameters.master_branch >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
-        debug: true
-        ignore_errors: false
     - slack/notify:
         tag_pattern: << pipeline.parameters.tag_pattern >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
-        debug: true
-        ignore_errors: false
 
 deploy_notification:
   steps:

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,6 +1,12 @@
 fail_notification:
   steps:
     - slack/notify:
+        branch_pattern: << pipeline.parameters.master_branch >>
+        channel: << pipeline.parameters.slack_notification_channel >>
+        event: fail
+        template: basic_fail_1
+    - slack/notify:
+        tag_pattern: << pipeline.parameters.tag_regex >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
@@ -8,6 +14,7 @@ fail_notification:
 deploy_notification:
   steps:
     - slack/notify:
+        tag_pattern: << pipeline.parameters.tag_regex >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: pass
         template: success_tagged_deploy_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,6 +1,12 @@
 fail_notification:
   steps:
     - slack/notify:
+        branch_pattern: << pipeline.parameters.master_branch >>
+        channel: << pipeline.parameters.slack_notification_channel >>
+        event: fail
+        template: basic_fail_1
+    - slack/notify:
+        tag_pattern: << pipeline.parameters.tag_pattern >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
@@ -8,6 +14,7 @@ fail_notification:
 deploy_notification:
   steps:
     - slack/notify:
+        tag_pattern: << pipeline.parameters.tag_pattern >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: pass
         template: success_tagged_deploy_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -5,11 +5,13 @@ fail_notification:
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
+        debug: true
     - slack/notify:
         tag_pattern: << pipeline.parameters.tag_pattern >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
+        debug: true
 
 deploy_notification:
   steps:

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,17 +1,5 @@
 fail_notification:
   steps:
-    # the orb setup wrongly assumes that run in a container with sudo user
-    - run:
-        name: Setup slack notification logs
-        environment:
-          LOG_PATH: /tmp/slack-orb/logs
-          POST_TO_SLACK_LOG: post-to-slack.json
-        command: |
-          mkdir -p $LOG_PATH
-
-          if [ ! -f "$LOG_PATH/$POST_TO_SLACK_LOG" ]; then
-              echo "[]" | tee $LOG_PATH/$POST_TO_SLACK_LOG
-          fi
     - slack/notify:
         branch_pattern: << pipeline.parameters.master_branch >>
         channel: << pipeline.parameters.slack_notification_channel >>

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,11 +1,7 @@
 fail_notification:
   steps:
-    - run:
-        name: artificial fail
-        command: |
-          false
     - slack/notify:
-        branch_pattern: slack_notifications
+        branch_pattern: << pipeline.parameters.master_branch >>
         event: fail
         template: basic_fail_1
     - slack/notify:

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,5 +1,9 @@
 fail_notification:
   steps:
+    - run:
+        name: artificial fail
+        command: |
+          false
     - slack/notify:
         branch_pattern: << pipeline.parameters.master_branch >>
         channel: << pipeline.parameters.slack_notification_channel >>

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,78 +1,13 @@
 fail_notification:
   steps:
-    - run:
-        name: Send failure notification
-        environment:
-          NOTIFY_BRANCH: << pipeline.parameters.master_branch >>
-          HOOK_TEMPLATE: |
-            {
-              "text": "CircleCI job **%s** failed on branch **%s** by @%s",
-              "attachments": [
-                {
-                  "title": "Build Link",
-                  "title_link": "%s",
-                  "color": "#FAD6D6"
-                }
-              ]
-            }
-        command: |
-          if [ -n "$CIRCLE_BRANCH" ]; then
-            if [ "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH:?}" ]; then
-              HOOK_DATA=$(printf "$HOOK_TEMPLATE" "${CIRCLE_JOB:?}" "${CIRCLE_BRANCH:?}" "${CIRCLE_USERNAME:-unknown}" "${CIRCLE_BUILD_URL:?}")
-              curl -X POST -H 'Content-Type: application/json' ${ROCKET_HOOK_URL:?} --data "${HOOK_DATA:?}"
-            fi
-          fi
-        when: on_fail
+    - slack/notify:
+        channel: << pipeline.parameters.slack_notification_channel >>
+        event: fail
+        template: basic_fail_1
 
-
-fail_notification_nix:
+deploy_notification:
   steps:
-    - run:
-        name: Send failure notification
-        environment:
-          NOTIFY_BRANCH: << pipeline.parameters.master_branch >>
-          HOOK_TEMPLATE: |
-            {
-              "text": "CircleCI job **%s** failed on branch **%s** by @%s",
-              "attachments": [
-                {
-                  "title": "Build Link",
-                  "title_link": "%s",
-                  "color": "#FAD6D6"
-                }
-              ]
-            }
-        command: |
-          if [ -n "$CIRCLE_BRANCH" ]; then
-            if [ "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH:?}" ]; then
-              HOOK_DATA=$(printf "$HOOK_TEMPLATE" "${CIRCLE_JOB:?}" "${CIRCLE_BRANCH:?}" "${CIRCLE_USERNAME:-unknown}" "${CIRCLE_BUILD_URL:?}")
-              nix-shell webhook.nix -j auto --run "curl -X POST -H 'Content-Type: application/json' ${ROCKET_HOOK_URL:?} --data \"${HOOK_DATA:?}\""
-            fi
-          fi
-        when: on_fail
-
-fail_notification_system_test:
-  steps:
-    - run:
-        name: Send failure notification on system test
-        environment:
-          NOTIFY_BRANCH: << pipeline.parameters.master_branch >>
-          HOOK_TEMPLATE: |
-            {
-              "text": "CircleCI job **%s** failed on branch **%s** by @%s",
-              "attachments": [
-                {
-                  "title": "Build Link",
-                  "title_link": "%s",
-                  "color": "#FAD6D6"
-                }
-              ]
-            }
-        command: |
-          if [ -n "$CIRCLE_BRANCH" ]; then
-            if [ "$CIRCLE_BRANCH" = "${NOTIFY_BRANCH:?}" ]; then
-              HOOK_DATA=$(printf "$HOOK_TEMPLATE" "${CIRCLE_JOB:?}" "${CIRCLE_BRANCH:?}" "${CIRCLE_USERNAME:-unknown}" "${CIRCLE_BUILD_URL:?}")
-              curl -X POST -H 'Content-Type: application/json' ${ROCKET_HOOK_URL_SYSTEM_TEST:?} --data "${HOOK_DATA:?}"
-            fi
-          fi
-        when: on_fail
+    - slack/notify:
+        channel: << pipeline.parameters.slack_notification_channel >>
+        event: pass
+        template: success_tagged_deploy_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -2,12 +2,10 @@ fail_notification:
   steps:
     - slack/notify:
         branch_pattern: << pipeline.parameters.master_branch >>
-        channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
     - slack/notify:
         tag_pattern: << pipeline.parameters.tag_pattern >>
-        channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
 
@@ -15,6 +13,5 @@ deploy_notification:
   steps:
     - slack/notify:
         tag_pattern: << pipeline.parameters.tag_pattern >>
-        channel: << pipeline.parameters.slack_notification_channel >>
         event: pass
         template: success_tagged_deploy_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -2,9 +2,6 @@ fail_notification:
   steps:
     - slack/notify:
         branch_pattern: << pipeline.parameters.master_branch >>
-        event: fail
-        template: basic_fail_1
-    - slack/notify:
         tag_pattern: << pipeline.parameters.tag_pattern >>
         event: fail
         template: basic_fail_1
@@ -12,6 +9,7 @@ fail_notification:
 deploy_notification:
   steps:
     - slack/notify:
+        branch_pattern: ""
         tag_pattern: << pipeline.parameters.tag_pattern >>
         event: pass
         template: success_tagged_deploy_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,7 +1,7 @@
 fail_notification:
   steps:
     - slack/notify:
-        branch_pattern: slack_notifications
+        branch_pattern: << pipeline.parameters.master_branch >>
         tag_pattern: << pipeline.parameters.tag_pattern >>
         event: fail
         template: basic_fail_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -6,12 +6,14 @@ fail_notification:
         event: fail
         template: basic_fail_1
         debug: true
+        ignore_errors: false
     - slack/notify:
         tag_pattern: << pipeline.parameters.tag_pattern >>
         channel: << pipeline.parameters.slack_notification_channel >>
         event: fail
         template: basic_fail_1
         debug: true
+        ignore_errors: false
 
 deploy_notification:
   steps:

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,7 +1,7 @@
 fail_notification:
   steps:
     - slack/notify:
-        branch_pattern: << pipeline.parameters.master_branch >>
+        branch_pattern: slack_notifications
         tag_pattern: << pipeline.parameters.tag_pattern >>
         event: fail
         template: basic_fail_1

--- a/.circleci/config/commands/@notifications.yml
+++ b/.circleci/config/commands/@notifications.yml
@@ -1,5 +1,17 @@
 fail_notification:
   steps:
+    # the orb setup wrongly assumes that run in a container with sudo user
+    - run:
+        name: Setup slack notification logs
+        environment:
+          LOG_PATH: /tmp/slack-orb/logs
+          POST_TO_SLACK_LOG: post-to-slack.json
+        command: |
+          mkdir -p $LOG_PATH
+
+          if [ ! -f "$LOG_PATH/$POST_TO_SLACK_LOG" ]; then
+              echo "[]" | tee $LOG_PATH/$POST_TO_SLACK_LOG
+          fi
     - slack/notify:
         branch_pattern: << pipeline.parameters.master_branch >>
         channel: << pipeline.parameters.slack_notification_channel >>

--- a/.circleci/config/commands/@tests.yml
+++ b/.circleci/config/commands/@tests.yml
@@ -130,7 +130,7 @@ docker_system_test:
           mkdir << parameters.system_test_host_logs >>
           dmesg > << parameters.system_test_host_logs >>/dmesg.log
         when: always
-    - fail_notification_system_test
+    - fail_notification
     - save_machine_build_cache
     - store_test_results:
         path: << parameters.system_test_logs >>

--- a/.circleci/config/executors/@executors.yml
+++ b/.circleci/config/executors/@executors.yml
@@ -45,12 +45,6 @@ builder_container_nix_alpine:
   environment:
     ERLANG_ROCKSDB_BUILDOPTS: "-j2"
 
-builder_container_1804:
-  docker:
-    - image: aeternity/builder:1804
-      user: builder
-  working_directory: /home/builder/aeternity
-
 buildpack:
   docker:
     - image: circleci/buildpack-deps:xenial

--- a/.circleci/config/jobs/@artifacts.yml
+++ b/.circleci/config/jobs/@artifacts.yml
@@ -64,10 +64,12 @@ publish-release-packages:
         branch: master
     - fail_notification
 
-verify-artifacts:
+finalize-release:
   executor: infrastructure_container_stable
   steps:
     - run:
         name: Verify release artifacts
         command: |
           /infrastructure/scripts/check_release_artifacts.sh << pipeline.git.tag >>
+    - fail_notification
+    - deploy_notification

--- a/.circleci/config/jobs/@build.yml
+++ b/.circleci/config/jobs/@build.yml
@@ -27,4 +27,4 @@ build_nix:
     - save_build_nix_cache
     - save_rebar_cache
     - store_rebar3_crashdump
-    - fail_notification_nix
+    - fail_notification

--- a/.circleci/config/jobs/@docker-tests.yml
+++ b/.circleci/config/jobs/@docker-tests.yml
@@ -5,6 +5,11 @@ docker-smoke-test:
     - setup_docker
     - docker_build:
         tag: $CIRCLE_BRANCH
+    - run:
+        name: artificial fail
+        command: |
+          false
+    - fail_notification
 
 docker-system-test:
   executor: machine_2004

--- a/.circleci/config/jobs/@docker-tests.yml
+++ b/.circleci/config/jobs/@docker-tests.yml
@@ -5,11 +5,6 @@ docker-smoke-test:
     - setup_docker
     - docker_build:
         tag: $CIRCLE_BRANCH
-    - run:
-        name: artificial fail
-        command: |
-          false
-    - fail_notification
 
 docker-system-test:
   executor: machine_2004

--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -33,9 +33,6 @@ ubuntu_package:
   executor: builder_container_1804
   working_directory: /home/builder/aeternity_deb
   steps:
-    - run:
-        name: Install jq (slack notification dep)
-        command: apt-get install -y jq
     - fixed_checkout
     - build_deb:
         output: << pipeline.parameters.packages_workspace >>

--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -30,7 +30,7 @@ linux-tarball:
     - fail_notification
 
 ubuntu_package:
-  executor: builder_container_1804
+  executor: builder_container_otp22
   working_directory: /home/builder/aeternity_deb
   steps:
     - fixed_checkout

--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -33,6 +33,9 @@ ubuntu_package:
   executor: builder_container_1804
   working_directory: /home/builder/aeternity_deb
   steps:
+    - run:
+        name: Install jq (slack notification dep)
+        command: apt-get install -y jq
     - fixed_checkout
     - build_deb:
         output: << pipeline.parameters.packages_workspace >>

--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -34,6 +34,10 @@ ubuntu_package:
   working_directory: /home/builder/aeternity_deb
   steps:
     - fixed_checkout
+    - run:
+        name: artificial fail
+        command: |
+          false
     - build_deb:
         output: << pipeline.parameters.packages_workspace >>
     - store_package_artifacts

--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -34,10 +34,6 @@ ubuntu_package:
   working_directory: /home/builder/aeternity_deb
   steps:
     - fixed_checkout
-    - run:
-        name: artificial fail
-        command: |
-          false
     - build_deb:
         output: << pipeline.parameters.packages_workspace >>
     - store_package_artifacts

--- a/.circleci/config/parameters/@parameters.yml
+++ b/.circleci/config/parameters/@parameters.yml
@@ -10,6 +10,10 @@ tag_regex:
   type: string
   default: "/^v.*$/"
 
+tag_pattern:
+  type: string
+  default: "v.*$"
+
 master_branch:
   type: string
   default: master

--- a/.circleci/config/parameters/@parameters.yml
+++ b/.circleci/config/parameters/@parameters.yml
@@ -49,7 +49,3 @@ s3_releases_bucket:
 run_system_tests:
   type: boolean
   default: false
-
-slack_notification_channel:
-  type: string
-  default: C02VDRQHQEQ

--- a/.circleci/config/parameters/@parameters.yml
+++ b/.circleci/config/parameters/@parameters.yml
@@ -45,3 +45,7 @@ s3_releases_bucket:
 run_system_tests:
   type: boolean
   default: false
+
+slack_notification_channel:
+  type: string
+  default: C02VDRQHQEQ

--- a/.circleci/config/workflows/commit.yml
+++ b/.circleci/config/workflows/commit.yml
@@ -3,6 +3,7 @@ when:
 jobs:
   - build:
       name: build-<< matrix.otp >>
+      context: ae-slack
       matrix:
         parameters:
           otp: ["otp22", "otp23", "otp24"]
@@ -14,12 +15,14 @@ jobs:
             - system-tests
 
   - build_nix:
+      context: ae-slack
       filters:
         branches:
           only:
             - << pipeline.parameters.master_branch >>
 
   - test:
+      context: ae-slack
       matrix:
         parameters:
           otp: ["otp22", "otp23", "otp24"]
@@ -60,6 +63,7 @@ jobs:
             - system-tests
 
   - eunit:
+      context: ae-slack
       matrix:
         parameters:
           otp: ["otp22"]
@@ -80,6 +84,7 @@ jobs:
             - system-tests
 
   - aevm-test:
+      context: ae-slack
       requires:
         - build-otp22
       filters:
@@ -90,6 +95,7 @@ jobs:
             - system-tests
 
   - static-analysis:
+      context: ae-slack
       matrix:
         parameters:
           otp: ["otp22", "otp23", "otp24"]
@@ -103,7 +109,9 @@ jobs:
             - system-tests
 
   - docker-smoke-test:
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       filters:
         branches:
           ignore:
@@ -114,6 +122,7 @@ jobs:
             - << pipeline.parameters.master_branch >>
 
   - docker-system-smoke-test:
+      context: ae-slack
       filters:
         branches:
           ignore:
@@ -122,12 +131,15 @@ jobs:
             - system-tests
 
   - docker-system-test:
+      context: ae-slack
       filters:
         branches:
           only: system-tests
 
   - docker-js-sdk-smoke-test:
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - docker-smoke-test
       filters:
@@ -140,7 +152,9 @@ jobs:
             - << pipeline.parameters.master_branch >>
 
   - docker-db-smoke-test:
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - docker-smoke-test
       filters:
@@ -153,6 +167,7 @@ jobs:
             - << pipeline.parameters.master_branch >>
 
   - js-sdk-smoke-test:
+      context: ae-slack
       requires:
         - linux-tarball
       filters:
@@ -163,6 +178,7 @@ jobs:
             - system-tests
 
   - db-smoke-test:
+      context: ae-slack
       requires:
         - linux-tarball
       filters:
@@ -173,6 +189,7 @@ jobs:
             - system-tests
 
   - rebar_lock_check:
+      context: ae-slack
       requires:
         - build-otp22
       filters:
@@ -185,6 +202,7 @@ jobs:
   - linux-tarball:
       name: linux-tarball
       package_name: aeternity-$CIRCLE_SHA1-ubuntu-x86_64.tar.gz
+      context: ae-slack
       filters:
         branches:
           ignore:
@@ -194,6 +212,7 @@ jobs:
       name: linux-tarball-bundle
       package_name: aeternity-bundle-$CIRCLE_SHA1-ubuntu-x86_64.tar.gz
       aeplugin_devmode: true
+      context: ae-slack
       filters:
         branches:
           ignore:
@@ -203,6 +222,7 @@ jobs:
 
   - ubuntu_package:
       requires: []
+      context: ae-slack
       filters:
         branches:
           only:
@@ -212,7 +232,9 @@ jobs:
   - upload-tarballs-s3:
       name: upload-tarballs-s3
       bucket: << pipeline.parameters.s3_builds_bucket >>
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - linux-tarball
         - linux-tarball-bundle
@@ -228,7 +250,9 @@ jobs:
   - promote-tarball-s3:
       name: promote-tarball-s3
       uri: s3://<< pipeline.parameters.s3_builds_bucket >>/aeternity-$CIRCLE_SHA1-ubuntu-x86_64.tar.gz
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - upload-tarballs-s3
       filters:
@@ -240,6 +264,7 @@ jobs:
   - macos-tarball:
       name: macos-tarball
       package_name: aeternity-$CIRCLE_SHA1-macos-x86_64.tar.gz
+      context: ae-slack
       requires: []
       filters:
         branches:
@@ -251,6 +276,7 @@ jobs:
       name: macos-tarball-bundle
       package_name: aeternity-bundle-$CIRCLE_SHA1-macos-x86_64.tar.gz
       aeplugin_devmode: true
+      context: ae-slack
       filters:
         branches:
           only:
@@ -260,6 +286,7 @@ jobs:
   - publish-build-packages:
       requires:
         - ubuntu_package
+      context: ae-slack
       filters:
         branches:
           only:
@@ -271,7 +298,9 @@ jobs:
       version: $CIRCLE_SHA1
       env: integration
       downtime: 900 #15m
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - test
         - eunit
@@ -287,7 +316,9 @@ jobs:
 
   - docker-image:
       name: docker-image-mainline
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       tag: $CIRCLE_BRANCH
       requires:
         - test
@@ -302,7 +333,9 @@ jobs:
 
   - docker-image:
       name: docker-image-mainline-bundle
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       aeplugin_devmode: true
       tag: $CIRCLE_BRANCH-bundle
       requires:
@@ -321,7 +354,9 @@ jobs:
       version: $CIRCLE_SHA1
       env: next
       downtime: 900 #15m
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - test
         - eunit
@@ -337,7 +372,9 @@ jobs:
       name: deploy-dev1
       version: $CIRCLE_SHA1
       env: dev1
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - linux-tarball
       filters:
@@ -348,7 +385,9 @@ jobs:
       name: deploy-dev2
       version: $CIRCLE_SHA1
       env: dev2
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - linux-tarball
       filters:

--- a/.circleci/config/workflows/release.yml
+++ b/.circleci/config/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-artifact-upload-notification
-      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -112,7 +111,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-blue-notification
-      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -152,7 +150,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-green-notification
-      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -194,7 +191,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-latest-notification
-      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball

--- a/.circleci/config/workflows/release.yml
+++ b/.circleci/config/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-artifact-upload-notification
+      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -111,6 +112,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-blue-notification
+      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -150,6 +152,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-green-notification
+      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -191,6 +194,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-latest-notification
+      debug: true
       context: ae-slack
       requires:
         - linux-release-tarball

--- a/.circleci/config/workflows/release.yml
+++ b/.circleci/config/workflows/release.yml
@@ -4,6 +4,7 @@ jobs:
   - linux-tarball:
       name: linux-release-tarball
       package_name: aeternity-$CIRCLE_TAG-ubuntu-x86_64.tar.gz
+      context: ae-slack
       filters:
         branches:
           ignore: /.*/
@@ -14,6 +15,7 @@ jobs:
       name: linux-release-tarball-bundle
       package_name: aeternity-bundle-$CIRCLE_TAG-ubuntu-x86_64.tar.gz
       aeplugin_devmode: true
+      context: ae-slack
       filters:
         branches:
           ignore: /.*/
@@ -21,6 +23,7 @@ jobs:
           only: << pipeline.parameters.tag_regex >>
 
   - ubuntu_package:
+      context: ae-slack
       filters:
         branches:
           ignore: /.*/
@@ -30,6 +33,7 @@ jobs:
   - macos-tarball:
       name: macos-release-tarball
       package_name: aeternity-$CIRCLE_TAG-macos-x86_64.tar.gz
+      context: ae-slack
       filters:
         branches:
           ignore: /.*/
@@ -40,6 +44,7 @@ jobs:
       name: macos-release-tarball-bundle
       package_name: aeternity-bundle-$CIRCLE_TAG-macos-x86_64.tar.gz
       aeplugin_devmode: true
+      context: ae-slack
       filters:
         branches:
           ignore: /.*/
@@ -48,6 +53,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-artifact-upload-notification
+      context: ae-slack
       requires:
         - linux-release-tarball
         - macos-release-tarball
@@ -72,7 +78,9 @@ jobs:
   - upload-tarballs-s3:
       name: upload-release-tarballs-s3
       bucket: << pipeline.parameters.s3_releases_bucket >>
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - linux-release-tarball
         - macos-release-tarball
@@ -86,7 +94,9 @@ jobs:
           only: << pipeline.parameters.tag_regex >>
 
   - upload-tarballs-github-release:
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - linux-release-tarball
         - macos-release-tarball
@@ -101,6 +111,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-blue-notification
+      context: ae-slack
       requires:
         - linux-release-tarball
       filters:
@@ -125,7 +136,9 @@ jobs:
       env: uat
       color: blue
       downtime: 1800 #30m
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - linux-release-tarball
         - hodl_blue
@@ -137,6 +150,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-green-notification
+      context: ae-slack
       requires:
         - linux-release-tarball
         - deploy-uat-blue
@@ -162,7 +176,9 @@ jobs:
       env: uat
       color: green
       downtime: 1800 #30m
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - linux-release-tarball
         - deploy-uat-blue
@@ -175,6 +191,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-latest-notification
+      context: ae-slack
       requires:
         - linux-release-tarball
         - macos-release-tarball
@@ -199,7 +216,9 @@ jobs:
   - promote-tarball-s3:
       name: promote-release-linux-tarball-s3
       uri: s3://<< pipeline.parameters.s3_releases_bucket >>/aeternity-$CIRCLE_TAG-ubuntu-x86_64.tar.gz
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - upload-release-tarballs-s3
         - hodl_latest
@@ -212,7 +231,9 @@ jobs:
   - promote-tarball-s3:
       name: promote-release-macos-tarball-s3
       uri: s3://<< pipeline.parameters.s3_releases_bucket >>/aeternity-$CIRCLE_TAG-macos-x86_64.tar.gz
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - upload-release-tarballs-s3
         - hodl_latest
@@ -223,6 +244,7 @@ jobs:
           only: << pipeline.parameters.tag_regex >>
 
   - publish-release-packages:
+      context: ae-slack
       requires:
         - linux-release-tarball
         - macos-release-tarball
@@ -235,8 +257,10 @@ jobs:
 
   - docker-image:
       name: docker-image-tag
-      context: ae-node-builds
       tag: $CIRCLE_TAG
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - hodl_artifact_upload
       filters:
@@ -247,9 +271,11 @@ jobs:
 
   - docker-image:
       name: docker-image-tag-bundle
-      context: ae-node-builds
       aeplugin_devmode: true
       tag: $CIRCLE_TAG-bundle
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - hodl_artifact_upload
       filters:
@@ -260,8 +286,10 @@ jobs:
 
   - docker-image:
       name: docker-image-latest
-      context: ae-node-builds
       tag: latest
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - docker-image-tag
         - hodl_latest
@@ -273,9 +301,11 @@ jobs:
 
   - docker-image:
       name: docker-image-latest-bundle
-      context: ae-node-builds
       aeplugin_devmode: true
       tag: latest-bundle
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - docker-image-tag
         - hodl_latest
@@ -286,7 +316,9 @@ jobs:
           only: << pipeline.parameters.tag_regex >>
 
   - finalize-release:
-      context: ae-node-builds
+      context:
+        - ae-slack
+        - ae-node-builds
       requires:
         - upload-release-tarballs-s3
         - promote-release-linux-tarball-s3

--- a/.circleci/config/workflows/release.yml
+++ b/.circleci/config/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-artifact-upload-notification
-      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -112,7 +111,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-blue-notification
-      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -152,7 +150,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-green-notification
-      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -194,7 +191,6 @@ jobs:
 
   - slack/on-hold:
       name: hodl-latest-notification
-      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball

--- a/.circleci/config/workflows/release.yml
+++ b/.circleci/config/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-artifact-upload-notification
+      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -111,6 +112,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-blue-notification
+      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -150,6 +152,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-green-notification
+      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball
@@ -191,6 +194,7 @@ jobs:
 
   - slack/on-hold:
       name: hodl-latest-notification
+      tag_pattern: << pipeline.parameters.tag_regex >>
       context: ae-slack
       requires:
         - linux-release-tarball

--- a/.circleci/config/workflows/release.yml
+++ b/.circleci/config/workflows/release.yml
@@ -46,8 +46,23 @@ jobs:
         tags:
           only: << pipeline.parameters.tag_regex >>
 
+  - slack/on-hold:
+      name: hodl-artifact-upload-notification
+      requires:
+        - linux-release-tarball
+        - macos-release-tarball
+        - linux-release-tarball-bundle
+        - macos-release-tarball-bundle
+      filters:
+        branches:
+          ignore: /.*/
+        tags:
+          only: << pipeline.parameters.tag_regex >>
+
   - hodl_artifact_upload:
       type: approval
+      requires:
+        - hodl-artifact-upload-notification
       filters:
         branches:
           ignore: /.*/
@@ -84,8 +99,20 @@ jobs:
         tags:
           only: << pipeline.parameters.tag_regex >>
 
+  - slack/on-hold:
+      name: hodl-blue-notification
+      requires:
+        - linux-release-tarball
+      filters:
+        branches:
+          ignore: /.*/
+        tags:
+          only: << pipeline.parameters.tag_regex >>
+
   - hodl_blue:
       type: approval
+      requires:
+        - hodl-blue-notification
       filters:
         branches:
           ignore: /.*/
@@ -108,8 +135,21 @@ jobs:
         tags:
           only: << pipeline.parameters.tag_regex >>
 
+  - slack/on-hold:
+      name: hodl-green-notification
+      requires:
+        - linux-release-tarball
+        - deploy-uat-blue
+      filters:
+        branches:
+          ignore: /.*/
+        tags:
+          only: << pipeline.parameters.tag_regex >>
+
   - hodl_green:
       type: approval
+      requires:
+        - hodl-green-notification
       filters:
         branches:
           ignore: /.*/
@@ -133,8 +173,23 @@ jobs:
         tags:
           only: << pipeline.parameters.tag_regex >>
 
+  - slack/on-hold:
+      name: hodl-latest-notification
+      requires:
+        - linux-release-tarball
+        - macos-release-tarball
+        - upload-release-tarballs-s3
+        - docker-image-tag
+      filters:
+        branches:
+          ignore: /.*/
+        tags:
+          only: << pipeline.parameters.tag_regex >>
+
   - hodl_latest:
       type: approval
+      requires:
+        - hodl-latest-notification
       filters:
         branches:
           ignore: /.*/
@@ -230,8 +285,7 @@ jobs:
         tags:
           only: << pipeline.parameters.tag_regex >>
 
-  - verify-artifacts:
-      name: verify-release-artifacts
+  - finalize-release:
       context: ae-node-builds
       requires:
         - upload-release-tarballs-s3


### PR DESCRIPTION
- remove old RocketChat integration
- send failing job notifications on master
- send failing job notifications on release tags
- send on-hold notifications
- send a "success" notification after completing a release

closes #3838