### PR TITLE
GH4009: Allow contract call by name

### DIFF
--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -1116,7 +1116,7 @@ add_call(Call0, TxHash, Trees, Env) ->
         end,
 
     Call1 = aect_call:set_contract(ContractPubkey, Call0),
-    Call2 = aect_call:set_ct_call_id(ContractPubkey, Call1),
+    Call2 = aect_call:set_ct_call_id(undefined, Call1),
     Call3 = aect_call:set_id(NewId, Call2),
     aect_utils:insert_call_in_trees(Call3, Trees).
 

--- a/apps/aechannel/src/aesc_utils.erl
+++ b/apps/aechannel/src/aesc_utils.erl
@@ -1106,18 +1106,19 @@ tx_hash_to_contract_pubkey(TxHash) ->
 
 add_call(Call0, TxHash, Trees, Env) ->
     ContractPubkey = tx_hash_to_contract_pubkey(TxHash),
-    Call1          = aect_call:set_contract(ContractPubkey, Call0),
-    Caller         = aect_call:caller_pubkey(Call1),
+    Caller         = aect_call:caller_pubkey(Call0),
     NewId =
         case aetx_env:ga_nonce(Env, Caller) of
             {value, Nonce} ->
                 aect_call:ga_id(Nonce, ContractPubkey);
             none ->
-                aect_call:id(Caller, aect_call:caller_nonce(Call1), ContractPubkey)
+                aect_call:id(Caller, aect_call:caller_nonce(Call0), ContractPubkey)
         end,
 
-    Call = aect_call:set_id(NewId, Call1),
-    aect_utils:insert_call_in_trees(Call, Trees).
+    Call1 = aect_call:set_contract(ContractPubkey, Call0),
+    Call2 = aect_call:set_ct_call_id(ContractPubkey, Call1),
+    Call3 = aect_call:set_id(NewId, Call2),
+    aect_utils:insert_call_in_trees(Call3, Trees).
 
 -spec add_event(aec_trees:trees(), binary(), aetx_env:env()) ->
                        {ok, aec_trees:trees(), aetx_env:env()}.

--- a/apps/aecontract/src/aect_call.erl
+++ b/apps/aecontract/src/aect_call.erl
@@ -91,12 +91,13 @@ new(CallerId, Nonce, CtId, BlockHeight, GasPrice) ->
 -spec new(aeser_id:id(), non_neg_integer(), aeser_id:id(), aec_keys:pubkey(), aec_blocks:height(), amount()) -> call().
 new(CallerId, Nonce, CtId, CtCallId, BlockHeight, GasPrice) ->
     {_, CallerPubkey} = aeser_id:specialize(CallerId),
+    {_, CtPubkey}     = aeser_id:specialize(CtId),
     C = #call{ id           = id(CallerPubkey, Nonce, CtCallId)
              , caller_id    = CallerId
              , caller_nonce = Nonce
              , height       = BlockHeight
              , contract_id  = CtId
-             , ct_call_id   = if CtCallId /= CtId -> CtCallId; true -> undefined end
+             , ct_call_id   = if CtCallId /= CtPubkey -> CtCallId; true -> undefined end
              , gas_price    = GasPrice
              , gas_used     = 0     %% These are filled later
              , return_value = <<>>  %% in aect_call_tx:process()

--- a/apps/aecontract/src/aect_call.erl
+++ b/apps/aecontract/src/aect_call.erl
@@ -13,8 +13,10 @@
         , ga_id/2
         , id/3
         , new/5
+        , new/6
         , contract_id/1
         , contract_pubkey/1
+        , ct_call_id/1
         , caller_id/1
         , caller_pubkey/1
         , caller_nonce/1
@@ -27,6 +29,7 @@
         , serialize/1
         , serialize_for_client/1
         , set_contract/2
+        , set_ct_call_id/2
         , set_caller/3
         , set_caller_nonce/2
         , set_id/2
@@ -41,6 +44,7 @@
 
 -define(CONTRACT_INTERACTION_TYPE, contract_call).
 -define(CONTRACT_INTERACTION_VSN, 2).
+-define(NAMED_CONTRACT_INTERACTION_VSN, 3).
 
 %%%===================================================================
 %%% Types
@@ -54,6 +58,7 @@
               , caller_nonce :: integer()
               , height       :: aec_blocks:height()
               , contract_id  :: aeser_id:id()
+              , ct_call_id   :: undefined | binary() %% set to name if named call
               , gas_price    :: amount()
               , gas_used     :: amount()
               , return_value :: binary()
@@ -79,14 +84,19 @@
 %%%===================================================================
 
 -spec new(aeser_id:id(), non_neg_integer(), aeser_id:id(), aec_blocks:height(), amount()) -> call().
-new(CallerId, Nonce, ContractId, BlockHeight, GasPrice) ->
+new(CallerId, Nonce, CtId, BlockHeight, GasPrice) ->
+    {_, CtPubkey} = aeser_id:specialize(CtId),
+    new(CallerId, Nonce, CtId, CtPubkey, BlockHeight, GasPrice).
+
+-spec new(aeser_id:id(), non_neg_integer(), aeser_id:id(), aec_keys:pubkey(), aec_blocks:height(), amount()) -> call().
+new(CallerId, Nonce, CtId, CtCallId, BlockHeight, GasPrice) ->
     {_, CallerPubkey} = aeser_id:specialize(CallerId),
-    {_, ContractPubkey} = aeser_id:specialize(ContractId),
-    C = #call{ id           = id(CallerPubkey, Nonce, ContractPubkey)
+    C = #call{ id           = id(CallerPubkey, Nonce, CtCallId)
              , caller_id    = CallerId
              , caller_nonce = Nonce
              , height       = BlockHeight
-             , contract_id  = ContractId
+             , contract_id  = CtId
+             , ct_call_id   = if CtCallId /= CtId -> CtCallId; true -> undefined end
              , gas_price    = GasPrice
              , gas_used     = 0     %% These are filled later
              , return_value = <<>>  %% in aect_call_tx:process()
@@ -116,6 +126,7 @@ serialize(#call{caller_id    = CallerId,
                 caller_nonce = CallerNonce,
                 height       = Height,
                 contract_id  = ContractId,
+                ct_call_id   = undefined,
                 gas_price    = GasPrice,
                 gas_used     = GasUsed,
                 return_value = ReturnValue,
@@ -135,46 +146,112 @@ serialize(#call{caller_id    = CallerId,
       , {return_value, ReturnValue}
       , {return_type, serialize_return_type(ReturnType)}
       , {log, Log}
+     ]);
+serialize(#call{caller_id    = CallerId,
+                caller_nonce = CallerNonce,
+                height       = Height,
+                contract_id  = ContractId,
+                ct_call_id   = CtCallId,
+                gas_price    = GasPrice,
+                gas_used     = GasUsed,
+                return_value = ReturnValue,
+                return_type  = ReturnType,
+                log          = Log
+               }) ->
+    aeser_chain_objects:serialize(
+      ?CONTRACT_INTERACTION_TYPE,
+      ?NAMED_CONTRACT_INTERACTION_VSN,
+      serialization_template(?NAMED_CONTRACT_INTERACTION_VSN),
+      [ {caller_id, CallerId}
+      , {caller_nonce, CallerNonce}
+      , {height, Height}
+      , {contract_id, ContractId}
+      , {ct_call_id, CtCallId}
+      , {gas_price, GasPrice}
+      , {gas_used, GasUsed}
+      , {return_value, ReturnValue}
+      , {return_type, serialize_return_type(ReturnType)}
+      , {log, Log}
      ]).
 
 -spec deserialize(id(), binary()) -> call().
 deserialize(CallId, B) ->
     {?CONTRACT_INTERACTION_TYPE, Vsn, Fields} =
         aeser_chain_objects:deserialize_type_and_vsn(B),
-    case Vsn of
-        ?CONTRACT_INTERACTION_VSN ->
-            [ {caller_id, CallerId}
-            , {caller_nonce, CallerNonce}
-            , {height, Height}
-            , {contract_id, ContractId}
-            , {gas_price, GasPrice}
-            , {gas_used, GasUsed}
-            , {return_value, ReturnValue}
-            , {return_type, ReturnType}
-            , {log, Log}
-            ] =  aeserialization:decode_fields(
-                   serialization_template(?CONTRACT_INTERACTION_VSN),
-                   Fields)
-    end,
+    Call =
+        case Vsn of
+            ?CONTRACT_INTERACTION_VSN ->
+                [ {caller_id, CallerId}
+                , {caller_nonce, CallerNonce}
+                , {height, Height}
+                , {contract_id, ContractId}
+                , {gas_price, GasPrice}
+                , {gas_used, GasUsed}
+                , {return_value, ReturnValue}
+                , {return_type, ReturnType}
+                , {log, Log}
+                ] = aeserialization:decode_fields(
+                        serialization_template(?CONTRACT_INTERACTION_VSN), Fields),
+                #call{ id           = CallId
+                     , caller_id    = CallerId
+                     , caller_nonce = CallerNonce
+                     , height       = Height
+                     , contract_id  = ContractId
+                     , ct_call_id   = undefined
+                     , gas_price    = GasPrice
+                     , gas_used     = GasUsed
+                     , return_value = ReturnValue
+                     , return_type  = deserialize_return_type(ReturnType)
+                     , log          = Log
+                     };
+
+            ?NAMED_CONTRACT_INTERACTION_VSN ->
+                [ {caller_id, CallerId}
+                , {caller_nonce, CallerNonce}
+                , {height, Height}
+                , {contract_id, ContractId}
+                , {ct_call_id, CtCallId}
+                , {gas_price, GasPrice}
+                , {gas_used, GasUsed}
+                , {return_value, ReturnValue}
+                , {return_type, ReturnType}
+                , {log, Log}
+                ] = aeserialization:decode_fields(
+                        serialization_template(?NAMED_CONTRACT_INTERACTION_VSN), Fields),
+                #call{ id           = CallId
+                     , caller_id    = CallerId
+                     , caller_nonce = CallerNonce
+                     , height       = Height
+                     , contract_id  = ContractId
+                     , ct_call_id   = CtCallId
+                     , gas_price    = GasPrice
+                     , gas_used     = GasUsed
+                     , return_value = ReturnValue
+                     , return_type  = deserialize_return_type(ReturnType)
+                     , log          = Log
+                     }
+        end,
     %% TODO: check caller_id type
