### PR TITLE
Fix structure problem in schema, handle hyphens

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1310,7 +1310,7 @@
                             "description" : "Transactions insection endpoints",
                             "type" : "boolean"
                         },
-                        "node_operator" : {
+                        "node-operator" : {
                             "description" : "Node operator endpoints",
                             "type" : "boolean",
                             "default" : false

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1291,42 +1291,46 @@
                     }
                 },
                 "endpoints" : {
-                    "gossip" : {
-                        "description" : "Gossip protocol API",
-                        "type" : "boolean"
-                    },
-                    "name_service" : {
-                        "description" : "Name resolution API",
-                        "type" : "boolean"
-                    },
-                    "chain" : {
-                        "description" : "Chain state inspection endpoints",
-                        "type" : "boolean"
-                    },
-                    "transactions" : {
-                        "description" : "Transactions insection endpoints",
-                        "type" : "boolean"
-                    },
-                    "node_operator" : {
-                        "description" : "Node operator endpoints",
-                        "type" : "boolean",
-                        "default" : false
-                    },
-                    "dev" : {
-                        "description" : "Development only API - for validation of client implementations. Should not be used in real life scenarios",
-                        "type" : "boolean"
-                    },
-                    "debug" : {
-                        "description" : "Deprecated. See also 'http > internal > debug_endpoints'",
-                        "type" : "boolean"
-                    },
-                    "obsolete" : {
-                        "description" : "Old endpoints that will be removed",
-                        "type" : "boolean"
-                    },
-                    "dry-run" : {
-                        "description" : "External protected dry run endpoint",
-                        "type" : "boolean"
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "gossip" : {
+                            "description" : "Gossip protocol API",
+                            "type" : "boolean"
+                        },
+                        "name_service" : {
+                            "description" : "Name resolution API",
+                            "type" : "boolean"
+                        },
+                        "chain" : {
+                            "description" : "Chain state inspection endpoints",
+                            "type" : "boolean"
+                        },
+                        "transactions" : {
+                            "description" : "Transactions insection endpoints",
+                            "type" : "boolean"
+                        },
+                        "node_operator" : {
+                            "description" : "Node operator endpoints",
+                            "type" : "boolean",
+                            "default" : false
+                        },
+                        "dev" : {
+                            "description" : "Development only API - for validation of client implementations. Should not be used in real life scenarios",
+                            "type" : "boolean"
+                        },
+                        "debug" : {
+                            "description" : "Deprecated. See also 'http > internal > debug_endpoints'",
+                            "type" : "boolean"
+                        },
+                        "obsolete" : {
+                            "description" : "Old endpoints that will be removed",
+                            "type" : "boolean"
+                        },
+                        "dry-run" : {
+                            "description" : "External protected dry run endpoint",
+                            "type" : "boolean"
+                        }
                     }
                 },
                 "debug" : {

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -400,10 +400,11 @@ schema_key_names(NamePfx, KeyPfx, Map, Acc0) when is_map(Map) ->
       fun(SubKey, SubMap, Acc) ->
               NamePfx1 = NamePfx ++ "__" ++ string:to_upper(binary_to_list(SubKey)),
               KeyPfx1 = KeyPfx ++ [SubKey],
-              Acc1 = case os:getenv(NamePfx1) of
+              EnvKey = unhyphenate(NamePfx1),
+              Acc1 = case os:getenv(EnvKey) of
                          false -> Acc;
                          Value ->
-                             [{NamePfx1, KeyPfx1, Value} | Acc]
+                             [{EnvKey, KeyPfx1, Value} | Acc]
                      end,
               case maps:find(<<"properties">>, SubMap) of
                   error ->
@@ -412,6 +413,12 @@ schema_key_names(NamePfx, KeyPfx, Map, Acc0) when is_map(Map) ->
                       schema_key_names(NamePfx1, KeyPfx1, Props, Acc1)
               end
       end, Acc0, Map).
+
+%% Unfortunately, the config schema contains some names with hyphens in them.
+%% Since hyphens aren't allowed in OS environment names, we replace them with underscores.
+%% This should be safe, since we DO NOT stupidly have names that differ only on '-' v '_'.
+unhyphenate(Str) ->
+    re:replace(Str, <<"\\-">>, <<"_">>, [global, {return, list}]).
 
 %% ======================================================================
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,12 +26,13 @@ The contents of the config file will be validated against a JSON-Schema, located
 It is possible to set configuration values from the command line or shell scripts using
 OS environment variables. The variable names correspond to a path in the config schema,
 using the name prefix `AE__` and with each level name, converted to uppercase, separated
-by two underscores.
+by two underscores. Any hyphen (`"-"`) is replaced by an underscore (`"_"`).
 
 Examples:
 
 `AE__PEERS` corresponds to `{"peers": ...}`
 `AE__HTTP__CORS__MAX_AGE` corresponds to `{"http": {"cors": {"max_age": ...}}}`
+`AE__HTTP__ENDPOINTS__DRY_RUN` corresponds to `{"http": {"endpoints": {"dry-run": ...}}}`
 
 Simple configuration values (integers, strings, booleans) are given as-is. Structured values
 (arrays, objects) need to be encoded as JSON data.

--- a/docs/release-notes/next/GH-4062-hyphens-in-config-variables.md
+++ b/docs/release-notes/next/GH-4062-hyphens-in-config-variables.md
@@ -1,0 +1,6 @@
+* While it should be possible to override config values using OS environment variables,
+  this didn't work for e.g. `http:endpoints:dry-run`, since the name contains a hyphen.
+  Generally, it didn't work for any children of `http:endpoints`, since that schema subtree
+  was improperly structured. This has been fixed, and for any config variable whose name contains
+  a hyphen, the corresponding OS environment variable should replace any hyphen with an underscore:
+  `AE__HTTP__ENDPOINTS__DRY_RUN=true`.

--- a/docs/release-notes/next/GH-4062-hyphens-in-config-variables.md
+++ b/docs/release-notes/next/GH-4062-hyphens-in-config-variables.md
@@ -4,3 +4,7 @@
   was improperly structured. This has been fixed, and for any config variable whose name contains
   a hyphen, the corresponding OS environment variable should replace any hyphen with an underscore:
   `AE__HTTP__ENDPOINTS__DRY_RUN=true`.
+* The config variable `http:endpoints:node_operator` has been changed to `node-operator`, since
+  this is what was expected by the application code. Due to the structural error above, it was
+  possible to specify `node-operator` even before, and this is the only thing that would have worked.
+  With the corrected structure and name change, such a setting will also be properly validated.


### PR DESCRIPTION
See #4062

Found a structural problem in the aeternity config schema.
Also, any hyphens in config variable names are replaced by underscores.