### PR TITLE
Use -1 when name_ttl is not specified on name_update events

### DIFF
--- a/apps/aefate/src/aefa_chain_api.erl
+++ b/apps/aefate/src/aefa_chain_api.erl
@@ -465,7 +465,7 @@ tx_event_data(aens_revoke, {Pubkey, NameId}, _Type) ->
 tx_event_data(aens_update, {Pubkey, NameHash, TTL, ClientTTL, Pointers}, _Type) ->
     ok(aens_update_tx:new(#{ account_id => acct_id(Pubkey)
                            , name_id    => name_id(NameHash)
-                           , name_ttl   => val(TTL, 0)
+                           , name_ttl   => val(TTL, -1)
                            , pointers   => val(Pointers, [])
                            , client_ttl => val(ClientTTL, 0)
                            , nonce => 0


### PR DESCRIPTION
Right now, there's no way to distinguish on the env event if the AENS
update was called using `Some(0)` (update the name to expire
immediately) or `None` (don't update the name TTL).

This implementation now returns name_ttl = 0 when it was supposed to
expire immediately and `name_ttl = -1` when the name_ttl is supposed
to remain untouched.