### PR TITLE
GH3674: fix delegated signatures for non-existing accounts (in Ceres)

### DIFF
--- a/apps/aefate/src/aefa_chain_api.erl
+++ b/apps/aefate/src/aefa_chain_api.erl
@@ -60,7 +60,7 @@
         , eval_primops/2
         ]).
 
--export([ check_delegation_signature/4
+-export([ check_delegation_signature/5
         , is_onchain/1
         ]).
 
@@ -353,9 +353,9 @@ next_nonce(Pubkey, #state{primop_state = PState0,
             end
     end.
 
--spec check_delegation_signature(pubkey(), binary(), binary(), state()) ->
+-spec check_delegation_signature(pubkey(), binary(), binary(), aect_contracts:vm_version(), state()) ->
                                         {'ok', state()} | 'error'.
-check_delegation_signature(Pubkey, Binary, Signature,
+check_delegation_signature(Pubkey, Binary, Signature, VmVersion,
                            #state{ primop_state = PState} = State) ->
     case aeprimop_state:find_account(Pubkey, PState) of
         {Account, PState1} ->
@@ -363,14 +363,20 @@ check_delegation_signature(Pubkey, Binary, Signature,
                 generalized ->
                     error;
                 basic ->
-                    BinaryForNetwork = aec_governance:add_network_id(Binary),
-                    case enacl:sign_verify_detached(Signature, BinaryForNetwork, Pubkey) of
-                        true  -> {ok, State#state{primop_state = PState1}};
-                        false -> error
-                    end
+                    State1 = State#state{primop_state = PState1},
+                    verify_delegation_signature(Pubkey, Binary, Signature, State1)
             end;
+        none when VmVersion >= ?VM_FATE_SOPHIA_3 ->
+            verify_delegation_signature(Pubkey, Binary, Signature, State);
         none ->
             error
+    end.
+
+verify_delegation_signature(Pubkey, Binary, Signature, State) ->
+    BinaryForNetwork = aec_governance:add_network_id(Binary),
+    case enacl:sign_verify_detached(Signature, BinaryForNetwork, Pubkey) of
+        true  -> {ok, State};
+        false -> error
     end.
 
 %%%-------------------------------------------------------------------

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -2195,7 +2195,8 @@ check_delegation_signature(Type, Data, SignBin, Current, ES0) ->
             VerifyOp = aeb_fate_opcodes:m_to_op('VERIFY_SIG'),
             ES = spend_gas(aeb_fate_opcodes:gas_cost(VerifyOp), ES0),
             API = aefa_engine_state:chain_api(ES),
-            case aefa_chain_api:check_delegation_signature(Pubkey, Bin, SignBin, API) of
+            VmVersion = aefa_engine_state:vm_version(ES),
+            case aefa_chain_api:check_delegation_signature(Pubkey, Bin, SignBin, VmVersion, API) of
                 {ok, API1} ->
                     aefa_engine_state:set_chain_api(API1, ES);
                 error ->


### PR DESCRIPTION
Consensus breaking - guarded with `VmVersion` switch.

Fixes #3674 

This PR is supported by the Æternity Crypto Foundation