### PR TITLE
shutdown exit is wrapped by gen_server

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -167,7 +167,7 @@ opt_call(Req, Else) ->
 try_call(Req, Else) ->
     try gen_server:call(?MODULE, Req)
     catch
-        exit:shutdown ->
+        exit:{shutdown, _} ->
             do_else(Else)
     end.
 


### PR DESCRIPTION
See issue #4043 
Previous fix didn't solve the problem