### PR TITLE
Protect Fee and GasPrice in GaMetaTx

### DIFF
--- a/apps/aechannel/test/aesc_fsm_SUITE.erl
+++ b/apps/aechannel/test/aesc_fsm_SUITE.erl
@@ -3619,7 +3619,8 @@ meta(Owner, AuthOpts, SignedTx) ->
     TxBin    = aec_governance:add_network_id(aetx:serialize_to_binary(Aetx)),
     %% authenticate the inner tx, that could be a transaction instance or yet
     %% another meta
-    AuthData = make_authdata(AuthOpts, Nonce, aec_hash:hash(tx, TxBin)),
+    TxHash   = aega_test_utils:auth_data_hash(AuthOpts, TxBin),
+    AuthData = make_authdata(AuthOpts, Nonce, TxHash),
     %% produce the new layer of meta authenticating the inner tx and not the
     %% innermost one, but include the inner tx
     aecore_suite_utils:meta_tx(Owner, AuthOpts, AuthData, SignedTx).

--- a/apps/aega/src/aega_meta_tx.erl
+++ b/apps/aega/src/aega_meta_tx.erl
@@ -25,6 +25,7 @@
          version/1,
          serialization_template/1,
          serialize/1,
+         serialize_auth_data/3,
          deserialize/2,
          for_client/1,
          valid_at_protocol/2
