### PR TITLE
Use A-B table pair for account states (GC) - no init:restart()

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1529,6 +1529,15 @@ handle_table_errors(Tables, Mode, [{missing_table, aec_peers = Table} | Tl]) ->
 handle_table_errors(Tables, Mode, [{missing_table, aesc_state_cache_v2} | Tl]) ->
     aesc_db:create_tables(Mode),
     handle_table_errors(Tables, Mode, Tl);
+handle_table_errors(Tables, Mode, [{missing_table, Table} | Tl] = Errors) ->
+    case lists:keymember(Table, 1, Tables) of
+        true ->
+            new_table_migration(Table, Tables),
+            handle_table_errors(Tables, Mode, Tl);
+        false ->
+            lager:error("Database check failed: ~p", [Errors]),
+            erlang:error({table_check, Errors})
+    end;
 handle_table_errors(Tables, Mode, [{callback, {Mod, Fun, Args}} | Tl]) ->
     apply(Mod, Fun, Args),
     handle_table_errors(Tables, Mode, Tl);

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -858,8 +858,8 @@ make_primary_state_tab(T, P) ->
 
 cache_primary_state_tabs() ->
     lager:debug("Caching primary for gced tabs", []),
-    maps:foreach(
-      fun(T, #{copies := Ts}) ->
+    maps:fold(
+      fun(T, #{copies := Ts}, _) ->
               Key = {primary_state_tab, T},
               case dirty_get_chain_state_value(Key) of
                   undefined ->
@@ -868,8 +868,9 @@ cache_primary_state_tabs() ->
                       cache_primary_state_tab(T, P);
                   P ->
                       cache_primary_state_tab(T, P)
-              end
-      end, gced_tables()).
+              end,
+              ok
+      end, ok, gced_tables()).
 
 cache_primary_state_tab(T, P) ->
     lager:debug("Caching primary for ~p: ~p", [T, P]),

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -77,6 +77,9 @@
 -export([ fold_mempool/2
         ]).
 
+-export([ state_tab/1
+        , make_primary_state_tab/2
+        , secondary_state_tab/1 ]).
 
 %% MP trees backend
 -export([ find_accounts_node/1
@@ -201,25 +204,53 @@ tables(Mode0) ->
     Ts.
 
 tables_(Mode) ->
-    [?TAB(aec_blocks)
-   , ?TAB(aec_headers, [{index, [height]}])
-   , ?TAB(aec_chain_state)
-   , ?TAB(aec_contract_state)
-   , ?TAB(aec_call_state)
-   , ?TAB(aec_block_state)
-   , ?TAB(aec_oracle_cache)
-   , ?TAB(aec_oracle_state)
-   , ?TAB(aec_account_state)
-   , ?TAB(aec_channel_state)
-   , ?TAB(aec_name_service_cache)
-   , ?TAB(aec_name_service_state)
-   , ?TAB(aec_signed_tx)
-   , ?TAB(aec_tx_location)
-   , ?TAB(aec_tx_pool)
-   , ?TAB(aec_discovered_pof)
-   , ?TAB(aec_signal_count)
-   , ?TAB(aec_peers)
-    ].
+    add_gc_extra_tabs(
+      [ ?TAB(aec_blocks)
+      , ?TAB(aec_headers, [{index, [height]}])
+      , ?TAB(aec_chain_state)
+      , ?TAB(aec_contract_state)
+      , ?TAB(aec_call_state)
+      , ?TAB(aec_block_state)
+      , ?TAB(aec_oracle_cache)
+      , ?TAB(aec_oracle_state)
+      , ?TAB(aec_account_state)
+      , ?TAB(aec_channel_state)
+      , ?TAB(aec_name_service_cache)
+      , ?TAB(aec_name_service_state)
+      , ?TAB(aec_signed_tx)
+      , ?TAB(aec_tx_location)
+      , ?TAB(aec_tx_pool)
+      , ?TAB(aec_discovered_pof)
+      , ?TAB(aec_signal_count)
+      , ?TAB(aec_peers)
+      ]).
+
+add_gc_extra_tabs(Tabs) ->
+    lists:foldr(fun maybe_add_gc_tab/2, [], Tabs).
+
+maybe_add_gc_tab({Tab, Spec0} = Entry, Acc) ->
+    case maps:get(Tab, gced_tables(), undefined) of
+        #{copies := Tabs} when is_list(Tabs) ->
+            Spec = ensure_record_name(Tab, Spec0),
+            [{T, note_other_tabs(Tabs -- [T], Spec)} || T <- Tabs] ++ Acc;
+        undefined -> [Entry | Acc]
+     end.
+
+ensure_record_name(T, Spec) ->
+    case lists:keymember(record_name, 1, Spec) of
+        true ->
+            Spec;
+        false ->
+            [{record_name, T}|Spec]
+    end.
+
+gced_tables() ->
+    #{aec_account_state => #{copies => [aec_account_state, aec_account_state_1]}}.
+
+note_other_tabs(Ts, Props) ->
+    UPs = proplists:get_value(user_properties, Props, []),
+    lists:keystore(user_properties, 1, Props,
+                   {user_properties, [{aec_db_gc_other_tabs, Ts}|UPs]}).
 
 migrate_tables() -> migrate_tables(all, undefined).
 
@@ -801,8 +832,51 @@ write_block_state(Hash, Trees, AccDifficulty, ForkId, Fees, Fraud) ->
            write(BlockState)
        end).
 
+state_tab(T) ->
+    persistent_term:get({primary_state_tab, T}, T).
+
+secondary_state_tab(T) ->
+    Prim = persistent_term:get({primary_state_tab, T}),
+    #{copies := Tabs} = maps:get(T, gced_tables()),
+    [Secondary] = Tabs -- [Prim],
+    Secondary.
+
+make_primary_state_tab(T, P) ->
+    lager:debug("New primary for ~p: ~p", [T, P]),
+    case maps:find(T, gced_tables()) of
+        {ok, #{copies := Tabs}} ->
+            case lists:member(P, Tabs) of
+                true ->
+                    ?t(write(#aec_chain_state{key = {primary_state_tab, T}, value = P}));
+                false ->
+                    error({not_a_state_tab_candidate, {T, P}})
+            end,
+            cache_primary_state_tab(T, P);
+        error ->
+            error({not_a_gced_state_tab, T})
+    end.
+
+cache_primary_state_tabs() ->
+    lager:debug("Caching primary for gced tabs", []),
+    maps:foreach(
+      fun(T, #{copies := Ts}) ->
+              Key = {primary_state_tab, T},
+              case dirty_get_chain_state_value(Key) of
+                  undefined ->
+                      P = hd(Ts),
+                      ?t(write(#aec_chain_state{key = Key, value = P})),
+                      cache_primary_state_tab(T, P);
+                  P ->
+                      cache_primary_state_tab(T, P)
+              end
+      end, gced_tables()).
+
+cache_primary_state_tab(T, P) ->
+    lager:debug("Caching primary for ~p: ~p", [T, P]),
+    persistent_term:put({primary_state_tab, T}, P).
+
 write_accounts_node(Hash, Node) ->
-    ?t(write(#aec_account_state{key = Hash, value = Node})).
+    ?t(write(state_tab(aec_account_state), #aec_account_state{key = Hash, value = Node}, write)).
 
 write_accounts_node(Table, Hash, Node) ->
     ?t(write(Table, #aec_account_state{key = Hash, value = Node}, write)).
@@ -1092,13 +1166,13 @@ dirty_find_ns_cache_node(Hash) ->
     end.
 
 find_accounts_node(Hash) ->
-    case ?t(read(aec_account_state, Hash)) of
+    case ?t(read(state_tab(aec_account_state), Hash)) of
         [#aec_account_state{value = Node}] -> {value, Node};
         [] -> none
     end.
 
 dirty_find_accounts_node(Hash) ->
-    case ?dirty_dirty_read(aec_account_state, Hash) of
+    case ?dirty_dirty_read(state_tab(aec_account_state), Hash) of
         [#aec_account_state{value = Node}] -> {value, Node};
         [] -> none
     end.
@@ -1243,7 +1317,7 @@ load_database() ->
     lager:debug("tables loaded", []),
     convert_top_block_entry(),
     lager:debug("top block entry converted", []),
-    aec_db_gc:maybe_swap_nodes(),
+    cache_primary_state_tabs(),
     prepare_mnesia_bypass().
 
 wait_for_tables() ->

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -36,7 +36,7 @@
          stop/0]).
 
 %% for internal use only
--export([maybe_swap_nodes/0]).
+%% -export([maybe_swap_nodes/0]).
 
 %% gen_statem callbacks
 -export([callback_mode/0, init/1, terminate/3, code_change/4]).
@@ -51,6 +51,7 @@
          min_height :: undefined | non_neg_integer(),     % if hash_not_found error, try GC from this height
          synced     :: boolean(),                         % we only run GC (repeatedly) if chain is synced
          height     :: undefined | non_neg_integer(),     % latest height of MPT hashes stored in tab
+         last_swap  :: undefined | non_neg_integer(),     % last swap height. Not undefined means secondary needs clearing
          hashes     :: undefined | pid() | reference()}). % hashes tab (or process filling the tab 1st time)
 
 -include_lib("aecore/include/aec_db.hrl").
@@ -106,8 +107,8 @@ stop() ->
     gen_statem:stop(?MODULE).
 
 %% called from aec_db on startup
-maybe_swap_nodes() ->
-    maybe_swap_nodes(?GCED_TABLE_NAME, ?TABLE_NAME).
+%% maybe_swap_nodes() ->
+%%     maybe_swap_nodes(?GCED_TABLE_NAME, ?TABLE_NAME).
 
 %%%===================================================================
 %%% gen_statem callbacks
@@ -175,8 +176,7 @@ handle_event(info, {_, top_changed, #{info := #{height := Height}}}, idle,
                     FromHeight = max(Height - History, 0),
                     ?PROTECT(?TIMED(collect_reachable_hashes(FromHeight, Height)),
                              fun ({Time, {ok, Hashes}}) ->
-                                     ets:give_away(Hashes, Parent, {{FromHeight, Height}, Time})
-
+                                     store_cache_and_give_away(Hashes, Parent, FromHeight, Height, Time)
                              end)
             end),
     {keep_state, Data#data{height = Height, hashes = Pid}};
@@ -214,32 +214,50 @@ handle_event(info, {_, top_changed, #{info := #{block_type := key, height := Hei
              #data{enabled = true, synced = true, height = LastHeight, hashes = Hashes} = Data)
   when is_reference(Hashes) ->
     if Height > LastHeight ->
-            ?PROTECT(range_collect_reachable_hashes(Height, Data),
+            ?PROTECT(range_collect_reachable_hashes(Height, Data, both),
                      fun ({ok, _}) -> {keep_state, Data#data{height = Height}} end,
                      signal_scanning_failed_keep_state(Data));
        true ->
             %% in case previous key block was a fork, we can receive top_changed event
             %% with the same or lower height as seen last time
-            ?PROTECT(collect_reachable_hashes_delta(Height, Hashes),
+            ?PROTECT(collect_reachable_hashes_delta(Height, Hashes, both),
                      fun ({ok, _}) -> {keep_state, Data} end,
                      (signal_scanning_failed_keep_state(Data)))
+    end;
+handle_event(info, {_, top_changed, #{info := #{block_type := key, height := Height}}}, idle,
+             #data{last_swap = LastSwap} = Data) ->
+    if is_integer(LastSwap),
+       Height > LastSwap ->
+            Secondary = aec_db:secondary_state_tab(?TABLE_NAME),
+            lager:debug("Will clear secondary (~p)", [Secondary]),
+            aec_db:clear_table(Secondary),
+            {keep_state, Data#data{last_swap = undefined}};
+       true ->
+            {keep_state, Data}
     end;
 
 %% with valid GC state, if we are on key block boundary, we can
 %% clear the table and insert reachable hashes back
-handle_event({call, _From}, maybe_garbage_collect, ready,
+handle_event({call, From}, maybe_garbage_collect, ready,
              #data{enabled = true, synced = true, hashes = Hashes} = Data)
   when Hashes /= undefined, not is_pid(Hashes) ->
     Header = aec_chain:top_header(),
     case aec_headers:type(Header) of
         key ->
             Height  = aec_headers:height(Header),
-            ?PROTECT(range_collect_reachable_hashes(Height, Data),
-                     %% we exit here as GCEd table is swapped at startup
-                     fun ({ok, _}) -> store_cache_and_restart(Hashes, ?GCED_TABLE_NAME) end,
+            T0 = erlang:system_time(millisecond),
+            ?PROTECT(range_collect_reachable_hashes(Height, Data, both),
+                     fun ({ok, _}) ->
+                             Secondary = aec_db:secondary_state_tab(?TABLE_NAME),
+                             aec_db:make_primary_state_tab(?TABLE_NAME, Secondary),
+                             lager:debug("GC swap time: ~p ms", [erlang:system_time(millisecond) - T0]),
+                             {next_state, idle, Data#data{hashes = undefined,
+                                                          last_swap = Height},
+                              {reply, From, ok}}
+                     end,
                      signal_scanning_failed_keep_state(Data));
         micro ->
-            {keep_state, Data}
+            {keep_state, Data, {reply, From, nop}}
     end;
 handle_event({call, From}, maybe_garbage_collect, _, Data) ->
     {keep_state, Data, {reply, From, nop}};
@@ -258,10 +276,11 @@ callback_mode() -> handle_event_function.
 %%% Internal functions
 %%%===================================================================
 
+
 %% From - To (inclusive)
 collect_reachable_hashes(FromHeight, ToHeight) when FromHeight < ToHeight ->
     {ok, Hashes} = collect_reachable_hashes_fullscan(FromHeight),     % table is created here
-    {ok, Hashes} = range_collect_reachable_hashes(FromHeight, ToHeight, Hashes), % and reused
+    {ok, Hashes} = range_collect_reachable_hashes_(FromHeight, ToHeight, Hashes, ets), % and reused
     {ok, Hashes}.
 
 collect_reachable_hashes_fullscan(Height) ->
@@ -273,77 +292,54 @@ collect_reachable_hashes_fullscan(Height) ->
 
 %% assumes Height - 1, Height - 2, ... down to Height - History
 %% are in Hashes from previous runs
-collect_reachable_hashes_delta(Height, Hashes) ->
+-spec collect_reachable_hashes_delta(non_neg_integer(), _, 'both' | 'ets') -> {'ok', _}.
+collect_reachable_hashes_delta(Height, Hashes, Tgt) ->
     MPT = get_mpt(Height),
     ?LOG("GC diffscan at height ~p of accounts with hash ~w",
          [Height, aeu_mp_trees:root_hash(MPT)]),
-    {ok, aeu_mp_trees:visit_reachable_hashes(MPT, Hashes, fun store_unseen_hash/3)}.
+    Acc0 = case Tgt of
+               ets -> Hashes;
+               both -> {Hashes, aec_db:secondary_state_tab(?TABLE_NAME)}
+           end,
+    {ok, aeu_mp_trees:visit_reachable_hashes(MPT, Acc0, fun store_unseen_hash/3)}.
 
-range_collect_reachable_hashes(ToHeight, #data{height = LastHeight, hashes = Hashes}) ->
-    range_collect_reachable_hashes(LastHeight, ToHeight, Hashes).
-range_collect_reachable_hashes(LastHeight, ToHeight, Hashes) ->
-    [collect_reachable_hashes_delta(H, Hashes) || H <- lists:seq(LastHeight + 1, ToHeight)],
+range_collect_reachable_hashes(ToHeight, #data{height = LastHeight, hashes = Hashes}, Tgt) ->
+    range_collect_reachable_hashes_(LastHeight, ToHeight, Hashes, Tgt).
+
+range_collect_reachable_hashes_(LastHeight, ToHeight, Hashes, Tgt) ->
+    [collect_reachable_hashes_delta(H, Hashes, Tgt) || H <- lists:seq(LastHeight + 1, ToHeight)],
     {ok, Hashes}.
 
-store_cache_and_restart(Hashes, GCedTab) ->
-    lager:debug("will terminate conductor", []),
-    {atomic, ok} = create_accounts_table(GCedTab),
-    {ok, _Count} = store_cache(Hashes, GCedTab),
-    supervisor:terminate_child(aec_conductor_sup, aec_conductor),
-    init:restart(),
-    sys:suspend(self(), infinity).
+    %% aec_db:make_primary_state_tab(aec_account_state, Secondary).
 
-create_accounts_table(Name) ->
-    Rec = ?TABLE_NAME,
-    Fields = record_info(fields, ?TABLE_NAME),
-    mnesia:create_table(Name, aec_db:tab(aec_db:backend_mode(), Rec, Fields, [{record_name, Rec}])).
+store_cache_and_give_away(Hashes, Parent, FromHeight, Height, Time) ->
+    {Time1, {ok, _}} = ?TIMED(store_cache(Hashes)),
+    ets:give_away(Hashes, Parent, {{FromHeight, Height}, Time + Time1}).
 
+store_cache(Hashes) ->
+    Secondary = aec_db:secondary_state_tab(?TABLE_NAME),
+    aec_db:clear_table(Secondary),
+    store_cache(Hashes, Secondary).
 
-iter(Fun, ets, Tab) ->
-    ets:foldl(fun ({Hash, Node}, ok) -> Fun(Hash, Node), ok end, ok, Tab);
-iter(Fun, mnesia, Tab) ->
-    aec_db:foldl(fun (X, ok) -> Fun(element(2, X), element(3, X)), ok end, ok, Tab).
+iter(Fun, Tab) ->
+    ets:foldl(fun ({Hash, Node}, ok) -> Fun(Hash, Node), ok end, ok, Tab).
 
-
-write_nodes(SrcMod, SrcTab, TgtTab) ->
+write_nodes(SrcTab, TgtTab) ->
     ?TIMED(aec_db:ensure_transaction(
              fun () ->
                      iter(fun (Hash, Node) ->
                                   aec_db:write_accounts_node(TgtTab, Hash, Node)
-                          end, SrcMod, SrcTab)
+                          end, SrcTab)
              end)).
 
 store_cache(SrcHashes, TgtTab) ->
     NodesCount = ets:info(SrcHashes, size),
     ?LOG("Writing ~p reachable account nodes to table ~p ...", [NodesCount, TgtTab]),
-    {WriteTime, ok} = write_nodes(ets, SrcHashes, TgtTab),
+    {WriteTime, ok} = write_nodes(SrcHashes, TgtTab),
     ?LOG("Writing reachable account nodes took ~p seconds", [WriteTime / 1000000]),
     DBCount = length(aec_db:dirty_select(TgtTab, [{'_', [], [1]}])),
     ?LOG("GC cache has ~p aec_account_state records", [DBCount]),
     {ok, NodesCount}.
-
-maybe_swap_nodes(SrcTab, TgtTab) ->
-    try aec_db:dirty_first(SrcTab) of % table exists
-        H when is_binary(H) ->        % and is non empty
-            swap_nodes(SrcTab, TgtTab);
-        '$end_of_table' ->
-            mnesia:delete_table(SrcTab)
-    catch
-        exit:{aborted,{no_exists,[_]}} ->
-            ok
-    end.
-
-swap_nodes(SrcTab, TgtTab) ->
-    ?LOG("Clearing table ~p ...", [TgtTab]),
-    {atomic, ok} = aec_db:clear_table(TgtTab),
-    ?LOG("Writing garbage collected accounts ..."),
-    {WriteTime, ok} = write_nodes(mnesia, SrcTab, TgtTab),
-    ?LOG("Writing garbage collected accounts took ~p seconds", [WriteTime / 1000000]),
-    DBCount = length(aec_db:dirty_select(TgtTab, [{'_', [], [1]}])),
-    ?LOG("DB has ~p aec_account_state records", [DBCount]),
-    ?LOG("Removing garbage collected table ~p ...", [SrcTab]),
-    mnesia:delete_table(SrcTab),
-    ok.
 
 -spec get_mpt(non_neg_integer()) -> aeu_mp_trees:tree().
 get_mpt(Height) ->
@@ -366,6 +362,15 @@ get_mpt_from_hash(Hash) ->
 store_hash(Hash, Node, Tab) ->
     ets:insert_new(Tab, {Hash, Node}),
     {continue, Tab}.
+
+store_unseen_hash(Hash, Node, {Ets, Tab} = Acc) ->
+    case ets:lookup(Ets, Hash) of
+        [_] -> stop;
+        [] ->
+            ets:insert_new(Ets, {Hash, Node}),
+            aec_db:write_accounts_node(Tab, Hash, Node),
+            {continue, Acc}
+    end;
 store_unseen_hash(Hash, Node, Tab) ->
     case ets:lookup(Tab, Hash) of
         [_] -> stop;


### PR DESCRIPTION
This is derived from the larger work under issue #3883 - a quick fix in order to avoid blocking the conductor for an extended period of time and to avoid doing `init:restart()` in order to perform the GC swap.

Strategy:
* Use an A-B pair for the `accounts` state tree, and an `aec_chain_state` value pointing to the current primary
* The above pointer is also cached as a persistent_term, since it's checked at each state tree access.
* The fullsweep process spawned by `aec_gb_gc` now also dumps the live state tree to the secondary table in the db
* The 'diff' sweeps for subsequent blocks update both the ets cache and the secondary table
* The call from the conductor now only modifies the pointer to the new primary (after verifying that the cache is up-to-date)