### PR TITLE
In HC, genesis block has an empty info

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -240,7 +240,7 @@ genesis_raw_header() ->
         no_value,
         0,
         0,
-        default,
+        0, %% no info in genesis block
         ?CERES_PROTOCOL_VSN).
 genesis_difficulty() -> 0.
 

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -240,7 +240,7 @@ genesis_raw_header() ->
         no_value,
         0,
         0,
-        0, %% no info in genesis block
+        default,
         ?CERES_PROTOCOL_VSN).
 genesis_difficulty() -> 0.
 

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -296,16 +296,18 @@ new_key_header(Height, PrevHash, PrevKeyHash, RootHash, Miner, Beneficiary,
                     key_seal     = KeySeal,
                     nonce        = Nonce,
                     time         = Time,
-                    info         = make_info(Version, Info),
+                    info         = make_info(Height, Version, Info),
                     version      = Version
                }).
 
-make_info(Version, Info) when (Version >= ?MINERVA_PROTOCOL_VSN), ?IS_INT_INFO(Info) ->
+make_info(0, _Version, default) ->
+    <<>>;
+make_info(_, Version, Info) when (Version >= ?MINERVA_PROTOCOL_VSN), ?IS_INT_INFO(Info) ->
     <<Info:?OPTIONAL_INFO_BYTES/unit:8>>;
-make_info(Version, default) when Version >= ?MINERVA_PROTOCOL_VSN ->
+make_info(_, Version, default) when Version >= ?MINERVA_PROTOCOL_VSN ->
     PointReleaseInfo = aeu_info:block_info(),
     <<PointReleaseInfo:?OPTIONAL_INFO_BYTES/unit:8>>;
-make_info(_Version, default) ->
+make_info(_, _Version, default) ->
     <<>>.
 
 -spec new_micro_header(height(), block_header_hash(), block_header_hash(),
@@ -358,7 +360,7 @@ info(#key_header{info = <<I:?OPTIONAL_INFO_BYTES/unit:8>>}) ->
 
 -spec set_info(key_header(), info()) -> key_header().
 set_info(#key_header{version = Vsn} = H, I) ->
-    H#key_header{info = make_info(Vsn, I)}.
+    H#key_header{info = make_info(height(H), Vsn, I)}.
 
 -spec prev_hash(header()) -> block_header_hash().
 prev_hash(#key_header{prev_hash = H}) -> H;


### PR DESCRIPTION
Ever since Minerva protocol upgrade, keyblocks come with an info field. It
represents the node's version. This field is not validated in any way and is
intended to be used for signaling soft upgrades. All networks so far had
started from a Roma genesis block (empty info field).

Genesis block is being computed according to the latest protocol. Since HCs
start from CERES protocol, the genesis block includes the node's version at
that height. Although this is not validated, it impacts heavily the syncing
capabilities of nodes - it limits HC nodes to the same fork as the one the
genesis block was produced on.

This PR makes the genesis to have an empty field for HC nodes.
