### PR TITLE
Gh3871 crash during rollback

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1,4 +1,4 @@
-%%% -*- erlang-indent-level: 4 -*-
+%%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
 %%%-------------------------------------------------------------------
 %%% @copyright (C) 2017, Aeternity Anstalt
 %%% @doc Main conductor of the mining
@@ -62,6 +62,7 @@
         , is_leader/0
         , get_beneficiary/0
         , get_next_beneficiary/0
+        , note_rollback/1
         ]).
 
 %% Chain API
@@ -240,14 +241,28 @@ init(Options) ->
     lager:debug("Options = ~p", [Options]),
     process_flag(trap_exit, true),
     ok     = init_chain_state(),
+    State1 = acquire_top_and_consensus(),
+    State2 = set_option(autostart, Options, State1),
+    State3 = set_option(strictly_follow_top, Options, State2),
+    {ok, State4} = set_beneficiary(State3),
+    State5 = init_miner_instances(State4),
+    State6 = set_stratum_mode(State5), %% May overwrite beneficiary.
+
+    aec_metrics:try_update([ae,epoch,aecore,chain,height],
+                           aec_blocks:height(aec_chain:top_block())),
+    epoch_mining:info("Miner process initialized ~p", [State6]),
+    aec_events:subscribe(candidate_block),
+    %% NOTE: The init continues at handle_info(init_continue, State).
+    self() ! init_continue,
+    {ok, State6}.
+
+acquire_top_and_consensus() ->
     TopBlockHash0 = aec_chain:top_block_hash(),
     {ok, TopHeader0} = aec_chain:get_header(TopBlockHash0),
     ConsensusModule = aec_headers:consensus_module(TopHeader0),
     ConsensusConfig = aec_consensus:get_consensus_config_at_height(aec_headers:height(TopHeader0)),
-
     %% Might mutate the DB in some cases
     ConsensusModule:start(ConsensusConfig), %% Might do nothing or it might spawn a genserver :P
-
     Consensus = #consensus{ micro_block_cycle = aec_governance:micro_block_cycle()
                           , leader = false
                           , consensus_module = ConsensusModule },
@@ -260,6 +275,7 @@ init(Options) ->
                    aec_chain:top_height()}
           end),
 
+<<<<<<< HEAD
     State1 = #state{ top_block_hash     = TopBlockHash,
                      top_key_block_hash = TopKeyBlockHash,
                      top_height         = TopHeight,
@@ -276,6 +292,12 @@ init(Options) ->
     %% NOTE: The init continues at handle_info(init_continue, State).
     self() ! init_continue,
     {ok, State5}.
+=======
+    #state{ top_block_hash     = TopBlockHash,
+	    top_key_block_hash = TopKeyBlockHash,
+	    top_height         = TopHeight,
+	    consensus          = Consensus}.
+>>>>>>> Notify conductor and tx_pool after rollback
 
 init_chain_state() ->
     case aec_chain:genesis_hash() of
@@ -410,6 +432,17 @@ handle_call(is_leader, _From, State = #state{ consensus = Cons }) ->
     {reply, Cons#consensus.leader, State};
 handle_call(reinit_chain, _From, State) ->
     reinit_chain_impl(State);
+handle_call({note_rollback, Info}, _From, State) ->
+    #state{ top_block_hash = TBHash
+	  , top_key_block_hash = TopKeyBlockHash
+	  , top_height = TopHeight
+	  , consensus = Consensus } = acquire_top_and_consensus(),
+    State1 = State#state{ top_block_hash = TBHash
+			, top_key_block_hash = TopKeyBlockHash
+			, top_height = TopHeight
+			, consensus = Consensus },
+    aec_tx_pool:note_rollback(Info),
+    {reply, ok, State1};
 handle_call(Request, _From, State) ->
     epoch_mining:error("Received unknown request: ~p", [Request]),
     Reply = ok,
@@ -524,6 +557,9 @@ get_next_beneficiary() ->
     TopHeader = aec_chain:top_header(),
     Consensus = aec_consensus:get_consensus_module_at_height(aec_headers:height(TopHeader) + 1),
     get_next_beneficiary(Consensus).
+
+note_rollback(Info) ->
+    gen_server:call(?SERVER, {note_rollback, Info}).
 
 set_mode(State) ->
     ConsensusModule = consensus_module(State),

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -822,7 +822,7 @@ do_top_change(#{old_height := OldHeight, new_height := NewHeight}, State)
     %% that the transactions in the deleted blocks were thereby undone
     %% (they may still be in the database, but their location info is gone)
     {ok, do_update_sync_top_target(NewHeight, State)};
-do_top_change(#{type := Type, old_hash := OldHash, new_hash := NewHash} = Info, State0) ->
+do_top_change(#{type := Type, old_hash := OldHash, new_hash := NewHash}, State0) ->
     %% NG: does this work for common ancestor for micro blocks?
     {ok, Ancestor} =
         aec_db:ensure_activity(async_dirty,


### PR DESCRIPTION
See issue #3871 (and aeternity/aeplugin_dev_mode#15)

After reproducing the problem in the dev_mode_SUITE, the suggested fix is to notify the conductor (and tx_pool) after completed rollback to give them a chance to update their state. The observed crash appears to be due to the conductor notifying aec_tx_pool of top change with outdated parameters.