### PR TITLE
Move dev mode emitter into core node as part of new app

### DIFF
--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -54,7 +54,7 @@
              [ {basic, []}
              , {nosync, [aehttp, aemon]}
              , {active, [aesync, aehttp, aemon, aestratum]}
-             , {dev, [aehttp]}
+             , {dev, [aehttp, aedevmode]}
              ]}
           , {mode, normal}
           , {modes,

--- a/apps/aedevmode/src/aedevmode.app.src
+++ b/apps/aedevmode/src/aedevmode.app.src
@@ -1,0 +1,28 @@
+%% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
+{application, aedevmode,
+ [{description, "Helpers for Aeternity dev mode consensus"},
+  {vsn, {cmd, "cat ../../VERSION"}},
+  {registered, []},
+  {mod, {aedevmode_app, []}},
+  {start_phases, []},
+  {applications,
+   [kernel,
+    stdlib,
+    aeutils,
+    aecore
+  ]},
+  {runtime_dependencies, []},
+  {env, [
+         {'$setup_hooks',
+          [
+           {normal, [
+                     {300, {aedevmode_app, post_check, []}}
+                    ]}
+          ]}
+        ]},
+  {modules, []},
+
+  {maintainers, []},
+  {licenses, []},
+  {links, []}
+ ]}.

--- a/apps/aedevmode/src/aedevmode_app.erl
+++ b/apps/aedevmode/src/aedevmode_app.erl
@@ -1,0 +1,28 @@
+-module(aedevmode_app).
+-behavior(application).
+
+-export([ start/2
+        , stop/1 ]).
+
+-export([post_check/0]).
+
+start(_StartType, _StartArgs) ->
+    aedevmode_sup:start_link().
+
+stop(_State) ->
+    lager:info("Stopping aedevmode_app", []),
+    ok.
+
+%% Run at 300, i.e. after normal env checks AND the db start
+post_check() ->
+    case aecore_env:is_dev_mode() of
+        true ->
+            Pub = patron_pubkey_for_testing(),
+            aeu_env:suggest_config([<<"mining">>, <<"beneficiary">>], Pub);
+        false ->
+            ok
+    end.
+
+patron_pubkey_for_testing() ->
+    #{pubkey := Pub} = aecore_env:patron_keypair_for_testing(),
+    aeser_api_encoder:encode(account_pubkey, Pub).

--- a/apps/aedevmode/src/aedevmode_emitter.erl
+++ b/apps/aedevmode/src/aedevmode_emitter.erl
@@ -1,0 +1,239 @@
+%% -*- erlang-indent-mode: 4; indent-tabs-mode: nil -*-
+-module(aedevmode_emitter).
+-behavior(gen_server).
+
+-export([start_link/0]).
+
+-export([
+          emit_keyblocks/1
+        , emit_microblock/0
+        , mine_until_txs_on_chain/2
+        ]).
+
+-export([
+          set_keyblock_interval/1
+        , set_microblock_interval/1
+        , auto_emit_microblocks/1
+        , get_keyblock_interval/0
+        , get_microblock_interval/0
+        , get_auto_emit_microblocks/0
+        ]).
+
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3 ]).
+
+-record(st, { keyblock_interval = 0
+            , kb_tref
+            , microblock_interval = 0
+            , mb_tref
+            , auto_emit = false }).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+emit_keyblocks(N) when is_integer(N), N > 0 ->
+    gen_server:call(?MODULE, {emit_keyblocks, N}).
+
+set_keyblock_interval(I) when is_integer(I), I >= 0 ->
+    gen_server:call(?MODULE, {set_keyblock_interval, I}).
+
+set_microblock_interval(I) when is_integer(I), I >= 0 ->
+    gen_server:call(?MODULE, {set_microblock_interval, I}).
+
+auto_emit_microblocks(Bool) when is_boolean(Bool) ->
+    gen_server:call(?MODULE, {auto_emit_microblocks, Bool}).
+
+get_keyblock_interval() ->
+    gen_server:call(?MODULE, get_keyblock_interval).
+
+get_microblock_interval() ->
+    gen_server:call(?MODULE, get_microblock_interval).
+
+get_auto_emit_microblocks() ->
+    gen_server:call(?MODULE, get_auto_emit_microblocks).
+
+emit_microblock() ->
+    gen_server:call(?MODULE, emit_microblock).
+
+mine_until_txs_on_chain(TxHashes, Max) when is_list(TxHashes),
+                                            is_integer(Max),
+                                            Max > 0 ->
+    gen_server:call(?MODULE, {mine_until_txs_on_chain, TxHashes, Max}).
+
+init([]) ->
+    aec_events:subscribe(tx_created),
+    aec_events:subscribe(tx_received),
+    aec_events:subscribe(top_changed),
+    case aec_chain:top_height() of
+        0 ->
+            aec_conductor:consensus_request(emit_kb);
+        _ ->
+            ok
+    end,
+    {ok, #st{ keyblock_interval   = cfg(<<"keyblock_interval">>)
+            , microblock_interval = cfg(<<"microblock_interval">>)
+            , auto_emit           = cfg(<<"auto_emit_microblocks">>) }}.
+
+cfg(K) ->
+    {ok, V} = aeu_env:find_config([<<"dev_mode">>, K], [user_config, schema_default]),
+    V.
+
+handle_call({set_keyblock_interval, I}, _From, St) ->
+    case I of
+        _ when is_integer(I), I >= 0 ->
+            St1 = restart_keyblock_timer(St#st{keyblock_interval = I}),
+            {reply, ok, St1};
+        _ ->
+            {reply, {error, invalid}, St}
+    end;
+handle_call({set_microblock_interval, I}, _From, St) ->
+    case I of
+        _ when is_integer(I), I >= 0 ->
+            St1 = restart_microblock_timer(St#st{microblock_interval = I}),
+            {reply, ok, St1};
+        _ ->
+            {reply, {error, invalid}, St}
+    end;
+handle_call({auto_emit_microblocks, Bool}, _From, St) ->
+    case Bool of
+        _ when is_boolean(Bool) ->
+            St1 = check_if_existing_txs(Bool, St),
+            {reply, ok, St1#st{auto_emit = Bool}};
+        _ ->
+            {reply, {error, invalid}, St}
+    end;
+handle_call(get_keyblock_interval, _From, #st{keyblock_interval = I} = St) ->
+    {reply, I, St};
+handle_call(get_microblock_interval, _From, #st{microblock_interval = I} = St) ->
+    {reply, I, St};
+handle_call(get_auto_emit_microblocks, _From, #st{auto_emit = Bool} = St) ->
+    {reply, Bool, St};
+handle_call({emit_keyblocks, N}, _From, St) ->
+    St1 = emit_keyblocks_(N, St),
+    {reply, ok, St1};
+handle_call(emit_microblock, _From, St) ->
+    {reply, ok, emit_microblock_(St)};
+handle_call({mine_until_txs_on_chain, TxHashes, Max}, _From, St) ->
+    {Reply, St1} = mine_until_txs_on_chain_(TxHashes, Max, St),
+    {reply, Reply, St1};
+handle_call(_Req, _From, St) ->
+    {reply, {error, unknown_call}, St}.
+
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+handle_info({gproc_ps_event, Event, #{info := STx}}, St)
+  when Event == tx_created; Event == tx_received ->
+    Hashes = [aetx_sign:hash(STx) | flush_tx_events()],
+    lager:info("Tx pool events hashes: ~p", [[encode_hash(H) || H <- Hashes]]),
+    case St#st.auto_emit of
+        true ->
+            {_, St1} = mine_until_txs_on_chain_(Hashes, 10, St),
+            {noreply, St1};
+        false ->
+            {noreply, St}
+    end;
+handle_info({gproc_ps_event, top_changed, #{info := Info}}, St) ->
+    Type = maps:get(block_type, Info),
+    St1 = restart_block_timer(Type, St),
+    case Info of
+        #{block_type := key, height := Height} ->
+            lager:info("New key block - height: ~p", [Height]);
+        #{block_type := micro} ->
+            info_micro_block(Info)
+    end,
+    {noreply, St1};
+handle_info({timeout, _, emit_kb_ping}, St) ->
+    {noreply, emit_keyblock(St)};
+handle_info({timeout, _, emit_mb_ping}, St) ->
+    {noreply, emit_microblock_(St)};
+handle_info(_Msg, St) ->
+    {noreply, St}.
+
+terminate(_Reason, _St) ->
+    ok.
+
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
+
+info_micro_block(#{block_type := micro, block_hash := BHash, height := Height}) ->
+    case aec_chain:get_block(BHash) of
+        {ok, Block} ->
+            Txs = aec_blocks:txs(Block),
+            lager:info("New micro block - height: ~p, ~p txs",
+                       [Height, length(Txs)]);
+        {error, Reason} ->
+            %% Shouldn't happen
+            lager:info("New micro block - height: ~p, CANNOT READ (~p)",
+                       [Height, Reason])
+    end.
+
+flush_tx_events() ->
+    receive
+        {gproc_ps_event, Event, #{info := STx}} when Event == tx_created;
+                                                     Event == tx_received ->
+            [aetx_sign:hash(STx) | flush_tx_events()]
+    after 0 ->
+            []
+    end.
+
+encode_hash(Hash) ->
+    aeser_api_encoder:encode(tx_hash, Hash).
+
+emit_keyblock(St) ->
+    aec_conductor:consensus_request(emit_kb),
+    St.
+
+emit_keyblocks_(N, St) ->
+    aec_conductor:consensus_request({mine_blocks, N, key}),
+    St.
+
+emit_microblock_(St) ->
+    aec_conductor:consensus_request(emit_mb),
+    St.
+
+check_if_existing_txs(true, #st{auto_emit = false} = St) ->
+    case aec_tx_pool:peek(100) of
+        {ok, [_|_] = Txs} ->
+            lager:info("~p txs already in mempool", [length(Txs)]),
+            Hashes = [aetx_sign:hash(STx) || STx <- Txs],
+            {_, St1} = mine_until_txs_on_chain_(Hashes, 50, St),
+            St1;
+        _ ->
+            St
+    end;
+check_if_existing_txs(_, St) ->
+    St.
+
+mine_until_txs_on_chain_(TxHashes, Max, St) ->
+    Reply = aec_conductor:consensus_request(
+              {mine_blocks_until_txs_on_chain, TxHashes, Max}),
+    {Reply, St}.
+
+restart_block_timer(key, St) ->
+    restart_keyblock_timer(St);
+restart_block_timer(micro, St) ->
+    restart_microblock_timer(St).
+
+restart_keyblock_timer(#st{keyblock_interval = 0} = St) ->
+    St;
+restart_keyblock_timer(#st{keyblock_interval = I, kb_tref = TRef0} = St) ->
+    cancel_timer(TRef0),
+    TRef = erlang:start_timer(I * 1000, self(), emit_kb_ping),
+    St#st{kb_tref = TRef}.
+
+restart_microblock_timer(#st{microblock_interval = 0} = St) ->
+    St;
+restart_microblock_timer(#st{microblock_interval = I, mb_tref = TRef0} = St) ->
+    cancel_timer(TRef0),
+    TRef = erlang:start_timer(I * 1000, self(), emit_mb_ping),
+    St#st{mb_tref = TRef}.
+
+cancel_timer(undefined) ->
+    ok;
+cancel_timer(TRef) ->
+    erlang:cancel_timer(TRef).

--- a/apps/aedevmode/src/aedevmode_emitter.erl
+++ b/apps/aedevmode/src/aedevmode_emitter.erl
@@ -166,10 +166,9 @@ info_micro_block(#{block_type := micro, block_hash := BHash, height := Height}) 
             Txs = aec_blocks:txs(Block),
             lager:info("New micro block - height: ~p, ~p txs",
                        [Height, length(Txs)]);
-        {error, Reason} ->
+        error ->
             %% Shouldn't happen
-            lager:info("New micro block - height: ~p, CANNOT READ (~p)",
-                       [Height, Reason])
+            lager:info("New micro block - height: ~p, CANNOT READ", [Height])
     end.
 
 flush_tx_events() ->

--- a/apps/aedevmode/src/aedevmode_sup.erl
+++ b/apps/aedevmode/src/aedevmode_sup.erl
@@ -1,0 +1,28 @@
+-module(aedevmode_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+-define(CHILD(Mod,N,Type), {Mod,{Mod,start_link,[]},permanent,N,Type,[Mod]}).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%====================================================================
+%% Supervisor callbacks
+%%====================================================================
+
+init([]) ->
+    ChildSpecs =
+        [?CHILD(aedevmode_emitter, 5000, worker) ],
+    {ok, {{one_for_one, 0, 10}, ChildSpecs}}.

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -2256,8 +2256,29 @@
                     }
                 }
             }
+        },
+        "dev_mode" : {
+            "type" : "object",
+            "description" : "Settings for when dev mode consensus is activated",
+            "additionalProperties" : false,
+            "properties" : {
+                "keyblock_interval" : {
+                    "type" : "integer",
+                    "default" : 0,
+                    "description" : "Interval, in seconds, between keyblocks. If 0, keyblocks are only produced on-demand"
+                },
+                "microblock_interval" : {
+                    "type" : "integer",
+                    "default" : 0,
+                    "description" : "Interval, in seconds, between microblocks. If 0, microblocks are only produced on-demand"
+                },
+                "auto_emit_microblocks" : {
+                    "type" : "boolean",
+                    "default" : false,
+                    "description" : "Emit microblocks as soon as transactions have been pushed to the mempool"
+                }
+            }
         }
-
     },
     "definitions" : {
         "key_value_pattern": {

--- a/apps/aeutils/src/aeu_plugins.erl
+++ b/apps/aeutils/src/aeu_plugins.erl
@@ -83,14 +83,7 @@ is_dev_mode() ->
 %% Checks if a given config key (list of binary keys corresponding to the AE
 %% config schema) is already configured. If not, the suggested value is used.
 suggest_config(Key, Value) ->
-    case aeu_env:user_config(Key) of
-        {ok, _} ->
-            {error, already_configured};
-        undefined ->
-            Map = kv_to_config_map(Key, Value),
-            aeu_env:update_config(Map, false),
-            ok
-    end.
+    aeu_env:suggest_config(Key, Value).
 
 load_schema(SchemaFilename) ->
     {ok, AppName} = application:get_application(),
@@ -256,8 +249,3 @@ bin(B) when is_binary(B) ->
     B;
 bin(Str) ->
     iolist_to_binary(Str).
-
-kv_to_config_map([H], V) ->
-    #{H => V};
-kv_to_config_map([H|T], V) ->
-    #{H => kv_to_config_map(T, V)}.

--- a/rebar.config
+++ b/rebar.config
@@ -128,7 +128,7 @@
           {rocksdb, load}, {mnesia_rocksdb, load}, {mnesia, load},
           parse_trans, exometer_core, ranch, aeminer, aecore, aeapi, aehttp, enacl, enoise,
           aebytecode, aeserialization, aevm, aechannel, aefate, aemon, aestratum, ecrecover,
-          aesync, ecli]},
+          aesync, ecli, aedevmode]},
         {sys_config, "./config/sys.config"},
         {vm_args, "./config/vm.args"},
 


### PR DESCRIPTION
As the basic dev mode functionality turns out to be useful for many different scenarios, it was suggested that it move into the core node. Here is a first implementation.

This would require some adaptations in the aeplugin_dev_mode application.