### PR TITLE
Ceres: prepare AENS auction changes

### DIFF
--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -779,26 +779,6 @@ decode_data_(aevm, Type, Data0) ->
     after
         cleanup_tempfiles()
     end.
-%%     case get_type(Type) of
-%%         {ok, SophiaType} ->
-%%             try aeb_heap:from_binary(SophiaType, Data) of
-%%                 {ok, Term} ->
-%%                     try aect_sophia:prepare_for_json(SophiaType, Term) of
-%%                         R -> {ok, R}
-%%                     catch throw:R -> R
-%%                     end;
-%%                 {error, _} -> {error, <<"bad type/data">>}
-%%             catch _T:_E ->    {error, <<"bad argument">>}
-%%             end;
-%%         {error, _} = E -> E
-%%     end.
-
-get_type(Type) ->
-    case aeso_compiler:sophia_type_to_typerep(to_str(Type)) of
-        {ok, _Type} = R -> R;
-        {error, ErrorAtom} ->
-            {error, unicode:characters_to_binary(atom_to_list(ErrorAtom))}
-    end.
 
 %% Convert to old style hex literals.
 legacy_args(Vsn, Args) when Vsn =< ?SOPHIA_MINERVA ->

--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -94,7 +94,7 @@ start_link() ->
 %% ParentConnMod :: atom() - module name of the http client module aehttpc_btc | aehttpc_aeternity
 %% FetchInterval :: integer() | on_demand - millisecs between parent chain checks or when asked (useful for test)
 %% ParentHosts :: [#{host => Host, port => Port, user => User, password => Pass}]
-%% NetworkID :: binary() - the parent chain's network id 
+%% NetworkID :: binary() - the parent chain's network id
 %% SignModule :: atom() - module name of the module that keeps the keys for the parent chain transactions to be signed
 %% HCPCPairs :: [{binary(), binary()}] - mapping from hyperchain address to child chain address
 %% Recipient :: binary() - the parent chain address to which the commitments must be sent to
@@ -210,7 +210,7 @@ handle_info(check_parent, #state{parent_hosts = ParentNodes,
                 aec_parent_chain_cache:post_block(NewParentTop),
                 %_Commitments = fetch_commitments(Mod, Node, Seed,
                 %                                 aec_parent_chain_block:hash(NewParentTop))
-                %% Commitments may include varying view on what is the latest 
+                %% Commitments may include varying view on what is the latest
                 %%   block.
                 %% Commitments include:
                 %%   [{Committer, Committers view of child chain top hash}]

--- a/apps/aecore/test/aec_parent_chain_cache_tests.erl
+++ b/apps/aecore/test/aec_parent_chain_cache_tests.erl
@@ -486,10 +486,6 @@ height_to_hash(Height) when is_integer(Height) -> <<Height:32/unit:8>>.
 %%             {0, 0},
 %%             MeaningfulBytes),
 %%     Height.
-block_by_height(Height, Commitments) ->
-    B0 = block_by_height(Height),
-    aec_parent_chain_block:set_commitments(B0, Commitments).
-
 
 block_by_height(Height) ->
     Hash = height_to_hash(Height),
@@ -641,24 +637,3 @@ filter_meck_events(Module, Function) ->
             M =:= Module andalso F =:= Function
         end,
         meck:history(Module)).
-
-mock_commitments_list(_BlockHashesMap) ->
-    meck:expect(aec_parent_connector, request_block_by_height,
-                fun(Height) ->
-                    spawn(
-                        fun() ->
-                            Block = block_by_height(Height),
-                            ?TEST_MODULE:post_block(Block)
-                        end)
-            end).
-
-mock_commitments_list(all, L) ->
-    meck:expect(aec_parent_connector, request_block_by_height,
-                fun(Height) ->
-                    spawn(
-                        fun() ->
-                            Block0 = block_by_height(Height),
-                            Block = aec_parent_chain_block:set_commitments(Block0, L),
-                            ?TEST_MODULE:post_block(Block)
-                        end)
-            end).

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -568,7 +568,7 @@ start_node(N, Config, ExtraEnv) ->
             _ ->
                 ["-pa ", MyDir, " -config ./" ++ ConfigFilename]
         end,
