### PR TITLE
Fix aec_db:is_in_tx_pool() test + corresponding calling code

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1051,7 +1051,7 @@ add_tx_hash_to_mempool(TxHash) when is_binary(TxHash) ->
       [{aec_tx_pool, TxHash}]).
 
 is_in_tx_pool(TxHash) ->
-    ?t(mnesia:read(aec_tx_pool, TxHash)) =:= ?TX_IN_MEMPOOL.
+    ?t(mnesia:read(aec_tx_pool, TxHash)) =/= ?TX_IN_MEMPOOL.
 
 remove_tx_from_mempool(TxHash) when is_binary(TxHash) ->
     ?t(mnesia:delete({aec_tx_pool, TxHash}),

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1051,7 +1051,7 @@ add_tx_hash_to_mempool(TxHash) when is_binary(TxHash) ->
       [{aec_tx_pool, TxHash}]).
 
 is_in_tx_pool(TxHash) ->
-    ?t(mnesia:read(aec_tx_pool, TxHash)) =/= ?TX_IN_MEMPOOL.
+    ?t(mnesia:read(aec_tx_pool, TxHash)) =/= [].
 
 remove_tx_from_mempool(TxHash) when is_binary(TxHash) ->
     ?t(mnesia:delete({aec_tx_pool, TxHash}),

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -864,13 +864,13 @@ update_pool_on_tx_hash(TxHash, {#dbs{gc_db = GCDb} = Dbs, OriginsCache, GCHeight
             ets:insert(Handled, {TxHash}),
             {ok, Tx} = aec_db:dirty_get_signed_tx(TxHash),
             case aec_db:is_in_tx_pool(TxHash) of
-                true ->
+                false ->
                     %% Added to chain
                     Key = pool_db_key(Tx),
                     pool_db_raw_delete(Dbs, Key),
                     aec_tx_pool_gc:delete_hash(GCDb, TxHash),
                     add_to_origins_cache(OriginsCache, Tx);
-                false ->
+                true ->
                     Key = pool_db_key(Tx),
                     pool_db_raw_put(Dbs, GCHeight, Key, Tx, TxHash)
             end


### PR DESCRIPTION
See issue #3880 

The test in `aec_db:is_in_tx_pool/1` is erroneous, but the calling code compensated by reversing the logic.