### PR TITLE
SC: Support extracting call data

### DIFF
--- a/apps/aechannel/src/aesc_offchain_update.erl
+++ b/apps/aechannel/src/aesc_offchain_update.erl
@@ -18,6 +18,7 @@
          is_contract_create/1,
          extract_call/1,
          extract_caller/1,
+         extract_call_data/1,
          extract_contract_pubkey/1,
          extract_amounts/1,
          extract_abi_version/1]).
@@ -482,6 +483,10 @@ extract_caller(#call_contract{caller_id = CallerId}) ->
     account_pubkey(CallerId);
 extract_caller(#create_contract{owner_id = OwnerId}) ->
     account_pubkey(OwnerId).
+
+-spec extract_call_data(update()) -> binary().
+extract_call_data(#call_contract{call_data = CallData}) ->
+    CallData.
 
 -spec is_call(update()) -> boolean().
 is_call(#call_contract{}) ->


### PR DESCRIPTION
Needed for e.g. the State Channel Market Demo, this PR exports a function for extracting call data from a State Channel contract call transaction.

This is necessary for any SC app developed in Erlang, in order to inspect the contract call arguments before signing.