### PR TITLE
Remove rebar3 specific warning message not related to Aeternity

### DIFF
--- a/scripts/aeternity_bin
+++ b/scripts/aeternity_bin
@@ -784,10 +784,6 @@ case "$1" in
                 HEART_OPTION="daemon_boot"
                 ;;
             start)
-                # TODO, add here the right annoying message asking users to consider
-                # instead using systemd or some such other init system
-                echo "'start' has been deprecated, replaced by 'daemon' and will be removed in the short-term, please consult rebar3.org on why you should be"\
-                     "using 'foreground' and an init tool such as 'systemd'"
                 shift
                 START_OPTION="console"
                 HEART_OPTION="daemon"


### PR DESCRIPTION
Remove the warning about using start vs foreground until we decide to impose this on our users

This PR was sponsored by the ACF