### PR TITLE
Limit body request length

### DIFF
--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -23,7 +23,6 @@
 -define(DEFAULT_CHANNEL_WEBSOCKET_LISTEN_ADDRESS, <<"127.0.0.1">>).
 -define(DEFAULT_CHANNEL_ACCEPTORS, 10).
 
--define(MAX_REQUEST_LINE_LENGTH, 1024).
 % 6M gas per microblock/tx / 20 gas per byte = 300kB
 % 400k after encoding
 -define(DEFAULT_MAX_SKIP_BODY_LENGTH, 440000).
@@ -146,7 +145,6 @@ start_http_api(Target, LogicHandler) ->
             },
     Env = #{env => #{dispatch => Dispatch},
             idle_timeout => 480000,
-            max_request_line_length => ?MAX_REQUEST_LINE_LENGTH,
             max_skip_body_length => get_http_max_skip_body_length(),
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
@@ -169,7 +167,6 @@ start_channel_websocket() ->
                              , {ip, ListenAddress} ]
             },
     Env = #{ env => #{dispatch => Dispatch}
-           , max_request_line_length => ?MAX_REQUEST_LINE_LENGTH
            , max_skip_body_length => get_http_max_skip_body_length()},
     lager:debug("Opts = ~p", [Opts]),
     {ok, _} = cowboy:start_clear(channels_socket, Opts, Env),

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -26,6 +26,8 @@
 -define(DEFAULT_CHANNEL_WEBSOCKET_LISTEN_ADDRESS, <<"127.0.0.1">>).
 -define(DEFAULT_CHANNEL_ACCEPTORS, 10).
 
+-define(MAX_REQUEST_LINE_LENGTH, 1024).
+
 %% Application callbacks
 -export([start/2, stop/1]).
 
@@ -145,6 +147,7 @@ start_http_api(Target, LogicHandler) ->
             },
     Env = #{env => #{dispatch => Dispatch},
             idle_timeout => 480000,
+            max_request_line_length => ?MAX_REQUEST_LINE_LENGTH,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
                             cowboy_handler]},
@@ -165,7 +168,8 @@ start_channel_websocket() ->
             , socket_opts => [ {port, Port}
                              , {ip, ListenAddress} ]
             },
-    Env = #{env => #{dispatch => Dispatch}},
+    Env = #{ env => #{dispatch => Dispatch}
+           , max_request_line_length => ?MAX_REQUEST_LINE_LENGTH},
     lager:debug("Opts = ~p", [Opts]),
     {ok, _} = cowboy:start_clear(channels_socket, Opts, Env),
     ok.

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -23,9 +23,8 @@
 -define(DEFAULT_CHANNEL_WEBSOCKET_LISTEN_ADDRESS, <<"127.0.0.1">>).
 -define(DEFAULT_CHANNEL_ACCEPTORS, 10).
 
-% 6M gas per microblock/tx / 20 gas per byte = 300kB
-% 400k after encoding
--define(DEFAULT_MAX_SKIP_BODY_LENGTH, 440000).
+% cowboy default
+-define(DEFAULT_MAX_SKIP_BODY_LENGTH, 1000000).
 
 %% Application callbacks
 -export([start/2, stop/1]).

--- a/apps/aehttp/test/aehttp_ae_sim.erl
+++ b/apps/aehttp/test/aehttp_ae_sim.erl
@@ -37,7 +37,6 @@ start_cowboy(Name, Port) ->
             {ip, {127,0,0,1}},
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
-            max_request_line_length => 1024,
             max_skip_body_length => 440000,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,

--- a/apps/aehttp/test/aehttp_ae_sim.erl
+++ b/apps/aehttp/test/aehttp_ae_sim.erl
@@ -38,6 +38,7 @@ start_cowboy(Name, Port) ->
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
             max_request_line_length => 1024,
+            max_skip_body_length => 440000,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
                             cowboy_handler]},

--- a/apps/aehttp/test/aehttp_ae_sim.erl
+++ b/apps/aehttp/test/aehttp_ae_sim.erl
@@ -37,7 +37,7 @@ start_cowboy(Name, Port) ->
             {ip, {127,0,0,1}},
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
-            max_skip_body_length => 440000,
+            max_skip_body_length => 1000000,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
                             cowboy_handler]},

--- a/apps/aehttp/test/aehttp_ae_sim.erl
+++ b/apps/aehttp/test/aehttp_ae_sim.erl
@@ -37,6 +37,7 @@ start_cowboy(Name, Port) ->
             {ip, {127,0,0,1}},
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
+            max_request_line_length => 1024,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
                             cowboy_handler]},

