### PR TITLE
Extend get_generation timeout to handle larger generations

### DIFF
--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -61,6 +61,7 @@
 -define(DEFAULT_FIRST_PING_TIMEOUT, 30000).
 -define(DEFAULT_NOISE_HS_TIMEOUT, 5000).
 -define(DEFAULT_CLOSE_TIMEOUT, 3000).
+-define(GET_GENERATION_TIMEOUT, 60000).
 %% The number of peers sent in ping message.
 -define(DEFAULT_GOSSIPED_PEERS_COUNT, 32).
 
@@ -107,7 +108,7 @@ get_generation(PeerId, Hash) ->
     get_generation(PeerId, Hash, backward).
 
 get_generation(PeerId, Hash, Dir) ->
-    call(PeerId, {get_generation, [Hash, Dir]}).
+    call(PeerId, {get_generation, [Hash, Dir]}, ?GET_GENERATION_TIMEOUT).
 
 tx_pool_sync_init(PeerId) ->
     call(PeerId, {tx_pool, [sync_init]}).


### PR DESCRIPTION
Thinking that increasing this single timeout ought to allow clean sync against the largest generations in UAT. Let's see.

This PR was sponsored by the ACF