### PR TITLE
Fix broken swagger definition

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2038,7 +2038,7 @@ paths:
         - internal
         - node-operator
       operationId: GetPeerCount
-      description: Get the number of peers in the different pools. This is to be used to catch if a node loses connectivity 
+      description: Get the number of peers in the different pools. This is to be used to catch if a node loses connectivity
       parameters:
         - $ref: '#/components/parameters/intAsString'
       responses:
@@ -3711,7 +3711,7 @@ components:
       type: object
       properties:
         next_nonce:
-          type: integer
+          $ref: "#/components/schemas/UInt64"
       required:
         - next_nonce
     CheckTxInPoolResponse:

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1432,6 +1432,10 @@ get_accounts_next_nonce_sut(Id) ->
     Host = external_address(),
     http_request(Host, get, "accounts/" ++ binary_to_list(Id) ++ "/next-nonce", []).
 
+get_accounts_next_nonce_sut_(Id) ->
+    Host = external_address(),
+    http_request(Host, get, "accounts/" ++ binary_to_list(Id) ++ "/next-nonce?int-as-string", []).
+
 get_accounts_next_nonce_sut(Id, Strategy) when Strategy =:= max; Strategy =:= continuity ->
     StrategyL = atom_to_list(Strategy),
     Host = external_address(),
@@ -3007,6 +3011,12 @@ spend_transaction(_Config) ->
     {ok, 200, #{<<"next_nonce">> := NextNonce}} = get_accounts_next_nonce_sut(MinerID),
     {ok, 200, #{<<"next_nonce">> := NextNonce}} = get_accounts_next_nonce_sut(MinerID, max),
     {ok, 200, #{<<"next_nonce">> := NextNonce}} = get_accounts_next_nonce_sut(MinerID, continuity),
+    case aecore_suite_utils:http_api_version() of
+        oas3 ->
+            {ok, 200, #{<<"next_nonce">> := NextNonceBin}} = get_accounts_next_nonce_sut_(MinerID),
+            NextNonce = binary_to_integer(NextNonceBin);
+        _ -> pass
+    end,
     RandAddress = random_hash(),
     Payload = <<"hejsan svejsan">>,
     Encoded = #{sender_id => MinerAddress,

--- a/docs/release-notes/next/fix_swagger_definition.md
+++ b/docs/release-notes/next/fix_swagger_definition.md
@@ -1,0 +1,2 @@
+* Fixes a bug in the OAS3 definition for endpoint "/accounts/{pubkey}/next-nonce" in a combination with `int-to-string` flag
+


### PR DESCRIPTION
When the flag `int-as-string` is raised - the resulting integer is encoded as a string. The corresponding type in the swagger definition had to be adjusted.