@@ -397,8 +398,12 @@ auth_data_inner_tx(P, #ga_meta_tx{} = Tx) ->
         false ->
             Fee = fee(Tx),
             GasPrice = gas_price(Tx),
-            {InnerTx, aec_hash:hash(tx, <<Fee:256, GasPrice:256, BinForNetwork/binary>>)}
+            {InnerTx, aec_hash:hash(tx, serialize_auth_data(Fee, GasPrice, BinForNetwork))}
     end.
+
+serialize_auth_data(Fee, GasPrice, Binary) ->
+    Hash = aec_hash:hash(tx, Binary),
+    <<Fee:256, GasPrice:256, Hash/binary>>.
 
 set_ga_context(Env0, Tx) ->
     Env1 = aetx_env:set_context(Env0, aetx_ga),

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -1504,9 +1504,7 @@ prep_meta(Owner, AuthOpts, InnerTx0) ->
             {InnerTx0, aetx_sign:new(InnerTx0, [])}
         end,
     TxBin    = aec_governance:add_network_id(aetx:serialize_to_binary(InnerTx)),
-    Fee      = maps:get(fee, AuthOpts, maps:get(fee, aega_test_utils:ga_meta_tx_default(<<0:256>>))),
-    GasPrice = maps:get(gas_price, AuthOpts, maps:get(gas_price, aega_test_utils:ga_meta_tx_default(<<0:256>>))),
-    TxHash   = aega_test_utils:auth_data_hash(Fee, GasPrice, TxBin),
+    TxHash   = aega_test_utils:auth_data_hash(AuthOpts, TxBin),
     AuthData = make_authdata(AuthOpts, TxHash),
     Options1 = maps:merge(#{auth_data => AuthData, tx => InnerSTx}, AuthOpts),
     MetaTx   = aega_test_utils:ga_meta_tx(Owner, Options1),  %% here we can tamper the fee and gas_price
@@ -1692,7 +1690,8 @@ sign_tx(Pubkey, plain, Tx, S) ->
     aec_test_utils:sign_tx(Tx, PrivKey);
 sign_tx(Pubkey, AuthOpts, Tx, _S) ->
     TxBin    = aec_governance:add_network_id(aetx:serialize_to_binary(Tx)),
-    AuthData = make_authdata(AuthOpts, aec_hash:hash(tx, TxBin)),
+    TxHash   = aega_test_utils:auth_data_hash(AuthOpts, TxBin),
+    AuthData = make_authdata(AuthOpts, TxHash),
     Options1 = #{auth_data => AuthData, tx => aetx_sign:new(Tx, [])},
     MetaTx   = aega_test_utils:ga_meta_tx(Pubkey, Options1),
     aetx_sign:new(MetaTx, []).

--- a/apps/aega/test/aega_test_utils.erl
+++ b/apps/aega/test/aega_test_utils.erl
@@ -42,7 +42,15 @@ ga_attach_tx_default(PubKey) ->
 
 ga_meta_tx(PubKey, Spec0) ->
     Spec = maps:merge(ga_meta_tx_default(PubKey), Spec0),
-    {ok, Tx} = aega_meta_tx:new(Spec),
+    Spec1 = case maps:get(tamper_fee, Spec0, false) of
+                true -> maps:put(fee, maps:get(fee, Spec) + 100, Spec);
+                false -> Spec
+            end,
+    Spec2 = case maps:get(tamper_gas_price, Spec0, false) of
+                true -> maps:put(gas_price, maps:get(gas_price, Spec1) + 100, Spec1);
+                false -> Spec1
+            end,
+    {ok, Tx} = aega_meta_tx:new(Spec2),
     Tx.
 
 ga_meta_tx_default(PubKey) ->

--- a/apps/aega/test/aega_test_utils.erl
+++ b/apps/aega/test/aega_test_utils.erl
@@ -178,7 +178,7 @@ sign_tx(STx, [Sig | Sigs], S) ->
 
 auth_data_hash(Opts, TxBin) ->
     Fee      = maps:get(fee, Opts, maps:get(fee, ga_meta_tx_default(<<0:256>>))),
-    GasPrice = maps:get(gas_price,Opts, maps:get(gas_price, ga_meta_tx_default(<<0:256>>))),
+    GasPrice = maps:get(gas_price, Opts, maps:get(gas_price, ga_meta_tx_default(<<0:256>>))),
     auth_data_hash(Fee, GasPrice, TxBin).
 
 auth_data_hash(Fee, GasPrice, TxBin) ->

--- a/apps/aega/test/aega_test_utils.erl
+++ b/apps/aega/test/aega_test_utils.erl
@@ -176,6 +176,11 @@ sign_tx(STx, [Sig | Sigs], S) ->
             end
     end.
 
+auth_data_hash(Pubkey, TxBin) ->
+    Fee      = maps:get(fee, aega_test_utils:ga_meta_tx_default(Pubkey)),
+    GasPrice = maps:get(gas_price, aega_test_utils:ga_meta_tx_default(Pubkey)),
+    auth_data_hash(Fee, GasPrice, TxBin).
+
 auth_data_hash(Fee, GasPrice, TxBin) ->
     case aect_test_utils:latest_protocol_version() >= ?CERES_PROTOCOL_VSN of
         true ->

--- a/apps/aega/test/aega_test_utils.erl
+++ b/apps/aega/test/aega_test_utils.erl
@@ -176,6 +176,14 @@ sign_tx(STx, [Sig | Sigs], S) ->
             end
     end.
 
+auth_data_hash(Fee, GasPrice, TxBin) ->
+    case aect_test_utils:latest_protocol_version() >= ?CERES_PROTOCOL_VSN of
+        true ->
+            H = aec_hash:hash(tx, <<Fee:256, GasPrice:256, TxBin/binary>>),
+            H;
+        false -> aec_hash:hash(tx, TxBin)
+    end.
+
 basic_auth_sign(Nonce, TxHash, PrivKey) ->
     Val = case aega_SUITE:abi_version() of
               ?ABI_AEVM_SOPHIA_1 -> <<32:256, TxHash/binary, Nonce:256>>;

--- a/docs/release-notes/next-ceres/GH3417-tamper_protection_on_ga_meta_tx.md
+++ b/docs/release-notes/next-ceres/GH3417-tamper_protection_on_ga_meta_tx.md
@@ -1,0 +1,5 @@
+* Include fields `fee` and `gas_price` in GAMetaTx when computing the TX-hash
+  of the inner transaction. This way a malicious miner can't change them before
+  inserting the transaction in a micro block. Note: The authentication logic
+  still needs to _actually_ use the Auth.TxHash during authentication for this
+  to take effect!

--- a/rebar.config
+++ b/rebar.config
@@ -73,7 +73,7 @@
                      {ref, "7497345"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                          {ref,"eb68fe3"}}},
+                          {ref,"177bf60"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
                         {ref, "cee4b3c"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"eb68fe331bd476910394966b7f5ede7a74d37e35"}},
+      {ref,"177bf604b2a05e940f92cf00e96e6e269e708245"}},
   0},
  {<<"aesophia_aci_encoder">>,
   {git,"https://github.com/aeternity/aesophia_aci_encoder",


### PR DESCRIPTION
fixes #3417

By making fee and gas_price part of the authentication data, it is no longer possible for a miner to increase the fee or gas_price without invalidating the transaction.

This PR is supported by the Æternity Crypto Foundation