### PR TITLE
Consensus contract improvements

### DIFF
--- a/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
@@ -1170,8 +1170,8 @@ validator_can_not_unstake_below_30_percent_treshold(_Config) ->
     %% 30% treshold for Alice: 12000
     UnstakeAmt = 8000,
 
-    {revert, <<"Validator can not withdraw below the 30% treshold">>}
-        = unstake_(Alice, UnstakeAmt + 1, Alice, TxEnv, Trees6),
+    ?assertEqual({revert, <<"Validator can not withdraw below the treshold">>},
+                 unstake_(Alice, UnstakeAmt + 1, Alice, TxEnv, Trees6)),
     {ok, _, _} = unstake_(Alice, UnstakeAmt, Alice, TxEnv, Trees6),
 
     ok.

--- a/docs/release-notes/next-hc/GH-3990-consensus-contract-improvements.md
+++ b/docs/release-notes/next-hc/GH-3990-consensus-contract-improvements.md
@@ -1,0 +1,4 @@
+* When staking, return shares bought, stake, and execution height.
+* When unstaking, return shares bought, stake, and execution height.
+* Allow validator to become online at contract creation height
+* Staker should not be able to be left with less than the minimum stake

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -103,8 +103,6 @@ main contract MainStaking =
       pending_unstake       = {}
       }
 
-
-
   entrypoint online_validators() =
     let vs = Map.to_list(state.online_validators)
     [ (v, s) | (v, {stake = s}) <- vs ]
@@ -171,7 +169,7 @@ main contract MainStaking =
           OFFLINE => put(state{offline_validators[to] = new_validator})
         {stake = Call.value, shares = shares, execution_height = height }
 
-  stateful entrypoint unstake(from : address, stakes : int) : int =
+  stateful entrypoint unstake(from : address, stakes : int) : staking_response =
     let validator : validator = get_validator(from)
     let payout = validator.ct.unstake(Call.caller, stakes)
     assert_allowed_to_unstake(from, Call.caller, validator)
@@ -187,7 +185,7 @@ main contract MainStaking =
     switch(validator_bucket(from))
       ONLINE => put(state{online_validators[from] = new_validator{ stake @ s = s - payout}, total_stake @ ts = ts - payout})
       OFFLINE => put(state{offline_validators[from] = new_validator{ stake @ s = s - payout }})
-    payout
+    { stake = payout, shares = stakes, execution_height = Chain.block_height + state.unstake_delay}
 
   payable stateful entrypoint reward(to : address) =
     assert_protocol_call()

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -11,7 +11,7 @@ contract interface StakingValidator =
                              delegates : map(address, int),
                              shares : int }
   entrypoint init : (address, int) => unit
-  payable stateful entrypoint stake : address => unit
+  payable stateful entrypoint stake : address => int
   payable entrypoint profit : () => unit
   stateful entrypoint distribute_unstake : () => unit
   stateful entrypoint unstake : (address, int) => int
@@ -19,6 +19,7 @@ contract interface StakingValidator =
   entrypoint balance : (address) => int
   entrypoint shares : (address) => int
   entrypoint all_shares : () => int
+  entrypoint estimate_stake_shares : (int) => int
   stateful entrypoint set_name : (string) => unit
   stateful entrypoint set_description : (string) => unit
   stateful entrypoint set_avatar_url : (string) => unit
@@ -144,13 +145,15 @@ main contract MainStaking =
     switch(state.stake_delay)
       0 =>
         let validator : validator = get_validator(to)
-        validator.ct.stake(value = Call.value, Call.caller)
+        let shares = validator.ct.stake(value = Call.value, Call.caller)
         let new_validator = maybe_set_stake_limit(to, Call.caller, validator{ stake @ s = s + Call.value })
         switch(validator_bucket(to))
           ONLINE => put(state{online_validators[to] = new_validator, total_stake @ ts = ts + Call.value })
           OFFLINE => put(state{offline_validators[to] = new_validator})
+        shares
       _ =>
         let validator : validator = get_validator(to)
+        let shares = validator.ct.estimate_stake_shares(Call.value)
         let new_validator = maybe_set_stake_limit(to, Call.caller, validator{ pending_stake @ ps = ps + Call.value })
         let height  = Chain.block_height + state.stake_delay
         let pending_transfer = { validator = to, staker = Call.caller, stake = Call.value}
@@ -161,8 +164,7 @@ main contract MainStaking =
         switch(validator_bucket(to))
           ONLINE => put(state{online_validators[to] = new_validator})
           OFFLINE => put(state{offline_validators[to] = new_validator})
