### PR TITLE
Allow running HCs on iris

### DIFF
--- a/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
@@ -170,8 +170,8 @@ end_per_suite(_Config) ->
 
 init_per_group(_, Config) ->
     case aect_test_utils:latest_protocol_version() of
-        PreCeres when PreCeres < ?CERES_PROTOCOL_VSN ->
-            {skip, from_ceres_on};
+        PreIris when PreIris < ?IRIS_PROTOCOL_VSN ->
+            {skip, from_iris_on};
         _ ->
             aect_test_utils:init_per_group(fate, Config, fun(X) -> X end)
     end.

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -463,7 +463,7 @@ genesis_protocol_version() ->
       ?ETS_CACHE_TABLE,
       genesis_protocol_version,
       fun() ->
-            aec_hard_forks:protocol_effective_at_height(0)
+            hd(lists:sort(maps:keys(aec_hard_forks:protocols())))
       end).
 
 

--- a/apps/aecore/src/aec_fork_block_settings.erl
+++ b/apps/aecore/src/aec_fork_block_settings.erl
@@ -24,6 +24,7 @@
 -define(MINERVA_DIR, ".minerva").
 -define(FORTUNA_DIR, ".fortuna").
 -define(LIMA_DIR,    ".lima").
+-define(IRIS_DIR,    ".iris").
 -define(CERES_DIR,   ".ceres").
 
 -spec dir(aec_hard_forks:protocol_vsn()) -> string().
@@ -34,6 +35,7 @@ dir(ProtocolVsn) ->
             ?MINERVA_PROTOCOL_VSN -> ?MINERVA_DIR;
             ?FORTUNA_PROTOCOL_VSN -> ?FORTUNA_DIR;
             ?LIMA_PROTOCOL_VSN    -> ?LIMA_DIR;
+            ?IRIS_PROTOCOL_VSN    -> ?IRIS_DIR;
             ?CERES_PROTOCOL_VSN   -> ?CERES_DIR
         end,
     filename:join(aeu_env:data_dir(aecore), Dir).

--- a/docs/release-notes/next-hc/set_hyperchains_to_iris.md
+++ b/docs/release-notes/next-hc/set_hyperchains_to_iris.md
@@ -1,0 +1,1 @@
+* Allows running a HC not only on CERES protocol but also on IRIS


### PR DESCRIPTION
So far HCs could have been run only on CERES protocol version. Since the MDW
does not yet support it, currently it is impossible to run the MDW on a HC.
This blocks running the explorer as well.

This PR allows running the HC on IRIS protocol version as well. Since the
contracts require some functionality that is activated with IRIS: the codebase
would work on previous protocols as well but the contracts will fail.


The work on this PR is being supported by ACF.

