### PR TITLE
Update mnesia_rocksdb dep (batch dummy ref issue)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -64,7 +64,7 @@
         % The rocksdb dependencies are removed on win32 to reduce build times,
         % because they are currently not working on win32.
         {mnesia_rocksdb, {git, "https://github.com/aeternity/mnesia_rocksdb.git",
-                         {ref, "b65e82e"}}},
+                         {ref, "4489e5d"}}},
 
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                   {ref, "33be529"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -105,7 +105,7 @@
   0},
  {<<"mnesia_rocksdb">>,
   {git,"https://github.com/aeternity/mnesia_rocksdb.git",
-      {ref,"b65e82ed71e057f393cc02cc37a4998b96d64fb9"}},
+      {ref,"4489e5d7430c9f8294c2dca189e0353d2e58f8c4"}},
   0},
  {<<"nat">>,
   {git,"https://github.com/benoitc/erlang-nat.git",


### PR DESCRIPTION
Updating mnesia_rocksdb to address the following problem:

```
16:13:55.643 [error] CRASH REPORT Process aec_tx_pool_gc with 0 neighbours crashed with reason: bad argument in call to rocksdb:release_batch('$mrdb_batch_ref_dummy') in mrdb:maps_foreach_/2 line 1097
```