### PR TITLE
Skip fetching rewards for HC

### DIFF
--- a/apps/aeapi/src/aeapi.erl
+++ b/apps/aeapi/src/aeapi.erl
@@ -499,7 +499,7 @@ format_txs(Txs, MBHash) ->
     end.
 
 format_block_txs(KeyBlock) ->
-    RewardTxs = reward_txs(KeyBlock),
+    RewardTxs = reward_txs(KeyBlock, aec_consensus:get_genesis_consensus_module()),
     PreTxs = expiry_txs(KeyBlock),
     ForkTxs = hardfork_txs(aec_blocks:height(KeyBlock)),
     case RewardTxs ++ PreTxs ++ ForkTxs of
@@ -533,8 +533,9 @@ expiry_txs(KeyBlock0) ->
             aetx_env:events(TxEnv2)
     end.
 
-
-reward_txs(Block) ->
+reward_txs(_Block, aec_consensus_hc) -> 
+    [];
+reward_txs(Block, _Consensus) ->
     %% Block rewards.
     %% In this block the reward for the beneficiary 180 blocks earlier will be paid
     %% We don't store the amount on chain, so need to re-calculate


### PR DESCRIPTION
When getting reward txs for `aehttp_dispatch_rosetta` and `aeapi:balance_change_events_in_block`, the `aec_chain_state:grant_fees` is called a new empty tree so the rewards contract cannot be found.

Stacktrace:
```
hc_mdw_1           | ** (stop) {:not_present, <<44, 26, 213, 116, 116, 32, 96, 143, 44, 180, 164, 123, 151, 222, 122, 136, 178, 142, 105, 53, 169, 46, 236, 24, 207, 214, 30, 225, 76, 206, 177, 104>>}
hc_mdw_1           |     (aecontract 6.7.0+28.a3b800516) /home/builder/aeternity/apps/aecontract/src/aect_state_tree.erl:187: :aect_state_tree.get_contract/3
hc_mdw_1           |     (aecore 6.7.0+28.a3b800516) /home/builder/aeternity/apps/aecore/src/aec_consensus_hc.erl:492: :aec_consensus_hc.call_consensus_contract_/6
hc_mdw_1           |     (aecore 6.7.0+28.a3b800516) /home/builder/aeternity/apps/aecore/src/aec_consensus_hc.erl:225: :aec_consensus_hc.state_grant_reward/4
hc_mdw_1           |     (stdlib 3.14.2.2) lists.erl:1267: :lists.foldl/3
hc_mdw_1           |     (aecore 6.7.0+28.a3b800516) /home/builder/aeternity/apps/aecore/src/aec_chain_state.erl:943: :aec_chain_state.grant_fees/5
```

This unblocks @dincho 's works on HC localnet. Other lighter approaches might be:
a) `:aec_consensus_hc.state_grant_reward/4` puts the HC reward contract into the tree before calling `call_consensus_contract_` with `REWARDS_CONTRACT` (but still sounds like forcing the state)
b) or what seems to be a more elegant way, `:aec_consensus_hc.call_consensus_contract_` would not receive the tree, only the height, gets the tree from the keyblock with `:aec_db.get_block_state()` which would have the contract.
c) other idea?