### PR TITLE
Improve docs with regards of backwards incompatible config changes

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1552,10 +1552,10 @@
                         "^[1-9][0-9]*$" : {
                             "description" : "Minimum height at which the given consensus algorithm gets activated. By default from genesis Cuckoo cycle based BitcoinNG is used.",
                             "type" : "object",
-                            "required": ["name"],
+                            "required": ["type"],
                             "properties": {
-                                "name": {
-                                    "description": "The name of the consensus algorithm used at the given height",
+                                "type": {
+                                    "description": "The type of the consensus algorithm used at the given height (ex. pow_cuckoo, smart_contract or hyper_chain)",
                                     "type": "string"
                                 },
                                 "config": {

--- a/docs/release-notes/next-hc/GH-4081_network_id.md
+++ b/docs/release-notes/next-hc/GH-4081_network_id.md
@@ -1,4 +1,2 @@
 * Removes the default consensus for networks with `network_id` starting with a
   `hc_` prefix
-* Changes the key that defines the consensus in the config: it used to be
-  called `name` and now it is renamed to `type`

--- a/docs/release-notes/next/GH-4081_network_id.md
+++ b/docs/release-notes/next/GH-4081_network_id.md
@@ -1,0 +1,3 @@
+* Changes the key that defines the consensus in the config: it used to be
+  called `name` and now it is renamed to `type`. *:warning: *This is backwards
+  incompatible change** :warning:


### PR DESCRIPTION
This PR makes the release note more explicit: the change `/s/name/type` in consensus config is not backwards compatible.