### PR TITLE
Set explicit user id for docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN ln -fs librocksdb.so.6.13.3 /usr/local/lib/librocksdb.so.6.13 \
 COPY --from=builder /app/_build/prod/rel/aeternity /home/aeternity/node
 
 # Aeternity app won't run as root for security reasons
-RUN useradd --shell /bin/bash aeternity \
+RUN useradd --uid 1000 --shell /bin/bash aeternity \
     && chown -R aeternity:aeternity /home/aeternity
 
 # Switch to non-root user


### PR DESCRIPTION
Sets the current user id explicitly to make sure it's the same as the one set on the Mdw:
https://github.com/aeternity/ae_mdw/blob/a94b1d2acf0df30a16572d301aaf68eaf4d2a5cc/Dockerfile#L130

This allows setting the permission of existing `mdw` and `mnesia` database under Mdw `data/` without inspecting to which id the `aeternity` user is mapped to.