### PR TITLE
Re-instate erlang rocksdb LZ4 and Snappy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SWAGGER_ENDPOINTS_SPEC = apps/aeutils/src/endpoints.erl
 OAS_ENDPOINTS_SPEC = apps/aeutils/src/oas_endpoints.erl
 OAS_YAML = apps/aehttp/priv/oas3.yaml
 
-export ERLANG_ROCKSDB_OPTS=-DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON
+export ERLANG_ROCKSDB_OPTS ?= -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON
 
 # Packages from master MUST be pre-releases. Git master version
 # usually is higher then the last stable release. However

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ SWAGGER_ENDPOINTS_SPEC = apps/aeutils/src/endpoints.erl
 OAS_ENDPOINTS_SPEC = apps/aeutils/src/oas_endpoints.erl
 OAS_YAML = apps/aehttp/priv/oas3.yaml
 
+export ERLANG_ROCKSDB_OPTS=-DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON
+
 # Packages from master MUST be pre-releases. Git master version
 # usually is higher then the last stable release. However
 # packages with newer stable version MUST always have higher version


### PR DESCRIPTION
The version of erlang-rocksdb we are using removed lz4 and snappy from its defaults. Our production builds enable these in some circleci config. This PR enables them for developer builds.

This PR was sponsored by the ACF 