### PR TITLE
Refactoring of State Channels responder connection handling

### DIFF
--- a/apps/aechannel/src/aesc_acceptors.erl
+++ b/apps/aechannel/src/aesc_acceptors.erl
@@ -1,0 +1,179 @@
+-module(aesc_acceptors).
+-behavior(gen_server).
+
+-export([start_link/0]).
+
+-export([ start_acceptors/3
+        , start_acceptors/5
+        , stop_acceptors/1
+        , worker_done/1
+        ]).
+
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3 ]).
+
+-define(DEFAULT_N, 1).
+-define(SHUTDOWN_TIME, 5000).
+
+-record(st, { ports  = #{}
+            , socks  = #{}
+            , linked = #{} }).
+
+start_acceptors(Port, LSock, InitF) ->
+    start_acceptors(Port, LSock, InitF, ?DEFAULT_N, #{}).
+
+start_acceptors(Port, LSock, InitF, N, Opts) ->
+    gen_server:call(?MODULE, {start_acceptors, Port, LSock, InitF, N, Opts}).
+
+stop_acceptors(Port) ->
+    gen_server:call(?MODULE, {stop_acceptors, Port}, 2*?SHUTDOWN_TIME).
+
+worker_done(Port) ->
+    lager:debug("Acceptor 'done' on port ~p", [Port]),
+    gen_server:cast(?MODULE, {worker_done, self(), Port}).
+
+%% gen_server API & callbacks ==================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    process_flag(trap_exit, true),
+    {ok, #st{}}.
+
+
+handle_call({start_acceptors, Port, LSock, InitF, N, Opts}, _From, #st{ ports = Ports
+                                                                      , socks = Socks} = St) ->
+    LSMRef = erlang:monitor(port, LSock),
+    PortMap = #{ n => N
+               , lsock => LSock
+               , init_f => InitF
+               , opts => Opts
+               , workers => #{}},
+    St1 = maybe_start_workers(Port, St#st{socks = Socks#{LSock => #{ mref => LSMRef
+                                                                   , port => Port}},
+                                          ports = Ports#{Port => PortMap}}),
+    {reply, ok, St1};
+handle_call({stop_acceptors, Port}, _From, #st{ports = Ports} = St) ->
+    St1 = case maps:is_key(Port, Ports) of
+              true ->
+                  stop_workers(Port, St);
+              false ->
+                  St
+          end,
+    {reply, ok, St1};
+handle_call(_, _, St) ->
+    {reply, {error, unknown_call}, St}.
+
+handle_cast({worker_done, Pid, Port}, St) ->
+    St1 = delete_worker(Pid, Port, St),
+    {noreply, maybe_start_workers(Port, St1)};
+handle_cast(_, St) ->
+    {noreply, St}.
+
+handle_info({'EXIT', Pid, _}, #st{linked = Linked} = St) ->
+    case maps:find(Pid, Linked) of
+        {ok, Port} ->
+            St1 = delete_worker(Pid, Port, St),
+            {noreply, maybe_start_workers(Port, St1)};
+        error ->
+            {noreply, St}
+    end;
+handle_info({'DOWN', _MRef, port, LSock, _}, #st{socks = Socks} = St) ->
+    St1 = case maps:find(LSock, Socks) of
+              {ok, #{port := Port}} ->
+                  Socks1 = maps:remove(LSock, Socks),
+                  #st{ports = Ports1} = St1_ = stop_workers(Port, St#st{socks = Socks1}),
+                  St1_#st{ports = maps:remove(Port, Ports1)};
+              error ->
+                  St
+          end,
+    {noreply, St1};
+handle_info(_, St) ->
+    {noreply, St}.
+
+terminate(_, _) ->
+    ok.
+
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
+
+%% Internal functions ==========================================================
+
+
+maybe_start_workers(Port, #st{ports = Ports} = St) ->
+    case maps:find(Port, Ports) of
+        {ok, #{ n := N
+              , workers := Ws } = Map} when map_size(Ws) < N ->
+            {Pids, Map1} = start_workers_(Port, N, Ws, Map),
+            Ports1 = Ports#{Port := Map1},
+            Linked1 = add_map_elems(Pids, Port, St#st.linked),
+            St#st{ports = Ports1, linked = Linked1};
+        _ ->
+            St
+    end.
+
+start_workers_(Port, N, Ws, #{lsock := LSock,
+                             init_f := InitF,
+                             opts := Opts} = Map) ->
+    Pids = [start_worker_(InitF, Port, LSock, Opts) || _ <- lists:seq(1, N - map_size(Ws))],
+    Ws1 = add_map_elems(Pids, 1, Ws),
+    {Pids, Map#{workers := Ws1}}.
+
+start_worker_(InitF, Port, LSock, Opts) ->
+    {ok, Pid} = InitF(Port, LSock, Opts),
+    Pid.
+
+delete_worker(Pid, Port, #st{linked = Linked, ports = Ports} = St) ->
+    Ports1 = case maps:find(Port, Ports) of
+                 {ok, #{workers := Ws} = Map} ->
+                     Ws1 = maps:remove(Pid, Ws),
+                     Map1 = Map#{workers := Ws1},
+                     Ports#{Port := Map1};
+                 error ->
+                     Ports
+             end,
+    Linked1 = maps:remove(Pid, Linked),
+    St#st{linked = Linked1, ports = Ports1}.
+
+stop_workers(Port, #st{ports = Ports, linked = Linked} = St) ->
+    case maps:find(Port, Ports) of
+        {ok, #{workers := Ws} = Map} ->
+            Pids = maps:keys(Ws),
+            shut_down_pids(Pids),
+            Map1 = Map#{workers := Ws},
+            Linked1 = maps:without(Pids, Linked),
+            St#st{ports = Ports#{Port := Map1}, linked = Linked1};
+        error ->
+            St
+    end.
+
+shut_down_pids(Pids) ->
+    [unlink(P) || P <- Pids],
+    MRefs = maps:from_list([{P, erlang:monitor(process, P)} || P <- Pids]),
+    TRef = erlang:start_timer(?SHUTDOWN_TIME, self(), worker_shutdown),
+    [exit(P, shutdown) || P <- Pids],
+    await_downs(MRefs, TRef).
+
+await_downs(MRefs, TRef) when map_size(MRefs) > 0 ->
+    receive
+        {'DOWN', MRef, _, _, _} when is_map_key(MRef, MRefs) ->
+            await_downs(maps:remove(MRef, MRefs), TRef);
+        {timeout, TRef, worker_shutdown} ->
+            [kill_worker(Pid, MRef) || {Pid, MRef} <- maps:to_list(MRefs)]
+    end;
+await_downs(_, TRef) ->
+    erlang:cancel_timer(TRef),
+    ok.
+
+kill_worker(Pid, MRef) ->
+    erlang:demonitor(MRef),
+    exit(Pid, kill).
+
+add_map_elems(Keys, Value, Map) ->
+    maps:merge(Map, maps:from_list([{K, Value} || K <- Keys])).
+

--- a/apps/aechannel/src/aesc_acceptors.erl
+++ b/apps/aechannel/src/aesc_acceptors.erl
@@ -45,7 +45,6 @@ init([]) ->
     process_flag(trap_exit, true),
     {ok, #st{}}.
 
-
 handle_call({start_acceptors, Port, LSock, InitF, N, Opts}, _From, #st{ ports = Ports
                                                                       , socks = Socks} = St) ->
     LSMRef = erlang:monitor(port, LSock),
@@ -103,7 +102,6 @@ code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
 
 %% Internal functions ==========================================================
-
 
 maybe_start_workers(Port, #st{ports = Ports} = St) ->
     case maps:find(Port, Ports) of
@@ -176,4 +174,3 @@ kill_worker(Pid, MRef) ->
 
 add_map_elems(Keys, Value, Map) ->
     maps:merge(Map, maps:from_list([{K, Value} || K <- Keys])).
-

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -5030,7 +5030,13 @@ handle_info(Msg, #data{cur_statem_state = St} = D) ->
 %% * discard   - handle calls, but drop unknown casts (could be e.g. a stray
 %%               signing reply in the open state).
 handle_common_event(E, Msg, M, #data{cur_statem_state = St} = D) ->
-    lager:debug("handle_common_event(~p, ~p, ~p, ~p, D)", [E, Msg, St, M]),
+    case M of
+	discard ->
+	    %% Don't log debug as it risks flooding logs
+	    ok;
+       _ ->
+	    lager:debug("handle_common_event(~p, ~p, ~p, ~p, D)", [E, Msg, St, M])
+    end,
     handle_common_event_(E, Msg, St, M, D).
 
 handle_common_event_(timeout, Info, _St, _M, D) when D#data.ongoing_update == true ->

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1304,7 +1304,7 @@ open(cast, {?LEAVE, Msg}, #data{ role = Role
             lager:debug("leave msg error: ~p", [E]),
             keep_state(D)
     end;
-open(cast, {?SHUTDOWN, Msg}, D) ->
+open(cast, {?SHUTDDOWN, Msg}, D) ->
     shutdown_msg_received(Msg, D);
 open(Type, Msg, D) ->
     handle_common_event(Type, Msg, discard, D).
@@ -4171,10 +4171,9 @@ invalid(What) ->
 prepare_for_reestablish(#data{ opts = Opts
                              , on_chain_id = ChanId } = D) ->
     try
-        {ok, _SessionPid} = start_noise_session(#{existing_channel_id => ChanId},
-                                                Opts#{role => responder}),
-        %% We don't save the session pid here
-        D
+        {ok, SessionPid} = start_noise_session(#{existing_channel_id => ChanId},
+					       Opts#{role => responder}),
+        D#data{session = #prelim_session{pid = SessionPid}}
     ?CATCH_LOG(_E)
             D
     end.

--- a/apps/aechannel/src/aesc_fsm.erl
+++ b/apps/aechannel/src/aesc_fsm.erl
@@ -1,3 +1,4 @@
+%% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
 %% @doc This modules implements the State Channel FSM and its external API. The
 %% FSM is used for both state channel roles, 'responder' and 'initiator',
 %% because most logic is shared with the initialization being specific to the
@@ -3834,7 +3835,6 @@ check_limits(Opts) ->
     end.
 
 init_(#{opts := Opts0} = Arg) ->
-    
     {ReestablishOpts, ConnectOpts, Opts1} =
         { maps:with(?REESTABLISH_OPTS_KEYS, Opts0)
         , connection_opts(Arg)
@@ -4166,7 +4166,7 @@ prepare_for_reestablish(#data{ opts = Opts
                              , on_chain_id = ChanId } = D) ->
     try
         {ok, SessionPid} = start_noise_session(#{existing_channel_id => ChanId},
-					       Opts#{role => responder}),
+                                               Opts#{role => responder}),
         D#data{session = #prelim_session{pid = SessionPid}}
     ?CATCH_LOG(_E)
             D
@@ -5025,11 +5025,11 @@ handle_info(Msg, #data{cur_statem_state = St} = D) ->
 %%               signing reply in the open state).
 handle_common_event(E, Msg, M, #data{cur_statem_state = St} = D) ->
     case M of
-	discard ->
-	    %% Don't log debug as it risks flooding logs
-	    ok;
-       _ ->
-	    lager:debug("handle_common_event(~p, ~p, ~p, ~p, D)", [E, Msg, St, M])
+        discard ->
+            %% Don't log debug as it risks flooding logs
+            ok;
+        _ ->
+            lager:debug("handle_common_event(~p, ~p, ~p, ~p, D)", [E, Msg, St, M])
     end,
     handle_common_event_(E, Msg, St, M, D).
 
@@ -5781,7 +5781,7 @@ apply_non_malicious_txs_([], #data{} = Data) -> %% applied all
     {ok, Data};
 apply_non_malicious_txs_([{BlockHash, SignedTx} | Rest],
                          #data{state = State0, opts = Opts} = Data) when
-is_binary(BlockHash) -> 
+is_binary(BlockHash) ->
     Aetx = aetx_sign:innermost_tx(SignedTx),
     {Mod, Tx} = aetx:specialize_callback(Aetx),
     State =
@@ -5852,4 +5852,3 @@ is_onchain_tx_malicious(Mod, Tx, State, BlockHash) when is_binary(BlockHash) ->
             when UnexpectedRound < LastValidRound + 1 -> true;
         _ -> false
     end.
-

--- a/apps/aechannel/src/aesc_fsm.hrl
+++ b/apps/aechannel/src/aesc_fsm.hrl
@@ -137,6 +137,8 @@
                   , pick            :: integer()
                   }).
 
+-record(prelim_session, {pid :: pid()}).
+
 %% ==================================================================
 %% Records and Types
 
@@ -144,7 +146,7 @@
               , channel_status                  :: undefined | attached | open | closing
               , cur_statem_state                :: undefined | atom()
               , state                           :: aesc_offchain_state:state() | function()
-              , session                         :: undefined | pid()
+              , session                         :: undefined | pid() | #prelim_session{}
               , client                          :: undefined | pid()
               , client_mref                     :: undefined | reference()
               , client_connected = true         :: boolean()

--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -3,9 +3,9 @@
 
 -export([
           start_link/0
-        , listen/3
+        , ensure_listener/1
+        , ensure_listener/2
         , close/1
-        , ensure_acceptor/2
         , lsock_info/1  %% (LSock) -> lsock_info(LSock, all).
         , lsock_info/2  %% (LSock, Item | list(Item)) -> undefined | map()
         ]).
@@ -23,15 +23,15 @@
         , record_fields/1]).
 
 -record(st, {
-              responders = new_tab(aesc_listeners_responders)
-            , ports = new_tab(aesc_listeners_ports)
+              ports = new_tab(aesc_listeners_ports)
+            , pids  = new_tab(aesc_listeners_pids)
             , socks = new_tab(aesc_listener_socks)
             , refs  = new_tab(aesc_listeners_refs)
             }).
--record(resp, {key}).
--record(port, {key, mref, lsock}).
+-record(port, {key, mref, lsock, type}).
+-record(pid , {key, lsock, mref}).          % key :: {Port, pid()}
 -record(sock, {key, port}).
--record(ref , {mref, port, lsock, responder, pid}).
+-record(ref , {mref, port, lsock, pid}).
 
 -define(SERVER, ?MODULE).
 
@@ -50,15 +50,14 @@ record_fields(st) -> record_info(fields, st);
 record_fields(_ ) -> no.
 %% ==================================================================
 
+ensure_listener(Port) ->
+    ensure_listener(Port, #{}).
 
-listen(Port, Responder, Opts) ->
-    call({listen, Port, Responder, Opts}).
+ensure_listener(Port, Opts) ->
+    call({ensure_listener, Port, Opts}).
 
 close(Port) ->
     call({close, Port}).
-
-ensure_acceptor(Port, Responder) ->
-    call({ensure_acceptor, Port, Responder}).
 
 lsock_info(LSock) ->
     lsock_info(LSock, all).
@@ -66,135 +65,118 @@ lsock_info(LSock) ->
 lsock_info(LSock, Item) ->
     call({lsock_info, LSock, Item}).
 
-await_new_responder(Responder, Port, Timeout) ->
-    receive
-	{gproc_ps_event, {new_channel_responder, Responder, Port}, #{info := Info}} ->
-	    {ok, Info}
-    after Timeout ->
-	    {error, timeout}
-    end.
-
-
-announce_new_responder(Responder, Port, Pid) ->
-    gproc_ps:tell_singles(l, new_channel_responder, #{ sender => self()
-						     , time => os:timestamp()
-						     , info => #{pid => Pid}}).
-
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 init([]) ->
-    St = start_listeners(),
+    St = start_listeners(#st{}),
     {ok, St}.
 
-start_listeners() ->
-    St0 = #st{},
+start_listeners(St0) ->
     Key = [<<"channels">>, <<"listeners">>],
-    case aeu_env:find_config(Key, [user_config, {default, []}]) of
+    case aeu_env:find_config(Key, [user_config, {value, []}]) of
 	{ok, Ls0} ->
 	    {ok, [#{<<"acceptors">> := AcceptorsDefault}]} = aeu_env:schema_default_values(Key),
 	    Ls = lists:map(
 		   fun(#{<<"port">> := P} = L) ->
 			   As = maps:get(<<"acceptors">>, L, AcceptorsDefault),
-			   #{port => P, acceptors => As}
+			   #{port => P, acceptors => As, type => preconfigured}
 		   end, Ls0),
 	    lager:info("Preconfigured channel listeners: ~p", [Ls]),
 	    lager:info("Acceptors default: ~p", [AcceptorsDefault]),
-            
-	    St;
+            lists:foldl(fun new_listener_or_fail/2, St0, Ls);
 	_ ->
-	    St
+	    St0
     end.
 
-new_listener(#{port := Port, acceptors
-
-insert_responder(Port, Pid, Responder, LSock, IsFirst, #st{ responders = Resps
-							  , ports      = Ports
-							  , socks      = Socks
-							  , refs       = Refs } = St) ->
-    MRef = erlang:monitor(process, Pid),
-    RPort = #port{ key = {Port, Pid}, mref = MRef },
-    {Ports1, Socks1} =
-	case IsFirst of
-	    true ->
-		{db_insert(Ports, [ #port{key = {Port, 0}, lsock = LSock}
-				  , RPort ]),
-		 db_insert(Socks, #sock{key = LSock, port = Port})};
-	    false ->
-		{db_insert(Ports, RPort), Socks}
-	end,
-    Refs1 = db_insert(Refs, #ref{ mref = MRef
-				, port = Port
-				, responder = Responder
-				, lsock = LSock
-				, pid = Pid }),
-    Resps1 = db_insert(Resps, #resp{key = {Port, Responder, Pid}}),
-    announce_new_responder(Responder, Port, Pid),
-    St#st{ responders = Resps1
-	 , ports = Ports1
-	 , socks = Socks1
-	 , refs = Refs1 }.
-
-handle_call({listen, Port, Responder, Opts}, {Pid,_Ref}, #st{ ports = Ports } = St) ->
-    case db_lookup(Ports, {Port,0}) of
-        [#port{lsock = LSock}] ->
-	    St1 = insert_responder(Port, Pid, Responder, LSock, false, St),
-	    %% MRef = erlang:monitor(process, Pid),
-	    %% Ports1 = db_insert(Ports, #port{key = {Port, Pid}, mref = MRef}),
-	    %% Refs1 = db_insert(Refs, #ref{ mref = MRef
-	    %%                             , port = Port
-	    %%                             , responder = Responder
-	    %%                             , lsock = LSock
-            %%                             , pid = Pid }),
-            %% Resps1 = db_insert(Resps, #resp{key = {Port, Responder, Pid}}),
-            {reply, {ok, LSock}, St1};
+new_listener_or_fail(#{port := Port} = L, #st{ports = Ports} = St) ->
+    case db_lookup(Ports, Port) of
+        [_] ->
+            error({duplicate_port, Port});
         [] ->
-            try gen_tcp:listen(Port, Opts) of
-                {ok, LSock} ->
-		    St1 = insert_responder(Port, Pid, Responder, LSock, true, St),
-                    %% MRef = erlang:monitor(process, Pid),
-                    %% Ports1 = db_insert(
-                    %%            Ports, [#port{key = {Port,0}, lsock = LSock},
-                    %%                    #port{key = {Port,Pid},
-                    %%                          lsock = LSock,
-                    %%                          mref = MRef}]),
-                    %% Socks1 = db_insert(Socks, #sock{key = LSock, port = Port}),
-                    %% Refs1 = db_insert(Refs, #ref{mref = MRef, port = Port,
-                    %%                              responder = Responder,
-                    %%                              lsock = LSock, pid = Pid}),
-                    %% Resps1 = db_insert(Resps, #resp{key = {Port, Responder, Pid}}),
-                    %% {reply, {ok, LSock}, St#st{ responders = Resps1
-                    %%                           , ports = Ports1
-                    %%                           , socks = Socks1
-                    %%                           , refs  = Refs1 }};
-		    {reply, {ok, LSock}, St1};
-                {error, _} = Error ->
-                    {reply, Error, St}
+            new_listener_(L, St)
+    end.
+
+ensure_listener_(Port, Opts, Pid, #st{ports = Ports} = St) ->
+    case db_lookup(Ports, Port) of
+        [#port{lsock = LSock}] ->
+            lager:debug("Listener already active on port ~p: ~p", [Port, LSock]),
+            {ok, LSock, St};
+        [] ->
+            lager:debug("No listener on port ~p yet - create one", [Port]),
+            As = acceptors(St),
+            try new_listener(#{port => Port, opts => Opts, acceptors => As,
+                               type => dynamic, pid => Pid}, St)
             catch
                 error:Reason ->
-                    {reply, {exception, Reason}, St}
+                    {error, {exception, Reason}}
             end
+    end.
+
+new_listener(#{port := Port} = L, #st{ ports = Ports } = St) ->
+    St1 = new_listener_(L, St),
+    [#port{lsock = LSock}] = db_lookup(Ports, Port),
+    {ok, LSock, St1}.
+
+-spec new_listener_(map(), #st{}) -> #st{} | no_return().
+new_listener_(#{port := Port, acceptors := As, type := Type} = L, #st{ports = Ports, socks = Socks} = St) ->
+    try gen_tcp:listen(Port, listen_opts(St)) of
+        {ok, LSock} ->
+            lager:debug("New listener on port ~p: ~p", [Port, LSock]),
+            Ports1 = db_insert(Ports, #port{key = Port, lsock = LSock, type = Type}),
+            Socks1 = db_insert(Socks, #sock{key = LSock, port = Port}),
+            start_acceptors(LSock, Port, As),
+            maybe_dynamic(L, LSock, St#st{ports = Ports1, socks = Socks1});
+        {error, Err} ->
+            lager:error("Cannot open State Channel listener on ~p: ~p", [Port, Err]),
+            error({Err, Port})
+    catch
+        error:Ex ->
+            lager:error("Cannot open State Channel listener on ~p: CAUGHT error:~p", [Port, Ex]),
+            error({Ex, Port})
+    end.
+
+maybe_dynamic(#{type := dynamic, pid := Pid, port := Port}, LSock, #st{refs = Refs, pids = Pids} = St) ->
+    MRef = erlang:monitor(process, Pid),
+    Refs1 = db_insert(Refs, #ref{ mref  = MRef
+                                , port  = Port
+                                , lsock = LSock
+                                , pid   = Pid }),
+    Pids1 = db_insert(Pids, #pid{key = {Port, Pid}, lsock = LSock, mref = MRef}),
+    St#st{refs = Refs1, pids = Pids1};
+maybe_dynamic(_, _, St) ->
+    St.
+
+listen_opts(_) ->
+    [ {reuseaddr, true}
+    , {mode, binary} ].
+
+%% Default number of concurrent acceptors to initiate for a listener.
+acceptors(_) ->
+    1.
+
+handle_call({ensure_listener, Port, Opts}, {Pid,_Ref}, #st{} = St) ->
+    case ensure_listener_(Port, Opts, Pid, St) of
+        {ok, LSock, St1} ->
+            {reply, {ok, LSock}, St1};
+        {error, _} = Error ->
+            {reply, Error, St}
     end;
-handle_call({close, LSock}, {Pid,_Ref}, #st{ responders = Resps
-                                           , socks = Socks
-                                           , ports = Ports
+handle_call({close, LSock}, {Pid,_Ref}, #st{ socks = Socks
+                                           , pids  = Pids
                                            , refs  = Refs} = St) ->
     case db_lookup(Socks, LSock) of
         [#sock{port = Port}] ->
-            case db_lookup(Ports, {Port, Pid}) of
-                [#port{mref = MRef}] ->
-                    [#ref{ responder = Responder }]
-                        = db_lookup(Refs, MRef),
+            case db_lookup(Pids, {Port, Pid}) of
+                [#pid{mref = MRef}] ->
                     erlang:demonitor(MRef),
                     Refs1 = db_delete(Refs, MRef),
-                    Ports1 = db_delete(Ports, {Port, Pid}),
-                    Resps1 = db_delete(Resps, {Port, Responder, Pid}),
+                    Pids1 = db_delete(Pids, {Port, Pid}),
                     {reply, ok, maybe_close_lsock(
-                                  Port, LSock, St#st{ responders = Resps1
-                                                    , refs  = Refs1
-                                                    , ports = Ports1 })};
+                                  Port, LSock, St#st{ refs = Refs1
+                                                    , pids = Pids1 })};
                 [] ->
-                    {reply, {exception, not_found}, St}
+                    {reply, ok, maybe_close_lsock(Port, LSock, St)}
             end;
         [] ->
             {reply, {exception, not_found}, St}
@@ -215,17 +197,14 @@ handle_call(_Req, _From, St) ->
 handle_cast(_Msg, St) ->
     {noreply, St}.
 
-handle_info({'DOWN', MRef, process, Pid, _Reason}, #st{ responders = Resps
-                                                      , refs = Refs
-                                                      , ports = Ports} = St) ->
+handle_info({'DOWN', MRef, process, Pid, _Reason}, #st{ refs = Refs
+                                                      , pids = Pids } = St) ->
     case db_lookup(Refs, MRef) of
-        [#ref{port = Port, lsock = LSock, responder = Responder, pid = Pid}] ->
+        [#ref{port = Port, lsock = LSock, pid = Pid}] ->
             Refs1  = db_delete(Refs, MRef),
-            Ports1 = db_delete(Ports, {Port,Pid}),
-            Resps1 = db_delete(Resps, {Port, Responder, Pid}),
-            {noreply, maybe_close_lsock(Port, LSock, St#st{ responders = Resps1
-                                                          , refs  = Refs1
-                                                          , ports = Ports1 })};
+            Pids1  = db_delete(Pids, {Port, Pid}),
+            {noreply, maybe_close_lsock(Port, LSock, St#st{ refs  = Refs1
+                                                          , pids  = Pids1 })};
         [] ->
             {noreply, St}
     end;
@@ -246,26 +225,33 @@ call(Req) ->
             Other
     end.
 
-start_acceptors(LSock, Port) ->
-    aec_jobs_queues:add_queue({?MODULE, Port}, [ {producer, fun() ->
-								    init_job(LSock, Port)
-							    end}
-					       , {standard_counter, 10} ]).
+start_acceptors(LSock, Port, As) ->
+    InitF = fun aesc_session_noise:start_generic_acceptor/3,
+    aesc_acceptors:start_acceptors(Port, LSock, InitF, As, []).
 
-init_job(LSock, Port) ->
-    aesc_session_noise:start_generic_acceptor(LSock, Port).
+stop_acceptors(Port) ->
+    aesc_acceptors:stop_acceptors(Port).
 
-maybe_close_lsock(Port, LSock, #st{ ports = Ports, socks = Socks } = St) ->
-    case db_next(Ports, {Port,0}) of
+maybe_close_lsock(Port, LSock, #st{ pids = Pids } = St) ->
+    case db_next(Pids, {Port,0}) of
         {Port,_}        -> St;
         '$end_of_table' -> St;
         {_OtherPort, _} ->
             %% no more references to LSock
+            close_lsock_if_dynamic(Port, LSock, St)
+    end.
+
+close_lsock_if_dynamic(Port, LSock, #st{ports = Ports, socks = Socks} = St) ->
+    case db_lookup(Ports, Port) of
+        [#port{lsock = LSock, type = T}] when element(1,T) == dynamic ->
+            stop_acceptors(Port),
             ok = gen_tcp:close(LSock),
             Socks1 = db_delete(Socks, LSock),
-            Ports1 = db_delete(Ports, {Port, 0}),
+            Ports1 = db_delete(Ports, Port),
             St#st{ ports = Ports1
-                 , socks = Socks1 }
+                 , socks = Socks1 };
+        _ ->
+            St
     end.
 
 new_tab(Name) ->
@@ -282,9 +268,6 @@ db_delete(#{db := Tab, keypos := _P} = Db, Key) ->
     ets:delete(Tab, Key),
     Db.
 
-db_insert(#{keypos := _P, db := Tab} = Db, Objs) when is_list(Objs) ->
-    ets:insert(Tab, Objs),
-    Db;
 db_insert(#{db := Tab, keypos := _P} = Db, Obj) ->
     ets:insert(Tab, Obj),
     Db.
@@ -295,16 +278,13 @@ db_next(#{db := Tab, keypos := _P}, Key) ->
 db_select(#{db := Tab}, Pat) ->
     ets:select(Tab, Pat).
 
-list_pids(#{db := PortsTab}, P) ->
-    ets:select(PortsTab, [{ #port{ key = {P,'$1'}, _ = '_'}, [], ['$1'] }]).
+list_pids(Pids, P) ->
+    db_select(Pids, [{ #pid{ key = {P,'$1'}, _ = '_'}, [], ['$1'] }]).
 
-get_lsock_info(pids, #{port := Port} = I, #st{ ports = Ports }) ->
-    I#{pids => list_pids(Ports, Port)};
+get_lsock_info(pids, #{port := Port} = I, #st{ pids = Pids }) ->
+    I#{pids => list_pids(Pids, Port)};
 get_lsock_info(Item, I, _) when Item == port; Item == lsock ->
     I;
-get_lsock_info(responders, #{port := Port} = I, #st{ responders = Resps }) ->
-    Rs = db_select(Resps, [{ #resp{ key = { Port, '$1', '_'}, _ = '_' }, [], ['$1'] }]),
-    I#{responders => lists:usort(Rs)};
 get_lsock_info(Items, I, St) when is_list(Items) ->
     lists:foldl(
       fun(Item, Acc) ->

--- a/apps/aechannel/src/aesc_listeners.erl
+++ b/apps/aechannel/src/aesc_listeners.erl
@@ -1,3 +1,4 @@
+%% -*- mode:erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
 -module(aesc_listeners).
 -behaviour(gen_server).
 
@@ -75,18 +76,18 @@ init([]) ->
 start_listeners(St0) ->
     Key = [<<"channels">>, <<"listeners">>],
     case aeu_env:find_config(Key, [user_config, {value, []}]) of
-	{ok, Ls0} ->
-	    {ok, [#{<<"acceptors">> := AcceptorsDefault}]} = aeu_env:schema_default_values(Key),
-	    Ls = lists:map(
-		   fun(#{<<"port">> := P} = L) ->
-			   As = maps:get(<<"acceptors">>, L, AcceptorsDefault),
-			   #{port => P, acceptors => As, type => preconfigured}
-		   end, Ls0),
-	    lager:info("Preconfigured channel listeners: ~p", [Ls]),
-	    lager:info("Acceptors default: ~p", [AcceptorsDefault]),
+{ok, Ls0} ->
+    {ok, [#{<<"acceptors">> := AcceptorsDefault}]} = aeu_env:schema_default_values(Key),
+            Ls = lists:map(
+                   fun(#{<<"port">> := P} = L) ->
+                           As = maps:get(<<"acceptors">>, L, AcceptorsDefault),
+                           #{port => P, acceptors => As, type => preconfigured}
+                   end, Ls0),
+            lager:info("Preconfigured channel listeners: ~p", [Ls]),
+            lager:info("Acceptors default: ~p", [AcceptorsDefault]),
             lists:foldl(fun new_listener_or_fail/2, St0, Ls);
-	_ ->
-	    St0
+        _ ->
+            St0
     end.
 
 new_listener_or_fail(#{port := Port} = L, #st{ports = Ports} = St) ->
@@ -292,4 +293,3 @@ get_lsock_info(Items, I, St) when is_list(Items) ->
       end, I, Items);
 get_lsock_info(all, I, St) ->
     get_lsock_info([pids, responders], I, St).
-

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -1,3 +1,4 @@
+%% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
 -module(aesc_session_noise).
 
 -behaviour(gen_server).
@@ -9,7 +10,7 @@
 -export([ connect/3                 % called by FSM
         , accept/2                  % called by FSM
         , close/1
-	, start_generic_acceptor/3  % called by acceptor pool
+        , start_generic_acceptor/3  % called by acceptor pool
         , start_link/1
         ]).
 
@@ -132,12 +133,12 @@ close(Session) ->
             {exit, {noproc, _}} ->
                 unlink(Session),
                 ok;
-	    {exit, {normal,_}} ->
-		ok;
+            {exit, {normal,_}} ->
+                ok;
             {exit, R} ->
                 lager:error("Unexpected exit error during session closing: ~p, ~p", [R, StackTrace]),
                 unlink(Session),
-		kill_session(Session),
+                kill_session(Session),
                 ok
         end
     end.
@@ -147,8 +148,8 @@ kill_session(Session) ->
     MRef = erlang:monitor(process, Session),
     exit(Session, kill),
     receive
-	{'DOWN', MRef, _, _, _} ->
-	    ok
+        {'DOWN', MRef, _, _, _} ->
+            ok
     end.
 
 %% ==================================================================
@@ -452,21 +453,21 @@ register_responder(#{ initiator := I, responder := R, port := Port }) ->
 establish({accept, #{port := Port, lsock := LSock}, NoiseOpts}, St) ->
     lager:debug("LSock = ~p", [LSock]),
     case accept_tcp(LSock, Port) of
-	{ok, TcpSock} ->
-	    lager:debug("Accept TcpSock = ~p", [TcpSock]),
+        {ok, TcpSock} ->
+            lager:debug("Accept TcpSock = ~p", [TcpSock]),
             %% Since we have a connection, no need to hold up the acceptor pool
             aesc_acceptors:worker_done(Port),
-	    EnoiseOpts = enoise_opts(accept, NoiseOpts),
-	    lager:debug("EnoiseOpts (accept) = ~p", [EnoiseOpts]),
-	    case enoise:accept(TcpSock, EnoiseOpts) of
-		{ok, EConn, _FinalSt} ->
-		    St1 = St#st{ econn = EConn },
-		    {ok, St1};
-		Err1 ->
-		    Err1
-	    end;
-	Err ->
-	    Err
+            EnoiseOpts = enoise_opts(accept, NoiseOpts),
+            lager:debug("EnoiseOpts (accept) = ~p", [EnoiseOpts]),
+            case enoise:accept(TcpSock, EnoiseOpts) of
+                {ok, EConn, _FinalSt} ->
+                    St1 = St#st{ econn = EConn },
+                    {ok, St1};
+                Err1 ->
+                    Err1
+            end;
+Err ->
+    Err
     end;
 establish({connect, Host, Port, Opts}, St) ->
     TcpOpts = tcp_opts(connect, Opts),
@@ -490,12 +491,12 @@ establish_connect(Retries, Host, Port, TcpOpts, Opts, Timeout, St)
                     St1 = St#st{econn = EConn},
                     {ok, St1};
                 Err1 ->
-		    lager:debug("Failed to pair with responder: ~p", [Err1]),
-		    sleep_retry_connect(Retries-1, Host, Port, TcpOpts, Opts, Timeout, St)
+                    lager:debug("Failed to pair with responder: ~p", [Err1]),
+                    sleep_retry_connect(Retries-1, Host, Port, TcpOpts, Opts, Timeout, St)
             end;
         Err ->
-	    lager:debug("TCP connect failure: ~p", [Err]),
-	    sleep_retry_connect(Retries-1, Host, Port, TcpOpts, Opts, Timeout, St)
+            lager:debug("TCP connect failure: ~p", [Err]),
+            sleep_retry_connect(Retries-1, Host, Port, TcpOpts, Opts, Timeout, St)
     end.
 
 sleep_retry_connect(Retries, Host, Port, TcpOpts, Opts, Timeout, St) ->

--- a/apps/aechannel/src/aesc_session_noise.erl
+++ b/apps/aechannel/src/aesc_session_noise.erl
@@ -6,10 +6,10 @@
 
 %% ==================================================================
 %% Process API
--export([ connect/3
-        , accept/2
+-export([ connect/3                 % called by FSM
+        , accept/2                  % called by FSM
         , close/1
-	, start_generic_acceptor/2
+	, start_generic_acceptor/3  % called by acceptor pool
         , start_link/1
         ]).
 
@@ -59,6 +59,7 @@
 %% helpers
 -export([ patterns/0
         , record_fields/1
+        , pp_msg/1
         ]).
 
 -record(st, { init_op     :: op()
@@ -93,25 +94,32 @@
 start_link(Arg) when is_map(Arg) ->
     gen_server:start_link(?MODULE, Arg, []).
 
+%% Called by the initiator FSM. This starts a connector process.
+%% The connector will 
 connect(Host, Port, Opts) ->
     StartOpts = [#{fsm => self(), op => {connect, Host, Port, Opts}}],
     aesc_session_noise_sup:start_child(StartOpts).
 
-accept(#{ port := Port, responder := R } = Opts, NoiseOpts) ->
-    case aesc_listeners:ensure_acceptor(Port, R) of
-        ok ->
+%% Called by the responder FSM. The FSM doesn't actually start an acceptor, but
+%% simply register with a special Gproc key so that the automatically started
+%% acceptors (see `start_generic_acceptor/3') can find them.
+%%
+accept(#{ port := Port } = Opts, NoiseOpts) ->
+    case aesc_listeners:ensure_listener(Port, NoiseOpts) of
+        {ok, _} ->
             register_responder(Opts);
-        {error, } = Error ->
+        {error, _} = Error ->
             Error
     end.
 
-start_generic_acceptor(LSock, Port, NoiseOpts) ->
-    TcpOpts = tcp_opts(listen, NoiseOpts),
-    lager:debug("listen: Opts0 = ~p; TcpOpts = ~p", [Opts0, TcpOpts]),
+start_generic_acceptor(Port, LSock, Opts) ->
+    TcpOpts = tcp_opts(listen, Opts),
+    NoiseOpts = proplists:get_value(noise, Opts, noise_defaults()),
+    lager:debug("generic acceptor: Opts = ~p; TcpOpts = ~p", [Opts, TcpOpts]),
     Op = {accept, #{port => Port, lsock => LSock}, NoiseOpts},
-    StartOpts = [#{type => generic_acceptor, port => Port, op => Op}],
-    aesc_session_noise_sup:start_child(StartOpts),
-    ok.
+    StartOpts = #{ type => generic_acceptor, port => Port, op => Op
+                  , noise => NoiseOpts},
+    start_link(StartOpts).
 
 close(undefined) ->
     ok;
@@ -134,6 +142,7 @@ close(Session) ->
         end
     end.
 
+-spec kill_session(pid() | port()) -> 'ok'.
 kill_session(Session) ->
     MRef = erlang:monitor(process, Session),
     exit(Session, kill),
@@ -191,9 +200,9 @@ record_fields(_ ) -> no.
 %% ==================================================================
 %% gen_server API
 
-init(#{type := generic_acceptor, port := Port, op := Op} = Arg) ->
+init(#{type := generic_acceptor, port := Port, op := Op}) ->
     lager:debug("generic_acceptor for port ~p", [Port]),
-    St = #st{ init_op = Op },
+    St = #st{ init_op = Op},
     cast(self(), post_init),
     {ok, St};
 init(#{fsm := Fsm, op := Op} = Arg) ->
@@ -223,7 +232,11 @@ handle_cast(post_init, #st{fsm = Fsm, init_op = Op} = St) ->
         {ok, St1} ->
             %% As the monitor was created and the session established we don't
             %% need the link anymore.
-            unlink(Fsm),
+            if is_pid(Fsm) ->
+                    unlink(Fsm);
+               true ->
+                    ok
+            end,
             {noreply, St1};
         {error, Err} ->
             %% If we can't establish a connection the process must terminate to
@@ -260,7 +273,7 @@ handle_info(Msg, St) ->
 
 handle_info_({noise, EConn, Data}, #st{econn = EConn, fsm = Fsm} = St) ->
     {Type, Info} = Msg = aesc_codec:dec(Data),
-    lager:debug("Msg = ~p", [Msg]),
+    lager:debug("Msg = ~p", [pp_msg(Msg)]),
     St1 = case {Type, Fsm} of
               {?CH_OPEN, undefined} ->
                   locate_fsm(Type, Info, St);
@@ -286,17 +299,63 @@ terminate(_Reason, #st{econn = EConn}) ->
 code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
 
+%% Lager Debugging: The following code reduces logging noise related to hashes and keys
+%% Given that lager does compile-time transformation of the code, these functions are only
+%% called when there will actually be output.
+
+pp_msg({Tag, M}) when is_atom(Tag), is_map(M) ->
+    {Tag, pp_msg(M)};
+pp_msg({Tag1, Tag2, M}) when is_atom(Tag1), is_atom(Tag2), is_map(M) ->
+    {Tag1, Tag2, pp_msg(M)};
+pp_msg(M) when is_map(M) ->
+    maps:map(fun pp_elem/2, M);
+pp_msg(M) ->
+    M.
+
+pp_elem(K, Hash) when K == chain_hash
+                    ; K == initiator
+                    ; K == responder
+                    ; K == temporary_channel_id
+                    ; K == block_hash
+                    ; K == channel_id ->
+    abbrev_hash(Hash);
+pp_elem(data, D) ->
+    case D of
+        #{tx := Hash} ->
+            D#{tx := abbrev_hash(Hash)};
+        _ ->
+            D
+    end;
+pp_elem(_, X) ->
+    X.
+
+abbrev_hash(H) when byte_size(H) > 12 ->
+    First = binary:part(H, 0, 5),
+    Last  = binary:part(H, byte_size(H), -5),
+    <<First/binary, 0,0,0,0, Last/binary>>;
+abbrev_hash(H) ->
+    H.
+
+%% End Lager Debugging
 
 %% ==================================================================
 %% gen_server API (internal)
 
-locate_fsm(Type, MInfo, #st{ init_op = {accept, SnInfo, _Opts} } = St) ->
-    lager:debug("Type = ~p, MInfo = ~p, SnInfo = ~p", [Type, MInfo, SnInfo]),
-    %% any duplicates overridden by what was received
-    Info0 = maps:merge(maps:with([ initiator
-                                 , responder
-                                 , port ], SnInfo), MInfo),
-    Info = Info0#{reestablish => (Type =:= ?CH_REESTABL)},
+locate_fsm(Type, Msg, #st{init_op = {accept, #{port := Port}, _}} = St) ->
+    Info = case {Type, Msg} of
+               {?CH_OPEN, #{ chain_hash := _
+                           , initiator  := _
+                           , responder  := _ }} ->
+                   Msg#{port => Port};
+               {?CH_REESTABL, #{ chain_hash := ChainHash
+                               , channel_id := ChanId }} ->
+                   #{ reestablish => true
+                    , chain_hash => ChainHash
+                    , channel_id => ChanId
+                    , port       => Port };
+               _ ->
+                   error(protocol_error)
+           end,
     Cands = get_cands(Type, Info),
     lager:debug("Cands = ~p", [Cands]),
     try_cands(Cands, 5, 0, Type, Info, St).
@@ -318,14 +377,15 @@ get_cands(?CH_OPEN, #{ initiator := I
              {'=:=', '$1', any}}], ['$_'] }]));
 get_cands(?CH_REESTABL, #{ chain_hash := Chain
                          , channel_id := ChId
-                         , responder  := R
                          , port := Port}) ->
     gproc:select({l,p},
-                 [{ {responder_reestabl_regkey(Chain, ChId, R, Port), '_', '_'},
+                 [{ {responder_reestabl_regkey(Chain, ChId, Port), '_', '_'},
                     [], ['$_'] }]).
 
-responder_reestabl_regkey(Chain, ChId, R, Port) ->
-    {p, l, {?MODULE, accept_reestabl, Chain, ChId, R, Port}}.
+responder_reestabl_regkey(Chain, ChId, Port) ->
+    K = {p, l, {?MODULE, accept_reestabl, Chain, ChId, Port}},
+    lager:debug("RegKey = ~p", [K]),
+    K.
 
 responder_regkey(R, I, Port) ->
     {p, l, {?MODULE, accept, R, I, Port}}.
@@ -362,11 +422,11 @@ close_econn(EConn) ->
     end.
 
 cast(P, Msg) ->
-    lager:debug("to noise session ~p: ~p", [P, Msg]),
+    lager:debug("to noise session ~p: ~p", [P, pp_msg(Msg)]),
     gen_server:cast(P, Msg).
 
 call(P, Msg) ->
-    lager:debug("Call to noise session ~p: ~p", [P, Msg]),
+    lager:debug("Call to noise session ~p: ~p", [P, pp_msg(Msg)]),
     gen_server:call(P, Msg).
 
 tell_fsm({_, _} = Msg, #st{fsm = Fsm}) ->
@@ -375,67 +435,27 @@ tell_fsm({_, _} = Msg, #st{fsm = Fsm}) ->
 %% ==================================================================
 %% Process API (internal)
 
-accept_(#{ reestablish := true
-         , chain_hash  := ChainH
-         , channel_id  := ChId
-         , responder   := R
-         , port        := Port } = Opts, NoiseOpts) ->
-    Regkey = responder_reestabl_regkey(ChainH, ChId, R, Port),
-    lager:debug("Regkey = ~p", [Regkey]),
-    gproc:reg(Regkey),
-    StartOpts = [#{fsm => self(), op => {accept, Opts, NoiseOpts}}],
-    aesc_session_noise_sup:start_child(StartOpts);
-accept_(#{ initiator := I, responder := R, port := Port } = Opts, NoiseOpts) ->
-    Regkey = responder_regkey(R, I, Port),
-    lager:debug("Regkey = ~p", [Regkey]),
-    gproc:reg(Regkey),
-    StartOpts = [#{fsm => self(), op => {accept, Opts, NoiseOpts}}],
-    aesc_session_noise_sup:start_child(StartOpts).
-
 register_responder(#{ reestablish := true
                     , chain_hash  := ChainH
                     , channel_id  := ChId
-                    , responder   := R
-                    , port        := Port } = Opts, NoiseOpts) ->
-    Regkey = responder_reestabl_regkey(ChainH, ChId, R, Port),
+                    , port        := Port }) ->
+    Regkey = responder_reestabl_regkey(ChainH, ChId, Port),
     lager:debug("Regkey = ~p", [Regkey]),
-    gproc:reg(Regkey);
-register_responder(#{ initiator := I, responder := R, port := Port } = Opts, NoiseOpts) ->
+    gproc:reg(Regkey),
+    ok;
+register_responder(#{ initiator := I, responder := R, port := Port }) ->
     Regkey = responder_regkey(R, I, Port),
     lager:debug("Regkey = ~p", [Regkey]),
-    gproc:reg(Regkey).
+    gproc:reg(Regkey),
+    ok.
 
-establish({accept, #{responder := R, port := Port, lsock := LSock}, NoiseOpts}, St) ->
-    lager:debug("LSock = ~p", [LSock]),
-    AcceptTimeout = proplists:get_value(accept_timeout, NoiseOpts, ?ACCEPT_TIMEOUT),
-    case accept_tcp(LSock, Port, R, AcceptTimeout) of
-        {ok, TcpSock} ->
-            lager:debug("Accept TcpSock = ~p", [TcpSock]),
-            %% TODO: extract/check something from FinalState?
-            EnoiseOpts = enoise_opts(accept, NoiseOpts),
-            lager:debug("EnoiseOpts (accept) = ~p", [EnoiseOpts]),
-            case enoise:accept(TcpSock, EnoiseOpts) of
-                {ok, EConn, _FinalSt} ->
-                    %% At this point, we should de-couple from the parent fsm and instead
-                    %% attach to the fsm we eventually pair with, once the `CH_OPEN`
-                    %% (or `CH_REESTABL`) message arrives from the other side.
-                    erlang:demonitor(St#st.fsm_mon_ref),
-                    St1 = St#st{ econn = EConn
-                               , fsm = undefined
-                               , fsm_mon_ref = undefined },
-                    {ok, St1};
-                Err1 ->
-                    Err1
-            end;
-        Err ->
-            Err
-    end;
 establish({accept, #{port := Port, lsock := LSock}, NoiseOpts}, St) ->
     lager:debug("LSock = ~p", [LSock]),
-    AcceptTimeout = proplists:get_value(accept_timeout, NoiseOpts, ?ACCEPT_TIMEOUT),
-    case accept_tcp(LSock, Port, AcceptTimeout) of
+    case accept_tcp(LSock, Port) of
 	{ok, TcpSock} ->
 	    lager:debug("Accept TcpSock = ~p", [TcpSock]),
+            %% Since we have a connection, no need to hold up the acceptor pool
+            aesc_acceptors:worker_done(Port),
 	    EnoiseOpts = enoise_opts(accept, NoiseOpts),
 	    lager:debug("EnoiseOpts (accept) = ~p", [EnoiseOpts]),
 	    case enoise:accept(TcpSock, EnoiseOpts) of
@@ -482,37 +502,13 @@ sleep_retry_connect(Retries, Host, Port, TcpOpts, Opts, Timeout, St) ->
     sleep(Timeout, St#st.fsm_mon_ref),
     establish_connect(Retries, Host, Port, TcpOpts, Opts, Timeout, St).
 
-accept_tcp(LSock, Port, AcceptTimeout) ->
-    case gen_tcp:accept(LSock, AcceptTimeout) of
+accept_tcp(LSock, Port) ->
+    case gen_tcp:accept(LSock) of
         {ok, _} = Ok ->
             Ok;
-        {error, timeout} ->
-            lager:debug("Timeout on accept call; terminate", []),
-	    {error, shutdown}
-    end.
-
-accept_tcp(LSock, Port, R, AcceptTimeout) ->
-    case gen_tcp:accept(LSock, AcceptTimeout) of
-        {ok, _} = Ok ->
-            Ok;
-        {error, timeout} ->
-            lager:debug("Timeout on accept call; see if we should retry", []),
-            case aesc_listeners:lsock_info(LSock, [port, responders]) of
-                #{ port := Port, responders := Rs } ->
-                    case lists:member(R, Rs) of
-                        true ->
-                            lager:debug("Still listeners on this port, loop", []),
-                            accept_tcp(LSock, Port, R, AcceptTimeout);
-                        false ->
-                            lager:debug("No listeners for ~p on this port", [R]),
-                            {error, shutdown}
-                    end;
-                _Other ->
-                    lager:debug("_Other = ~p", [_Other]),
-                    {error, shutdown}
-            end;
-        Error ->
-            Error
+        {error, Reason} ->
+            lager:debug("Error from accept (~p); terminate: ~p", [Port, Reason]),
+            {error, shutdown}
     end.
 
 sleep(T, Ref) ->
@@ -550,7 +546,7 @@ tcp_opts(_Op, Opts) ->
     end.
 
 noise_defaults() ->
-    [{noise, <<"Noise_XK_25519_ChaChaPoly_BLAKE2b">>}].
+    [{noise, <<"Noise_NN_25519_ChaChaPoly_BLAKE2b">>}].
 
 tcp_defaults() ->
     [ {active, true}

--- a/apps/aechannel/src/aesc_sup.erl
+++ b/apps/aechannel/src/aesc_sup.erl
@@ -20,5 +20,6 @@ init([]) ->
                                 , ?CHILD(aesc_limits, 5000, worker)
                                 , ?CHILD(aesc_fsm_sup, 5000, supervisor)
                                 , ?CHILD(aesc_session_noise_sup, 5000, supervisor)
+                                , ?CHILD(aesc_acceptors, 5000, worker)
                                 , ?CHILD(aesc_listeners, 5000, worker)
                                 ]}}.

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1370,7 +1370,34 @@
                     "description" : "Max number of active state channel clients allowed on node",
                     "type" : "integer",
                     "default" : 1000
-                }
+                },
+		"ad_hoc_listen_ports" : {
+		    "type" : "boolean",
+		    "description" : "Whether to allow responders to listen on any ports other than preconfigured ones",
+		    "default" : true
+		},
+		"listeners" : {
+		    "description" : "Pre-configured responder listen ports",
+		    "type" : "array",
+		    "items" : {
+			"type" : "object",
+			"additionalProperties" : false,
+			"required" : [
+			    "port"
+			],
+			"properties" : {
+			    "port" : {
+				"type" : "integer",
+				"description" : "Listen port number"
+			    },
+			    "acceptors" : {
+				"type" : "integer",
+				"description" : "Number of concurrent acceptors on port (default: 1)",
+				"default" : 1
+			    }
+			}
+		    }
+		}
             }
         },
         "websocket" : {

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -260,11 +260,20 @@ schema_default_values(Path) ->
             RecursiveDefault =
                 fun R(_PName,
                       #{<<"type">> := <<"object">>, <<"properties">> := Props}) ->
-                          maps:map(fun(PN, #{<<"type">> := <<"object">>} = PP) -> R(PN, PP);
-                                      (_PN, #{<<"default">> := Def}) -> Def
-                                    end, Props);
+                        maps:map(fun(PN, #{<<"type">> := <<"object">>} = PP) ->
+                                         R(PN, PP);
+                                    (PN, #{<<"type">> := <<"array">>, <<"items">> := Items}) ->
+                                         [R(PN, Items)];
+                                    (_PN, #{<<"default">> := Def}) -> Def;
+                                    (_PN, _) -> undefined
+                                 end, Props);
+                    R(PName,
+                     #{<<"type">> := <<"array">>, <<"items">> := Items}) ->
+                        [R(PName, Items)];
                     R(_PName, #{<<"default">> := Def}) ->
-                        Def
+                        Def;
+                    R(_PName, _) ->
+                        undefined
                 end,
             Res = RecursiveDefault(<<"root">>, Tree),
             {ok, Res}


### PR DESCRIPTION
See issue #4011 

We introduce an acceptor dispatcher (`aesc_acceptors`), which ensures that a new acceptor is started as soon as an acceptor connects at the TCP level. The newly connected acceptor needs to negotiate a noise session, then find a waiting responder and match to it.

Some preparation has been made to support pre-configured listen ports, together with the size of the acceptor pool. The `aesc_listeners` server no longer worries about responder pubkeys. Since we need to support dynamically requested listen ports, the server differentiates between `preconfigured` and `dynamic` listeners: the latter are automatically removed when there are no processes alive that expressed interest via `aesc_listeners:ensure_listener/2`.

Default acceptor pool size is `1`. Given that it takes less than a millisecond from a connect to the creation of a new acceptor, it's unlikely that this will be a bottlenect, except possibly for heavily loaded SC server applications (in which case, the chain is much more likely to be the bottleneck).

Also, some reduction of debug log noise by compacting hashes and keys (keeping the first and last 5 bytes, and sticking 4 zeroes in the middle).