-    contract = aeser_id:specialize_type(ContractId),
-    #call{ id           = CallId
-         , caller_id    = CallerId
-         , caller_nonce = CallerNonce
-         , height       = Height
-         , contract_id  = ContractId
-         , gas_price    = GasPrice
-         , gas_used     = GasUsed
-         , return_value = ReturnValue
-         , return_type  = deserialize_return_type(ReturnType)
-         , log          = Log
-         }.
+    contract = aeser_id:specialize_type(Call#call.contract_id),
+    Call.
 
 serialization_template(?CONTRACT_INTERACTION_VSN) ->
     [ {caller_id, id}
     , {caller_nonce, int}
     , {height, int}
     , {contract_id, id}
+    , {gas_price, int}
+    , {gas_used, int}
+    , {return_value, binary}
+    , {return_type, int}
+    , {log, [{binary, [binary], binary}]}
+    ];
+serialization_template(?NAMED_CONTRACT_INTERACTION_VSN) ->
+    [ {caller_id, id}
+    , {caller_nonce, int}
+    , {height, int}
+    , {contract_id, id}
+    , {ct_call_id, binary}
     , {gas_price, int}
     , {gas_used, int}
     , {return_value, binary}
@@ -242,9 +319,15 @@ height(#call{height = Height}) ->
 contract_id(#call{contract_id = ContractId}) ->
     ContractId.
 
+-spec ct_call_id(call()) -> aec_keys:pubkey().
+ct_call_id(#call{ct_call_id = undefined, contract_id = ContractId}) ->
+    aeser_id:specialize(ContractId, contract);
+ct_call_id(#call{ct_call_id = CtCallId}) ->
+    CtCallId.
+
 -spec contract_pubkey(call()) -> aec_keys:pubkey().
 contract_pubkey(#call{contract_id = ContractId}) ->
-  aeser_id:specialize(ContractId, contract).
+    aeser_id:specialize(ContractId, contract).
 
 -spec return_type(call()) -> ok | error | revert.
 return_type(#call{return_type = ReturnType}) ->
@@ -288,6 +371,10 @@ set_height(X, I) ->
 set_contract(X, I) ->
     I#call{contract_id = aeser_id:create(contract, assert_field(contract, X))}.
 
+-spec set_ct_call_id(undefined | aec_keys:pubkey(), call()) -> call().
+set_ct_call_id(X, I) ->
+    I#call{ct_call_id = assert_field(ct_call_id, X)}.
+
 -spec set_return_value(binary(), call()) -> call().
 set_return_value(X, I) ->
     I#call{return_value = assert_field(return_value, X)}.
@@ -315,6 +402,7 @@ assert_fields(I) ->
            , {caller_nonce, I#call.caller_nonce}
            , {height,       I#call.height}
            , {contract,     contract_pubkey(I)}
+           , {ct_call_id,   I#call.ct_call_id}
            , {return_value, I#call.return_value}
            , {gas_price,    I#call.gas_price}
            , {gas_used,     I#call.gas_used}
@@ -331,6 +419,8 @@ assert_field(caller,           <<_:?PUB_SIZE/binary>> = X) -> X;
 assert_field(caller_nonce,     X) when is_integer(X), X >= 0 -> X;
 assert_field(height,           X) when is_integer(X), X >= 0 -> X;
 assert_field(contract,         <<_:?PUB_SIZE/binary>> = X) -> X;
+assert_field(ct_call_id,       <<_:?PUB_SIZE/binary>> = X) -> X;
+assert_field(ct_call_id,       undefined = X) -> X;
 assert_field(return_value,     X) when is_binary(X) -> X;
 assert_field(gas_price,        X) when is_integer(X), X >= 0 -> X;
 assert_field(gas_used,         X) when is_integer(X), X >= 0 -> X;

--- a/apps/aecontract/src/aect_call_state_tree.erl
+++ b/apps/aecontract/src/aect_call_state_tree.erl
@@ -96,13 +96,13 @@ prune_without_backend(Trees) ->
 
 -spec insert_call(aect_call:call(), tree()) -> tree().
 insert_call(Call, Tree) ->
-    CtId = aect_call:contract_pubkey(Call),
-    add_call(insert, CtId, Call, Tree).
+    CtCallId = aect_call:ct_call_id(Call),
+    add_call(insert, CtCallId, Call, Tree).
 
 -spec enter_auth_call(aect_call:call(), tree()) -> tree().
 enter_auth_call(Call, Tree) ->
-    CtId       = aect_call:caller_pubkey(Call),
-    add_call(enter, CtId, Call, Tree).
+    CallerId = aect_call:caller_pubkey(Call),
+    add_call(enter, CallerId, Call, Tree).
 
 -spec lookup_call(aect_contracts:pubkey(), aect_call:id(), tree()) ->
     {value, aect_call:call()} | none.

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -333,7 +333,8 @@
 all() ->
     [{group, protocol_interaction},
      {group, aevm},
-     {group, fate}
+     {group, fate},
+     {group, fate_named}
     ].
 
 %% To skip one level of indirection...
@@ -356,12 +357,10 @@ all() ->
                        , bad_aens_pointer_handling_lima_to_iris
                        ]).
 
--define(FATE_TODO, [
-                   ]).
-
 groups() ->
     [ {aevm, [], ?ALL_TESTS ++ ?AEVM_SPECIFIC}
     , {fate, [], ?ALL_TESTS ++ ?FATE_SPECIFIC}
+    , {fate_named, [], ?ALL_TESTS ++ ?FATE_SPECIFIC}
     , {protocol_interaction, [], [ aevm_version_interaction
                                  , create_contract_init_error_no_create_account
                                  ]}
@@ -591,6 +590,14 @@ init_per_group(aevm, Cfg) ->
     aect_test_utils:init_per_group(aevm, Cfg, fun(X) -> X end);
 init_per_group(fate, Cfg) ->
     aect_test_utils:init_per_group(fate, Cfg, fun(X) -> X end);
+init_per_group(fate_named, Cfg) ->
+    case aect_test_utils:latest_protocol_version() of
+        P when P >= ?CERES_PROTOCOL_VSN ->
+            meck:new(aens, [passthrough]),
+            aect_test_utils:init_per_group(fate, [{ct_named_calls, true} | Cfg], fun(X) -> X end);
+        _ ->
+            {skip, named_contract_calls_not_before_ceres}
+    end;
 init_per_group(protocol_interaction, Cfg) ->
     case aect_test_utils:latest_protocol_version() of
         ?IRIS_PROTOCOL_VSN ->
@@ -635,23 +642,17 @@ init_per_group(protocol_interaction_fate, Cfg) ->
         _ ->
             {skip, only_test_protocol_interaction_on_latest_protocol}
     end;
-init_per_group(Group, Cfg) ->
-    case ?IS_FATE_SOPHIA(?config(vm_version, Cfg)) of
-        true ->
-            case lists:member({group, Group}, ?FATE_TODO) of
-                true ->
-                    {skip, not_working_yet_for_fate};
-                false ->
-                    Cfg
-            end;
-        false -> Cfg
-    end.
+init_per_group(_Group, Cfg) ->
+    Cfg.
 
 end_per_group(protocol_interaction, Cfg) ->
     meck:unload(aec_hard_forks),
     Cfg;
 end_per_group(protocol_interaction_fate, Cfg) ->
     meck:unload(aec_hard_forks),
+    Cfg;
+end_per_group(fate_named, Cfg) ->
+    meck:unload(aens),
     Cfg;
 end_per_group(_Grp, Cfg) ->
     Cfg.
@@ -714,7 +715,9 @@ init_per_testcase(TC = bad_aens_pointer_handling_lima_to_iris, Config) ->
 init_per_testcase(TC, Config) ->
     init_per_testcase_common(TC, Config).
 
-init_per_testcase_common(TC, Config) ->
+init_per_testcase_common(_TC, Config) ->
+    put('$ct_named_calls', proplists:get_value(ct_named_calls, Config, false)),
+
     VmVersion = ?config(vm_version, Config),
     ABIVersion = ?config(abi_version, Config),
     SophiaVersion = ?config(sophia_version, Config),
@@ -737,17 +740,7 @@ init_per_testcase_common(TC, Config) ->
     put('$sophia_version', SophiaVersion),
     put('$protocol_version', ProtocolVersion),
     put('$aci_disabled', AciDisabled),
-    case ?IS_AEVM_SOPHIA(VmVersion) of
-        true ->
-            Config;
-        false ->
-            case lists:member(TC, ?FATE_TODO) of
-                true ->
-                    {skip, not_working_yet_for_fate};
-                false ->
-                    Config
-            end
-    end.
+    Config.
 
 end_per_testcase(fate_environment, _Config) ->
     meck:unload(aefa_chain_api),
@@ -766,12 +759,16 @@ end_per_testcase(bad_aens_pointer_handling_lima_to_iris, _Config) ->
 end_per_testcase(_TC, _Config) ->
     ok.
 
+-define(CT_NAMED_CALL_NAME, <<"contractpointer.chain">>).
+-define(CT_NAMED_CALL_NHASH, element(2, aens:get_name_hash(?CT_NAMED_CALL_NAME))).
+-define(CT_NAMED_CALL_NOBJ, aens_names:new(?CT_NAMED_CALL_NHASH, <<0:256>>, 50000)).
+
 %%%===================================================================
 %%% Create contract
 %%%===================================================================
 
 create_contract_negative_gas_price_zero(_Cfg) ->
-    {PubKey, S1} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
+    {PubKey, S1} = aect_test_utils:setup_new_account(new_state()),
     PrivKey      = aect_test_utils:priv_key(PubKey, S1),
 
     Overrides = #{gas_price => 0},
@@ -784,14 +781,14 @@ create_contract_negative_gas_price_zero(_Cfg) ->
     ok.
 
 create_contract_negative(_Cfg) ->
-    {PubKey, S1} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
+    {PubKey, S1} = aect_test_utils:setup_new_account(new_state()),
     Trees        = aect_test_utils:trees(S1),
     PrivKey      = aect_test_utils:priv_key(PubKey, S1),
     CurrHeight   = 1,
     Env          = aetx_env:tx_env(CurrHeight),
 
     %% Test creating a bogus account
-    {BadPubKey, BadS} = aect_test_utils:setup_new_account(aect_test_utils:new_state()),
+    {BadPubKey, BadS} = aect_test_utils:setup_new_account(new_state()),
     BadPrivKey        = aect_test_utils:priv_key(BadPubKey, BadS),
     RTx1              = create_tx(BadPubKey, S1),
     {error, _, S1}    = sign_and_apply_transaction(RTx1, BadPrivKey, S1),
@@ -817,7 +814,7 @@ create_contract_negative(_Cfg) ->
     ok.
 
 create_contract_init_error_call_wrong_function(_Cfg) ->
-    S  = aect_test_utils:new_state(),
+    S  = new_state(),
     S0 = aect_test_utils:setup_miner_account(?MINER_PUBKEY, S),
     {PubKey, S1} = aect_test_utils:setup_new_account(S0),
     {ok, Code}   = compile_contract(identity),
@@ -827,7 +824,7 @@ create_contract_init_error_call_wrong_function(_Cfg) ->
     ok.
 
 create_contract_init_error(_Cfg) ->
-    S  = aect_test_utils:new_state(),
+    S  = new_state(),
     S0 = aect_test_utils:setup_miner_account(?MINER_PUBKEY, S),
     {PubKey, S1} = aect_test_utils:setup_new_account(S0),
     PrivKey      = aect_test_utils:priv_key(PubKey, S1),
@@ -876,7 +873,7 @@ create_contract_init_error(_Cfg) ->
     ok.
 
 create_contract_init_error_no_create_account(Cfg) ->
-    S  = aect_test_utils:new_state(),
+    S  = new_state(),
     S0 = aect_test_utils:setup_miner_account(?MINER_PUBKEY, S),
     {PubKey, S1} = aect_test_utils:setup_new_account(S0),
     PrivKey      = aect_test_utils:priv_key(PubKey, S1),
@@ -941,7 +938,7 @@ create_contract_init_error_illegal_instructions_in_sophia(_Cfg) ->
     lists:foreach(F, Tests).
 
 create_contract_init_error_illegal_instruction_(OP, ErrReason) when is_binary(ErrReason) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = call(fun new_account/2, [10000000 * aec_test_utils:min_gas_price()]),
     {ok, Code} = compile_contract(minimal_init),
     HackedCode = hack_bytecode(Code, OP),
@@ -955,7 +952,7 @@ create_contract_init_error_illegal_instruction_(OP, ErrReason) when is_binary(Er
     ok.
 
 create_version_too_high(Cfg) ->
-    S  = aect_test_utils:new_state(),
+    S  = new_state(),
     S0 = aect_test_utils:setup_miner_account(?MINER_PUBKEY, S),
     {PubKey, S1} = aect_test_utils:setup_new_account(S0),
     PrivKey      = aect_test_utils:priv_key(PubKey, S1),
@@ -996,7 +993,7 @@ hack_fate_code(Serialized, Hack) ->
 create_contract(_Cfg) -> create_contract_(aec_test_utils:min_gas_price()).
 
 create_contract_(ContractCreateTxGasPrice) ->
-    S  = aect_test_utils:new_state(),
+    S  = new_state(),
     S0 = aect_test_utils:setup_miner_account(?MINER_PUBKEY, S),
     {PubKey, S1} = aect_test_utils:setup_new_account(S0),
     PrivKey      = aect_test_utils:priv_key(PubKey, S1),
@@ -1100,7 +1097,7 @@ create_contract_upfront_deposit(_Cfg) ->
     ok.
 
 sender_balance_in_create(CreateTxOpts) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Sender = call(fun new_account/2, [10000000 * aec_test_utils:min_gas_price()]),
     Ct = call(fun create_contract/5, [Sender, upfront_charges, {}, CreateTxOpts]),
     SenderBalInCt = call(fun call_contract/6, [Sender, Ct, initialSenderBalance, word, {}]),
@@ -1154,7 +1151,7 @@ default_tx_env(Options) ->
 %%%===================================================================
 
 call_contract_negative_insufficient_funds(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1 = call(fun new_account/2, [2000000 * aec_test_utils:min_gas_price()]),
     IdC = call(fun create_contract/4, [Acc1, identity, {}]),
 
@@ -1174,7 +1171,7 @@ call_contract_negative_insufficient_funds(_Cfg) ->
     ok.
 
 call_contract_negative_gas_price_zero(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1 = call(fun new_account/2, [2000000 * aec_test_utils:min_gas_price()]),
     IdC  = call(fun create_contract/4, [Acc1, identity, {}]),
     S    = state(),
@@ -1194,7 +1191,7 @@ call_contract_negative(_Cfg) ->
 call_contract(_Cfg) -> call_contract_(2 * aec_test_utils:min_gas_price()).
 
 call_contract_(ContractCallTxGasPrice) ->
-    S  = aect_test_utils:new_state(),
+    S  = new_state(),
     S0 = aect_test_utils:setup_miner_account(?MINER_PUBKEY, S),
 
     {Owner,  S1}  = aect_test_utils:setup_new_account(S0),
@@ -1286,7 +1283,7 @@ call_contract_upfront_amount(_Cfg) ->
     ok.
 
 sender_balance_in_call(CallTxOpts) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Sender = call(fun new_account/2, [10000000 * aec_test_utils:min_gas_price()]),
     Ct = call(fun create_contract/4, [Sender, upfront_charges, {}]),
     _SenderBalInCt = call(fun call_contract/7, [Sender, Ct, senderBalance, word, {}, CallTxOpts]).
@@ -1299,7 +1296,7 @@ call_contract_error_value(_Cfg) ->
     DefaultOpts = #{fee => F, gas_price => GasPrice, gas => G, amount => 0},
     Bal = fun(A, S) -> {B, S} = account_balance(A, S), B end,
     %% Initialization.
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1 = call(fun new_account/2, [10000000 * aec_test_utils:min_gas_price()]),
     IdC = call(fun create_contract/5, [Acc1, value_on_err, {}, DefaultOpts#{deposit => 0}]),
     RemC = call(fun create_contract/5, [Acc1, remote_value_on_err, {}, DefaultOpts#{deposit => 0}]),
@@ -1346,7 +1343,7 @@ call_contract_error_value(_Cfg) ->
 %% error messages! However, we need to also test that the messages are
 %% sanitized under normal conditions.
 call_contract_error_sanitized(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1 = call(fun new_account/2, [10000000 * aec_test_utils:min_gas_price()]),
     IdC = ?call(create_contract, Acc1, value_on_err, {}),
     {Kind, Err} = ?call(call_contract, Acc1, IdC, err, word, {}, #{amount => 5, dry_run => false}),
@@ -1438,7 +1435,7 @@ get_call(Contract0, Call0, S) ->
     {Call, S}.
 
 state_tree(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1  = ?call(new_account, 100),
     Ct1   = ?call(insert_contract, Acc1, <<"Code for C1">>),
     Ct1   = ?call(get_contract, Ct1),
@@ -1454,6 +1451,21 @@ state_tree(_Cfg) ->
     Ct1   = ?call(get_contract, Ct1),
     {code, <<"Code for C1">>} = aect_contracts:code(Ct1),
     ok.
+
+init_new_state() ->
+    state(new_state()).
+
+new_state() ->
+    S       = aect_test_utils:new_state(),
+    case get('$ct_named_calls') of
+        true ->
+            Trees   = aect_test_utils:trees(S),
+            NTrees  = aec_trees:ns(Trees),
+            NTrees1 = aens_state_tree:enter_name(?CT_NAMED_CALL_NOBJ, NTrees),
+            aect_test_utils:set_trees(aec_trees:set_ns(Trees, NTrees1), S);
+        _ ->
+            S
+    end.
 
 %%%===================================================================
 %%% More elaborate Sophia contracts
@@ -1583,6 +1595,27 @@ call_contract(Caller, ContractKey, Fun, Type, Args, Options, S) ->
 
 call_contract_with_calldata(Caller, ContractKey, Type, Calldata, Options, S) ->
     Nonce    = aect_test_utils:next_nonce(Caller, S),
+    {CtId, CtCallId} =
+        case get('$ct_named_calls') of
+            true ->
+                ct:pal("Doing named call!", []),
+                {ok, NHash} = aens:get_name_hash(?CT_NAMED_CALL_NAME),
+                meck:expect(aens, resolve_from_name_object,
+                            fun(Key, NameObj) ->
+                                case (Key == <<"contract_pubkey">>) andalso
+                                     (aens_names:id(NameObj) == aeser_id:create(name, NHash)) of
+                                    true ->
+                                        {ok, aeser_id:create(contract, ContractKey)};
+                                    false ->
+                                        meck:passthrough([Key, NameObj])
+                                end
+                            end),
+                {aeser_id:create(name, NHash), NHash};
+            _ ->
+                ct:pal("Not doing named call!", []),
+                {aeser_id:create(contract, ContractKey), ContractKey}
+        end,
+
     CallTx   = aect_test_utils:call_tx(Caller, ContractKey,
                 maps:merge(
                 #{ nonce       => Nonce
@@ -1591,13 +1624,14 @@ call_contract_with_calldata(Caller, ContractKey, Type, Calldata, Options, S) ->
                  , fee         => maps:get(fee, Options, 1000000 * aec_test_utils:min_gas_price())
                  , amount      => 0
                  , gas         => 140000
+                 , contract_id => CtId
                  }, maps:without([height, return_gas_used, return_logs], Options)), S),
     PrivKey  = aect_test_utils:priv_key(Caller, S),
     case sign_and_apply_transaction(CallTx, PrivKey, S, Options) of
         {ok, S1} ->
-            CallKey  = aect_call:id(Caller, Nonce, ContractKey),
+            CallKey  = aect_call:id(Caller, Nonce, CtCallId),
             CallTree = aect_test_utils:calls(S1),
-            Call     = aect_call_state_tree:get_call(ContractKey, CallKey, CallTree),
+            Call     = aect_call_state_tree:get_call(CtCallId, CallKey, CallTree),
             {_, Tx}  = aetx:specialize_type(CallTx),
             ABI      = aect_call_tx:abi_version(Tx),
             Result   = call_result(ABI, Type, Call),
@@ -1713,7 +1747,7 @@ to_words(Bin) ->
 
 sophia_list_comp(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_FORTUNA, no_list_comprehensions_in_fortuna),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 100000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, list_comp, {}),
 
@@ -1737,7 +1771,7 @@ sophia_list_comp(_Cfg) ->
 
 sophia_stdlib_tests(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_FORTUNA, no_stdlib_in_fortuna),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 100000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, stdlib_tests, {}),
     {} = ?call(call_contract, Acc, C, test, {tuple, []}, {}),
@@ -1745,14 +1779,14 @@ sophia_stdlib_tests(_Cfg) ->
 
 
 sophia_identity(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1 = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc1, identity, {}),
     42    = ?call(call_contract,   Acc1, IdC, main_, word, 42),
     ok.
 
 sophia_remote_identity(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1 = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     %% Remote calling the identity contract
     IdC   = ?call(create_contract, Acc1, identity, {}),
@@ -1764,7 +1798,7 @@ sophia_remote_identity(_Cfg) ->
     ok.
 
 sophia_remote_gas(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ctr1 = ?call(create_contract, Acc, remote_gas_test, {0}),
     Ctr2 = ?call(create_contract, Acc, remote_gas_test, {0}),
@@ -1797,7 +1831,7 @@ sophia_remote_gas(_Cfg) ->
 
 sophia_higher_order_state(_Cfg) ->
     ?skipRest(not ?IS_FATE_SOPHIA(vm_version()), higher_order_state_only_in_fate),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, higher_order_state, {}),
     1   = ?call(call_contract, Acc, Ct, apply, word, {1}),
@@ -1811,7 +1845,7 @@ sophia_higher_order_state(_Cfg) ->
 
 sophia_clone(_Cfg) ->
     ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, clone_not_pre_iris),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc     = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Remote  = ?call(create_contract, Acc, higher_order_state, {}),
     Ct      = ?call(create_contract, Acc, clone_test, {}),
@@ -1836,7 +1870,7 @@ sophia_clone(_Cfg) ->
 
 sophia_create(_Cfg) ->
     ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, create_not_pre_iris),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000000000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, create_test, {}, #{gas => 1000000000000}),
     R1  = ?call(call_contract, Acc, Ct, increaseByThree, word, {2137}, #{gas => 1000000000000, amount => 1000000}),
@@ -1845,7 +1879,7 @@ sophia_create(_Cfg) ->
 
 sophia_bytecode_hash(_Cfg) ->
     ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, bytecode_hash_not_pre_iris),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Remote  = ?call(create_contract, Acc, higher_order_state, {}),
     Ct  = ?call(create_contract, Acc, bytecode_hash_test, {}),
@@ -1869,7 +1903,7 @@ sophia_bytecode_hash(_Cfg) ->
 
 sophia_factories(_Cfg) ->
     ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, factories_not_pre_iris),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000000000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, factories, {}, #{gas => 10000000000000}),
     ?assertEqual(1, ?call(call_contract, Acc, Ct, add, word, {1}, #{gas => 1000000000000000})),
@@ -1880,7 +1914,7 @@ sophia_factories(_Cfg) ->
 
 sophia_bignum(_Cfg) ->
     ?skipRest(vm_version() < ?VM_AEVM_SOPHIA_2, no_arithmetic_errors_pre_minerva),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, bignum, {}),
     65536 = ?call(call_contract, Acc, Ct, tetr1, word, {2, 4}),
@@ -1895,7 +1929,7 @@ sophia_bignum(_Cfg) ->
     ok.
 
 sophia_call_caller(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     CtR1 = ?call(create_contract, Acc, identity, {}),
     CtR2 = ?call(create_contract, Acc, call_caller, {}),
@@ -1915,7 +1949,7 @@ sophia_call_caller(_Cfg) ->
 %% Test that the Auth.tx function works properly, in order to do
 %% this we need to pass a ga_tx in Options.
 sophia_auth_tx(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, tx_auth, {}),
 
@@ -2107,7 +2141,7 @@ sophia_auth_tx(_Cfg) ->
 
 
 aevm_version_interaction(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     ForkHeights   = ?config(fork_heights, Cfg),
     RomaHeight    = maps:get(minerva, ForkHeights) - 1,
     MinervaHeight = maps:get(fortuna, ForkHeights) - 1,
@@ -2215,7 +2249,7 @@ aevm_version_interaction(Cfg) ->
     ok.
 
 sophia_strings(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, strings, {}),
 
@@ -2272,7 +2306,7 @@ sophia_strings(_Cfg) ->
     ok.
 
 sophia_aevm_exploits(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     {ok, Code} = compile_contract(exploits),
     StringType = aeb_heap:to_binary(string),
@@ -2301,7 +2335,7 @@ hack_type(HackFun, NewType, SerCode) ->
 
 sophia_functions(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_MINERVA, letfun_broken_pre_sophia_3),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, functions, {}),
     [6, 7, 8]       = ?call(call_contract, Acc, Ct, test1, {list, word}, [1, 2, 3]),
@@ -2310,7 +2344,7 @@ sophia_functions(_Cfg) ->
     ok.
 
 sophia_no_reentrant(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc, identity, {}),
     RemC  = ?call(create_contract, Acc, remote_call, {}, #{amount => 100}),
@@ -2321,7 +2355,7 @@ sophia_no_reentrant(_Cfg) ->
     ok.
 
 sophia_state(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1         = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     InitStack    = [<<"top">>, <<"middle">>, <<"bottom">>],
     Stack        = ?call(create_contract, Acc1, stack, InitStack),
@@ -2338,7 +2372,7 @@ sophia_state(_Cfg) ->
     ok.
 
 sophia_remote_state(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Ct1 = ?call(create_contract, Acc, remote_state2, {<<"ct1-initial">>}),
     Ct2 = ?call(create_contract, Acc, remote_state2, {<<"ct2-initial">>}),
@@ -2347,7 +2381,7 @@ sophia_remote_state(_Cfg) ->
 
 %% There was a bug matching on _::_.
 sophia_match_bug(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1      = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Poly      = ?call(create_contract, Acc1, polymorphism_test, {}),
     [5, 7, 9] = ?call(call_contract, Acc1, Poly, foo, {list, word}, {}),
@@ -2356,7 +2390,7 @@ sophia_match_bug(_Cfg) ->
     ok.
 
 sophia_spend(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1         = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     Acc2         = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     Ct1          = ?call(create_contract, Acc1, spend_test, {}, #{amount => 10000}),
@@ -2384,7 +2418,7 @@ sophia_spend(_Cfg) ->
     ok.
 
 sophia_typed_calls(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc    = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     Server = ?call(create_contract, Acc, multiplication_server, {}, #{amount => 0}),
     Client = ?call(create_contract, Acc, contract_types, {?cid(Server)}, #{amount => 1000}),
@@ -2400,7 +2434,7 @@ sophia_typed_calls(_Cfg) ->
     ok.
 
 sophia_call_origin(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc       = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     EnvC      = ?call(create_contract, Acc, environment, {?cid(<<0:256>>)}, #{}),
     [error(EnvC) || not is_binary(EnvC)],
@@ -2432,7 +2466,7 @@ sophia_call_origin(_Cfg) ->
 
 sophia_contract_creator(_Cfg) ->
     ?skipRest(vm_version() < ?VM_AEVM_SOPHIA_3, contract_creator_not_in_minerva),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1      = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     Acc2      = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     Acc3      = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
@@ -2452,7 +2486,7 @@ sophia_contract_creator(_Cfg) ->
 %% Oracles tests
 
 sophia_oracles(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     FixedTTL          = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc               = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
@@ -2508,7 +2542,7 @@ sophia_oracles(_Cfg) ->
 
 sophia_oracles_type_error_on_query_1(_Cfg) ->
     %% Create a query of the wrong type.
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     FixedTTL          = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc               = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
@@ -2525,7 +2559,7 @@ sophia_oracles_type_error_on_query_1(_Cfg) ->
 
 sophia_oracles_type_error_on_query_2(_Cfg) ->
     %% Create a query of the correct type, but to an oracle with wrong response type.
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     FixedTTL          = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc               = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
@@ -2545,7 +2579,7 @@ sophia_oracles_type_error_on_query_2(_Cfg) ->
 
 sophia_oracles_type_error_on_response_1(_Cfg) ->
     %% Make a query with correct type, but respond with the wrong type.
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     FixedTTL          = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc               = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
@@ -2566,7 +2600,7 @@ sophia_oracles_type_error_on_response_1(_Cfg) ->
 sophia_oracles_type_error_on_response_2(_Cfg) ->
     %% Make a query with correct type, respond with the correct type
     %% (for the oracle), but using the wrong type for the oracle
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     FixedTTL          = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc               = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
@@ -2588,7 +2622,7 @@ sophia_oracles_type_error_on_response_2(_Cfg) ->
 sophia_oracles_type_error_on_get(_Cfg) ->
     %% Create a correct query/response, but try to get the question/answer assuming
     %% that the oracle has a different type.
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     FixedTTL          = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc               = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
@@ -2620,7 +2654,7 @@ sophia_oracles_type_error_on_get(_Cfg) ->
     ok.
 
 sophia_oracles_interact_with_no_vm_oracle(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL       = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     Acc               = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Ct                = ?call(create_contract, Acc, oracles_no_vm, {}, #{amount => 100000}),
@@ -2860,7 +2894,7 @@ combine_ttl_scenarios(Cmds1, Cmds2) ->
     lists:keymerge(1, Cmds1, Cmds2).
 
 run_ttl_scenario(Scenario) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     [ begin
         Ct = ?call(create_contract, Acc, oracles, {}, #{amount => 10000}),
@@ -3076,7 +3110,7 @@ sophia_oracles_qfee__flow_up_to_respond_(Cbs,
     QueryTxOpts    = #{fee => TxFee, gas_price => GasPrice, amount => QueryTxValue},
     RespondTxOpts  = #{fee => TxFee, gas_price => GasPrice, amount => 0},
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     OperatorAcc = call(fun new_account/2, [10000000 * aec_test_utils:min_gas_price()]),
     UserAcc = call(fun new_account/2, [10000000 * aec_test_utils:min_gas_price()]),
     CCbs = closed_oracle_cbs(Cbs,
@@ -3104,7 +3138,7 @@ sophia_oracles_qfee__flow_up_to_query_(Cbs,
                                        InitialOracleCtBalance,
                                        RegisterOpts,
                                        QueryOpts, QueryTxValue) ->
-    sophia_oracles_qfee__flow_up_to_query_(aect_test_utils:new_state(),
+    sophia_oracles_qfee__flow_up_to_query_(new_state(),
                                            Cbs,
                                            TxFee,
                                            GasPrice,
@@ -3856,7 +3890,7 @@ sophia_oracles_qfee__inner_error_after_primop__remote(_Cfg) ->
     {InitialOracleCtBalance, RegisterTxQFee, QueryTxValue, QueryTxQFee} =
         sophia_oracles_qfee__basic__data_(),
 
-    InitialState0 = aect_test_utils:new_state(),
+    InitialState0 = new_state(),
     {TmpAcc, InitialState1} = new_account(10000000 * aec_test_utils:min_gas_price(), InitialState0),
     {OracleErrCt, InitialState} = create_contract(TmpAcc, oracles_err, {}, #{amount => 0}, InitialState1),
 
@@ -3940,7 +3974,7 @@ sophia_oracles_qfee__outer_error_after_primop__remote(_Cfg) ->
                        | ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING_TYPE(non_neg_integer()),
          respond_ttl  :: ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING_TYPE(non_neg_integer())}).
 sophia_oracles_gas_ttl__measure_gas_used(Sc, Height, Gas) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Caller = call(fun new_account/2, [100000000000 * aec_test_utils:min_gas_price()]),
     Ct = call(fun create_contract/4, [Caller, oracles_gas, {}]),
     QFee=1,
@@ -4110,7 +4144,7 @@ sophia_oracles_gas_ttl__response(_Cfg) ->
 
 %% Testing external oracles, with provided Signatures
 sophia_signatures_oracles(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     RelativeTTL         = fun(Delta)  -> ?CHAIN_RELATIVE_TTL_MEMORY_ENCODING(Delta) end,
     FixedTTL            = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc                 = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
@@ -4170,7 +4204,7 @@ sophia_signature_check_gas_cost(_Cfg) ->
     %% Check that when checking the delegation signature, the gas cost increases.
     %% The delegation signature handling is handled jointly for all such
     %% operations, so it is sufficient to test one operation.
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     FixedTTL            = fun(Height) -> ?CHAIN_ABSOLUTE_TTL_MEMORY_ENCODING(Height) end,
     Acc                 = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Orc                 = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
@@ -4195,7 +4229,7 @@ sophia_signature_check_gas_cost(_Cfg) ->
     ok.
 
 sophia_signatures_aens(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     %% AENS transactions from contract - using 3rd party account
     Acc             = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
     NameAcc         = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
@@ -4306,7 +4340,7 @@ sign(Material, KeyHolder) ->
 
 %% Testing map functions and primitives
 sophia_maps(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, maps, {}, #{fee => 2000000 * aec_test_utils:min_gas_price()}),
 
@@ -4482,7 +4516,7 @@ sophia_maps(_Cfg) ->
     ok.
 
 sophia_map_benchmark(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 100000000 * aec_test_utils:min_gas_price()),
     N    = proplists:get_value(n, Cfg, 10),
     Map  = maps:from_list([{I, list_to_binary(integer_to_list(I))} || I <- lists:seq(1, N) ]),
@@ -4679,7 +4713,7 @@ sophia_map_benchmark(Cfg) ->
     ok.
 
 sophia_big_map_benchmark(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 100000000000000 * aec_test_utils:min_gas_price()),
     N     = proplists:get_value(n, Cfg, 1000),
     Batch = proplists:get_value(batch, Cfg, N),
@@ -4700,7 +4734,7 @@ sophia_big_map_benchmark(Cfg) ->
     ok.
 
 sophia_big_map(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 100000000000000 * aec_test_utils:min_gas_price()),
     N     = 200,
     Batch = 200,
@@ -4721,7 +4755,7 @@ sophia_big_map(_Cfg) ->
 
 sophia_registry(Cfg) ->
     ?skipRest(vm_version() =< ?VM_AEVM_SOPHIA_3, only_lima),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     N    = proplists:get_value(n, Cfg, 20),
     Acc  = ?call(new_account, 100000000000000 * aec_test_utils:min_gas_price()),
     Ct   = ?call(create_contract, Acc, registry, {}),
@@ -4732,7 +4766,7 @@ sophia_registry(Cfg) ->
     ok.
 
 sophia_pmaps(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, primitive_map, 0),
     {} = ?call(call_contract, Acc, Ct, set_remote, {tuple, []}, Ct),
@@ -4775,7 +4809,7 @@ sophia_pmaps(_Cfg) ->
     ok.
 
 sophia_chess(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     {Ct, _Gas} = ?call(create_contract, Acc, chess, {}, #{gas => 1000000, return_gas_used => true}),
     {some, <<"black king">>}  = ?call(call_contract, Acc, Ct, piece, {option, string}, {8, 5}),
@@ -4789,7 +4823,7 @@ sophia_chess(_Cfg) ->
     ok.
 
 sophia_map_of_maps(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     {Ct, _Gas} = ?call(create_contract, Acc, map_of_maps, {}, #{gas => 1000000, return_gas_used => true}),
     %% {}         = ?call(call_contract, Acc, Ct, setup_state, {tuple, []}, {}),
@@ -4828,7 +4862,7 @@ sophia_map_of_maps(_Cfg) ->
 
 sophia_maps_gc(_Cfg) ->
     ?skipRest(vm_version() =< ?VM_AEVM_SOPHIA_3, only_lima),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     %% Big to make sure it ends up in the store.
     InitA = maps:from_list([ {integer_to_binary(I), integer_to_binary(I + 100)}
@@ -4867,7 +4901,7 @@ sophia_maps_gc(_Cfg) ->
 %% aesophia/GH-204
 sophia_maps_gc_bug(_Cfg) ->
     ?skipRest(?IF_AEVM(true, false), only_fate),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc       = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ct        = ?call(create_contract, Acc, maps_gc_bug, {}),
     {}        = ?call(call_contract, Acc, Ct, set, {tuple, []}, {<<"bar">>}),
@@ -4881,7 +4915,7 @@ sophia_maps_gc_bug(_Cfg) ->
     end.
 
 sophia_polymorphic_entrypoint(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Ct1 = ?call(create_contract, Acc, polymorphic_entrypoint, {}, #{fee => 2000000 * aec_test_utils:min_gas_price()}),
     Ct2 = ?call(create_contract, Acc, polymorphic_entrypoint, {}, #{fee => 2000000 * aec_test_utils:min_gas_price()}),
@@ -4898,7 +4932,7 @@ sophia_polymorphic_entrypoint(_Cfg) ->
     ok.
 
 sophia_variant_types(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = <<AccId:256>> = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, variant_types, {}, #{fee => 2000000 * aec_test_utils:min_gas_price()}),
     Call = fun(Fn, Type, Args) -> ?call(call_contract, Acc, Ct, Fn, Type, Args) end,
@@ -4920,7 +4954,7 @@ sophia_variant_types(_Cfg) ->
     ok.
 
 sophia_arity_check(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Id = ?call(create_contract, Acc, identity,    {}, #{fee => 2000000 * aec_test_utils:min_gas_price()}),
     Ct = ?call(create_contract, Acc, remote_fail, {}, #{fee => 2000000 * aec_test_utils:min_gas_price()}),
@@ -4932,7 +4966,7 @@ sophia_arity_check(_Cfg) ->
 
 
 sophia_chain(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc         = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     <<Beneficiary:?BENEFICIARY_PUB_BYTES/unit:8>> = ?BENEFICIARY_PUBKEY,
     Ct1         = ?call(create_contract, Acc, chain, {}, #{amount => 10000}),
@@ -4942,7 +4976,7 @@ sophia_chain(_Cfg) ->
     ok.
 
 sophia_savecoinbase(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     <<Beneficiary:?BENEFICIARY_PUB_BYTES/unit:8>> = ?BENEFICIARY_PUBKEY,
 
@@ -4964,7 +4998,7 @@ sophia_no_callobject_for_remote_calls(_Cfg) ->
                     length(aect_call_state_tree:to_list(CallTree))
                  end,
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc, identity, {}),
     RemC  = ?call(create_contract, Acc, remote_call, {}, #{amount => 100}),
@@ -4985,7 +5019,7 @@ sophia_no_callobject_for_remote_calls(_Cfg) ->
     ok.
 
 sophia_operators(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc, operators, {}),
 
@@ -5023,7 +5057,7 @@ sophia_operators(_Cfg) ->
 sophia_bits(_Cfg) ->
     ?skipRest(vm_version() < ?VM_AEVM_SOPHIA_2,
               bitmaps_not_in_roma),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
 
     C = ?call(create_contract, Acc, bits, {}),
@@ -5097,7 +5131,7 @@ sophia_bits(_Cfg) ->
     ok.
 
 sophia_int_to_str(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc, int_to_str, {}),
 
@@ -5133,7 +5167,7 @@ sophia_events(Cfg) ->
     end.
 
 sophia_events_old(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc, events, {}),
 
@@ -5147,7 +5181,7 @@ sophia_events_old(_Cfg) ->
     ok.
 
 sophia_events_new(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, events, {}),
 
@@ -5252,7 +5286,7 @@ sophia_crypto(_Cfg) ->
     set_compiler_version(?VM_AEVM_SOPHIA_1, ?SOPHIA_FORTUNA),
     set_compiler_version(?VM_AEVM_SOPHIA_2, ?SOPHIA_FORTUNA),
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
 
     IdC = case RealCompilerVersion of
@@ -5461,7 +5495,7 @@ sophia_crypto_pairing_neg(_Cfg) ->
     %% For the negative test, overload the compiler
     set_compiler_version(?VM_FATE_SOPHIA_1, ?SOPHIA_IRIS_FATE),
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, crypto_pairing, {}),
 
@@ -5477,7 +5511,7 @@ sophia_crypto_pairing_neg(_Cfg) ->
 sophia_crypto_pairing_(_Cfg) ->
     ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, fancy_pairing_crypto_not_pre_iris),
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, crypto_pairing, {}),
 
@@ -5599,7 +5633,7 @@ sophia_safe_math(Cfg) ->
     end.
 
 sophia_safe_math() ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, safe_math, {}),
 
@@ -5643,7 +5677,7 @@ sophia_safe_math() ->
     ok.
 
 sophia_safe_math_old() ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, safe_math, {}),
 
@@ -5677,7 +5711,7 @@ sophia_safe_math_old() ->
     ok.
 
 sophia_compiler_version(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     IdC = ?call(create_contract, Acc, identity, {}, #{}),
     {value, C} = ?call(lookup_contract_by_id, IdC),
@@ -5689,7 +5723,7 @@ sophia_compiler_version(_Cfg) ->
 
 sophia_protected_call(_Cfg) ->
     ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, protected_call_only_since_iris),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     {ok, Code} = compile_contract(protected_call),
     HackedCode = hack_fate_code(Code,
@@ -5747,7 +5781,7 @@ sophia_protected_call(_Cfg) ->
     ok.
 
 sophia_aevm_bad_code(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     {ok, Code} = compile_contract(bad_code),
     %% Switch DUP3 against DUP11 - will make init crash...
@@ -5772,7 +5806,7 @@ hack_dup(A, B, <<X:8, Rest/binary>>) -> <<X:8, (hack_dup(A, B, Rest))/binary>>.
 
 sophia_aevm_bad_init(_Cfg) ->
     ?skipRest(vm_version() >= ?VM_AEVM_SOPHIA_4, old_bytecode_format_not_allowed_in_lima),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
 
     BadByteCode = <<249,2,163,70,1,160,148,150,21,128,247,154,18,103,230,176,30,42,133,14,242,51,251,159,51,
@@ -5806,7 +5840,7 @@ sophia_aevm_bad_init(_Cfg) ->
     ok.
 
 sophia_heap_to_heap_bug(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc, expose_put_size_check_bug, {}),
 
@@ -5819,7 +5853,7 @@ sophia_heap_to_heap_bug(_Cfg) ->
 
 sophia_namespaces(_Cfg) ->
     ?skipRest(vm_version() < ?VM_AEVM_SOPHIA_2, namespaces_not_in_roma),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, namespaces, {}),
     true  = ?call(call_contract, Acc, C, palindrome, bool, [1, 2, 3, 2, 1]),
@@ -5832,7 +5866,7 @@ sophia_namespaces(_Cfg) ->
 
 sophia_bytes(_Cfg) ->
     ?skipRest(vm_version() < ?VM_AEVM_SOPHIA_3, bytes_not_in_minerva),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     C    = ?call(create_contract, Acc, bytes_equality, {}),
     Bytes = fun(W) -> [{bytes, <<N:W/unit:8>>} || N <- [0, 1, 256, -1, 1 bsl ((W - 1) * 8)]] end,
@@ -5847,7 +5881,7 @@ sophia_bytes(_Cfg) ->
 
 sophia_bytes_remote(_Cfg) ->
     ?skipRest(vm_version() < ?VM_AEVM_SOPHIA_3, bytes_not_in_minerva),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     C    = ?call(create_contract, Acc, bytes_remote, {}),
     CR   = ?call(create_contract, Acc, bytes_remote, {}),
@@ -5861,7 +5895,7 @@ sophia_bytes_remote(_Cfg) ->
 
 sophia_bytes_to_x(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_MINERVA, bytes_to_x_not_in_minerva),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     C    = ?call(create_contract, Acc, bytes_to_x, {}),
 
@@ -5896,7 +5930,7 @@ sophia_bytes_to_x(_Cfg) ->
 
 sophia_bytes_concat(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_FORTUNA, bytes_concat_not_in_fortuna),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, bytes_concat, {}),
 
@@ -5925,7 +5959,7 @@ sophia_bytes_concat(_Cfg) ->
 
 sophia_address_checks(_Cfg) ->
     ?skipRest(vm_version() < ?VM_AEVM_SOPHIA_3, address_checks_not_in_minerva),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc  = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     C1   = ?call(create_contract, Acc, address_checks, {}),
     C2   = ?call(create_contract, Acc, address_checks, {}),
@@ -5992,7 +6026,7 @@ sophia_address_checks(_Cfg) ->
 
 
 sophia_too_little_gas_for_mem(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc   = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     IdC   = ?call(create_contract, Acc, counter, {4}),
 
@@ -6018,7 +6052,7 @@ run_scenario(#fundme_scenario
              , deadline = Deadline
              , events   = Events }) ->
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Denomination  = 1000 * 1000,
     StartingFunds = 1000 * 1000 * Denomination * aec_test_utils:min_gas_price(),
     InvestorNames = [ Investor || {contribute, Investor, _Amount, _Height} <- Events ],
@@ -6216,7 +6250,7 @@ aens_update(PubKey, NameHash, Pointers, Options, S) ->
     {ok, S1}.
 
 sophia_aens_resolve(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 400000000000000000000 * aec_test_utils:min_gas_price()),
     Ct       = ?call(create_contract, Acc, aens, {}, #{ amount => 100000 }),
     Name     = aens_test_utils:fullname(<<"foo">>),
@@ -6273,7 +6307,7 @@ sophia_aens_resolve(Cfg) ->
     ok.
 
 sophia_aens_lookup(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
     Ct       = ?call(create_contract, Acc, aens_lookup, {}, #{ amount => 20000000000000 * aec_test_utils:min_gas_price() }),
     Name1           = aens_test_utils:fullname(<<"bla">>),
@@ -6290,7 +6324,7 @@ sophia_aens_lookup(_Cfg) ->
 
 sophia_aens_transactions(Cfg) ->
     %% AENS transactions from contract
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
     Ct       = ?call(create_contract, Acc, aens, {}, #{ amount => 20000000000000 * aec_test_utils:min_gas_price() }),
 
@@ -6359,7 +6393,7 @@ sophia_aens_transactions(Cfg) ->
 
 sophia_aens_update_transaction(_Cfg) ->
     %% AENS transactions from contract
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
     Ct       = ?call(create_contract, Acc, aens, {}, #{ amount => 20000000000000 * aec_test_utils:min_gas_price() }),
 
@@ -6452,7 +6486,7 @@ sophia_aens_update_transaction(_Cfg) ->
 bad_aens_pointer_handling_lima_to_iris(Cfg) ->
     IrisHeight = maps:get(iris, ?config(fork_heights, Cfg)),
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 40000000000000 * aec_test_utils:min_gas_price()),
 
     Name1    = aens_test_utils:fullname(<<"foo">>),
@@ -6513,7 +6547,7 @@ bad_aens_pointer_handling_lima_to_iris(Cfg) ->
     ok.
 
 sophia_state_handling(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 50000000 * aec_test_utils:min_gas_price()),
     Ct0      = ?call(create_contract, Acc, remote_state, {}, #{ amount => 100000 }),
     %% Test an init function that calls a remote contract to compute the state
@@ -6582,7 +6616,7 @@ sophia_state_handling(_Cfg) ->
     ok.
 
 sophia_state_gas_arguments(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     ContractName =
         case vm_version() of
@@ -6633,7 +6667,7 @@ sophia_state_gas_arguments(_Cfg) ->
 
 sophia_state_gas_store_size(_Cfg) ->
     ?skipRest(not ?IS_FATE_SOPHIA(vm_version()), only_valid_for_fate),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     Ct0      = ?call(create_contract, Acc, remote_state, {}, #{ amount => 100000 }),
     Ct1      = ?call(create_contract, Acc, state_handling, {?cid(Ct0), 1}, #{ amount => 100000 }),
@@ -6698,7 +6732,7 @@ sophia_state_gas_store_size(_Cfg) ->
 
 sophia_use_memory_gas(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_FORTUNA, fate_gas_only_post_fortuna),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 20000000 * aec_test_utils:min_gas_price()),
     ContractName = use_memory,
     Ct0      = ?call(create_contract, Acc, ContractName, {}, #{ amount => 100000 }),
@@ -6768,7 +6802,7 @@ lima_migration(_Config) ->
     RootStr  = mtree:root_hash(MTree),
     ct:pal("Merkle-tree root hash: ~s", [RootStr]),
 
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 200000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, token_migration, {iolist_to_binary(RootStr), 0}, #{ amount => Total }),
 
@@ -6850,7 +6884,7 @@ lima_migration(_Config) ->
 
 
 fate_vm_interaction(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     ForkHeights = ?config(fork_heights, Cfg),
     LimaHeight = maps:get(lima, ForkHeights),
     IrisHeight = maps:get(iris, ForkHeights),
@@ -6919,7 +6953,7 @@ fate_vm_interaction(Cfg) ->
 
 
 fate_vm_version_switching(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     ForkHeights = ?config(fork_heights, Cfg),
     LimaHeight = maps:get(lima, ForkHeights),
     IrisHeight = maps:get(iris, ForkHeights),
@@ -6976,7 +7010,7 @@ fate_vm_version_switching(Cfg) ->
 
 
 contract_init_on_chain_fate(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     ForkHeights = ?config(fork_heights, Cfg),
     LimaHeight = maps:get(lima, ForkHeights),
     IrisHeight = maps:get(iris, ForkHeights),
@@ -7033,7 +7067,7 @@ get_ct_store(Ct) ->
     aect_contracts_store:contents(aect_contracts:state(Ct)).
 
 create_store(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1  = ?call(new_account, 100 * aec_test_utils:min_gas_price()),
     Ct1   = ?call(insert_contract, Acc1, <<"Code for C1">>),
     Ct1   = ?call(get_contract, Ct1),
@@ -7042,7 +7076,7 @@ create_store(_Cfg) ->
     ok.
 
 read_store(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1   = ?call(new_account, 100 * aec_test_utils:min_gas_price()),
     Ct1    = ?call(insert_contract, Acc1, <<"Code for C1">>),
     Ct1    = ?call(get_contract, Ct1),
@@ -7055,7 +7089,7 @@ read_store(_Cfg) ->
 
 
 store_zero_value(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1   = ?call(new_account, 100 * aec_test_utils:min_gas_price()),
     Ct1    = ?call(insert_contract, Acc1, <<"Code for C1">>),
     Ct1    = ?call(get_contract, Ct1),
@@ -7072,7 +7106,7 @@ store_zero_value(_Cfg) ->
     ok.
 
 merge_new_zero_value(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1   = ?call(new_account, 100 * aec_test_utils:min_gas_price()),
     Ct1    = ?call(insert_contract, Acc1, <<"Code for C1">>),
     Ct1    = ?call(get_contract, Ct1),
@@ -7187,7 +7221,7 @@ store_rand_exe_oplist(Ops, State, Dim, Tester, Acc, Spec) ->
 %%%%%%%%%%%%%%%%
 
 store_single_ops(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Dim={5,5,5},
     InitialState = store_rand_initial_state(Dim),
     Acc = ?call(new_account, 1000000000000000000000000000000000000000 * aec_test_utils:min_gas_price()),
@@ -7220,7 +7254,7 @@ store_single_ops(_Cfg) ->
 
 
 store_multiple_random_ops(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Dim={5,5,5},
     InitialState = store_rand_initial_state(Dim),
     Acc           = ?call(new_account, 1000000000000000000000000000000000000000 * aec_test_utils:min_gas_price()),
@@ -7255,7 +7289,7 @@ store_multiple_random_ops(_Cfg) ->
 
 
 store_onetype_random_ops(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Dim={5,5,5},
     InitialState = store_rand_initial_state(Dim),
     Acc = ?call(new_account, 1000000000000000000000000000000000000000 * aec_test_utils:min_gas_price()),
@@ -7302,7 +7336,7 @@ store_onetype_random_ops(_Cfg) ->
     ok.
 
 fate_vm_cross_protocol_store_big(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Dim={5,5,5},
     InitialState = store_rand_initial_state(Dim),
     ForkHeights   = ?config(fork_heights, Cfg),
@@ -7330,7 +7364,7 @@ fate_vm_cross_protocol_store_big(Cfg) ->
     ok.
 
 fate_vm_cross_protocol_store_multi_small(Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Dim={5,5,5},
     InitialState = store_rand_initial_state(Dim),
     ForkHeights   = ?config(fork_heights, Cfg),
@@ -7365,7 +7399,7 @@ fate_vm_cross_protocol_store_multi_small(Cfg) ->
 %%%===================================================================
 
 call_missing(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1      = ?call(new_account, 10000000 * aec_test_utils:min_gas_price()),
     Contract1 = ?call(create_contract, Acc1, remote_type_check, {}),
     Contract2 = ?call(create_contract, Acc1, remote_type_check, {}),
@@ -7375,7 +7409,7 @@ call_missing(_Cfg) ->
     ok.
 
 call_wrong_type(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc1     = ?call(new_account, 1000000000 * aec_test_utils:min_gas_price()),
     Contract1 = ?call(create_contract, Acc1, remote_type_check, {}),
     Contract2 = ?call(create_contract, Acc1, remote_type_check, {}),
@@ -7407,7 +7441,7 @@ call_wrong_type(_Cfg) ->
 %%%===================================================================
 
 fate_environment(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = <<AccInt:256>> = ?call(new_account, 100000000 * aec_test_utils:min_gas_price()),
     Acc1Balance = 123456789,
     <<Acc1Int:256>> = ?call(new_account, Acc1Balance),
@@ -7468,7 +7502,7 @@ fate_environment(_Cfg) ->
     ok.
 
 fate_list_of_maps(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, list_of_maps, {}, #{}),
     Map1 = #{<<"a">> => <<"b">>},
@@ -7478,7 +7512,7 @@ fate_list_of_maps(_Cfg) ->
 
 sophia_call_value(_Cfg) ->
     %% Test that we can use the value parameter to transfer funds
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     C1       = ?call(create_contract, Acc, spend_test, {}, #{}),
     C2       = ?call(create_contract, Acc, spend_test, {}, #{}),
@@ -7494,7 +7528,7 @@ sophia_call_value(_Cfg) ->
 
 sophia_payable_contract(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_FORTUNA, payable_not_pre_lima),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     C1  = ?call(create_contract, Acc, payable, {}, #{}),
     C2  = ?call(create_contract, Acc, non_payable, {}, #{}),
@@ -7523,7 +7557,7 @@ sophia_payable_contract(_Cfg) ->
 
 sophia_payable_entrypoint(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_FORTUNA, payable_not_pre_lima),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     C1  = ?call(create_contract, Acc, payable, {}, #{}),
 
@@ -7551,7 +7585,7 @@ sophia_payable_entrypoint(_Cfg) ->
     ok.
 
 sophia_private_entrypoint(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     C1  = ?call(create_contract, Acc, remote_private, {}, #{}),
     C2  = ?call(create_contract, Acc, remote_private, {}, #{}),
@@ -7592,7 +7626,7 @@ sophia_private_entrypoint(_Cfg) ->
     end.
 
 sophia_call_out_of_gas(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc      = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     RemC     = ?call(create_contract, Acc, remote_call, {}, #{}),
     IdC      = ?call(create_contract, Acc, identity, {}, #{}),
@@ -7628,7 +7662,7 @@ sophia_call_out_of_gas(_Cfg) ->
     ok.
 
 sophia_no_calls_to_init(_Cfg) ->
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 10000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, simple_auth, {123}, #{}),
 
@@ -7643,7 +7677,7 @@ sophia_no_calls_to_init(_Cfg) ->
 
 sophia_pattern_guards(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_LIMA_FATE, no_pattern_guards_until_iris),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 100000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, pattern_guards, {}),
     {}  = ?call(call_contract, Acc, C, test, {tuple, []}, {}),
@@ -7651,7 +7685,7 @@ sophia_pattern_guards(_Cfg) ->
 
 sophia_bitwise_operations(_Cfg) ->
     ?skipRest(sophia_version() =< ?SOPHIA_IRIS_FATE, no_bitwise_operations_until_ceres),
-    state(aect_test_utils:new_state()),
+    init_new_state(),
     Acc = ?call(new_account, 100000000000 * aec_test_utils:min_gas_price()),
     C   = ?call(create_contract, Acc, bitwise_ops, {}),
     {}  = ?call(call_contract, Acc, C, test, {tuple, []}, {}),

--- a/apps/aecore/src/aec_block_fork.erl
+++ b/apps/aecore/src/aec_block_fork.erl
@@ -214,8 +214,9 @@ apply_contract_call_tx(Tx, Trees, TxEnv) ->
     case aetx:process(Tx, Trees, TxEnv) of
         {ok, Trees1, _} ->
             {contract_call_tx, CallTx} = aetx:specialize_type(Tx),
+            %% Don't allow named contracts here :-)
+            {contract, ContractPubkey} = aeser_id:specialize(aect_call_tx:contract_id(CallTx)),
             CallPubkey     = aect_call_tx:call_id(CallTx),
-            ContractPubkey = aect_call_tx:contract_pubkey(CallTx),
             CallTree       = aec_trees:calls(Trees1),
             {value, Call}  = aect_call_state_tree:lookup_call(ContractPubkey, CallPubkey, CallTree),
             case aect_call:return_type(Call) of

--- a/apps/aecore/src/aec_dry_run.erl
+++ b/apps/aecore/src/aec_dry_run.erl
@@ -113,8 +113,13 @@ dry_run_res(STx, Trees, ok) ->
     Tx = aetx_sign:tx(STx),
     {Type, _} = aetx:specialize_type(Tx),
     case Type of
-        _ when Type =:= contract_call_tx;
-               Type =:= contract_create_tx;
+        contract_call_tx ->
+            {CB, CTx} = aetx:specialize_callback(Tx),
+            CtCallId  = CB:ct_call_id(CTx),
+            CallId    = CB:call_id(CTx),
+            CallObj   = lookup_call_object(CtCallId, CallId, Trees),
+            {Type, {ok, CallObj}};
+        _ when Type =:= contract_create_tx;
                Type =:= ga_attach_tx ->
             {CB, CTx} = aetx:specialize_callback(Tx),
             Contract  = CB:contract_pubkey(CTx),

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -1230,7 +1230,9 @@ make_fate_base_tx(BaseTxType, BaseTx, ES) ->
             Amount = aect_create_tx:amount(BaseTx),
             {VarGas(1) + AmtGas, MkVar(19, {Amount})};
         contract_call_tx ->
-            Ct     = aect_call_tx:contract_pubkey(BaseTx),
+            %% TODO: This isn't correct, a name is not an address...
+            %%       We should probably resolve the name
+            Ct     = aect_call_tx:ct_call_id(BaseTx),
             Amount = aect_call_tx:amount(BaseTx),
             {VarGas(2) + AddrGas + AmtGas, MkVar(20, {?FATE_ADDRESS(Ct), Amount})};
 

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -194,6 +194,7 @@
 -include_lib("aecore/include/blocks.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
 
+-define(AENS_RESOLVE_GAS_COST, 2000). %% TODO: make gas costs generally available?!
 -define(AVAILABLE_FROM(When, ES),
         aefa_engine_state:vm_version(ES) >= When
         orelse aefa_fate:abort({primop_error, ?FUNCTION_NAME, not_supported}, ES)).
@@ -1230,11 +1231,24 @@ make_fate_base_tx(BaseTxType, BaseTx, ES) ->
             Amount = aect_create_tx:amount(BaseTx),
             {VarGas(1) + AmtGas, MkVar(19, {Amount})};
         contract_call_tx ->
-            %% TODO: This isn't correct, a name is not an address...
-            %%       We should probably resolve the name
-            Ct     = aect_call_tx:ct_call_id(BaseTx),
+            CtId   = aect_call_tx:contract_id(BaseTx),
             Amount = aect_call_tx:amount(BaseTx),
-            {VarGas(2) + AddrGas + AmtGas, MkVar(20, {?FATE_ADDRESS(Ct), Amount})};
+            case aeser_id:specialize(CtId) of
+                {contract, CtPubkey} ->
+                    {VarGas(2) + AddrGas + AmtGas,
+                     MkVar(20, {?FATE_ADDRESS(CtPubkey), Amount})};
+                {name, NameHash} ->
+                    ?AVAILABLE_FROM(?VM_FATE_SOPHIA_3, ES),
+                    API = aefa_engine_state:chain_api(ES),
+                    case aefa_chain_api:aens_resolve_name_hash(NameHash, <<"contract_pubkey">>, API) of
+                        {ok, _Tag, CtPubkey, _API1} ->
+                            {VarGas(2) + AddrGas + AmtGas + ?AENS_RESOLVE_GAS_COST,
+                             MkVar(20, {?FATE_ADDRESS(CtPubkey), Amount})};
+                        _ ->
+                            aefa_fate:abort({primop_error, aens_resolve, no_contract_pubkey}, ES)
+                    end
+            end;
+
 
         ga_attach_tx ->
             {VarGas(0), MkVar(21, {})};

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -1470,9 +1470,9 @@ do_meta(Owner, AuthData, InnerTx, MetaTx, Opts, S) ->
                 {ok, Res0#{ ct_pubkey => NewContract
                           , init_res  => aect_call:return_type(InitCall) }};
             {contract_call_tx, CCTx} ->
-                Contract    = aect_call_tx:contract_pubkey(CCTx),
-                InnerCallId = aect_call:ga_id(AuthId, Contract),
-                InnerCall   = aect_call_state_tree:get_call(Contract, InnerCallId, CallTree),
+                CtCallId    = aect_call_tx:ct_call_id(CCTx),
+                InnerCallId = aect_call:ga_id(AuthId, CtCallId),
+                InnerCall   = aect_call_state_tree:get_call(CtCallId, InnerCallId, CallTree),
                 {ok, Res0#{ call_res => aect_call:return_type(InnerCall),
                             call_val => aect_call:return_value(InnerCall),
                             call_gas => aect_call:gas_used(InnerCall) }};

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -36,6 +36,7 @@
         , basic_minimum_fee/1
 
         , tx_check/1
+        , tx_auth_name_resolution/1
 
         , bitcoin_attach/1
         , bitcoin_spend_from/1
@@ -147,7 +148,8 @@ groups() ->
                   , basic_minimum_fee
                   ]}
 
-    , {tx, [], [tx_check
+    , {tx, [], [ tx_check
+               , tx_auth_name_resolution
                ]}
 
     , {bitcoin, [], [ bitcoin_attach
@@ -505,6 +507,66 @@ tx_check(_Cfg) ->
         ?call(ga_spend, Acc1, Auth("4"), Acc2, 200, 20000 * MinGP, #{fail => true}),
     ok.
 
+
+-define(CT_NAMED_CALL_NAME, <<"contractpointer.chain">>).
+-define(CT_NAMED_CALL_NHASH, element(2, aens:get_name_hash(?CT_NAMED_CALL_NAME))).
+-define(CT_NAMED_CALL_NOBJ, aens_names:new(?CT_NAMED_CALL_NHASH, <<0:256>>, 50000)).
+-define(CT_NAMED_CALL_NAME2, <<"contractpointer2.chain">>).
+-define(CT_NAMED_CALL_NHASH2, element(2, aens:get_name_hash(?CT_NAMED_CALL_NAME2))).
+-define(CT_NAMED_CALL_NOBJ2, aens_names:new(?CT_NAMED_CALL_NHASH2, <<0:256>>, 50000)).
+tx_auth_name_resolution(Cfg) ->
+    case aect_test_utils:latest_protocol_version() of
+        Vsn when Vsn =< ?IRIS_PROTOCOL_VSN -> {skip, named_contract_calls_not_pre_ceres};
+        _Vsn -> tx_auth_name_resolution_(Cfg)
+    end.
+
+tx_auth_name_resolution_(_Cfg) ->
+    S0 = aect_test_utils:new_state(),
+    Trees   = aect_test_utils:trees(S0),
+    NTrees  = aec_trees:ns(Trees),
+    NTrees1 = aens_state_tree:enter_name(?CT_NAMED_CALL_NOBJ, NTrees),
+    NTrees2 = aens_state_tree:enter_name(?CT_NAMED_CALL_NOBJ2, NTrees1),
+    S1 = aect_test_utils:set_trees(aec_trees:set_ns(Trees, NTrees2), S0),
+    state(S1),
+
+
+    MinGP = aec_test_utils:min_gas_price(),
+    Acc1 = ?call(new_account, 1000000000 * MinGP),
+    {ok, _} = ?call(attach, Acc1, "tx_auth", "authorize_named_call", []),
+
+    Auth = fun(N, CtAddr) -> #{ prep_fun => fun(_Tx) -> ?call(tx_auth_named, Acc1, N, CtAddr) end } end,
+    {ok, #{init_res := ok, ct_pubkey := Ct}} =
+        ?call(ga_create, Acc1, Auth("1", <<0:256>>), "identity", []),
+
+    CtNameId = aeser_id:create(name, ?CT_NAMED_CALL_NHASH),
+    CtNameId2 = aeser_id:create(name, ?CT_NAMED_CALL_NHASH2),
+    meck:new(aens, [passthrough]),
+    meck:expect(aens, resolve_from_name_object,
+                fun(Key, NameObj) ->
+                    NameId = aens_names:id(NameObj),
+                    case (Key == <<"contract_pubkey">>) of
+                        true when NameId == CtNameId ->
+                            {ok, aeser_id:create(contract, Ct)};
+                        true when NameId == CtNameId2 ->
+                            {error, pointer_id_not_found};
+                        _ ->
+                            meck:passthrough([Key, NameObj])
+                    end
+                end),
+
+    {ok, #{call_res := ok, call_val := Val}} =
+        ?call(ga_call, Acc1, Auth("2", Ct), Ct, "identity", "main_", ["42"], #{contract_id => CtNameId}),
+
+    ?assertMatchABI("42", 42, decode_call_result("identity", "main_", ok, Val)),
+
+    CtNameId3 = aeser_id:create(name, <<1:256>>),
+    {failed, authentication_failed} =
+        ?call(ga_call, Acc1, Auth("3", Ct), Ct, "identity", "main_", ["42"], #{contract_id => CtNameId2, fail => true}),
+    {failed, authentication_failed} =
+        ?call(ga_call, Acc1, Auth("3", Ct), Ct, "identity", "main_", ["42"], #{contract_id => CtNameId3, fail => true}),
+
+    meck:unload(aens),
+    ok.
 
 %%%===================================================================
 %%% Bitcoin GA tests
@@ -1700,6 +1762,10 @@ simple_auth(Args) ->
 
 tx_auth(_GA, Nonce, S) ->
     {aega_test_utils:make_calldata("tx_auth", "authorize", [Nonce]), S}.
+
+tx_auth_named(_GA, Nonce, CtAddr, S) ->
+    Enc = lists:flatten(io_lib:format("~s", [aeser_api_encoder:encode(account_pubkey, CtAddr)])),
+    {aega_test_utils:make_calldata("tx_auth", "authorize_named_call", [Nonce, Enc]), S}.
 
 
 basic_auth(GA, Nonce, TxHash, S) ->

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -34,7 +34,7 @@ tags:
   - name: dry-run
     description: External dry run endpoint.
   - name: node-operator
-    description: Endpoints to help the node oprator interact with the node
+    description: Endpoints to help the node operator interact with the node
 externalDocs:
   description: Find out more about Aeternity
   url: http://www.aeternity.com

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -342,7 +342,7 @@ produce_tx(contract_call_tx, Req) ->
                                        amount, gas, gas_price, fee, call_data]),
                  read_optional_params([{ttl, ttl, '$no_value'}]),
                  api_decode([{caller_id, caller_id, {id_hash, [account_pubkey]}},
-                                {contract_id, contract_id, {id_hash, [contract_pubkey]}}]),
+                             {contract_id, contract_id, {id_hash, [contract_pubkey, name]}}]),
                  api_str_to_int([abi_version, amount, gas, gas_price, fee, ttl]),
                  get_nonce_from_account_id(caller_id),
                  get_contract_code(contract_id, contract_code),

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -275,20 +275,37 @@ print_state() ->
         lager:info("State: ~p", [State])
     end.
 
-get_contract_code(ContractKey, CodeKey) ->
+
+get_contract_code(CtIdKey, CodeKey) ->
     fun(_Req, State) ->
-        ContractId = maps:get(ContractKey, State),
-        ContractPubKey = aeser_id:specialize(ContractId, contract),
-        TopBlockHash = aec_chain:top_block_hash(),
-        {ok, Trees} = aec_chain:get_block_state(TopBlockHash),
-        Tree = aec_trees:contracts(Trees),
-        case aect_state_tree:lookup_contract_with_code(ContractPubKey, Tree) of
-            none ->
-                Msg = "Contract address for key " ++ atom_to_list(ContractKey) ++ " not found",
-                {error, {404, [], #{<<"reason">> => list_to_binary(Msg)}}};
-            {value, _Contract, Code} ->
-                {ok, maps:put(CodeKey, Code, State)}
+        ContractId = maps:get(CtIdKey, State),
+        case aeser_id:specialize(ContractId) of
+            {contract, _} -> get_contract_code_(ContractId, CodeKey, State);
+            {name, NameHash} ->
+                TopBlockHash = aec_chain:top_block_hash(),
+                {ok, Trees}  = aec_chain:get_block_state(TopBlockHash),
+                case aens:resolve_hash(<<"contract_pubkey">>, NameHash, aec_trees:ns(Trees)) of
+                    {ok, ContractId1} -> get_contract_code_(ContractId1, CodeKey, State);
+                    {error, _} ->
+                        Msg = io_lib:format("Could not resolve contract address for '~ts'",
+                                            [aeser_api_encoder:encode(name, NameHash)]),
+                        {error, {404, [], #{<<"reason">> => iolist_to_binary(Msg)}}}
+                end
         end
+    end.
+
+get_contract_code_(ContractId, CodeKey, State) ->
+    TopBlockHash   = aec_chain:top_block_hash(),
+    {ok, Trees}    = aec_chain:get_block_state(TopBlockHash),
+    ContractPubKey = aeser_id:specialize(ContractId, contract),
+    Tree           = aec_trees:contracts(Trees),
+    case aect_state_tree:lookup_contract_with_code(ContractPubKey, Tree) of
+        none ->
+            Msg = io_lib:format("Contract code for '~ts' not found",
+                                [aeser_api_encoder:encode(contract_pubkey, ContractPubKey)]),
+            {error, {404, [], #{<<"reason">> => iolist_to_binary(Msg)}}};
+        {value, _Contract, Code} ->
+            {ok, maps:put(CodeKey, Code, State)}
     end.
 
 get_info_object_from_tx(TxKey, TypeKey, CallKey) ->
@@ -303,7 +320,7 @@ get_info_object_from_tx(TxKey, TypeKey, CallKey) ->
                         {ok, InfoObject} ->
                             {ok, maps:put(TypeKey, TxType, maps:put(CallKey, InfoObject, State))};
                         {error, transaction_without_info} ->
-                            %% Potentialluy one could return
+                            %% Potentially one could return
                             %% {ok, maps:put(TypeKey, TxType, maps:put(CallKey, atom_to_binary(TxType, utf8), State))};
                             %% That is not backward compatible, but consistent with inner Txs
                             {error, {400, [], #{<<"reason">> => <<"Tx has no info">>}}};

--- a/apps/aehttp/test/aehttp_contracts_SUITE.erl
+++ b/apps/aehttp/test/aehttp_contracts_SUITE.erl
@@ -69,6 +69,7 @@
 all() ->
     [ {group, aevm}
     , {group, fate}
+    , {group, fate_named}
     ].
 
 -define(ALL_TESTS,

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -88,6 +88,7 @@
     post_spend_tx_w_hash_sig/1,
     post_contract_and_call_tx/1,
     nonce_limit/1,
+    get_name_update/1,
     get_contract_create/1,
     get_contract_call/1,
     get_contract_bytecode/1,

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2190,7 +2190,7 @@ contract_transactions(_Config) ->    % miner has an account
     {ok, 404, #{<<"reason">> := <<"Account of caller_id not found">>}} =
         get_contract_call(maps:put(caller_id, RandAddress, ContractCallEncoded)),
     %% contract not found
-    {ok, 404, #{<<"reason">> := <<"Contract address for key contract_id not found">>}} =
+    {ok, 404, #{<<"reason">> := <<"Contract code for", _/binary>>}} =
         get_contract_call(maps:put(contract_id, RandContractAddress,
                                    ContractCallEncoded)),
 

--- a/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
+++ b/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
@@ -199,12 +199,14 @@ contract_call_spec(ContractPubkey, Name, Fun, Args, Amount, From, Nonce) ->
     {contract_call_tx, CallTx} =
         aetx:specialize_type(contract_call(ContractPubkey, Name, Fun, Args,
                                            Amount, From, Nonce)),
+    %% Don't allow named contracts!?
+    {contract, ContractPubKey} =
+        aeser_id:specialize(aect_call_tx:contract_id(CallTx)),
     Spec =
         #{  <<"caller">>          => aeser_api_encoder:encode(account_pubkey,
                                                               aect_call_tx:caller_pubkey(CallTx))
           , <<"nonce">>           => aect_call_tx:nonce(CallTx)
-          , <<"contract_pubkey">> => aeser_api_encoder:encode(contract_pubkey,
-                                                              aect_call_tx:contract_pubkey(CallTx))
+          , <<"contract_pubkey">> => aeser_api_encoder:encode(contract_pubkey, ContractPubKey)
           , <<"abi_version">>     => aect_call_tx:abi_version(CallTx)
           , <<"fee">>             => aect_call_tx:fee(CallTx)
           , <<"amount">>          => aect_call_tx:amount(CallTx)

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -355,27 +355,27 @@ contract_create_tx_instructions(OwnerPubkey, Amount, Deposit, GasLimit, GasPrice
                          CallData, Fee, Nonce)
     ].
 
--spec contract_call_tx_instructions(pubkey(), pubkey(), binary(),
+-spec contract_call_tx_instructions(pubkey(), id(), binary(),
                                     non_neg_integer(), non_neg_integer(),
                                     amount(), [binary()], abi_version(),
                                     pubkey(), fee(), nonce()) -> [op()].
-contract_call_tx_instructions(CallerPubKey, ContractPubkey, CallData,
+contract_call_tx_instructions(CallerPubKey, ContractId, CallData,
                               GasLimit, GasPrice, Amount, CallStack,
                               ABIVersion, Origin, Fee, Nonce) ->
     [ inc_account_nonce_op(CallerPubKey, Nonce)
-    , contract_call_op(CallerPubKey, ContractPubkey, CallData,
+    , contract_call_op(CallerPubKey, ContractId, CallData,
                        GasLimit, GasPrice, Amount,
                        ABIVersion, Origin, CallStack, Fee, Nonce)
     ].
 
 -spec contract_call_from_contract_instructions(
-        pubkey(), pubkey(), binary(), non_neg_integer(), non_neg_integer(),
+        pubkey(), id(), binary(), non_neg_integer(), non_neg_integer(),
         amount(), [binary()], abi_version(), pubkey(), fee(), nonce()
        ) -> [op()].
-contract_call_from_contract_instructions(CallerPubKey, ContractPubkey, CallData,
+contract_call_from_contract_instructions(CallerPubKey, ContractId, CallData,
                                          GasLimit, GasPrice, Amount, CallStack,
                                          ABIVersion, Origin, Fee, Nonce) ->
-    [ contract_call_op(CallerPubKey, ContractPubkey, CallData,
+    [ contract_call_op(CallerPubKey, ContractId, CallData,
                        GasLimit, GasPrice, Amount,
                        ABIVersion, Origin, CallStack, Fee, Nonce)
     ].
@@ -1288,14 +1288,13 @@ channel_settle({FromPubkey, ChannelPubkey,
 
 %%%-------------------------------------------------------------------
 
--spec contract_call_op(pubkey(), pubkey(), binary(), non_neg_integer(), non_neg_integer(),
+-spec contract_call_op(pubkey(), id(), binary(), non_neg_integer(), non_neg_integer(),
     amount(), abi_version(), hash(), list(), fee(), nonce()) ->
-    {contract_call, {pubkey(), pubkey(), binary(), non_neg_integer(), non_neg_integer(),
+    {contract_call, {pubkey(), id(), binary(), non_neg_integer(), non_neg_integer(),
         amount(), abi_version(), hash(), list(), fee(), nonce()}}.
-contract_call_op(CallerPubkey, ContractPubkey, CallData, GasLimit, GasPrice,
+contract_call_op(CallerPubkey, ContractId, CallData, GasLimit, GasPrice,
                  Amount, ABIVersion, Origin, CallStack, Fee, Nonce
                 ) when ?IS_HASH(CallerPubkey),
-                       ?IS_HASH(ContractPubkey),
                        is_binary(CallData),
                        ?IS_NON_NEG_INTEGER(GasLimit),
                        ?IS_NON_NEG_INTEGER(GasPrice),
@@ -1305,7 +1304,7 @@ contract_call_op(CallerPubkey, ContractPubkey, CallData, GasLimit, GasPrice,
                        is_list(CallStack),
                        ?IS_NON_NEG_INTEGER(Fee),
                        ?IS_NON_NEG_INTEGER(Nonce) ->
-    {contract_call, {CallerPubkey, ContractPubkey, CallData, GasLimit, GasPrice,
+    {contract_call, {CallerPubkey, ContractId, CallData, GasLimit, GasPrice,
                      Amount, ABIVersion, Origin, CallStack, Fee, Nonce}}.
 
 -spec split_payment(amount(), amount(), state()) -> {amount(), state()}.
@@ -1320,9 +1319,23 @@ split_payment(TotalAmount, Amount, S) ->
             {TotalAmount, S}
     end.
 
--spec contract_call({pubkey(), pubkey(), binary(), non_neg_integer(), non_neg_integer(),
-    amount(), abi_version(), hash(), list(), fee(), nonce()}, state()) -> state().
-contract_call({CallerPubkey, ContractPubkey, CallData, GasLimit, GasPrice,
+
+%% -spec contract_call({pubkey(), id(), binary(), non_neg_integer(), non_neg_integer(),
+%%                      amount(), abi_version(), hash(), list(), fee(), nonce()}, state()) -> state().
+contract_call({CallerPubkey, ContractId, CallData, GasLimit, GasPrice,
+               Amount, ABIVersion, Origin, CallStack, Fee, Nonce}, S) ->
+    case aeser_id:specialize(ContractId) of
+        {contract, ContractPubkey} ->
+            contract_call({CallerPubkey, ContractPubkey, ContractPubkey, CallData, GasLimit,
+                           GasPrice, Amount, ABIVersion, Origin, CallStack, Fee, Nonce}, S);
+        {name, NameHash} ->
+            S#state.protocol >= ?CERES_PROTOCOL_VSN orelse
+                runtime_error(contract_call_by_name_hash_not_available_at_protocol),
+            {ContractPubkey, S1} = int_resolve_name(NameHash, <<"contract_pubkey">>, S),
+            contract_call({CallerPubkey, ContractPubkey, NameHash, CallData, GasLimit,
+                           GasPrice, Amount, ABIVersion, Origin, CallStack, Fee, Nonce}, S1)
+    end;
+contract_call({CallerPubkey, ContractPubkey, CtCallId, CallData, GasLimit, GasPrice,
                Amount, ABIVersion, Origin, CallStack, Fee, Nonce}, S) ->
     {CallerId, TotalAmount} = get_call_env_specific(CallerPubkey, GasLimit,
                                                     GasPrice, Amount, Fee, S),
@@ -1347,7 +1360,7 @@ contract_call({CallerPubkey, ContractPubkey, CallData, GasLimit, GasPrice,
     %% Avoid writing the store back by skipping this state.
     Contract = get_contract_no_cache(ContractPubkey, S4),
     ContractCall = fun() ->
-                           run_contract(CallerId, Contract, GasLimit, Fee, GasPrice,
+                           run_contract(CallerId, Contract, CtCallId, GasLimit, Fee, GasPrice,
                                         CallData, _AllowInit = false, Origin, Amount, CallStack, Nonce, S4)
                    end,
     {Call, S5} = timed_contract_call(contract_call, ContractCall, CallData, CTVersion),
@@ -1621,7 +1634,7 @@ init_contract(Context, OwnerId, Code, Contract, GasLimit, GasPrice, CallData,
               OwnerPubkey, Fee, Nonce, RollbackS, S, MetricType, CTVersion) ->
     {InitContract, ChainContract, S1} = prepare_init_call(Code, Contract, S),
     ContractCall = fun() ->
-                           run_contract(OwnerId, Code, InitContract, GasLimit, Fee, GasPrice,
+                           run_contract(OwnerId, Code, InitContract, aect_contracts:pubkey(InitContract), GasLimit, Fee, GasPrice,
                                         CallData, _AllowInit = true, OwnerPubkey, _InitAmount = 0,
                                         _CallStack = [], Nonce, S1)
                    end,
@@ -1779,6 +1792,14 @@ contract_call_fail(Call0, Fee, S) ->
     false, binary(), amount(), list(), nonce(), state()) -> {call(), state()}.
 run_contract(CallerId, Contract, GasLimit, Fee, GasPrice, CallData, AllowInit,
              Origin, Amount, CallStack, Nonce, S) ->
+    ContractPubkey = aect_contracts:pubkey(Contract),
+    run_contract(CallerId, Contract, ContractPubkey, GasLimit, Fee, GasPrice, CallData,
+                 AllowInit, Origin, Amount, CallStack, Nonce, S).
+
+-spec run_contract(id(), contract(), binary(), number(), fee(), non_neg_integer(), binary(),
+    false, binary(), amount(), list(), nonce(), state()) -> {call(), state()}.
+run_contract(CallerId, Contract, CtCallId, GasLimit, Fee, GasPrice, CallData, AllowInit,
+             Origin, Amount, CallStack, Nonce, S) ->
     Code =
         case aect_contracts:code(Contract) of
             {code, C} -> C;
@@ -1788,17 +1809,17 @@ run_contract(CallerId, Contract, GasLimit, Fee, GasPrice, CallData, AllowInit,
                 {code, C} = aect_contracts:code(RefContract),
                 C
         end,
-    run_contract(CallerId, Code, Contract, GasLimit, Fee,
+    run_contract(CallerId, Code, Contract, CtCallId, GasLimit, Fee,
                  GasPrice, CallData, AllowInit, Origin, Amount, CallStack, Nonce, S).
 
--spec run_contract(id(), code() | binary(), contract(), number(), fee(), non_neg_integer(), binary(),
+-spec run_contract(id(), code() | binary(), contract(), binary(), number(), fee(), non_neg_integer(), binary(),
     boolean(), binary(), amount(), list(), nonce(), state()) -> {call(), state()}.
-run_contract(CallerId, Code, Contract, GasLimit, Fee, GasPrice, CallData, AllowInit,
+run_contract(CallerId, Code, Contract, CtCallId, GasLimit, Fee, GasPrice, CallData, AllowInit,
              Origin, Amount, CallStack, Nonce, S) ->
     %% We need to push all to the trees before running a contract.
     S1 = aeprimop_state:cache_write_through(S),
     ContractId = aect_contracts:id(Contract),
-    Call = aect_call:new(CallerId, Nonce, ContractId, S#state.height, GasPrice),
+    Call = aect_call:new(CallerId, Nonce, ContractId, CtCallId, S#state.height, GasPrice),
     {_, CallerPubKey} = aeser_id:specialize(CallerId),
     CallDef = #{ caller      => CallerPubKey
                , contract    => aect_contracts:pubkey(Contract)

--- a/apps/aeprimop/src/aeprimop.erl
+++ b/apps/aeprimop/src/aeprimop.erl
@@ -1745,7 +1745,7 @@ contract_init_call_success(Type, InitCall, Contract, GasLimit, Fee, RollbackS, S
 set_call_object_id(Call, #state{ tx_env = TxEnv }) ->
     case aetx_env:ga_nonce(TxEnv, aect_call:caller_pubkey(Call)) of
         {value, Nonce} ->
-            CallId = aect_call:ga_id(Nonce, aect_call:contract_pubkey(Call)),
+            CallId = aect_call:ga_id(Nonce, aect_call:ct_call_id(Call)),
             aect_call:set_id(CallId, Call);
         none ->
             Call

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -325,9 +325,13 @@ used_gas(#aetx{type = contract_create_tx, cb = CB, size = Size, tx = Tx}, _Heigh
     CallId = aect_call:ga_id(GANonce, ContractPubkey),
     base_gas(contract_create_tx, Version, CB:abi_version(Tx)) + size_gas(Size) + call_gas_used(Trees, ContractPubkey, CallId);
 used_gas(#aetx{type = contract_call_tx, cb = CB, size = Size, tx = Tx}, _Height, Version, Trees, #{ga_nonce := GANonce}) ->
-    ContractPubkey = CB:contract_pubkey(Tx),
-    CallId = aect_call:ga_id(GANonce, ContractPubkey),
-    base_gas(contract_call_tx, Version, CB:abi_version(Tx)) + size_gas(Size) + call_gas_used(Trees, ContractPubkey, CallId);
+    CtCallId = CB:ct_call_id(Tx),
+    CallId = aect_call:ga_id(GANonce, CtCallId),
+    base_gas(contract_call_tx, Version, CB:abi_version(Tx)) + size_gas(Size) + call_gas_used(Trees, CtCallId, CallId);
+used_gas(#aetx{type = contract_call_tx, cb = CB, size = Size, tx = Tx}, _Height, Version, Trees, _Ctx) ->
+    CtCallId = CB:ct_call_id(Tx),
+    CallId = CB:call_id(Tx),
+    base_gas(contract_call_tx, Version, CB:abi_version(Tx)) + size_gas(Size) + call_gas_used(Trees, CtCallId, CallId);
 used_gas(#aetx{type = Type, cb = CB, size = Size, tx = Tx}, _Height, Version, Trees, _Ctx) when ?IS_CONTRACT_TX(Type) ->
     ContractPubkey = CB:contract_pubkey(Tx),
     CallId = CB:call_id(Tx),

--- a/docs/release-notes/next-ceres/GH-4009-allow_contract_call_by_name.md
+++ b/docs/release-notes/next-ceres/GH-4009-allow_contract_call_by_name.md
@@ -1,0 +1,9 @@
+* Allow contracts to be called by name. The key `contract_pubkey` of the name
+  is resolved while running the transaction. This has consequences for the
+  contract call structure (`aect_call`) that gets a new field with the contract
+  call identifier. In order to be able to find the call result without doing
+  name resolution calls are stored relative to the id rather than the contract
+  pubkey.
+
+  NOTE: Names can change at any time (frontrunning is possible!) so only call
+  contracts by name when you trust the owner of the name!

--- a/test/contracts/tx_auth.aes
+++ b/test/contracts/tx_auth.aes
@@ -16,6 +16,19 @@ contract TxAuth =
           Chain.ContractCallTx(_, _)   => true
           _                            => false
 
+  stateful entrypoint authorize_named_call(n : int, addr : address) : bool =
+    require(n >= state.nonce, "Nonce too low")
+    require(n =< state.nonce, "Nonce too high")
+    put(state{ nonce = n + 1 })
+    switch(Auth.tx)
+      None      => abort("Not in Auth context")
+      Some(tx0) =>
+        switch(tx0.tx)
+          Chain.ContractCreateTx(_)    => true
+          Chain.ContractCallTx(ct, _)  => ct == addr
+          _                            => false
+
+
   entrypoint test_no_auth_tx() =
     None == Auth.tx
 


### PR DESCRIPTION
TODO:
- [x] HTTP API to create ContractCallTx should support a name as "contract id"
- [x] Add name resolve to GA AuthTx  
- [x] Test name resolve in GA Auth
- [x] Document the new changes in `aeternity/protocol` repo
- [x] Add release note

This PR is supported by the Æternity Crypto Foundation