--- a/apps/aehttp/test/aehttp_btc_sim.erl
+++ b/apps/aehttp/test/aehttp_btc_sim.erl
@@ -39,7 +39,7 @@ start_cowboy(Name, Port, Pid) ->
             {ip, {127,0,0,1}},
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
-            max_skip_body_length => 440000,
+            max_skip_body_length => 1000000,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
                             cowboy_handler]},

--- a/apps/aehttp/test/aehttp_btc_sim.erl
+++ b/apps/aehttp/test/aehttp_btc_sim.erl
@@ -40,6 +40,7 @@ start_cowboy(Name, Port, Pid) ->
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
             max_request_line_length => 1024,
+            max_skip_body_length => 440000,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
                             cowboy_handler]},

--- a/apps/aehttp/test/aehttp_btc_sim.erl
+++ b/apps/aehttp/test/aehttp_btc_sim.erl
@@ -39,7 +39,6 @@ start_cowboy(Name, Port, Pid) ->
             {ip, {127,0,0,1}},
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
-            max_request_line_length => 1024,
             max_skip_body_length => 440000,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,

--- a/apps/aehttp/test/aehttp_btc_sim.erl
+++ b/apps/aehttp/test/aehttp_btc_sim.erl
@@ -39,6 +39,7 @@ start_cowboy(Name, Port, Pid) ->
             {ip, {127,0,0,1}},
             {num_acceptors, 3}],
     Env = #{env => #{dispatch => Dispatch},
+            max_request_line_length => 1024,
             middlewares => [aehttp_cors_middleware,
                             cowboy_router,
                             cowboy_handler]},

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1235,6 +1235,18 @@
                         }
                     }
                 },
+                "protocol_options" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "max_skip_body_length": {
+                          "description": "Cowboy limit to request body size",
+                          "type": "integer",
+                          "example": 400000,
+                          "default": 1000000
+                        }
+                    }
+                },
                 "external" : {
                     "type" : "object",
                     "additionalProperties" : false,

--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -90,6 +90,9 @@ http:
         allow_methods: ["DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT"]
         # Indicates for how many seconds the results of a preflight request can be cached
         max_age: 1800
+    protocol_options:
+        # Cowboy limit to the body size of requests (in bytes)
+        max_skip_body_length: 1000000
     external:
         # Port used for external HTTP API
         port: 3013

--- a/config/dev.config
+++ b/config/dev.config
@@ -10,7 +10,7 @@
 
   { aehttp, [
       {protocol_options, [
-        {max_skip_body_length, 440000}
+        {max_skip_body_length, 1000000}
         ]},
       {external, [
           {acceptors, 10},

--- a/config/dev.config
+++ b/config/dev.config
@@ -9,6 +9,9 @@
   },
 
   { aehttp, [
+      {protocol_options, [
+        {max_skip_body_length, 440000}
+        ]},
       {external, [
           {acceptors, 10},
           {port, 3013}

--- a/config/sys.config
+++ b/config/sys.config
@@ -16,6 +16,9 @@
   },
 
   { aehttp, [
+      {protocol_options, [
+        {max_skip_body_length, 440000}
+        ]},
       {external, [
           {acceptors, 10},
           {port, 3013}

--- a/config/sys.config
+++ b/config/sys.config
@@ -17,7 +17,7 @@
 
   { aehttp, [
       {protocol_options, [
-        {max_skip_body_length, 440000}
+        {max_skip_body_length, 1000000}
         ]},
       {external, [
           {acceptors, 10},

--- a/docs/release-notes/next/limit_body_req_length.md
+++ b/docs/release-notes/next/limit_body_req_length.md
@@ -1,0 +1,14 @@
+* Provides a way to setup the API webserver to skip reading the http 
+  request body after an amount of bytes. When the length is too large
+  the webserver will close the connection. This is initially meant for 
+  the Mdw but Nodes with lower RAM spec would benefit too.
+  On sys.config, it's an `aehttp`
+  config with the property:
+    ```
+    {protocol_options, [
+        {max_skip_body_length, 1000000}
+        ]}
+    ```
+  The minimum recommended value is 400000 to fully read a POST with the max
+  amount of bytes/gas that AE protocol allows in a micro block.
+  


### PR DESCRIPTION
- Allows setting request body limit by the Mdw (default is 1MB)
- It would be a safer call to set a lower limit to the Node as well but as requested this depends on monitoring how the `/dry-run` have been used so the config value is kept to the one default to cowboy. 
