### PR TITLE
Reformat Ranch options to avoid deprecation warnings

### DIFF
--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -112,9 +112,9 @@ start_http_api(Target, LogicHandler) ->
     Dispatch = cowboy_router:compile([{'_', Paths}]),
 
     Opts = #{ num_acceptors => PoolSize
-	    , socket_opts => [ {port, Port}
-			     , {ip, ListenAddress} ]
-	    },
+            , socket_opts => [ {port, Port}
+                             , {ip, ListenAddress} ]
+            },
     Env = #{env => #{dispatch => Dispatch},
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
@@ -133,9 +133,9 @@ start_channel_websocket() ->
         ]}
     ]),
     Opts = #{ num_acceptors => Acceptors
-	    , socket_opts => [ {port, Port}
-			     , {ip, ListenAddress} ]
-	    },
+            , socket_opts => [ {port, Port}
+                             , {ip, ListenAddress} ]
+            },
     Env = #{env => #{dispatch => Dispatch}},
     lager:debug("Opts = ~p", [Opts]),
     {ok, _} = cowboy:start_clear(channels_socket, Opts, Env),

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -111,9 +111,10 @@ start_http_api(Target, LogicHandler) ->
     Paths = aehttp_api_router:get_paths(Target, LogicHandler),
     Dispatch = cowboy_router:compile([{'_', Paths}]),
 
-    Opts = [{port, Port},
-            {ip, ListenAddress},
-            {num_acceptors, PoolSize}],
+    Opts = #{ num_acceptors => PoolSize
+	    , socket_opts => [ {port, Port}
+			     , {ip, ListenAddress} ]
+	    },
     Env = #{env => #{dispatch => Dispatch},
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
@@ -131,9 +132,10 @@ start_channel_websocket() ->
             {"/channel", sc_ws_handler, []}
         ]}
     ]),
-    Opts = [{port, Port},
-            {ip, ListenAddress},
-            {num_acceptors, Acceptors}],
+    Opts = #{ num_acceptors => Acceptors
+	    , socket_opts => [ {port, Port}
+			     , {ip, ListenAddress} ]
+	    },
     Env = #{env => #{dispatch => Dispatch}},
     lager:debug("Opts = ~p", [Opts]),
     {ok, _} = cowboy:start_clear(channels_socket, Opts, Env),


### PR DESCRIPTION
See Issue #4017 

The change complies with the suggestion of the deprecation warnings issued at startup.