-    Env0 = 
+    Env0 =
         case ?config(build_to_connect_to_mainnet, Config) of
             true ->
                 [
@@ -853,9 +853,6 @@ wait_for_new_block_mined(T) when is_integer(T), T >= 0 ->
             end,
             {error, timeout_waiting_for_block}
     end.
-
-wait_for_new_block() ->
-    wait_for_new_block(30000).
 
 wait_for_new_block(T) when is_integer(T), T >= 0 ->
     receive

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -1996,10 +1996,6 @@ get_status_sut(IntAsString) ->
     Parameters = case IntAsString of true -> "?int-as-string"; false -> "" end,
     http_request(Host, get, "status" ++ Parameters, []).
 
-prepare_tx(TxType, Args) ->
-    SignHash = lists:last(aec_hard_forks:sorted_protocol_versions()) >= ?LIMA_PROTOCOL_VSN,
-    prepare_tx(TxType, Args, SignHash).
-
 prepare_tx(TxType, Args, SignHash) ->
     %assert_required_tx_fields(TxType, Args),
     {Host, Path} = tx_object_http_path(TxType),

--- a/apps/aehttp/test/aehttp_parent_connector_tests.erl
+++ b/apps/aehttp/test/aehttp_parent_connector_tests.erl
@@ -503,7 +503,7 @@ mock_sign_module(#{pubkey := ExpectedPubKey, privkey := PrivKey}) ->
     meck:new(?SIGN_MODULE, []),
     meck:expect(?SIGN_MODULE, sign_binary,
         fun(Bin, Pubkey) when Pubkey =:= ExpectedPubKey ->
-            Signature = enacl:sign_detached(Bin, PrivKey), 
+            Signature = enacl:sign_detached(Bin, PrivKey),
             {ok, Signature}
         end).
 

--- a/apps/aens/src/aens_pointer.erl
+++ b/apps/aens/src/aens_pointer.erl
@@ -59,10 +59,11 @@ serialize_id_for_client({data, Data}) ->
 serialize_id_for_client(Id) ->
     aeser_api_encoder:encode(id_hash, Id).
 
-%% TODO: check max length of key?
+-define(MAX_RAW_POINTER_SIZE, 1024).
+
 assert_key(Key) when is_binary(Key) -> ok.
 
-assert_data(Data) when is_binary(Data), byte_size(Data) =< 1024 -> ok.
+assert_data(Data) when is_binary(Data), byte_size(Data) =< ?MAX_RAW_POINTER_SIZE -> ok.
 
 assert_id(Id) ->
     assert_id_type(aeser_id:specialize_type(Id)).

--- a/apps/aestratum/test/aestratum_integration_SUITE.erl
+++ b/apps/aestratum/test/aestratum_integration_SUITE.erl
@@ -458,7 +458,6 @@ make_shortcut(Cfg) ->
 
 write_stratum_keys(AbsoluteKeysPath, Cfg) ->
     #{pubkey := PubKey, privkey := PrivKey} = ?config(stratum_keypair, Cfg),
-    MNodeTopDir = aecore_suite_utils:node_shortcut(?STRATUM_SERVER_NODE, Cfg),
     ct:log("AbsoluteKeysPath = ~p", [AbsoluteKeysPath]),
     filelib:ensure_dir(filename:join([AbsoluteKeysPath, "foo"])),
     file:write_file(filename:join(AbsoluteKeysPath, ?STRATUM_PRIVKEY_FILE), PrivKey),

--- a/docs/release-notes/next-ceres/aens_auction_adjustments.md
+++ b/docs/release-notes/next-ceres/aens_auction_adjustments.md
@@ -1,0 +1,3 @@
+* Adjust the AENS auction mechanism; 1. make auctions initially shorter, and 2.
+  new bids only extend auctions with a short period, and it is only extended if
+  the new bid comes near the end of the auction (within the extension period).


### PR DESCRIPTION
This introduce the necessary refactorings, and a logic mechanism for shorter auction extensions.  Related to #3853

This PR is supported by the Æternity Crypto Foundation