-
-         // total_stake @ ts = ts + Call.value,
+        shares
 
   stateful entrypoint unstake(from : address, stakes : int) : int =
     let validator : validator = get_validator(from)

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -68,6 +68,7 @@ main contract MainStaking =
 
   record state =
     { staking_validator_ct  : StakingValidator,
+      genesis_height        : int,
       online_validators     : map(address, validator),
       offline_validators    : map(address, validator),
       total_stake           : int,
@@ -90,6 +91,7 @@ main contract MainStaking =
                   unstake_delay : int
                   ) =
     { staking_validator_ct  = staking_validator_ct,
+      genesis_height        = Chain.block_height,
       online_validators     = {},
       offline_validators    = {},
       total_stake           = 0,
@@ -371,5 +373,7 @@ main contract MainStaking =
     else v
 
   function assert_allowed_to_set_online(v : validator) =
-    if(v.creation_height + state.online_delay =< Chain.block_height) true
-    else abort("Minimum height not reached")
+    if(Chain.block_height == state.genesis_height) true
+    else
+      if(v.creation_height + state.online_delay =< Chain.block_height) true
+      else abort("Minimum height not reached")

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -39,6 +39,11 @@ main contract MainStaking =
       pending_stake   : int,
       stake_limit     : int}
 
+  record staking_response =
+    { stake            : int,
+      shares           : int,
+      execution_height : int}
+
   record get_validator_response =
     { ct              : StakingValidator,
       address         : address,
@@ -140,7 +145,7 @@ main contract MainStaking =
               online_validators @ onv = Map.delete(Call.caller, onv),
               total_stake @ ts = ts - validator.stake})
 
-  payable stateful entrypoint stake(to : address) =
+  payable stateful entrypoint stake(to : address) : staking_response =
     require(Call.value >= state.stake_minimum, "Must stake the minimum amount")
     switch(state.stake_delay)
       0 =>
@@ -150,7 +155,7 @@ main contract MainStaking =
         switch(validator_bucket(to))
           ONLINE => put(state{online_validators[to] = new_validator, total_stake @ ts = ts + Call.value })
           OFFLINE => put(state{offline_validators[to] = new_validator})
-        shares
+        {stake = Call.value, shares = shares, execution_height = Chain.block_height }
       _ =>
         let validator : validator = get_validator(to)
         let shares = validator.ct.estimate_stake_shares(Call.value)
@@ -164,7 +169,7 @@ main contract MainStaking =
         switch(validator_bucket(to))
           ONLINE => put(state{online_validators[to] = new_validator})
           OFFLINE => put(state{offline_validators[to] = new_validator})
-        shares
+        {stake = Call.value, shares = shares, execution_height = height }
 
   stateful entrypoint unstake(from : address, stakes : int) : int =
     let validator : validator = get_validator(from)

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -352,7 +352,7 @@ main contract MainStaking =
       let validator = get_validator_state(v)
       let min_percent = state.validator_min_percent
       if((100 * balance) < (min_percent * validator.stake))
-        abort("Validator can not withdraw below the 30% treshold")
+        abort("Validator can not withdraw below the treshold")
       else false
 
   stateful function maybe_set_stake_limit(to : address, who : address, v : validator) : validator =

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -340,15 +340,23 @@ main contract MainStaking =
   function assert_allowed_to_unstake(from : address, who : address, v : validator) =
     if(from == who)
       let balance_left = v.ct.balance(from)
-      assert_min_stake(balance_left)
+      assert_validator_min_stake(balance_left)
       assert_min_percent_stake(who, balance_left)
     else
-      true
+      let balance_left = v.ct.balance(who)
+      assert_staker_min_stake(balance_left)
 
-  function assert_min_stake(balance : int) =
+  function assert_validator_min_stake(balance : int) =
       if(balance < state.validator_min_stake)
         abort("Validator can not withdraw below the treshold")
       else false
+
+  function assert_staker_min_stake(balance : int) =
+      if(balance == 0) false
+      else
+        if(balance < state.stake_minimum)
+          abort("Staker can not withdraw below the treshold")
+        else false
 
   function assert_min_percent_stake(v: address, balance : int) =
       let validator = get_validator_state(v)

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -31,6 +31,10 @@ main contract StakingValidator =
     let new_shares = calculate_shares(Call.value)
     add_shares(staker, new_shares)
     put(state{shares @ s = s + new_shares})
+    new_shares
+
+  entrypoint estimate_stake_shares(value : int) =
+    estimate_shares(value)
 
   payable entrypoint profit() =
     assert_caller()
@@ -112,6 +116,9 @@ main contract StakingValidator =
       stake_size
     else
       (stake_size * state.shares) / (contract_balance() - stake_size)
+
+  function estimate_shares(stake_size : int) =
+      (stake_size * state.shares) / contract_balance()
 
   function assert_caller() =
     require(Call.caller == state.main_staking_ct, "Only allowed through MainStaking")


### PR DESCRIPTION
Fixes: 
- [#3969: When staking, return shares bought and change returned as contract call method return values.](https://github.com/aeternity/aeternity/issues/3969)
- [#3971: When unstaking, return aetto received from the contract method](https://github.com/aeternity/aeternity/issues/3971)
- [#3999: Misleading message in the MainStaking contract](https://github.com/aeternity/aeternity/issues/3999)
- [#4001: Allow validator become online at height 0](https://github.com/aeternity/aeternity/issues/4001)
- [#3970: User should not be able to be left with less than the minimum stake](https://github.com/aeternity/aeternity/issues/3970)