### PR TITLE
Optimize block candidate production

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -320,10 +320,15 @@ get_candidate(MaxGas, BlockHash) ->
     get_candidate(MaxGas, [], BlockHash).
 
 -spec get_candidate(pos_integer(), [binary()], binary()) -> {ok, [aetx_sign:signed_tx()]}.
-get_candidate(MaxGas, IgnoreTxHashes, BlockHash) when is_integer(MaxGas), MaxGas > 0,
+get_candidate(MaxGas, IgnoreTxHashes, BlockHash) when is_integer(MaxGas),
                                                       is_binary(BlockHash) ->
-    ?TC(int_get_candidate(MaxGas, IgnoreTxHashes, BlockHash, dbs()),
-        {get_candidate, MaxGas, IgnoreTxHashes, BlockHash}).
+    case MaxGas >= aec_governance:min_tx_gas() of
+        true ->
+            ?TC(int_get_candidate(MaxGas, IgnoreTxHashes, BlockHash, dbs()),
+                {get_candidate, MaxGas, IgnoreTxHashes, BlockHash});
+        false ->
+            {ok, []}
+    end.
 
 %% It assumes that the persisted mempool has been updated.
 -spec top_change(top_change_info()) -> ok.

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -220,6 +220,7 @@ tx_pool_test_() ->
                GenesisProtocol = aec_block_genesis:version(),
                {ok, Hash} = aec_headers:hash_header(aec_block_genesis:genesis_header()),
                MaxGas = aec_governance:block_gas_limit(),
+               {ok, []} = aec_tx_pool:get_candidate(0, Hash),         % regression bug check
                {ok, STxs2} = aec_tx_pool:get_candidate(MaxGas, Hash),
                TotalGas = lists:sum([aetx:gas_limit(aetx_sign:tx(T), GenesisHeight, GenesisProtocol) || T <- STxs2 ]),
                MinGas = aetx:gas_limit(aetx_sign:tx(hd(STxs)), GenesisHeight, GenesisProtocol),


### PR DESCRIPTION
The `get_candidate()` function can return immediately if the remaining gas is less than the minimum tx gas.