### PR TITLE
Update to latest master rev of mnesia_rocksdb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -64,7 +64,7 @@
         % The rocksdb dependencies are removed on win32 to reduce build times,
         % because they are currently not working on win32.
         {mnesia_rocksdb, {git, "https://github.com/aeternity/mnesia_rocksdb.git",
-                         {ref, "4489e5d"}}},
+                         {ref, "0aecf5e"}}},
 
         {aeminer, {git, "https://github.com/aeternity/aeminer.git",
                   {ref, "33be529"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -105,7 +105,7 @@
   0},
  {<<"mnesia_rocksdb">>,
   {git,"https://github.com/aeternity/mnesia_rocksdb.git",
-      {ref,"4489e5d7430c9f8294c2dca189e0353d2e58f8c4"}},
+      {ref,"0aecf5ef0192c9d130b9b0aabd8656d27d278815"}},
   0},
  {<<"nat">>,
   {git,"https://github.com/benoitc/erlang-nat.git",


### PR DESCRIPTION
The latest version of mnesia_rocksdb contains, a new mutex implementation (PR aeternity/mnesia_rocksdb#35).

Running a mainnet sync on this version, there have been 2,740 transaction retries so far, at ca 71% sync progress.