### PR TITLE
Fix `int-as-string` in dry-run

### DIFF
--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -125,10 +125,10 @@ cache_enabled() ->
     aeu_env:user_config_or_env([<<"http">>, <<"cache">>, <<"enabled">>],
                                aehttp, [cache, enabled], ?DEFAULT_HTTP_CACHE_ENABLED).
 
-convert_all_ints_to_string(Map) ->
-   maps:map(
-      fun(_, I) when is_integer(I) -> integer_to_binary(I);
-         (_, M) when is_map(M) -> convert_all_ints_to_string(M);
-         (_, Other) -> Other
-      end,
-      Map).
+convert_all_ints_to_string(Val) ->
+   case Val of
+      _ when is_integer(Val) -> integer_to_binary(Val);
+      _ when is_map(Val) -> maps:map(fun(_, V) -> convert_all_ints_to_string(V) end, Val);
+      _ when is_list(Val) -> lists:map(fun(I) -> convert_all_ints_to_string(I) end, Val);
+      Other -> Other
+   end.

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -671,7 +671,7 @@ dry_run_accounts_([Account | Accounts], Acc) ->
         #{ <<"pub_key">> := EPK, <<"amount">> := Amount } ->
             case aeser_api_encoder:safe_decode(account_pubkey, EPK) of
                 {ok, PK} ->
-                    dry_run_accounts_(Accounts, [#{ pub_key => PK, amount => Amount } | Acc]);
+                    dry_run_accounts_(Accounts, [#{ pub_key => PK, amount => to_int(Amount) } | Acc]);
                 Err = {error, _Reason} ->
                     Err
             end;

--- a/apps/aehttp/test/aehttp_dryrun_SUITE.erl
+++ b/apps/aehttp/test/aehttp_dryrun_SUITE.erl
@@ -368,6 +368,14 @@ accounts(Config) ->
     {ok, 200, #{ <<"results">> := [#{ <<"result">> := <<"ok">> }, #{ <<"result">> := <<"ok">> }] }} =
         dry_run(Config, TopHash, [Tx2, Tx1], [#{ pub_key => EPub, amount => 1000000000000000}]),
 
+    %% Should work with amount as string
+    case proplists:get_value(swagger_version, Config) of
+        oas3 ->
+            {ok, 200, #{ <<"results">> := [#{ <<"result">> := <<"ok">> }, #{ <<"result">> := <<"ok">> }] }} =
+                dry_run(Config, TopHash, [Tx1, Tx2], [#{ pub_key => APub, amount => <<"100000000">> }]);
+        swagger2 -> none
+    end,
+
     ok.
 
 %% --- Internal functions ---

--- a/docs/release-notes/next/fix-int-as-string.md
+++ b/docs/release-notes/next/fix-int-as-string.md
@@ -1,0 +1,2 @@
+* Fixes serialisation if `int-as-string` is enabled: numbers in lists gets
+  converted to strings, `dry_run` endpoint accepts balance as string.


### PR DESCRIPTION
While working on https://github.com/aeternity/aepp-sdk-js/pull/1233 I found that dry-run endpoint is not fully compatible with `int-to-string` parameter:
- it doesn't accept account amount as string
- it returns an array of results that doesn't have nested fields converted to strings