### PR TITLE
Add bigint format type hint

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -286,6 +286,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: "bigint"
             minimum: 1
             example: 1
       responses:
@@ -819,6 +820,7 @@ paths:
           required: false
           schema:
             type: integer
+            format: "bigint"
             default: 20
             minimum: 1
             maximum: 1000
@@ -1801,6 +1803,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: "bigint"
             minimum: 0
       responses:
         "200":
@@ -2066,29 +2069,34 @@ paths:
 components:
   schemas:
     UInt:
+      format: "bigint"
       oneOf:
         - type: integer
           minimum: 0
         - type: string
     UInt16:
+      format: "bigint"
       oneOf:
         - type: integer
           minimum: 0
           maximum: 65535
         - type: string
     UInt32:
+      format: "bigint"
       oneOf:
         - type: integer
           minimum: 0
           maximum: 4294967295
         - type: string
     UInt64:
+      format: "bigint"
       oneOf:
         - type: integer
           minimum: 0
           maximum: 18446744073709552000
         - type: string
     TxBlockHeight:
+      format: "bigint"
       oneOf:
         - type: integer
           minimum: -1
@@ -3784,6 +3792,7 @@ components:
       required: true
       schema:
         type: integer
+        format: "bigint"
         minimum: 0
         maximum: 18446744073709552000
         example: 42


### PR DESCRIPTION
Here is a suggestion to add type hints, which can be used by the REST client generators, in order to encourage usage of the native JS type `bigint` (and similar types in other languages).

The format keyword is probably the right way to do it, according to the OAS spec. Here are some docs: https://swagger.io/docs/specification/data-models/data-types/
Search for "format modifier" in the page.

I am still not sure about the implications of this, let's discuss it first.