### PR TITLE
Add plugin config management support

### DIFF
--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -84,7 +84,7 @@ user_config() ->
 
 -spec user_config(list() | binary()) -> undefined | {ok, any()}.
 user_config(Key) when is_list(Key) ->
-    get_env(aeutils, ['$user_config'|Key]);
+    find_config(Key, [user_config]);
 user_config(Key) when is_binary(Key) ->
     get_env(aeutils, ['$user_config',Key]).
 
@@ -196,6 +196,13 @@ nested_map_get([H|T], L) when is_list(L) ->
             undefined
     end.
 
+lists_map_key_find({K,V,Then} = Pat, [#{} = H|T]) ->
+    case maps:find(K, H) of
+        {ok, V} ->
+            maps:find(Then, H);
+        error ->
+            lists_map_key_find(Pat, T)
+    end;
 lists_map_key_find(K, [#{} = H|T]) ->
     case maps:find(K, H) of
         {ok, _} = Ok ->


### PR DESCRIPTION
A plugin-specific version of `aeu_env:find_config/2` is added:

`aeu_plugins:find_config(PluginName, Key, Path) -> {ok, any()} | undefined`

The plugin schema is also cached, once the schema and the corresponding user config are validated.