### PR TITLE
Generalized GC (corrected base)

### DIFF
--- a/apps/aechannel/src/aesc_state_tree.erl
+++ b/apps/aechannel/src/aesc_state_tree.erl
@@ -17,7 +17,8 @@
          mtree_iterator/1,
          new_with_backend/1,
          new_with_dirty_backend/1,
-         root_hash/1]).
+         root_hash/1,
+         db/1]).
 
 -export([ from_binary_without_backend/1
         , to_binary_without_backend/1
@@ -90,6 +91,10 @@ lookup(PubKey, Tree) ->
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 root_hash(Tree) ->
     aeu_mtrees:root_hash(Tree).
+
+-spec db(tree()) -> {'ok', aeu_mp_trees:db()}.
+db(Tree) ->
+    aeu_mtrees:db(Tree).
 
 -spec to_binary_without_backend(tree()) -> binary().
 to_binary_without_backend(Tree) ->

--- a/apps/aecontract/src/aect_call_state_tree.erl
+++ b/apps/aecontract/src/aect_call_state_tree.erl
@@ -20,7 +20,8 @@
         , iterator/1
         , prune/2
         , prune_without_backend/1
-        , root_hash/1]).
+        , root_hash/1
+        , db/1 ]).
 
 -export([ from_binary_without_backend/1
         , to_binary_without_backend/1
@@ -88,11 +89,19 @@ new_with_dirty_backend(Hash) ->
 %% Calls and return values are only kept for one block.
 -spec prune(aec_blocks:height(), aec_trees:trees()) -> aec_trees:trees().
 prune(_,Trees) ->
-    aec_trees:set_calls(Trees, empty_with_backend()).
+    CTree = aec_trees:calls(Trees),
+    Empty = case has_backend(CTree) of
+                true  -> empty_with_backend();
+                false -> empty()
+            end,
+    aec_trees:set_calls(Trees, Empty).
 
 -spec prune_without_backend(aec_trees:trees()) -> aec_trees:trees().
 prune_without_backend(Trees) ->
     aec_trees:set_calls(Trees, empty()).
+
+has_backend(#call_tree{calls = CtTree}) ->
+    aeu_mtrees:has_backend(CtTree).
 
 -spec insert_call(aect_call:call(), tree()) -> tree().
 insert_call(Call, Tree) ->
@@ -137,6 +146,10 @@ call_id(<<_:?PUB_SIZE/unit:8, CallId/binary>> = _CallTreeId) ->
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 root_hash(#call_tree{calls = CtTree}) ->
     aeu_mtrees:root_hash(CtTree).
+
+-spec db(tree()) -> {ok, aeu_mp_trees:db()}.
+db(#call_tree{calls = CtTree}) ->
+    aeu_mtrees:db(CtTree).
 
 %% -- Commit to db --
 

--- a/apps/aecontract/src/aect_state_tree.erl
+++ b/apps/aecontract/src/aect_state_tree.erl
@@ -28,7 +28,8 @@
         , new_with_backend/1
         , new_with_dirty_backend/1
         , gc_cache/1
-        , root_hash/1]).
+        , root_hash/1
+        , db/1 ]).
 
 %% API - Proof of inclusion
 -export([ add_poi/3
@@ -264,6 +265,10 @@ lookup_contract_with_code(Pubkey, Tree, Options) ->
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 root_hash(#contract_tree{contracts = CtTree}) ->
     aeu_mtrees:root_hash(CtTree).
+
+-spec db(tree()) -> {ok, aeu_mp_trees:db()}.
+db(#contract_tree{contracts = CtTree}) ->
+    aeu_mtrees:db(CtTree).
 
 -spec add_poi(aect_contracts:pubkey(), aect_state_tree:tree(), aec_poi:poi()) ->
                      {'ok', aec_poi:poi()}

--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -77,7 +77,7 @@ new_state() ->
     #{}.
 
 trees(#{} = S) ->
-    maps:get(trees, S, aec_trees:new()).
+    maps:get(trees, S, aec_trees:new_without_backend()).
 
 set_trees(Trees, S) ->
     S#{trees => Trees}.

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1483,7 +1483,5 @@ key_headers_height_store_migration_step(Time, N, {TimeRead, {Headers, Cont}}) ->
     ).
 
 is_gc_disabled() ->
-    case aec_db_gc:config() of
-        #{enabled := Bool} when is_boolean(Bool) ->
-            Bool
-    end.
+    [Bool] = aec_db_gc:info([enabled]),
+    Bool.

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -77,36 +77,20 @@
 -export([ fold_mempool/2
         ]).
 
--export([ state_tab/1
+%% GC-related
+-export([ gced_tables/0
+        , primary_state_tab/1
         , make_primary_state_tab/2
-        , secondary_state_tab/1 ]).
+        , secondary_state_tab/1
+        , write_last_gc_switch/1
+        , read_last_gc_switch/0 ]).
 
 %% MP trees backend
--export([ find_accounts_node/1
-        , find_calls_node/1
-        , find_channels_node/1
-        , find_contracts_node/1
-        , find_ns_node/1
-        , find_ns_cache_node/1
-        , find_oracles_node/1
-        , find_oracles_cache_node/1
-        , dirty_find_accounts_node/1
-        , dirty_find_calls_node/1
-        , dirty_find_channels_node/1
-        , dirty_find_contracts_node/1
-        , dirty_find_ns_node/1
-        , dirty_find_ns_cache_node/1
-        , dirty_find_oracles_node/1
-        , dirty_find_oracles_cache_node/1
-        , write_accounts_node/2
-        , write_accounts_node/3
-        , write_calls_node/2
-        , write_channels_node/2
-        , write_contracts_node/2
-        , write_ns_node/2
-        , write_ns_cache_node/2
-        , write_oracles_node/2
-        , write_oracles_cache_node/2
+-export([ tree_table_name/1
+        , new_tree_context/2
+        , lookup_tree_node/2
+        , enter_tree_node/3
+        , node_is_in_primary/2
         ]).
 
 -export([ find_block_state/1
@@ -156,6 +140,8 @@
         , dirty_first/1
         , clear_table/1 ]).
 
+-export([cleanup/0]).
+
 -export([backend_mode/0]).
 
 -export([ install_test_env/0
@@ -183,8 +169,16 @@
 %% - one per state tree
 %% - untrusted peers
 
--define(BYPASS, {?MODULE, mnesia_bypass}).
--define(DIRECT_API, {?MODULE, direct_api}).
+%% Persistent-term keys.
+%% For cleanup purposes, we ensure that element(1,Key) == ?MODULE
+-define(PT_BYPASS,                  {?MODULE, mnesia_bypass}).
+-define(PT_DIRECT_API,              {?MODULE, direct_api}).
+-define(PT_ADDED_PTS,               {?MODULE, added_pts}).
+-define(PT_BACKEND_MODULE,          {?MODULE, backend_module}).
+-define(PT_CHAIN_MIGRATION(Key),    {?MODULE, chain_migration, Key}).
+-define(PT_MIGRATION_KEY_HEADERS,   {?MODULE, chain_migration, key_headers}).
+-define(PT_PRIMARY_STATE_TAB(Tree), {?MODULE, primary_state_tab, Tree}).
+
 
 -define(TAB(Record),
         {Record, tab(Mode, Record, record_info(fields, Record), [])}).
@@ -196,6 +190,38 @@
 
 -define(TX_IN_MEMPOOL, []).
 -define(PERSIST, true).
+
+%% As table names are to some extent dynamic, it's cumbersome to
+%% define a very specific type.
+-type table_name() :: atom().
+
+%% With tree names, we do have a specific type.
+%% This should be enough for Dialyzer to determine if we're mixing
+%% tree names and table names.
+-type tree_name() :: aec_trees:tree_name().
+
+-record(tree, { table              :: atom()
+              , mode = transaction :: dirty | transaction
+            }).
+
+-record(tree_gc, { primary            :: atom()
+                 , secondary          :: atom()
+                 , record             :: atom()
+                 , mode = transaction :: atom()
+                }).
+-type tree_context() :: #tree{} | #tree_gc{}.
+-type value() :: aeu_mp_trees:value().
+-type hash() :: aeu_mp_trees:key().
+
+-type gc_table_spec() :: #{ tree := tree_name()
+                          , copies := [table_name()] }.
+-type map_of_gced_tables() :: #{ table_name() := gc_table_spec() }.
+
+cleanup() ->
+    PTs = persistent_term:get(),
+    [persistent_term:erase(K) || {K,_} <- PTs,
+                                 element(1, K) == ?MODULE],
+    ok.
 
 tables(Mode0) ->
     Mode = expand_mode(Mode0),
@@ -230,7 +256,8 @@ add_gc_extra_tabs(Tabs) ->
 
 maybe_add_gc_tab({Tab, Spec0} = Entry, Acc) ->
     case maps:get(Tab, gced_tables(), undefined) of
-        #{copies := Tabs} when is_list(Tabs) ->
+        #{copies := Cs} when is_list(Cs) ->
+            Tabs = [Tab|Cs],
             Spec = ensure_record_name(Tab, Spec0),
             [{T, note_other_tabs(Tabs -- [T], Spec)} || T <- Tabs] ++ Acc;
         undefined -> [Entry | Acc]
@@ -244,8 +271,66 @@ ensure_record_name(T, Spec) ->
             [{record_name, T}|Spec]
     end.
 
+%% Some mapping code for TreeName -> TableName.
+%% For users of state trees, we want the API functions (with a few exceptions)
+%% to take the tree name (as in aec_trees:tree_name()). This module then needs to
+%% keep track of whether GC is enabled, and if so, which physical table is the
+%% current primary.
+%% The main exception is the make_primary_state_tab/2 function, called by
+%% the aec_db_gc module.
+%%
+%% An unfortunate legacy artifact is that the tree name oracles_cache is fixed
+%% in the serialization API, whereas the DB tables name is aec_oracle_cache.
+%% outside the aec_db module, it's always oracles_cache.
+%%
+-spec tree_table_name(binary() | table_name()) -> table_name().
+tree_table_name(T) when is_atom(T) ->
+    tree_table_name_a(T);
+tree_table_name(T) when is_list(T); is_binary(T) ->
+    tree_table_name_s(T).
+
+tree_table_name_s(Tree) ->
+    S = to_binary(Tree),
+    case S of
+        <<"accounts">>      -> aec_account_state;
+        <<"calls">>         -> aec_call_state;
+        <<"channels">>      -> aec_channel_state;
+        <<"contracts">>     -> aec_contract_state;
+        <<"ns">>            -> aec_name_service_state;
+        <<"ns_cache">>      -> aec_name_service_cache;
+        <<"oracles">>       -> aec_oracle_state;
+        <<"oracles_cache">> -> aec_oracle_cache
+    end.
+
+-spec tree_table_name_a(tree_name()) -> table_name().
+tree_table_name_a(A) ->
+    case A of
+        accounts      -> aec_account_state;
+        calls         -> aec_call_state;
+        channels      -> aec_channel_state;
+        contracts     -> aec_contract_state;
+        ns            -> aec_name_service_state;
+        ns_cache      -> aec_name_service_cache;
+        oracles       -> aec_oracle_state;
+        oracles_cache -> aec_oracle_cache
+    end.
+
+to_binary(B) when is_binary(B) -> B;
+to_binary(L) when is_list(L)   -> iolist_to_binary(L).
+
+%% We do not duplicate the canonical table name in the 'copies'
+-spec gced_tables() -> map_of_gced_tables().
 gced_tables() ->
-    #{aec_account_state => #{copies => [aec_account_state, aec_account_state_1]}}.
+    #{
+       aec_account_state      => #{tree => accounts , copies => [aec_account_state_1]}
+     , aec_call_state         => #{tree => calls    , copies => [aec_call_state_1]}
+     , aec_channel_state      => #{tree => channels , copies => [aec_channel_state_1]}
+     , aec_contract_state     => #{tree => contracts, copies => [aec_contract_state_1]}
+     , aec_name_service_state => #{tree => ns       , copies => [aec_name_service_state_1]}
+     , aec_name_service_cache => #{tree => ns_cache , copies => [aec_name_service_cache_1]}
+     , aec_oracle_state       => #{tree => oracles  , copies => [aec_oracle_state_1]}
+     , aec_oracle_cache       => #{tree => oracles_cache, copies => [aec_oracle_cache_1]}
+     }.
 
 note_other_tabs(Ts, Props) ->
     UPs = proplists:get_value(user_properties, Props, []),
@@ -427,7 +512,7 @@ activity(Type, Fun) when Type == async_dirty;
     end.
 
 use_mrdb_api() ->
-    persistent_term:get(?DIRECT_API, false).
+    persistent_term:get(?PT_DIRECT_API, false).
 
 ensure_activity(mnesia_rocksdb, Type, Fun) ->
     %% lager:debug("Backend = mnesia_rocksdb, Type = ~p, F = ~p:~p/0",
@@ -491,7 +576,7 @@ do_transaction(_BackendMod, Type, Fun) ->
     mnesia:activity(Type, Fun).
 
 bypass_on_commit(R) ->
-    case persistent_term:get(?BYPASS, no_bypass) of
+    case persistent_term:get(?PT_BYPASS, no_bypass) of
         rocksdb ->
             {mnesia, _, {tidstore, TStore, _, _}} = get(mnesia_activity_state),
             try mrdb:activity(
@@ -521,7 +606,7 @@ bypass_on_commit(R) ->
                     exit(Reason)
             end;
         Other ->
-            lager:debug("?BYPASS -> ~p", [Other]),
+            lager:debug("?PT_BYPASS -> ~p", [Other]),
             R
     end.
 
@@ -767,7 +852,7 @@ find_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
 %% When benchmarked on an cloud SSD it is faster then mnesia:index_read followed by filter
 -spec find_key_headers_and_hash_at_height(pos_integer()) -> [{binary(), aec_headers:key_header()}].
 find_key_headers_and_hash_at_height(Height) when is_integer(Height), Height >= 0 ->
-    case persistent_term:get({?MODULE, chain_migration, key_headers}, done) of
+    case persistent_term:get(?PT_MIGRATION_KEY_HEADERS, done) of
         in_progress ->
             R = dirty_select(aec_headers, [{ #aec_headers{key = '_',
                                                           value = '$1',
@@ -832,76 +917,87 @@ write_block_state(Hash, Trees, AccDifficulty, ForkId, Fees, Fraud) ->
            write(BlockState)
        end).
 
-state_tab(T) ->
-    persistent_term:get({primary_state_tab, T}, T).
+-spec secondary_state_tab(tree_name()) -> table_name().
+secondary_state_tab(Tree) ->
+    Tab = tree_table_name(Tree),
+    Prim = primary_state_tab(Tree),
+    secondary_state_tab_(Tab, Prim).
 
-secondary_state_tab(T) ->
-    Prim = persistent_term:get({primary_state_tab, T}),
-    #{copies := Tabs} = maps:get(T, gced_tables()),
-    [Secondary] = Tabs -- [Prim],
+secondary_state_tab_(Tab, Prim) ->
+    #{copies := Cs} = maps:get(Tab, gced_tables()),
+    [Secondary] = [Tab|Cs] -- [Prim],
     Secondary.
 
-make_primary_state_tab(T, P) ->
-    lager:debug("New primary for ~p: ~p", [T, P]),
-    case maps:find(T, gced_tables()) of
+-spec primary_state_tab(tree_name()) -> table_name().
+primary_state_tab(Tree) ->
+    persistent_term:get(?PT_PRIMARY_STATE_TAB(Tree)).
+
+set_primary_state_tab(Tree, Tab) ->
+    lager:debug("Set Primary (~p) -> ~p", [Tree, Tab]),
+    persistent_term:put(?PT_PRIMARY_STATE_TAB(Tree), Tab).
+
+-spec gc_enabled(tree_name()) -> false | {true, {table_name(), table_name()}}.
+gc_enabled(Tree) ->
+    try primary_state_tab(Tree) of
+        Prim ->
+            Tab = tree_table_name(Tree),
+            {true, {Prim, secondary_state_tab_(Tab, Prim)}}
+    catch
+        error:_ ->
+            false
+    end.
+
+write_last_gc_switch(Height) ->
+    lager:debug("Last GC height: ~p", [Height]),
+    ?t(write(#aec_chain_state{key = last_gc_switch, value = Height})).
+
+read_last_gc_switch() ->
+    R = ?t(case read(aec_chain_state, last_gc_switch) of
+               [] ->
+                   0;
+               [#aec_chain_state{value = Height}] ->
+                   Height
+           end),
+    lager:debug("<-- last GC Height: ~p", [R]),
+    R.
+
+-spec make_primary_state_tab(tree_name(), table_name()) -> ok.
+make_primary_state_tab(Tree, P) ->
+    lager:debug("New primary for ~p: ~p", [Tree, P]),
+    Tab = tree_table_name(Tree),
+    case maps:find(Tab, gced_tables()) of
         {ok, #{copies := Tabs}} ->
-            case lists:member(P, Tabs) of
+            case P =:= Tab orelse lists:member(P, Tabs) of
                 true ->
-                    ?t(write(#aec_chain_state{key = {primary_state_tab, T}, value = P}));
+                    ?t(write(#aec_chain_state{key = {primary_state_tab, Tree}, value = P}));
                 false ->
-                    error({not_a_state_tab_candidate, {T, P}})
+                    error({not_a_state_tab_candidate, {Tree, P}})
             end,
-            cache_primary_state_tab(T, P);
+            cache_primary_state_tab(Tree, P),
+            lager:debug("cached primary (~p): ~p", [Tree, primary_state_tab(Tree)]);
         error ->
-            error({not_a_gced_state_tab, T})
+            error({not_a_gced_state_tab, Tree})
     end.
 
 cache_primary_state_tabs() ->
     lager:debug("Caching primary for gced tabs", []),
     maps:fold(
-      fun(T, #{copies := Ts}, _) ->
-              Key = {primary_state_tab, T},
+      fun(T, #{tree := Tree, copies := _}, _) ->
+              Key = {primary_state_tab, Tree},
               case dirty_get_chain_state_value(Key) of
                   undefined ->
-                      P = hd(Ts),
-                      ?t(write(#aec_chain_state{key = Key, value = P})),
-                      cache_primary_state_tab(T, P);
+                      ?t(write(#aec_chain_state{key = Key, value = T})),
+                      cache_primary_state_tab(Tree, T);
                   P ->
                       cache_primary_state_tab(T, P)
               end,
               ok
       end, ok, gced_tables()).
 
+-spec cache_primary_state_tab(tree_name(), table_name()) -> ok.
 cache_primary_state_tab(T, P) ->
     lager:debug("Caching primary for ~p: ~p", [T, P]),
-    persistent_term:put({primary_state_tab, T}, P).
-
-write_accounts_node(Hash, Node) ->
-    ?t(write(state_tab(aec_account_state), #aec_account_state{key = Hash, value = Node}, write)).
-
-write_accounts_node(Table, Hash, Node) ->
-    ?t(write(Table, #aec_account_state{key = Hash, value = Node}, write)).
-
-write_calls_node(Hash, Node) ->
-    ?t(write(#aec_call_state{key = Hash, value = Node})).
-
-write_channels_node(Hash, Node) ->
-    ?t(write(#aec_channel_state{key = Hash, value = Node})).
-
-write_contracts_node(Hash, Node) ->
-    ?t(write(#aec_contract_state{key = Hash, value = Node})).
-
-write_ns_node(Hash, Node) ->
-    ?t(write(#aec_name_service_state{key = Hash, value = Node})).
-
-write_ns_cache_node(Hash, Node) ->
-    ?t(write(#aec_name_service_cache{key = Hash, value = Node})).
-
-write_oracles_node(Hash, Node) ->
-    ?t(write(#aec_oracle_state{key = Hash, value = Node})).
-
-write_oracles_cache_node(Hash, Node) ->
-    ?t(write(#aec_oracle_cache{key = Hash, value = Node})).
+    set_primary_state_tab(T, P).
 
 write_genesis_hash(Hash) when is_binary(Hash) ->
     ?t(write(#aec_chain_state{key = genesis_hash, value = Hash})).
@@ -930,11 +1026,11 @@ start_chain_migration(Key) ->
     %% Writes occur before the error store is initialized - if error keys are present then this will crash
     %% Fortunately this write will be correctly handled by the rocksdb bypass logic
     ?t(write(#aec_chain_state{key = {chain_migration_lock, Key}, value = lock})),
-    persistent_term:put({?MODULE, chain_migration, Key}, in_progress).
+    persistent_term:put(?PT_CHAIN_MIGRATION(Key), in_progress).
 
 finish_chain_migration(Key) ->
     ?t(delete(aec_chain_state, {chain_migration_lock, Key}, write)),
-    persistent_term:erase({?MODULE, chain_migration, Key}).
+    persistent_term:erase(?PT_CHAIN_MIGRATION(Key)).
 
 -spec chain_migration_status(atom()) -> in_progress | done.
 chain_migration_status(Key) ->
@@ -1082,101 +1178,110 @@ find_block_state_and_data(Hash, DirtyBackend) ->
         [] -> none
     end.
 
-find_oracles_node(Hash) ->
-    case ?t(read(aec_oracle_state, Hash)) of
-        [#aec_oracle_state{value = Node}] -> {value, Node};
-        [] -> none
+new_tree_context(Mode, Tree) when Mode == dirty;
+                                  Mode == transaction ->
+    ActivityType = case Mode of
+                       dirty -> async_dirty;
+                       transaction -> transaction
+                   end,
+    Res = case gc_enabled(Tree) of
+              {true, {Primary, Secondary}} ->
+                  Record = mnesia:table_info(Primary, record_name),
+                  #tree_gc{ primary   = Primary
+                          , secondary = Secondary
+                          , record    = Record
+                          , mode      = ActivityType };
+              false ->
+                  Tab = tree_table_name(Tree),
+                  #tree{ table = Tab
+                       , mode  = ActivityType }
+          end,
+    Res.
+
+%% Behaves like gb_trees:lookup(Key, Tree).
+-spec lookup_tree_node(hash(), tree_context()) -> none | {value, value()}.
+lookup_tree_node(Hash, #tree{table = T, mode = ActivityType}) ->
+    ensure_activity(ActivityType,
+                    fun() ->
+                            lookup_tree_node_(Hash, T, T)
+                    end);
+lookup_tree_node(Hash, #tree_gc{ primary   = Prim
+                               , secondary = Sec
+                               , record    = Rec
+                               , mode      = ActivityType }) ->
+    ensure_activity(ActivityType,
+                    fun() ->
+                            case lookup_tree_node_(Hash, Prim, Rec) of
+                                {value, _} = Res ->
+                                    Res;
+                                none ->
+                                    case lookup_tree_node_(Hash, Sec, Rec) of
+                                        none ->
+                                            none;
+                                        {value, V} = Res ->
+                                            promote_tree_node(Hash, V, Prim, Rec),
+                                            Res
+                                    end
+                            end
+                    end).
+
+lookup_tree_node_(Hash, T, Rec) ->
+    case read(T, Hash) of
+        [Obj] -> {value, get_tree_value(Rec, Obj)};
+        []    -> none
     end.
 
-dirty_find_oracles_node(Hash) ->
-    case ?dirty_dirty_read(aec_oracle_state, Hash) of
-        [#aec_oracle_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
+get_tree_value(Rec, {Rec, _, Value}) ->
+    Value.
 
-find_oracles_cache_node(Hash) ->
-    case ?t(read(aec_oracle_cache, Hash)) of
-        [#aec_oracle_cache{value = Node}] -> {value, Node};
-        [] -> none
-    end.
+node_is_in_primary(Hash, #tree_gc{ primary = Prim
+                                 , mode = ActivityType }) ->
+    ensure_activity(ActivityType,
+                    fun() ->
+                            case read(Prim, Hash) of
+                                [_] ->
+                                    true;
+                                [] ->
+                                    false
+                            end
+                    end).
 
-dirty_find_oracles_cache_node(Hash) ->
-    case ?dirty_dirty_read(aec_oracle_cache, Hash) of
-        [#aec_oracle_cache{value = Node}] -> {value, Node};
-        [] -> none
-    end.
+%% Behaves similary to gb_trees:enter(Key, Value, Tree) (but different return value)
+-spec enter_tree_node(hash(), binary(), tree_context()) -> ok.
+enter_tree_node(Hash, Value, #tree{table = T, mode = ActivityType}) ->
+    ensure_activity(ActivityType,
+                    fun() ->
+                            enter_tree_node_(Hash, Value, T, T)
+                    end);
+enter_tree_node(Hash, Value, #tree_gc{ primary = Prim
+                                     , record  = Rec
+                                     , mode    = ActivityType }) ->
+    ensure_activity(ActivityType,
+                    fun() ->
+                            enter_tree_node_(Hash, Value, Prim, Rec)
+                    end).
 
-find_calls_node(Hash) ->
-    case ?t(read(aec_call_state, Hash)) of
-        [#aec_call_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
+enter_tree_node_(Hash, Value, Tab, Rec) ->
+    Obj = mk_record(Rec, Hash, Value),
+    ?t(write(Tab, Obj, write)).
 
-dirty_find_calls_node(Hash) ->
-    case ?dirty_dirty_read(aec_call_state, Hash) of
-        [#aec_call_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
+%% Promotion is always dirty. For one thing, we don't want to ever roll back,
+%% and the data is immutable anyway.
+promote_tree_node(Hash, Value, Tab, Rec) ->
+    Obj = mk_record(Rec, Hash, Value),
+    activity(async_dirty, fun() ->
+                                  write(Tab, Obj, write)
+                          end).
 
-find_channels_node(Hash) ->
-    case ?t(read(aec_channel_state, Hash)) of
-        [#aec_channel_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
+mk_record(aec_account_state     , K, V) -> #aec_account_state{key = K, value = V};
+mk_record(aec_call_state        , K, V) -> #aec_call_state{key = K, value = V};
+mk_record(aec_channel_state     , K, V) -> #aec_channel_state{key = K, value = V};
+mk_record(aec_contract_state    , K, V) -> #aec_contract_state{key = K, value = V};
+mk_record(aec_name_service_state, K, V) -> #aec_name_service_state{key = K, value = V};
+mk_record(aec_name_service_cache, K, V) -> #aec_name_service_cache{key = K, value = V};
+mk_record(aec_oracle_state      , K, V) -> #aec_oracle_state{key = K, value = V};
+mk_record(aec_oracle_cache      , K, V) -> #aec_oracle_cache{key = K, value = V}.
 
-dirty_find_channels_node(Hash) ->
-    case ?dirty_dirty_read(aec_channel_state, Hash) of
-        [#aec_channel_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-find_contracts_node(Hash) ->
-    case ?t(read(aec_contract_state, Hash)) of
-        [#aec_contract_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-dirty_find_contracts_node(Hash) ->
-    case ?dirty_dirty_read(aec_contract_state, Hash) of
-        [#aec_contract_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-find_ns_node(Hash) ->
-    case ?t(read(aec_name_service_state, Hash)) of
-        [#aec_name_service_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-dirty_find_ns_node(Hash) ->
-    case ?dirty_dirty_read(aec_name_service_state, Hash) of
-        [#aec_name_service_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-find_ns_cache_node(Hash) ->
-    case ?t(read(aec_name_service_cache, Hash)) of
-        [#aec_name_service_cache{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-dirty_find_ns_cache_node(Hash) ->
-    case ?dirty_dirty_read(aec_name_service_cache, Hash) of
-        [#aec_name_service_cache{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-find_accounts_node(Hash) ->
-    case ?t(read(state_tab(aec_account_state), Hash)) of
-        [#aec_account_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
-
-dirty_find_accounts_node(Hash) ->
-    case ?dirty_dirty_read(state_tab(aec_account_state), Hash) of
-        [#aec_account_state{value = Node}] -> {value, Node};
-        [] -> none
-    end.
 
 get_chain_state_value(Key) ->
     ?t(case read(aec_chain_state, Key) of
@@ -1354,21 +1459,21 @@ prepare_mnesia_bypass() ->
         [] ->
             lager:debug("No bypass", []),
             %% Check whether we can bypass mnesia in some cases
-            persistent_term:erase(?BYPASS); %% TODO: add leveled backend here
+            persistent_term:erase(?PT_BYPASS); %% TODO: add leveled backend here
         [_|_] ->
             case aeu_env:find_config([<<"chain">>, <<"db_direct_access">>], [ user_config
                                                                             , schema_default
                                                                             , {value, false} ]) of
                 {ok, true} ->
                     lager:debug("Enabling direct access for rocksdb", []),
-                    persistent_term:put(?DIRECT_API, true);
+                    persistent_term:put(?PT_DIRECT_API, true);
                 _ ->
                     case aeu_env:find_config([<<"chain">>, <<"db_commit_bypass">>], [ user_config
                                                                                     , schema_default
                                                                                     , {value, true} ]) of
                         {ok, true} ->
                             lager:debug("Enabling bypass for rocksdb", []),
-                            persistent_term:put(?BYPASS, rocksdb);
+                            persistent_term:put(?PT_BYPASS, rocksdb);
                         _ ->
                             lager:debug("NOT enabling bypass logic for rocksdb", [])
                     end
@@ -1415,10 +1520,10 @@ start_db() ->
     end.
 
 put_backend_module(#{module := M}) ->
-    persistent_term:put({?MODULE, backend_module}, M).
+    persistent_term:put(?PT_BACKEND_MODULE, M).
 
 get_backend_module() ->
-    persistent_term:get({?MODULE, backend_module}).
+    persistent_term:get(?PT_BACKEND_MODULE).
 
 mrdb_get_ref(Tab) ->
     mnesia_rocksdb_admin:get_ref(Tab, undefined).
@@ -1438,7 +1543,7 @@ uninstall_test_env() ->
     remove_added_pts().
 
 ensure_backend_module() ->
-    Key = {aec_db, backend_module},
+    Key = ?PT_BACKEND_MODULE,
     case persistent_term:get(Key, error) of
         error ->
             note_added_pt(Key),
@@ -1452,13 +1557,14 @@ get_test_backend_module() ->
     list_to_existing_atom(Str).
 
 note_added_pt(Key) ->
-    Var = {?MODULE, added_pts},
+    Var = ?PT_ADDED_PTS,
     Set = persistent_term:get(Var, ordsets:new()),
     persistent_term:put(Var, ordsets:add_element(Key, Set)).
 
 remove_added_pts() ->
-    Keys = persistent_term:get({?MODULE, added_pts}, ordsets:new()),
-    [persistent_term:erase(K) || K <- Keys].
+    Keys = persistent_term:get(?PT_ADDED_PTS, ordsets:new()),
+    [persistent_term:erase(K) || K <- Keys],
+    persistent_term:erase(?PT_ADDED_PTS).
 
 %% == End Test setup env
 

--- a/apps/aecore/src/aec_db_backends.erl
+++ b/apps/aecore/src/aec_db_backends.erl
@@ -43,7 +43,7 @@ accounts_backend() ->
 
 -spec dirty_accounts_backend() -> aeu_mp_trees_db:db().
 dirty_accounts_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_accounts)).
+    aeu_mp_trees_db:new(db_spec({dirty, accounts})).
 
 -spec calls_backend() -> aeu_mp_trees_db:db().
 calls_backend() ->
@@ -51,7 +51,7 @@ calls_backend() ->
 
 -spec dirty_calls_backend() -> aeu_mp_trees_db:db().
 dirty_calls_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_calls)).
+    aeu_mp_trees_db:new(db_spec({dirty, calls})).
 
 -spec channels_backend() -> aeu_mp_trees_db:db().
 channels_backend() ->
@@ -59,7 +59,7 @@ channels_backend() ->
 
 -spec dirty_channels_backend() -> aeu_mp_trees_db:db().
 dirty_channels_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_channels)).
+    aeu_mp_trees_db:new(db_spec({dirty, channels})).
 
 -spec contracts_backend() -> aeu_mp_trees_db:db().
 contracts_backend() ->
@@ -67,7 +67,7 @@ contracts_backend() ->
 
 -spec dirty_contracts_backend() -> aeu_mp_trees_db:db().
 dirty_contracts_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_contracts)).
+    aeu_mp_trees_db:new(db_spec({dirty, contracts})).
 
 -spec ns_backend() -> aeu_mp_trees_db:db().
 ns_backend() ->
@@ -75,7 +75,7 @@ ns_backend() ->
 
 -spec dirty_ns_backend() -> aeu_mp_trees_db:db().
 dirty_ns_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_ns)).
+    aeu_mp_trees_db:new(db_spec({dirty, ns})).
 
 -spec ns_cache_backend() -> aeu_mp_trees_db:db().
 ns_cache_backend() ->
@@ -83,7 +83,7 @@ ns_cache_backend() ->
 
 -spec dirty_ns_cache_backend() -> aeu_mp_trees_db:db().
 dirty_ns_cache_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_ns_cache)).
+    aeu_mp_trees_db:new(db_spec({dirty, ns_cache})).
 
 -spec oracles_backend() -> aeu_mp_trees_db:db().
 oracles_backend() ->
@@ -91,7 +91,7 @@ oracles_backend() ->
 
 -spec dirty_oracles_backend() -> aeu_mp_trees_db:db().
 dirty_oracles_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_oracles)).
+    aeu_mp_trees_db:new(db_spec({dirty, oracles})).
 
 -spec oracles_cache_backend() -> aeu_mp_trees_db:db().
 oracles_cache_backend() ->
@@ -99,78 +99,36 @@ oracles_cache_backend() ->
 
 -spec dirty_oracles_cache_backend() -> aeu_mp_trees_db:db().
 dirty_oracles_cache_backend() ->
-    aeu_mp_trees_db:new(db_spec(dirty_oracles_cache)).
+    aeu_mp_trees_db:new(db_spec({dirty, oracles_cache})).
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
 
 db_spec(Type) ->
-    #{ handle => Type
+    Handle = aec_db:new_tree_context(context(Type), tab_name(Type)),
+    #{ handle => Handle
      , cache  => {gb_trees, gb_trees:empty()}
      , module => ?MODULE
      }.
 
+context({Ctxt, _}) when Ctxt == dirty; Ctxt == transaction ->
+    Ctxt;
+context(_) ->
+    transaction.
+
+tab_name({_, T}) -> tab_name(T);
+tab_name(T) when is_atom(T) -> T.
+
 mpt_db_get(Key, {gb_trees, Tree}) ->
     gb_trees:lookup(Key, Tree);
-mpt_db_get(Key, accounts) ->
-    aec_db:find_accounts_node(Key);
-mpt_db_get(Key, dirty_accounts) ->
-    aec_db:dirty_find_accounts_node(Key);
-mpt_db_get(Key, calls) ->
-    aec_db:find_calls_node(Key);
-mpt_db_get(Key, dirty_calls) ->
-    aec_db:dirty_find_calls_node(Key);
-mpt_db_get(Key, channels) ->
-    aec_db:find_channels_node(Key);
-mpt_db_get(Key, dirty_channels) ->
-    aec_db:dirty_find_channels_node(Key);
-mpt_db_get(Key, contracts) ->
-    aec_db:find_contracts_node(Key);
-mpt_db_get(Key, dirty_contracts) ->
-    aec_db:dirty_find_contracts_node(Key);
-mpt_db_get(Key, ns) ->
-    aec_db:find_ns_node(Key);
-mpt_db_get(Key, dirty_ns) ->
-    aec_db:dirty_find_ns_node(Key);
-mpt_db_get(Key, ns_cache) ->
-    aec_db:find_ns_cache_node(Key);
-mpt_db_get(Key, dirty_ns_cache) ->
-    aec_db:dirty_find_ns_cache_node(Key);
-mpt_db_get(Key, oracles) ->
-    aec_db:find_oracles_node(Key);
-mpt_db_get(Key, dirty_oracles) ->
-    aec_db:dirty_find_oracles_node(Key);
-mpt_db_get(Key, oracles_cache) ->
-    aec_db:find_oracles_cache_node(Key);
-mpt_db_get(Key, dirty_oracles_cache) ->
-    aec_db:dirty_find_oracles_cache_node(Key).
+mpt_db_get(Key, Handle) ->
+    aec_db:lookup_tree_node(Key, Handle).
 
 mpt_db_put(Key, Val, {gb_trees, Tree}) ->
     {gb_trees, gb_trees:enter(Key, Val, Tree)};
-mpt_db_put(Key, Val, Handle) when Handle =:= accounts; Handle =:= dirty_accounts ->
-    ok = aec_db:write_accounts_node(Key, Val),
-    Handle;
-mpt_db_put(Key, Val, Handle) when Handle =:= channels; Handle =:= dirty_channels ->
-    ok = aec_db:write_channels_node(Key, Val),
-    Handle;
-mpt_db_put(Key, Val, Handle) when Handle =:= ns; Handle =:= dirty_ns ->
-    ok = aec_db:write_ns_node(Key, Val),
-    Handle;
-mpt_db_put(Key, Val, Handle) when Handle =:= ns_cache; Handle =:= dirty_ns_cache ->
-    ok = aec_db:write_ns_cache_node(Key, Val),
-    Handle;
-mpt_db_put(Key, Val, Handle) when Handle =:= calls; Handle =:= dirty_calls ->
-    ok = aec_db:write_calls_node(Key, Val),
-    Handle;
-mpt_db_put(Key, Val, Handle) when Handle =:= contracts; Handle =:= dirty_contracts ->
-    ok = aec_db:write_contracts_node(Key, Val),
-    Handle;
-mpt_db_put(Key, Val, Handle) when Handle =:= oracles; Handle =:= dirty_oracles ->
-    ok = aec_db:write_oracles_node(Key, Val),
-    Handle;
-mpt_db_put(Key, Val, Handle) when Handle =:= oracles_cache; Handle =:= dirty_oracles_cache ->
-    ok = aec_db:write_oracles_cache_node(Key, Val),
+mpt_db_put(Key, Val, Handle) ->
+    ok = aec_db:enter_tree_node(Key, Val, Handle),
     Handle.
 
 mpt_db_drop_cache({gb_trees, _}) ->

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -22,57 +22,60 @@
 %% - writing of the reachable nodes from cache to disk
 %% - subsequent restart of the node
 %% - removing all old nodes and copying only reachable ones
-%%
-%% If uses wishes to keep GC off by default (as is in default config) but invoke it manually,
-%% that is possible with calling of aec_db_gc:run() or aec_db_gc:run(HistoryLength).
 
--behaviour(gen_statem).
+-behaviour(gen_server).
 
 %% API
--export([start_link/0,
-         start_link/3,
-         run/0,
-         run/1,
-         stop/0]).
+-export([start_link/0]).
 
-%% for internal use only
-%% -export([maybe_swap_nodes/0]).
+-export([ height_of_last_gc/0
+        , info/0
+        , info/1
+        ]).
 
-%% gen_statem callbacks
--export([callback_mode/0, init/1, terminate/3, code_change/4]).
--export([handle_event/4]).
+-export([maybe_garbage_collect/1]).
+
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
 
 -export([config/0]).
 
--record(data,
-        {enabled    :: boolean(),                         % do we garbage collect?
-         interval   :: non_neg_integer(),                 % how often (every `interval` blocks) GC runs
-         history    :: non_neg_integer(),                 % how many block state back from top to keep
-         min_height :: undefined | non_neg_integer(),     % if hash_not_found error, try GC from this height
-         synced     :: boolean(),                         % we only run GC (repeatedly) if chain is synced
-         height     :: undefined | non_neg_integer(),     % latest height of MPT hashes stored in tab
-         last_swap  :: undefined | non_neg_integer(),     % last swap height. Not undefined means secondary needs clearing
-         hashes     :: undefined | pid() | reference()}). % hashes tab (or process filling the tab 1st time)
+-type tree_name() :: aec_trees:tree_name().
+
+-type pid_ref() :: {pid(), reference()}.
+
+-record(scanner,
+        { tree   :: tree_name()
+        , height :: non_neg_integer()
+        , pid    :: pid_ref() }).
+
+-record(st,
+        {enabled        :: boolean(),                     % do we garbage collect?
+         history        :: non_neg_integer(),             % how many block state back from top to keep
+         min_height     :: undefined | non_neg_integer(), % if hash_not_found error, try GC from this height
+         during_sync    :: boolean(),                     % run GC from the beginning
+         synced         :: boolean(),                     % we only run GC if chain is synced
+         last_switch    :: non_neg_integer(),             % height at last switch
+         trees = []     :: [tree_name()],                 % State trees being GC:ed
+         scanners = []  :: [#scanner{}]                   % ongoing scans
+        }).
 
 -include_lib("aecore/include/aec_db.hrl").
 
 -define(DEFAULT_HISTORY, 500).
--define(DEFAULT_INTERVAL, 50000).
-
-%% interval from config +- random offset to avoid situation where large
-%% majority of nodes become unresponsive due to node restart invoked by GC
--define(INTERVAL_VARIANCE_PERCENT, 10).
--define(INTERVAL_VARIANCE, true). % comment this out for development only!
-
--define(GCED_TABLE_NAME, aec_account_state_gced).
--define(TABLE_NAME, aec_account_state).
 
 -define(TIMED(Expr), timer:tc(fun () -> Expr end)).
 -define(LOG(Fmt), lager:info(Fmt, [])).         % io:format(Fmt"~n")
 -define(LOG(Fmt, Args), lager:info(Fmt, Args)). % io:format(Fmt"~n", Args)
 -define(LOGERR(Fmt, Args), lager:error(Fmt, Args)). % io:format("ERROR:"Fmt"~n", Args)
 
--define(PROTECT(Expr, OkFun), ?PROTECT(Expr, OkFun, fun signal_scanning_failed/1)).
+%% -define(PROTECT(Expr, OkFun), ?PROTECT(Expr, OkFun, fun signal_scanning_failed/1)).
 -define(PROTECT(Expr, OkFun, ErrHeightFun),
         (try Expr of
              Res -> (OkFun)(Res)
@@ -83,28 +86,43 @@
                  (ErrHeightFun)(ErrHeight)
          end)).
 
+-define(JOBS_QUEUE, gc_scan).
+-define(SCAN_SLICE, 100).
+
 %%%===================================================================
 %%% API
 %%%===================================================================
 
+
 %% We don't support reconfiguration of config parameters when the GC is already up,
 %% doesn't seem to have practical utility.
 start_link() ->
-    #{enabled := Enabled, interval := Interval, history := History} = config(),
-    start_link(Enabled, Interval, History).
+    #{<<"enabled">> := _, <<"trees">> := _, <<"history">> := _} = Config = config(),
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
 
-start_link(Enabled, Interval, History) ->
-    gen_statem:start_link({local, ?MODULE}, ?MODULE, [Enabled, Interval, History], []).
+-spec maybe_garbage_collect(aec_headers:header()) -> ok | nop.
+maybe_garbage_collect(Header) ->
+    gen_server:call(
+      ?MODULE, {maybe_garbage_collect, aec_headers:height(Header), Header}).
 
-run() ->
-    #{history := History} = config(),
-    run(History).
+%% If GC is disabled, or there hasn't yet been a GC, this function returns 0.
+-spec height_of_last_gc() -> non_neg_integer().
+height_of_last_gc() ->
+    aec_db:ensure_activity(async_dirty, fun aec_db:read_last_gc_switch/0).
 
-run(History) when is_integer(History), History > 0 ->
-    gen_statem:call(?MODULE, {run, History}).
+info() ->
+    info(info_keys()).
 
-stop() ->
-    gen_statem:stop(?MODULE).
+info(Keys) when is_list(Keys) ->
+    case Keys -- info_keys() of
+        [] ->
+            gen_server:call(?MODULE, {info, Keys});
+        Invalid ->
+            error({invalid_info_keys, Invalid})
+    end.
+
+info_keys() ->
+    [enabled, history, last_gc, active_sweeps, during_sync, trees].
 
 %% called from aec_db on startup
 %% maybe_swap_nodes() ->
@@ -115,318 +133,295 @@ stop() ->
 %%%===================================================================
 
 %% Change of configuration parameters requires restart of the node.
-init([Enabled, Interval, History])
-  when is_integer(Interval), Interval > 0, is_integer(History), History > 0 ->
-    Interval1 =
-        if Enabled ->
-                aec_events:subscribe(top_changed),
-                aec_events:subscribe(chain_sync),
-                interval(Interval);
-           true ->
-                Interval
-        end,
-    Data = #data{enabled    = Enabled,
-                 interval   = Interval1,
-                 history    = History,
-                 min_height = undefined,
-                 synced     = false,
-                 height     = undefined,
-                 hashes     = undefined},
-    {ok, idle, Data}.
-
-
-handle_event({call, From}, {run, History}, idle, #data{enabled = false} = Data) ->
-    aec_events:subscribe(top_changed),
-    Data1 = Data#data{synced = true, enabled = true, interval = 1, history = History},
-    {keep_state, Data1, {reply, From, {ok, run_next_scan_height(Data1)}}};
-
-handle_event({call, From}, {run, History}, idle, #data{history = History, hashes = Hashes} = Data)
-  when is_pid(Hashes) -> % initial scanner pid already runs with the same history length, keep it
-    {keep_state, Data, {reply, From, {ok, run_next_scan_height(Data)}}};
-handle_event({call, From}, {run, History}, idle, #data{hashes = Hashes} = Data) ->
-    is_pid(Hashes) andalso exit(Hashes, kill),
-    Data1 = Data#data{synced = true, interval = 1, history = History,
-                      height = undefined, hashes = undefined},
-    {keep_state, Data1, {reply, From, {ok, run_next_scan_height(Data1)}}};
-
-handle_event({call, From}, {run, History}, ready, #data{history = History} = Data) -> % same history length, keep it
-    {keep_state, Data, {reply, From, {ok, run_next_scan_height(Data)}}};
-handle_event({call, From}, {run, History}, ready, #data{} = Data) ->
-    Data1 = Data#data{interval = 1, history = History,
-                      height = undefined, hashes = undefined},
-    {next_state, idle, Data1, {reply, From, {ok, run_next_scan_height(Data1)}}};
+init(#{ <<"enabled">>     := Enabled
+      , <<"trees">>       := Trees
+      , <<"during_sync">> := DuringSync
+      , <<"history">>     := History
+      , <<"minimum_height">> := MinHeight
+      } = Cfg) when is_integer(History), History > 0 ->
+    lager:debug("Cfg = ~p", [Cfg]),
+    LastSwitch = case Enabled of
+                     true ->
+                         aec_events:subscribe(chain_sync),
+                         aec_db:read_last_gc_switch();
+                     false ->
+                         0
+                 end,
+    lager:debug("LastSwitch = ~p", [LastSwitch]),
+    %% TODO: Make min_height configurable
+    Data = #st{enabled      = Enabled,
+               during_sync  = DuringSync,
+               trees        = Trees,
+               history      = History,
+               min_height   = MinHeight,
+               last_switch  = LastSwitch,
+               synced       = false},
+    {ok, Data}.
 
 %% once the chain is synced, there's no way to "unsync"
-handle_event(info, {_, chain_sync, #{info := {chain_sync_done, _}}}, idle,
-             #data{enabled = true} = Data) ->
+handle_info({_, chain_sync, #{info := {chain_sync_done, _}}}, St) ->
     case aec_sync:sync_progress() of
         {false, _, _} ->
-            {keep_state, Data#data{synced = true}};
+            {noreply, St#st{synced = true}};
         _ ->
-            {keep_state, Data}
+            {noreply, St}
     end;
 
-%% starting collection when the *interval* matches, and don't have a GC state (hashes = undefined)
-%% OR some MPT was missing previously so we try again later
-handle_event(info, {_, top_changed, #{info := #{height := Height}}}, idle,
-             #data{interval = Interval, history = History,
-                   enabled = true, synced = true, min_height = MinHeight,
-                   height = undefined, hashes = undefined} = Data)
-  when ((Height rem Interval) == 0 andalso MinHeight == undefined) orelse
-       (is_integer(MinHeight) andalso Height - History > MinHeight) ->
-    Parent = self(),
-    Pid = spawn_link(
-            fun () ->
-                    FromHeight = max(Height - History, 0),
-                    ?PROTECT(?TIMED(collect_reachable_hashes(FromHeight, Height)),
-                             fun ({Time, {ok, Hashes}}) ->
-                                     store_cache_and_give_away(Hashes, Parent, FromHeight, Height, Time)
-                             end)
-            end),
-    {keep_state, Data#data{height = Height, hashes = Pid}};
-
-%% the initial scan failed due to hash_not_present_in_db, reschedule it for later
-handle_event(info, {scanning_failed, ErrHeight}, idle,
-             #data{enabled = true, hashes = Pid} = Data)
-  when is_pid(Pid) ->
-    {keep_state, Data#data{height = undefined,
-                           hashes = undefined,
-                           min_height = ErrHeight}};
-%% later incremental scan failed due to hash_not_present_in_db, reschedule it for later
-handle_event(info, {scanning_failed, ErrHeight}, ready, #data{enabled = true} = Data) ->
-    {next_state, idle, Data#data{height = undefined,
-                                 hashes = undefined,
-                                 min_height = ErrHeight}};
-
-%% happens when scanning process is killed after it transfers hashes table, we ignore it
-%% (when we manually invoke GC via 'run')
-handle_event(info, {'ETS-TRANSFER', _, _, _}, idle,
-             #data{enabled = true, hashes = undefined} = Data) ->
-    {keep_state, Data};
-
-%% received GC state from the phase above
-handle_event(info, {'ETS-TRANSFER', Hashes, _, {{FromHeight, ToHeight}, Time}}, idle,
-             #data{enabled = true, hashes = Pid} = Data)
-  when is_pid(Pid) ->
-    ?LOG("Scanning of ~p reachable hashes in range <~p, ~p> took ~p seconds",
-         [ets:info(Hashes, size), FromHeight, ToHeight, Time / 1000000]),
-    {next_state, ready, Data#data{hashes = Hashes}};
-
-%% with valid GC state (reachable hashes in ETS cache), follow up on keeping that cache
-%% synchronized with Merkle-Patricia Trie on disk keeping the latest changes in accounts
-handle_event(info, {_, top_changed, #{info := #{block_type := key, height := Height}}}, ready,
-             #data{enabled = true, synced = true, height = LastHeight, hashes = Hashes} = Data)
-  when is_reference(Hashes) ->
-    if Height > LastHeight ->
-            ?PROTECT(range_collect_reachable_hashes(Height, Data, both),
-                     fun ({ok, _}) -> {keep_state, Data#data{height = Height}} end,
-                     signal_scanning_failed_keep_state(Data));
-       true ->
-            %% in case previous key block was a fork, we can receive top_changed event
-            %% with the same or lower height as seen last time
-            ?LOG("GC diffscan of accounts at height ~p", [Height]),
-            ?PROTECT(collect_reachable_hashes_delta(Height, Hashes, both),
-                     fun ({ok, _}) -> {keep_state, Data} end,
-                     (signal_scanning_failed_keep_state(Data)))
-    end;
-handle_event(info, {_, top_changed, #{info := #{block_type := key, height := Height}}}, idle,
-             #data{last_swap = LastSwap} = Data) ->
-    if is_integer(LastSwap),
-       Height > LastSwap ->
-            Secondary = aec_db:secondary_state_tab(?TABLE_NAME),
-            lager:debug("Will clear secondary (~p)", [Secondary]),
-            aec_db:clear_table(Secondary),
-            {keep_state, Data#data{last_swap = undefined}};
-       true ->
-            {keep_state, Data}
+handle_info({'DOWN', MRef, process, Pid, Reason}, #st{scanners = Scanners} = St) ->
+    case lists:keyfind({Pid, MRef}, #scanner.pid, Scanners) of
+        false ->
+            {noreply, St};
+        #scanner{tree = Tree, height = Height} = S ->
+            lager:error("GC Scanner process for ~p died: ~p", [Tree, Reason]),
+            signal_scanning_failed(Height),
+            {noreply, St#st{scanners = Scanners -- [S]}}
     end;
 
-%% with valid GC state, if we are on key block boundary, we can
-%% clear the table and insert reachable hashes back
-handle_event({call, From}, maybe_garbage_collect, ready,
-             #data{enabled = true, synced = true, hashes = Hashes} = Data)
-  when Hashes /= undefined, not is_pid(Hashes) ->
-    Header = aec_chain:top_header(),
+handle_info(_, St) ->
+    {noreply, St}.
+
+handle_call({maybe_garbage_collect, TopHeight, Header}, _From,
+            #st{enabled = true, synced = Synced, during_sync = DuringSync,
+                history = History, min_height = MinHeight,
+                trees = Trees, scanners = [], last_switch = Last} = St)
+  when (Synced orelse DuringSync), TopHeight >= MinHeight, TopHeight > Last + History ->
+    %% Double-check that the GC hasn't been requested on a microblock.
+    %% This would be a bug, since aec_conductor should only ask for keyblocks.
     case aec_headers:type(Header) of
         key ->
-            Height  = aec_headers:height(Header),
-            T0 = erlang:system_time(millisecond),
-            ?PROTECT(range_collect_reachable_hashes(Height, Data, both),
-                     fun ({ok, _}) ->
-                             Secondary = aec_db:secondary_state_tab(?TABLE_NAME),
-                             aec_db:make_primary_state_tab(?TABLE_NAME, Secondary),
-                             ?LOG("GC swap, time: ~p ms", [erlang:system_time(millisecond) - T0]),
-                             ets:delete(Hashes),
-                             {next_state, idle, Data#data{hashes = undefined,
-                                                          height = undefined,
-                                                          last_swap = Height},
-                              {reply, From, ok}}
+            ?PROTECT(perform_switch(Trees, TopHeight),
+                     fun(Scanners1) ->
+                             {reply, ok, St#st{ scanners = Scanners1
+                                              , last_switch = TopHeight}}
                      end,
-                     signal_scanning_failed_keep_state(Data));
+                     signal_switching_failed_and_reply(St, nop));
         micro ->
-            {keep_state, Data, {reply, From, nop}}
+            lager:warning("GC called on microblock - ignoring", []),
+            {reply, nop, St}
     end;
-handle_event({call, From}, maybe_garbage_collect, _, Data) ->
-    {keep_state, Data, {reply, From, nop}};
+handle_call({maybe_garbage_collect, _, _}, _From, St) ->
+    {reply, nop, St};
+handle_call({info, Keys}, _, St) ->
+    {reply, info_(Keys, St), St}.
 
-handle_event(_, _, _, Data) ->
-    {keep_state, Data}.
+%% the initial scan failed due to hash_not_present_in_db, reschedule it for later
+handle_cast({scanning_failed, ErrHeight}, St) ->
+    {noreply, St#st{min_height = ErrHeight}};
 
+handle_cast({scan_complete, Name}, #st{scanners = Scanners} = St) ->
+    Scanners1 = lists:keydelete(Name, #scanner.tree, Scanners),
+    {noreply, St#st{scanners = Scanners1}};
 
-terminate(_Reason, _State, _Data) -> void.
+handle_cast(_, St) ->
+    {noreply, St}.
 
-code_change(_, State, Data, _) -> {ok, State, Data}.
+terminate(_Reason, _St) -> ok.
 
-callback_mode() -> handle_event_function.
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
 
+info_(Keys, St) ->
+    maps:from_list(
+      [{K, info_item(K, St)} || K <- Keys]).
 
-%% From - To (inclusive)
-collect_reachable_hashes(FromHeight, ToHeight) when FromHeight < ToHeight ->
-    {ok, Hashes} = collect_reachable_hashes_fullscan(FromHeight),     % table is created here
-    {ok, Hashes} = range_collect_reachable_hashes_(FromHeight, ToHeight, Hashes, ets), % and reused
-    {ok, Hashes}.
+info_item(history, #st{history = H}) ->
+    H;
+info_item(last_gc, #st{last_switch = L}) ->
+    L;
+info_item(active_sweeps, #st{scanners = Scanners}) ->
+    [#{tree => T, pid => P, height => H} ||
+        #scanner{tree = T, height = H, pid = P} <- Scanners];
+info_item(during_sync, #st{during_sync = Flag}) ->
+    Flag;
+info_item(trees, #st{trees = Trees}) ->
+    Trees;
+info_item(enabled, #st{enabled = Bool}) ->
+    Bool.
 
-collect_reachable_hashes_fullscan(Height) ->
-    Tab = ets:new(gc_reachable_hashes, [public]),
-    MPT = get_mpt(Height),
-    ?LOG("GC fullscan at height ~p of accounts with hash ~w",
-         [Height, aeu_mp_trees:root_hash(MPT)]),
-    {ok, aeu_mp_trees:visit_reachable_hashes(MPT, Tab, fun store_hash/3)}.
+perform_switch(Trees, Height) ->
+    clear_secondary_tables(Trees),
+    ok = aec_db:ensure_transaction(
+           fun() ->
+                   switch_tables(Trees),
+                   aec_db:write_last_gc_switch(Height)
+           end),
+    [start_scanner(T, Height) || T <- Trees].
 
-%% assumes Height - 1, Height - 2, ... down to Height - History
-%% are in Hashes from previous runs
--spec collect_reachable_hashes_delta(non_neg_integer(), _, 'both' | 'ets') -> {'ok', _}.
-collect_reachable_hashes_delta(Height, Hashes, Tgt) ->
-    MPT = get_mpt(Height),
-    Acc0 = case Tgt of
-               ets -> Hashes;
-               both -> {Hashes, aec_db:secondary_state_tab(?TABLE_NAME)}
-           end,
-    {ok, aeu_mp_trees:visit_reachable_hashes(MPT, Acc0, fun store_unseen_hash/3)}.
+clear_secondary_tables(Trees) ->
+    [clear_secondary(T) || T <- Trees].
 
-range_collect_reachable_hashes(ToHeight, #data{height = LastHeight, hashes = Hashes}, Tgt) ->
-    range_collect_reachable_hashes_(LastHeight, ToHeight, Hashes, Tgt).
+clear_secondary(Name) ->
+    Secondary = aec_db:secondary_state_tab(Name),
+    lager:debug("Clearing secondary for ~p (~p)", [Name, Secondary]),
+    aec_db:clear_table(Secondary).
 
-range_collect_reachable_hashes_(LastHeight, ToHeight, Hashes, Tgt) ->
-    StartHeight = LastHeight + 1,
-    if StartHeight > ToHeight ->
-            {ok, Hashes};
-       true ->
-            ?LOG("GC diffscan of accounts at heights ~p to ~p", [StartHeight, ToHeight]),
-            [collect_reachable_hashes_delta(H, Hashes, Tgt)
-             || H <- lists:seq(StartHeight, ToHeight)],
-            {ok, Hashes}
+switch_tables(Trees) ->
+    [switch(T) || T <- Trees].
+
+switch(Name) ->
+    Secondary = aec_db:secondary_state_tab(Name),
+    lager:debug("Making ~p the primary for ~p", [Secondary, Name]),
+    aec_db:make_primary_state_tab(Name, Secondary),
+    ok.
+
+start_scanner(Name, Height) ->
+    Parent = self(),
+    S = spawn_monitor(fun() ->
+                              scan_tree(Name, Height, Parent)
+                      end),
+    #scanner{tree = Name, height = Height, pid = S}.
+
+scan_tree(Name, Height, Parent) ->
+    T0 = erlang:system_time(millisecond),
+    {ok, Count} = collect_reachable_hashes_fullscan(Name, Height),
+    T1 = erlang:system_time(millisecond),
+    lager:info("GC fullscan done for ~p, Height = ~p, Count = ~p, Time = ~p ms",
+               [Name, Height, Count, T1 - T0]),
+    gen_server:cast(Parent, {scan_complete, Name}),
+    ok.
+
+collect_reachable_hashes_fullscan(Tree, Height) ->
+    case get_mpt(Tree, Height) of
+        empty ->
+            lager:debug("Tree ~p empty - skipping scan", [Tree]),
+            {ok, 0};
+        MPT ->
+            lager:debug("GC fullscan for ~p at height ~p of accounts with hash ~w",
+                 [Tree, Height, aeu_mp_trees:root_hash(MPT)]),
+            {ok, visit_reachable(MPT)}
     end.
 
-    %% aec_db:make_primary_state_tab(aec_account_state, Secondary).
+visit_reachable(MPT) ->
+    {_, Count} = aeu_mp_trees:visit_reachable_hashes(MPT, init_acc(0), fun visit_count/3),
+    Count.
 
-store_cache_and_give_away(Hashes, Parent, FromHeight, Height, Time) ->
-    {Time1, {ok, _}} = ?TIMED(store_cache(Hashes)),
-    ets:give_away(Hashes, Parent, {{FromHeight, Height}, Time + Time1}).
+visit_count(_, _, {Ref, N}) ->
+    Acc1 = maybe_ask_jobs({Ref, N+1}),
+    {continue, Acc1}.
 
-store_cache(Hashes) ->
-    Secondary = aec_db:secondary_state_tab(?TABLE_NAME),
-    aec_db:clear_table(Secondary),
-    store_cache(Hashes, Secondary).
+init_acc(N) ->
+    case jobs:ask(?JOBS_QUEUE) of
+        {ok, NewRef} ->
+            {NewRef, N};
+        {error, Reason} ->
+            lager:error("Jobs return error: ~p", [Reason]),
+            signal_scanning_failed(0),
+            error(jobs_error)
+    end.
 
-iter(Fun, Tab) ->
-    ets:foldl(fun ({Hash, Node}, ok) -> Fun(Hash, Node), ok end, ok, Tab).
+maybe_ask_jobs({OldRef, N} = Acc) ->
+    case N rem ?SCAN_SLICE of
+        0 ->
+            jobs:done(OldRef),
+            init_acc(N);
+        _ ->
+            Acc
+    end.
 
-write_nodes(SrcTab, TgtTab) ->
-    ?TIMED(aec_db:ensure_transaction(
-             fun () ->
-                     iter(fun (Hash, Node) ->
-                                  aec_db:write_accounts_node(TgtTab, Hash, Node)
-                          end, SrcTab)
-             end)).
-
-store_cache(SrcHashes, TgtTab) ->
-    NodesCount = ets:info(SrcHashes, size),
-    ?LOG("Writing ~p reachable account nodes to table ~p ...", [NodesCount, TgtTab]),
-    {WriteTime, ok} = write_nodes(SrcHashes, TgtTab),
-    ?LOG("Writing reachable account nodes took ~p seconds", [WriteTime / 1000000]),
-    DBCount = length(aec_db:dirty_select(TgtTab, [{'_', [], [1]}])),
-    ?LOG("GC cache has ~p aec_account_state records", [DBCount]),
-    {ok, NodesCount}.
-
--spec get_mpt(non_neg_integer()) -> aeu_mp_trees:tree().
-get_mpt(Height) ->
+-spec get_mpt(tree_name(), non_neg_integer()) -> aeu_mp_trees:tree() | empty.
+get_mpt(Tree, Height) ->
     {ok, Hash} = aec_chain_state:get_key_block_hash_at_height(Height),
-    try get_mpt_from_hash(Hash) of
-        MPT -> MPT
-    catch
-        error:{hash_not_present_in_db, MissingHash}:Stacktrace ->
-            error({hash_not_present_in_db_at_height, Height, MissingHash, Stacktrace})
+    get_mpt_from_hash(Tree, Hash).
+
+get_mpt_from_hash(Tree, Hash) ->
+    {value, Trees} = aec_db:find_block_state(Hash, _DirtyBackend = true),
+    case tree_hash(Tree, Trees) of
+        {error, empty} ->
+            empty;
+        {ok, RootHash} ->
+            aeu_mp_trees:new(RootHash, db(Tree, Trees))
     end.
 
-get_mpt_from_hash(Hash) ->
-    {ok, Trees} = aec_chain:get_block_state(Hash),
-    AccountTree = aec_trees:accounts(Trees),
-    {ok, RootHash} = aec_accounts_trees:root_hash(AccountTree),
-    {ok, DB}       = aec_accounts_trees:db(AccountTree),
-    aeu_mp_trees:new(RootHash, DB).
-
-
-store_hash(Hash, Node, Tab) ->
-    ets:insert_new(Tab, {Hash, Node}),
-    {continue, Tab}.
-
-store_unseen_hash(Hash, Node, {Ets, Tab} = Acc) ->
-    case ets:lookup(Ets, Hash) of
-        [_] -> stop;
-        [] ->
-            ets:insert_new(Ets, {Hash, Node}),
-            aec_db:write_accounts_node(Tab, Hash, Node),
-            {continue, Acc}
-    end;
-store_unseen_hash(Hash, Node, Tab) ->
-    case ets:lookup(Tab, Hash) of
-        [_] -> stop;
-        []  -> store_hash(Hash, Node, Tab)
+tree_hash(Tree, Trees) ->
+    case Tree of
+        accounts      -> aec_trees:accounts_hash(Trees);
+        calls         -> aec_trees:calls_hash(Trees);
+        contracts     -> aec_trees:contracts_hash(Trees);
+        oracles       -> aec_trees:oracles_hash(Trees);
+        oracles_cache -> aec_trees:oracles_cache_hash(Trees);
+        channels      -> aec_trees:channels_hash(Trees);
+        ns            -> aec_trees:ns_hash(Trees);
+        ns_cache      -> aec_trees:ns_cache_hash(Trees)
     end.
+
+db(Tree, Trees) ->
+    {ok, DB} = case Tree of
+                   accounts ->
+                       aec_accounts_trees:db(aec_trees:accounts(Trees));
+                   calls ->
+                       aect_call_state_tree:db(aec_trees:calls(Trees));
+                   contracts ->
+                       aect_state_tree:db(aec_trees:contracts(Trees));
+                   oracles ->
+                       aeo_state_tree:oracles_db(aec_trees:oracles(Trees));
+                   oracles_cache ->
+                       aeo_state_tree:cache_db(aec_trees:oracles(Trees));
+                   channels ->
+                       aesc_state_tree:db(aec_trees:channels(Trees));
+                   ns ->
+                       aens_state_tree:ns_db(aec_trees:ns(Trees));
+                   ns_cache ->
+                       aens_state_tree:cache_db(aec_trees:ns(Trees))
+               end,
+    DB.
 
 signal_scanning_failed(ErrHeight) ->
-    ?MODULE ! {scanning_failed, ErrHeight}.
+    gen_server:cast(?MODULE, {scanning_failed, ErrHeight}).
 
-signal_scanning_failed_keep_state(Data) ->
+signal_switching_failed_and_reply(St, Reply) ->
     fun (ErrHeight) ->
             signal_scanning_failed(ErrHeight),
-            {keep_state, Data}
+            {reply, Reply, St}
     end.
-
-run_next_scan_height(#data{min_height = undefined}) ->
-    aec_headers:height(aec_chain:top_header()) + 1;
-run_next_scan_height(#data{min_height = MinHeight, history = History})
-  when is_integer(MinHeight) ->
-    MinHeight + History + 1.
-
--ifdef(TEST).
-interval(ConfigInterval) -> ConfigInterval. % for common test
--else.
-
--ifdef(INTERVAL_VARIANCE).
-interval(ConfigInterval) ->
-    case trunc(ConfigInterval * ?INTERVAL_VARIANCE_PERCENT / 100.0) of
-        0 ->
-            ConfigInterval;
-        Variance when Variance > 0 ->
-            Delta = rand:uniform(Variance) - (Variance div 2),
-            max(3, ConfigInterval + Delta)
-    end.
--else.
-interval(ConfigInterval) -> ConfigInterval.
--endif.
-
--endif. %% ifdef TEST
 
 config() ->
-    maps:from_list(
-      [{binary_to_atom(Key, utf8),
-        aeu_env:user_config([<<"chain">>, <<"garbage_collection">>, Key], Default)} ||
-          {Key, Default} <- [{<<"enabled">>, false},
-                             {<<"interval">>, ?DEFAULT_INTERVAL},
-                             {<<"history">>, ?DEFAULT_HISTORY}]]).
+    Trees = get_trees(),
+    %% In the LC below, we rely on the schema to provide default values.
+    M = maps:from_list(
+          [{Key, ok(aeu_env:find_config([<<"chain">>, <<"garbage_collection">>, Key],
+                                        [user_config, schema_default]))} ||
+              Key <- [<<"enabled">>,
+                      <<"history">>,
+                      <<"minimum_height">>,
+                      <<"during_sync">>]]),
+    M#{<<"trees">> => Trees}.
+
+ok({ok, Value}) -> Value.
+
+get_trees() ->
+    {ok, Trees} = aeu_env:find_config([<<"chain">>, <<"garbage_collection">>, <<"trees">>],
+                                      [user_config, schema_default]),
+    expand_trees(Trees).
+
+expand_trees(Trees) ->
+    Map = aec_trees:tree_map(),
+    binaries_to_atoms(Trees, Map).
+
+binaries_to_atoms(Bins, TreeMap) ->
+    binaries_to_atoms(Bins, TreeMap, {[], []}).
+
+binaries_to_atoms([], _, {Good, Bad}) ->
+    case Bad of
+        [] ->
+            lists:reverse(Good);
+        _ ->
+            error({invalid_tree_names, Bad})
+    end;
+binaries_to_atoms([B|Bins], TreeMap, {Good, Bad}) ->
+    Acc1 = try binary_to_existing_atom(B, utf8) of
+               A ->
+                   case maps:find(A, TreeMap) of
+                       {ok, Subs} ->
+                           {[A|Subs] ++ Good, Bad};
+                       error ->
+                           {Good, [B|Bad]}
+                   end
+           catch
+               error:_ ->
+                   {Good, [B|Bad]}
+           end,
+    binaries_to_atoms(Bins, TreeMap, Acc1).

--- a/apps/aecore/src/aec_trees.erl
+++ b/apps/aecore/src/aec_trees.erl
@@ -31,6 +31,17 @@
          sum_total_coin/1
         ]).
 
+-export([tree_map/0]).
+
+-export([accounts_hash/1,
+         contracts_hash/1,
+         calls_hash/1,
+         channels_hash/1,
+         ns_hash/1,
+         ns_cache_hash/1,
+         oracles_hash/1,
+         oracles_cache_hash/1]).
+
 -export([ deserialize_from_db/2
         , serialize_for_db/1
         % could get big, used in force progress
@@ -98,8 +109,20 @@
                    | 'ns'
                    | 'oracles'.
 
+-type supporting_tree_type() :: 'ns_cache'
+                              | 'oracles_cache'.
+
+-type tree_name() :: tree_type() | supporting_tree_type().
+
+-type supporting_trees() :: [supporting_tree_type()].
+-type tree_map() :: #{ tree_type() := supporting_trees() }.
+
 -export_type([ trees/0
              , poi/0
+             , tree_type/0
+             , supporting_tree_type/0
+             , tree_map/0
+             , tree_name/0
              ]).
 
 -define(VERSION, 1).
@@ -151,6 +174,18 @@ from_db_format(#trees{accounts = Accounts, calls = Calls, channels = Channels,
            ns        = aens_state_tree:from_db_format(Names),
            oracles   = aeo_state_tree:from_db_format(Oracles)
           }.
+
+%% This API function returns the (atom) names of the main trees,
+%% including possible supporting trees (e.g. caches).
+-spec tree_map() -> tree_map().
+tree_map() ->
+    #{ accounts  => []
+     , calls     => []
+     , channels  => []
+     , contracts => []
+     , ns        => [ns_cache]
+     , oracles   => [oracles_cache]
+     }.
 
 -spec new_poi(trees()) -> poi().
 new_poi(Trees) ->

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -33,6 +33,7 @@ prep_stop(State) ->
 
 stop(_State) ->
     lager:info("Stopping aecore app", []),
+    aec_db:cleanup(),
     ok.
 
 set_app_ctrl_mode() ->

--- a/apps/aehttp/test/aehttp_devmode_SUITE.erl
+++ b/apps/aehttp/test/aehttp_devmode_SUITE.erl
@@ -1536,14 +1536,12 @@ repeated_rollbacks_to_micro_hash(Config0) ->
 
 rollback_when_gc_enabled(Config) ->
     [{_, Node}] = ?config(nodes, Config), % important that there is only one
-    #{enabled  := false
-    , interval := Interval
-    , history  := History} = rpc:call(Node, aec_db_gc, config, []),
+    #{ <<"enabled">>  := false
+     , <<"history">>  := History} = rpc:call(Node, aec_db_gc, config, []),
     ShortHistory = 51,
     enable_gc(Node, ShortHistory),
-    #{enabled  := true 
-    , interval := Interval
-    , history  := ShortHistory} = rpc:call(Node, aec_db_gc, config, []),
+    #{ <<"enabled">>  := true
+     , <<"history">>  := ShortHistory} = rpc:call(Node, aec_db_gc, config, []),
     Height= rpc:call(Node, aec_chain, top_height, []),
     BlocksCnt = 3,
     true = BlocksCnt < ShortHistory,
@@ -1551,31 +1549,28 @@ rollback_when_gc_enabled(Config) ->
     ok = do_rollback(Node, Height),
     ct:log("Top height ~p", [Height]),
     disable_gc(Node, History),
-    #{enabled  := false
-    , interval := Interval
-    , history  := History} = rpc:call(Node, aec_db_gc, config, []),
+    #{ <<"enabled">>  := false
+     , <<"history">>  := History} = rpc:call(Node, aec_db_gc, config, []),
     ok.
 
 rollback_when_gc_enabled_and_beyond_kept_history(Config) ->
     [{_, Node}] = ?config(nodes, Config), % important that there is only one
-    #{enabled  := false
-    , interval := Interval
-    , history  := History} = rpc:call(Node, aec_db_gc, config, []),
+    #{ <<"enabled">>  := false
+     , <<"history">>  := History} = rpc:call(Node, aec_db_gc, config, []),
     ShortHistory = 51,
     enable_gc(Node, ShortHistory),
-    #{enabled  := true 
-    , interval := Interval
-    , history  := ShortHistory} = rpc:call(Node, aec_db_gc, config, []),
+    #{ <<"enabled">>  := true
+     , <<"history">>  := ShortHistory} = rpc:call(Node, aec_db_gc, config, []),
     Height= rpc:call(Node, aec_chain, top_height, []),
+    ct:log("TopHeight = ~p", [Height]),
     BlocksCnt = 53,
     true = BlocksCnt > ShortHistory,
     {ok, _} = aecore_suite_utils:mine_key_blocks(Node, BlocksCnt),
     ok = fail_rollback(Node, Height),
     ct:log("Top height ~p", [Height]),
     disable_gc(Node, History),
-    #{enabled  := false
-    , interval := Interval
-    , history  := History} = rpc:call(Node, aec_db_gc, config, []),
+    #{ <<"enabled">>  := false
+     , <<"history">>  := History} = rpc:call(Node, aec_db_gc, config, []),
     ok.
 
 

--- a/apps/aens/src/aens_state_tree.erl
+++ b/apps/aens/src/aens_state_tree.erl
@@ -26,6 +26,8 @@
          new_with_backend/2,
          new_with_dirty_backend/2,
          root_hash/1,
+         ns_db/1,
+         cache_db/1,
          auction_iterator/1,
          auction_iterator_next/1]).
 
@@ -219,6 +221,14 @@ lookup_name(Id, Tree) ->
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 root_hash(#ns_tree{mtree = MTree}) ->
     aeu_mtrees:root_hash(MTree).
+
+-spec ns_db(tree()) -> {'ok', aeu_mp_trees:db()}.
+ns_db(#ns_tree{mtree = MTree}) ->
+    aeu_mtrees:db(MTree).
+
+-spec cache_db(tree()) -> {'ok', aeu_mp_trees:db()}.
+cache_db(#ns_tree{cache = CTree}) ->
+    aeu_mtrees:db(CTree).
 
 -spec cache_root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 cache_root_hash(#ns_tree{cache = MTree}) ->

--- a/apps/aens/test/aens_test_utils.erl
+++ b/apps/aens/test/aens_test_utils.erl
@@ -41,7 +41,7 @@ new_state() ->
     #{}.
 
 trees(#{} = S) ->
-    maps:get(trees, S, aec_trees:new()).
+    maps:get(trees, S, aec_trees:new_without_backend()).
 
 set_trees(Trees, S) ->
     S#{trees => Trees}.

--- a/apps/aeoracle/src/aeo_state_tree.erl
+++ b/apps/aeoracle/src/aeo_state_tree.erl
@@ -29,6 +29,8 @@
         , prune/2
         , prune/3
         , root_hash/1
+        , oracles_db/1
+        , cache_db/1
         ]).
 
 -export([ from_binary_without_backend/1
@@ -205,6 +207,14 @@ is_oracle(Pubkey, #oracle_tree{ otree = OTree }) ->
 -spec root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 root_hash(#oracle_tree{otree = OTree}) ->
     aeu_mtrees:root_hash(OTree).
+
+-spec oracles_db(tree()) -> {'ok', aeu_mp_trees:db()}.
+oracles_db(#oracle_tree{otree = OTree}) ->
+    aeu_mtrees:db(OTree).
+
+-spec cache_db(tree()) -> {'ok', aeu_mp_trees:db()}.
+cache_db(#oracle_tree{cache = CTree}) ->
+    aeu_mtrees:db(CTree).
 
 -spec cache_root_hash(tree()) -> {ok, aeu_mtrees:root_hash()} | {error, empty}.
 cache_root_hash(#oracle_tree{cache = CTree}) ->

--- a/apps/aeoracle/test/aeo_test_utils.erl
+++ b/apps/aeoracle/test/aeo_test_utils.erl
@@ -36,7 +36,7 @@ new_state() ->
     #{}.
 
 trees(#{} = S) ->
-    maps:get(trees, S, aec_trees:new()).
+    maps:get(trees, S, aec_trees:new_without_backend()).
 
 set_trees(Trees, S) ->
     S#{trees => Trees}.

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1588,22 +1588,50 @@
                     "type" : "object",
                     "additionalProperties" : false,
                     "properties" : {
-                        "enabled": {
-                            "description": "If true, node will perform garbage collection of account state, removing unreachable merkle patricia nodes and free some disk space",
+                        "enabled" : {
+                            "description": "If true, node will perform garbage collection of state trees, removing unreachable merkle patricia nodes and free some disk space",
                             "type": "boolean",
                             "default": false
                         },
+                        "during_sync" : {
+                            "description" : "If true, node will start garbage-collecting immediately, without waiting for sync to complete",
+                            "type" : "boolean",
+                            "default" : false
+                        },
+                        "minimum_height" : {
+                            "description" : "Minimum height at which to trigger garbage collection",
+                            "type" : "integer",
+                            "minimum" : 0,
+                            "default" : 0
+                        },
                         "interval" : {
-                            "description": "How often (every `interval` block) should garbage collection run",
-                            "type": "integer",
-                            "minimum": 3,
-                            "default": 50000
+                            "description" : "DEPRECATED. How often (every `interval` block) should garbage collection run",
+                            "type" : "integer",
+                            "minimum" : 3,
+                            "default" : 50000
                         },
                         "history" : {
-                            "description": "How many blocks (back from the top) should be scanned for reachable hashes",
-                            "type": "integer",
-                            "minimum": 50,
-                            "default": 500
+                            "description" : "How many blocks (back from the top) should be scanned for reachable hashes",
+                            "type" : "integer",
+                            "minimum" : 50,
+                            "default" : 15000
+                        },
+                        "trees" : {
+                            "description": "Which state trees to scan. Default: all of them",
+                            "type" : "array",
+                            "items" : {
+                                "description" : "Tree name",
+                                "type" : "string",
+                                "enum" : ["accounts", "calls", "channels",
+                                          "contracts", "ns", "oracles"]
+                            },
+                            "minItems" : 1,
+                            "default" : ["accounts",
+                                         "calls",
+                                         "channels",
+                                         "contracts",
+                                         "ns",
+                                         "oracles"]
                         }
                     }
                 }
@@ -2113,6 +2141,21 @@
                         "max_time" : {
                             "type" : "integer",
                             "default" : 0
+                        }
+                    }
+                },
+                "gc_scan" : {
+                    "description" : "DB Garbage collection scan chunks",
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "counter" : {
+                            "type" : "integer",
+                            "default" : 1
+                        },
+                        "rate" : {
+                            "type" : "integer",
+                            "default" : 50
                         }
                     }
                 }

--- a/apps/aeutils/priv/db_rollback
+++ b/apps/aeutils/priv/db_rollback
@@ -166,14 +166,13 @@ header_by_height(Node, H) ->
             abort("Could not fetch header at height ~p", [H])
     end.
 
-
 assert_gc(Node, TopHeight, RollbackHeight) ->
-    #{enabled  := Enabled
-    , interval := _Interval
-    , history  := History} = rpc:call(Node, aec_db_gc, config, []),
+    #{ <<"enabled">>  := Enabled
+     , <<"history">>  := History} = rpc:call(Node, aec_db_gc, config, []),
     case Enabled of
         true ->
-            LowestAllowedHeight = TopHeight - History,
+            io:fwrite("GC enabled; History: ~p~n", [History]),
+            LowestAllowedHeight = TopHeight - History + 1,
             case RollbackHeight < LowestAllowedHeight of
                 true ->
                     abort("Rollback height (~p) is marked for GC. Lowest allowed rollback height is ~p",

--- a/apps/aeutils/priv/maintenance
+++ b/apps/aeutils/priv/maintenance
@@ -47,8 +47,8 @@ set_mode(Mode, Node, Timeout) ->
 get_mode(Node) ->
     Res = rpc:call(Node, app_ctrl, get_mode, []),
     Output = case Res of
-                 maintenance -> on
-                 _ -> off;
+                 maintenance -> on;
+                 _ -> off
              end,
     io:fwrite("~p~n", [Output]),
     erlang:halt(0).

--- a/apps/aeutils/src/aeu_mp_trees.erl
+++ b/apps/aeutils/src/aeu_mp_trees.erl
@@ -13,6 +13,7 @@
         , commit_reachable_to_db/1
         , construct_proof/3
         , db/1
+        , has_backend/1
         , delete/2
         , gc_cache/1
         , get/2
@@ -62,7 +63,7 @@
              }).
 
 -record(db_mpt, { hash :: <<>> | hash()
-                , db   = aeu_mp_trees_db:db()
+                , db   :: aeu_mp_trees_db:db()
                 }).
 
 -record(iter, { key  = <<>>          :: <<>> | key()
@@ -151,6 +152,10 @@ tree_no_cache(MPT = #mpt{}) ->
 -spec db(tree()) -> db().
 db(#mpt{ db = DB}) ->
     DB.
+
+-spec has_backend(tree()) -> boolean().
+has_backend(#mpt{ db = DB }) ->
+    ?MODULE =/= aeu_mp_trees_db:get_module(DB).
 
 -spec from_db_format(tree() | tuple()) -> tree().
 from_db_format(Tree = #mpt{}) -> Tree;

--- a/apps/aeutils/src/aeu_mp_trees_db.erl
+++ b/apps/aeutils/src/aeu_mp_trees_db.erl
@@ -21,6 +21,7 @@
         , is_db/1
         , get_cache/1
         , get_handle/1
+        , get_module/1
         , unsafe_write_to_backend/3
         ]).
 
@@ -127,6 +128,11 @@ get_cache(DB) ->
 get_handle(DB) ->
     #db{handle = Handle} = to_new_db(DB),
     Handle.
+
+-spec get_module(db()) -> atom().
+get_module(DB) ->
+    #db{module = Module} = to_new_db(DB),
+    Module.
 
 %%%===================================================================
 %%% Cache

--- a/apps/aeutils/src/aeu_mtrees.erl
+++ b/apps/aeutils/src/aeu_mtrees.erl
@@ -33,6 +33,7 @@
 %% API - Merkle tree
 -export([root_hash/1,
          db/1,
+         has_backend/1,
          lookup_with_proof/2,
          lookup_with_proof/3,
          verify_proof/4,
@@ -216,6 +217,10 @@ root_hash(Tree) ->
 -spec db(mtree()) -> {ok, db()}.
 db(Tree) ->
     {ok, aeu_mp_trees:db(Tree)}.
+
+-spec has_backend(mtree()) -> boolean().
+has_backend(Tree) ->
+    aeu_mp_trees:has_backend(Tree).
 
 -spec lookup_with_proof(key(), mtree()) -> none |
                                            {value_and_proof, value(), proof()}.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,4 +16,5 @@ There is also additional documentation on mining with CUDA and build and/or join
 - [Stratum](stratum.md)
 - [Network Monitoring](monitoring.md)
 - [Fork Resistance](fork-resistance.md)
+- [Garbage Collection](garbage-collection.md)
 - [Node API](api.md)

--- a/docs/garbage-collection.md
+++ b/docs/garbage-collection.md
@@ -1,0 +1,121 @@
+# Introduction
+
+This document describes how garbage collection works in the Aeternity node, and how to
+use it.
+
+## What is garbage collection?
+
+Blockchains act as "append-only" repositories, i.e. you can only add data, not modify it.
+At any given block height, the "state" of the blockchain is the set of current values
+of accounts, contract and oracle states, registered names and ongoing name auctions and
+active state channels. For any state object, it is possible to inspect its history by
+fetching its value relative to previous block heights. The "root hash" of a block header
+identifies a slice of the blockchain state trees representing all the live state and values
+that were current at that point in time.
+
+The drawback of this is of course that the size of the blockchain keeps growing. Ultimately,
+it becomes impractical to keep the entire chain on a local computer.
+
+Garbage collection is a way to "prune" the history of states, that is we keep the state of
+a number of blocks beneath the top, but delete the ones beneath that. Importantly, all the
+latest values of all accessible state is always kept. What is deleted is the state that
+has been overwritten at some point.
+
+## Configuration
+
+Garbage collection can be customized with the following configuration options:
+
+### `chain:garbage_collection:enabled`
+
+**type: `boolean`**
+**default: `false`**
+
+This is the master switch, controlling whether or not garbage collection is active.
+
+### `chain:garbage_collection:during_sync`
+
+**type: `boolean`**
+**default: `false`**
+
+If `true`, garbage collection will not wait for chain sync to complete.
+Garbage-collecting during chain sync will slow down the sync process - exactly how much
+depends on the settings, but around 30 % is a reasonable expectation. The upside is that
+the on-disk footprint stays small.
+
+Note that the node cannot be sure when sync is fully completed. Garbage collection will
+wait (if `during_sync: false`) for the first indication that sync has completed
+_given the information available_. New information may arrive when other peers are
+found, but the garbage collector will not go back to waiting, once activated.
+
+### `chain:garbage_collection:minimum_height`
+
+**type: `integer`** (non-negative)
+**default: `0`**
+
+If set to a value `> 0`, garbage collection will not kick in until this height is reached.
+This could be used to speed up sync (when used together with `during_sync: true`),
+since chain sync can proceed at full speed until the given height is reached.
+
+### `chain:garbage_collection:history`
+
+**type: `integer`** (minimum: `50`)
+**default: `15000`** (ca 31 days)
+
+Determines how much history to keep. The unit is number of key blocks.
+
+### `chain:garbage_collection:trees`
+
+**type: `array`**
+**default: _all the trees_**
+
+Makes it possible to garbage-collect only a subset of the state trees.
+This would be touched mainly if there is a requirement to actually keep the
+history of a given state (e.g. `accounts`), but still reduce the space requirement
+somewhat. It could also possibly be a way to reduce the overhead of garbage collection
+(also getting less space reduction).
+
+**Example: `["accounts", "ns"]` (the two largest state trees)
+
+The array may not be empty. An empty array would mean that nothing is garbage-collected.
+This effect is better achieved using `enabled: false`.
+
+### `regulators:gc_scan`
+
+**type: `object`**
+
+This group allows for configuration of the load regulation of the garbage-collection scans.
+You should not touch this unless you are knowledgeable of the node internals and willing
+to experiment. The way garbage collection works is that sets of A/B database table pairs
+are switched at a given height, and a scan is started for each tree, ensuring that all
+reachable state is promoted into the current "A" table. Once the scan has been completed,
+AND the `history` depth has been reached since the last switch, a clear-and-switch operation
+can be performed. This means that there is normally ample time to perform the sweeps, and
+the load regulation parameters can be set quite low.
+
+The situation is a little different during sync, as the `history` depth is likely to be
+reached very quickly. It is therefore possible that the load regulation becomes the factor
+determining how frequently data can be cleared.
+
+It is important to know that file system IO capacity can easily become the bottleneck,
+and trying to run faster, can lead to write stalls and internal timeouts.
+
+The unit of regulation is a "chunk" of `100` state tree object lookups. That is, the
+scanner will touch 100 trie nodes, then pause until the regulator gives permission to
+continue. Each tree has its own scanner process, running concurrently with the others.
+
+#### `regulators:gc_scan:counter`
+
+**type: `integer`** (minimum: `0` - meaning no counter regulation)
+**default: `1`**
+
+This controls how many scanner chunks can be actively processed at the same time.
+Increasing this value may not increase performance. It could even have the opposite effect.
+
+#### `regulators:gc_scan:rate`
+
+**type: `integer`** (minimum: `0` - meaning no counter regulation)
+**default: `50`**
+
+This controls how many chunks per second are allowed to run.
+Increasing this value may not increase performance, but lowering it, should lower
+the overhead of garbage collection, possibly at the cost of effective space reduction.

--- a/docs/release-notes/next/GH-3883-generalized-gc.md
+++ b/docs/release-notes/next/GH-3883-generalized-gc.md
@@ -1,0 +1,3 @@
+* Garbage collection has been rewritten, and now operates on all state trees. It is also
+  capable of running during chain sync.
+  See the documentation, garbage_collection.md, for information on how to configure it.


### PR DESCRIPTION
(replaces #4104)

See issue #3883 

This PR introduces a rewritten GC, using A/B table pairs for each state tree.
State tree object lookups on GC:d trees will try the A table first, then the B table. If found in B, the object is automatically promoted into A. Writes always go to A.

A GC switch (triggered by `aec_conductor` when all conditions are met), involves clearing B, then making it the new A, then starting a scanner process on the given height, which (slowly, in the background) touches each reachable node, ensuring that all reachable state is promoted into the new A. Meanwhile, all new blocks added to the chain will automatically write to the new A. When all such passes are complete for the given height, _and_ the requested history depth has been reached, a new switch can be performed.

The GC can run from the beginning, and adds ca 30% to the chain sync time with `history: 10000`.

The gc scans are regulated by `jobs`. If they run too slowly, more state than the requested history depth may be kept.