### PR TITLE
Update mnesia_rocksdb dep

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -64,7 +64,7 @@
         % The rocksdb dependencies are removed on win32 to reduce build times,
         % because they are currently not working on win32.
         {mnesia_rocksdb, {git, "https://github.com/aeternity/mnesia_rocksdb.git",
-                         {ref, "d1177b6"}}},
+                         {ref, "b65e82e"}}},
 
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                   {ref, "33be529"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -105,7 +105,7 @@
   0},
  {<<"mnesia_rocksdb">>,
   {git,"https://github.com/aeternity/mnesia_rocksdb.git",
-      {ref,"d1177b6ad4956d27c5387009acf87056cea38e82"}},
+      {ref,"b65e82ed71e057f393cc02cc37a4998b96d64fb9"}},
   0},
  {<<"nat">>,
   {git,"https://github.com/benoitc/erlang-nat.git",


### PR DESCRIPTION
This version of mnesia_rocksdb includes a bug fix and an optimization:
* Fix a push/pop error during transaction retry (aeternity/mnesia_rocksdb#32)
* Check out a batch reference only when needed for dirty activities (aeternity/mnesia_rocksdb#33)