### PR TITLE
HC: fix a deadlock

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -390,6 +390,7 @@ handle_call(stop_block_production,_From, State = #state{ consensus = Cons }) ->
     epoch_mining:info("Mining stopped"),
     aec_block_generator:stop_generation(),
     [ aec_tx_pool:garbage_collect() || is_record(Cons, consensus) andalso Cons#consensus.leader ],
+    aec_events:publish(stop_mining, []),
     State1 = kill_all_workers(State),
     State2 = State1#state{block_producing_state = 'stopped',
                           consensus = Cons#consensus{leader = false},

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -242,7 +242,12 @@ init(Options) ->
     lager:debug("Options = ~p", [Options]),
     process_flag(trap_exit, true),
     ok     = init_chain_state(),
-    State1 = acquire_top_and_consensus(),
+    IsProducingBlocks =
+        case get_option(autostart, Options) of
+            undefined   -> false;
+            {ok, R}  -> R
+        end,
+    State1 = acquire_top_and_consensus(IsProducingBlocks),
     State2 = set_option(autostart, Options, State1),
     State3 = set_option(strictly_follow_top, Options, State2),
     State4 = set_mode(State3),
@@ -256,14 +261,14 @@ init(Options) ->
     self() ! init_continue,
     {ok, State5}.
 
-acquire_top_and_consensus() ->
+acquire_top_and_consensus(BlockProducing) ->
     TopBlockHash0 = aec_chain:top_block_hash(),
     {ok, TopHeader0} = aec_chain:get_header(TopBlockHash0),
     ConsensusModule = aec_headers:consensus_module(TopHeader0),
     ConsensusConfig = aec_consensus:get_consensus_config_at_height(aec_headers:height(TopHeader0)),
 
     %% Might mutate the DB in some cases
-    ConsensusModule:start(ConsensusConfig), %% Might do nothing or it might spawn a genserver :P
+    ConsensusModule:start(ConsensusConfig, #{block_production => BlockProducing}), %% Might do nothing or it might spawn a genserver :P
 
     Consensus = #consensus{ micro_block_cycle = aec_governance:micro_block_cycle()
                           , leader = false
@@ -333,7 +338,8 @@ reinit_chain_impl(State1 = #state{ consensus = #consensus{consensus_module = Act
     TopHeight = aec_headers:height(TopHeader),
     ConsensusModule = aec_headers:consensus_module(TopHeader),
     ConsensusConfig = aec_consensus:get_consensus_config_at_height(aec_headers:height(TopHeader)),
-    ConsensusModule:start(ConsensusConfig), %% Might do nothing or it might spawn a genserver :P
+    BlockProducing = is_mining(State1),
+    ConsensusModule:start(ConsensusConfig, #{block_production => BlockProducing}), %% Might do nothing or it might spawn a genserver :P
     State2 = State1#state{top_block_hash = TopBlockHash,
                           top_key_block_hash = TopKeyBlockHash,
                           top_height = TopHeight},
@@ -419,7 +425,7 @@ handle_call({note_rollback, Info}, _From, State) ->
     #state{ top_block_hash = TBHash
 	  , top_key_block_hash = TopKeyBlockHash
 	  , top_height = TopHeight
-	  , consensus = Consensus } = acquire_top_and_consensus(),
+	  , consensus = Consensus } = acquire_top_and_consensus(is_mining(State)),
     State1 = State#state{ top_block_hash = TBHash
 			, top_key_block_hash = TopKeyBlockHash
 			, top_height = TopHeight
@@ -1423,7 +1429,8 @@ maybe_consensus_change(State, Block) ->
             true = ActiveConsensusModule:can_be_turned_off(),
             ActiveConsensusModule:stop(),
             NewConfig = aec_consensus:get_consensus_config_at_height(H+1),
-            NewConsensus:start(NewConfig),
+            Mining = is_mining(State),
+            NewConsensus:start(NewConfig, #{block_production => Mining}),
             #state{consensus = Consensus} = State,
             State#state{ consensus = Consensus#consensus{ consensus_module = NewConsensus } }
     end.
@@ -1511,3 +1518,6 @@ maybe_garbage_collect_accounts() ->
 consensus_module(#state{ consensus = #consensus{consensus_module =
                                                 ConsensusModule}}) ->
     ConsensusModule.
+
+is_mining(#state{block_producing_state = running}) -> true;
+is_mining(#state{block_producing_state = stopped}) -> false.

--- a/apps/aecore/src/aec_consensus.erl
+++ b/apps/aecore/src/aec_consensus.erl
@@ -102,7 +102,7 @@
 %% Some consensus implementations should ensure that it can be enabled at the given point in time
 %% for instance by killing the peer pool, bypassing the mining conductor etc...
 %% gets the configuration previously validated by assert_config/1
--callback start(consensus_config()) -> ok.
+-callback start(consensus_config(), map()) -> ok.
 %% Stops the given consensus
 %% Only required for consensuses for which can_be_turned_off() =:= true
 -callback stop() -> ok.

--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -10,7 +10,7 @@
 %% API
 -export([ can_be_turned_off/0
         , assert_config/1
-        , start/1
+        , start/2
         , stop/0
         , is_providing_extra_http_endpoints/0
         , client_request/1
@@ -81,7 +81,7 @@
 %% Configuration and extra features/http endpoints
 can_be_turned_off() -> true.
 assert_config(_Config) -> ok.
-start(_Config) ->
+start(_Config, _) ->
     load_whitelist(),
     case aec_governance:get_network_id() of
         <<"ae_mainnet">> -> force_community_fork();

--- a/apps/aecore/src/aec_consensus_common_tests.erl
+++ b/apps/aecore/src/aec_consensus_common_tests.erl
@@ -16,7 +16,7 @@
 %% API
 -export([ can_be_turned_off/0
         , assert_config/1
-        , start/1
+        , start/2
         , stop/0
         , is_providing_extra_http_endpoints/0
         , client_request/1
@@ -73,7 +73,7 @@
 
 can_be_turned_off() -> false.
 assert_config(_Config) -> ok.
-start(_Config) -> ok.
+start(_Config, _) -> ok.
 stop() -> ok.
 
 is_providing_extra_http_endpoints() -> false.

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -21,7 +21,7 @@
 %% API
 -export([ can_be_turned_off/0
         , assert_config/1
-        , start/1
+        , start/2
         , stop/0
         , is_providing_extra_http_endpoints/0
         , client_request/1
@@ -84,7 +84,7 @@
 can_be_turned_off() -> false.
 assert_config(_Config) -> ok.
 
-start(Config) ->
+start(Config, #{block_production := BlockProduction}) ->
     #{<<"stakers">> := StakersEncoded,
       <<"parent_chain">> :=
         #{  <<"start_height">> := StartHeight,
@@ -144,7 +144,8 @@ start(Config) ->
     start_dependency(aec_parent_connector, [ParentConnMod, FetchInterval,
                                             ParentHosts, NetworkId,
                                             SignModule, PCSpendPubkey]),
-    start_dependency(aec_parent_chain_cache, [StartHeight, CacheSize, Confirmations]),
+    start_dependency(aec_parent_chain_cache, [StartHeight, CacheSize,
+                                              Confirmations, BlockProduction]),
     ok.
 
 start_dependency(Mod, Args) ->

--- a/apps/aecore/src/aec_consensus_on_demand.erl
+++ b/apps/aecore/src/aec_consensus_on_demand.erl
@@ -15,7 +15,7 @@
 %% API
 -export([ can_be_turned_off/0
         , assert_config/1
-        , start/1
+        , start/2
         , stop/0
         , is_providing_extra_http_endpoints/0
         , client_request/1
@@ -72,7 +72,7 @@
 
 can_be_turned_off() -> false.
 assert_config(_Config) -> ok.
-start(_Config) -> ok.
+start(_Config, _) -> ok.
 stop() -> ok.
 
 is_providing_extra_http_endpoints() -> false.

--- a/apps/aecore/src/aec_consensus_smart_contract.erl
+++ b/apps/aecore/src/aec_consensus_smart_contract.erl
@@ -20,7 +20,7 @@
 %% API
 -export([ can_be_turned_off/0
         , assert_config/1
-        , start/1
+        , start/2
         , stop/0
         , is_providing_extra_http_endpoints/0
         , client_request/1
@@ -79,7 +79,7 @@
 can_be_turned_off() -> false.
 assert_config(_Config) -> ok.
 
-start(Config) ->
+start(Config, _) ->
     #{<<"stakers">> := StakersEncoded} = Config,
     Stakers =
         lists:map(

--- a/apps/aecore/src/aec_events.erl
+++ b/apps/aecore/src/aec_events.erl
@@ -19,6 +19,7 @@
 -include("blocks.hrl").
 
 -type event() :: start_mining
+               | stop_mining
                | block_created
                | micro_block_created
                | start_micro_mining

--- a/apps/aecore/test/aec_block_whitelist_tests.erl
+++ b/apps/aecore/test/aec_block_whitelist_tests.erl
@@ -99,7 +99,7 @@ test_start_mining_add_block() ->
     [_GB, B1, B2] = aec_test_utils:gen_blocks_only_chain(3, preset_accounts(Keys)),
     BH2 = aec_blocks:to_header(B2),
     meck:expect(aec_fork_block_settings, block_whitelist, 0, #{2 => <<"AAA">>}),
-    aec_consensus_bitcoin_ng:start(#{}),
+    aec_consensus_bitcoin_ng:start(#{}, #{}),
     ?assertEqual(ok, aec_conductor:post_block(B1)),
     %% Does not go pass conductor checks
     ?assertEqual({error,blocked_by_whitelist}, aec_conductor:post_block(B2)),
@@ -108,7 +108,7 @@ test_start_mining_add_block() ->
 
     %% Whitelisted blocks make it to the DB
     meck:expect(aec_fork_block_settings, block_whitelist, 0, #{2 => header_hash(BH2)}),
-    aec_consensus_bitcoin_ng:start(#{}),
+    aec_consensus_bitcoin_ng:start(#{}, #{}),
     ?assertEqual(ok, aec_conductor:post_block(B2)),
 
     aec_test_utils:wait_for_it(

--- a/apps/aecore/test/aec_parent_chain_cache_tests.erl
+++ b/apps/aecore/test/aec_parent_chain_cache_tests.erl
@@ -455,7 +455,10 @@ unmock_parent_connector() ->
 mock_events() ->
     meck:new(aec_events, []),
     meck:expect(aec_events, subscribe,
-                fun(top_changed) -> ok end),
+                fun(top_changed) -> ok;
+                   (start_mining) -> ok;
+                   (stop_mining) -> ok
+                end),
     ok.
 
 unmock_events() ->

--- a/docs/release-notes/next-hc/fix_commitments.md
+++ b/docs/release-notes/next-hc/fix_commitments.md
@@ -1,0 +1,2 @@
+* Fixes a bug in commitments production - there was a race condition that
+  could lead to deadlocks


### PR DESCRIPTION
Fixes a special race condition in which a starting node could end up in a
deadlock between the cache (waiting for the mining state) and the conductor
(waiting for the cache). This PR revises the flow of messages so the cache
keeps locally the block producing state of the conductor.
