### PR TITLE
Return 410 code for queries beyond GC point

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1403,13 +1403,13 @@ handle_successfully_added_block(Block, Hash, true, PrevKeyHeader, Events, State,
             (BlockType == key) andalso
                 aec_metrics:try_update(
                   [ae,epoch,aecore,blocks,key,info], info_value(NewTopBlock)),
+            [ maybe_garbage_collect(NewTopBlock) || BlockType == key ],
             IsLeader = is_leader(NewTopBlock, PrevKeyHeader, ConsensusModule),
             case IsLeader of
                 true ->
                     ok; %% Don't spend time when we are the leader.
                 false ->
-                    aec_tx_pool:garbage_collect(),
-                    [ maybe_garbage_collect(NewTopBlock) || BlockType == key ]
+                    aec_tx_pool:garbage_collect()
             end,
             {ok, setup_loop(State2, true, IsLeader, Origin)}
     end.

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1537,9 +1537,11 @@ initialize_db(ram) ->
 
 install_test_env() ->
     ensure_backend_module(),
+    aec_db_gc:install_test_env(),
     ok.
 
 uninstall_test_env() ->
+    aec_db_gc:cleanup(),
     remove_added_pts().
 
 ensure_backend_module() ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -144,8 +144,10 @@
 
 -export([backend_mode/0]).
 
+-ifdef(TEST).
 -export([ install_test_env/0
         , uninstall_test_env/0 ]).
+-endif.
 
 -include("blocks.hrl").
 -include("aec_db.hrl").
@@ -1535,6 +1537,7 @@ initialize_db(ram) ->
 %% == Test setup env
 %% Ensures that e.g. persistent terms are present, logging which ones had to be added.
 
+-ifdef(TEST).
 install_test_env() ->
     ensure_backend_module(),
     aec_db_gc:install_test_env(),
@@ -1557,7 +1560,6 @@ ensure_backend_module() ->
 get_test_backend_module() ->
     Str = os:getenv("AETERNITY_TESTCONFIG_DB_BACKEND", "mnesia"),
     list_to_existing_atom(Str).
-
 note_added_pt(Key) ->
     Var = ?PT_ADDED_PTS,
     Set = persistent_term:get(Var, ordsets:new()),
@@ -1567,6 +1569,7 @@ remove_added_pts() ->
     Keys = persistent_term:get(?PT_ADDED_PTS, ordsets:new()),
     [persistent_term:erase(K) || K <- Keys],
     persistent_term:erase(?PT_ADDED_PTS).
+-endif.
 
 %% == End Test setup env
 

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -29,6 +29,7 @@
 -export([start_link/0]).
 
 -export([ height_of_last_gc/0
+        , state_at_height_still_reachable/1
         , info/0
         , info/1
         ]).
@@ -102,13 +103,32 @@ start_link() ->
 
 -spec maybe_garbage_collect(aec_headers:header()) -> ok | nop.
 maybe_garbage_collect(Header) ->
-    gen_server:call(
-      ?MODULE, {maybe_garbage_collect, aec_headers:height(Header), Header}).
+    case get_cached_enabled_status() of
+        true ->
+            gen_server:call(
+              ?MODULE, {maybe_garbage_collect, aec_headers:height(Header), Header});
+        false ->
+            nop
+    end.
 
 %% If GC is disabled, or there hasn't yet been a GC, this function returns 0.
 -spec height_of_last_gc() -> non_neg_integer().
 height_of_last_gc() ->
-    aec_db:ensure_activity(async_dirty, fun aec_db:read_last_gc_switch/0).
+    case get_cached_enabled_status() of
+        true ->
+            aec_db:ensure_activity(async_dirty, fun aec_db:read_last_gc_switch/0);
+        false ->
+            0
+    end.
+
+state_at_height_still_reachable(Height) ->
+    case get_cached_enabled_status() of
+        true ->
+            #{last_gc := LastGC} = info([last_gc]),
+            LastGC =< Height;
+        false ->
+            true
+    end.
 
 info() ->
     info(info_keys()).
@@ -129,7 +149,7 @@ info_keys() ->
 %%     maybe_swap_nodes(?GCED_TABLE_NAME, ?TABLE_NAME).
 
 %%%===================================================================
-%%% gen_statem callbacks
+%%% gen_server callbacks
 %%%===================================================================
 
 %% Change of configuration parameters requires restart of the node.
@@ -140,6 +160,7 @@ init(#{ <<"enabled">>     := Enabled
       , <<"minimum_height">> := MinHeight
       } = Cfg) when is_integer(History), History > 0 ->
     lager:debug("Cfg = ~p", [Cfg]),
+    cache_enabled_status(Enabled),
     LastSwitch = case Enabled of
                      true ->
                          aec_events:subscribe(chain_sync),
@@ -185,6 +206,7 @@ handle_call({maybe_garbage_collect, TopHeight, Header}, _From,
                 history = History, min_height = MinHeight,
                 trees = Trees, scanners = [], last_switch = Last} = St)
   when (Synced orelse DuringSync), TopHeight >= MinHeight, TopHeight > Last + History ->
+    lager:debug("WILL collect. St = ~p", [lager:pr(St, ?MODULE)]),
     %% Double-check that the GC hasn't been requested on a microblock.
     %% This would be a bug, since aec_conductor should only ask for keyblocks.
     case aec_headers:type(Header) of
@@ -200,6 +222,7 @@ handle_call({maybe_garbage_collect, TopHeight, Header}, _From,
             {reply, nop, St}
     end;
 handle_call({maybe_garbage_collect, _, _}, _From, St) ->
+    lager:debug("Won't collect. St = ~p", [lager:pr(St, ?MODULE)]),
     {reply, nop, St};
 handle_call({info, Keys}, _, St) ->
     {reply, info_(Keys, St), St}.
@@ -210,6 +233,12 @@ handle_cast({scanning_failed, ErrHeight}, St) ->
 
 handle_cast({scan_complete, Name}, #st{scanners = Scanners} = St) ->
     Scanners1 = lists:keydelete(Name, #scanner.tree, Scanners),
+    case Scanners1 of
+        [] ->
+            aec_events:publish(gc, scans_complete);
+        _ ->
+            ok
+    end,
     {noreply, St#st{scanners = Scanners1}};
 
 handle_cast(_, St) ->
@@ -249,6 +278,7 @@ perform_switch(Trees, Height) ->
                    switch_tables(Trees),
                    aec_db:write_last_gc_switch(Height)
            end),
+    aec_events:publish(gc, {gc_switch, Height}),
     [start_scanner(T, Height) || T <- Trees].
 
 clear_secondary_tables(Trees) ->
@@ -377,6 +407,12 @@ signal_switching_failed_and_reply(St, Reply) ->
             signal_scanning_failed(ErrHeight),
             {reply, Reply, St}
     end.
+
+cache_enabled_status(Bool) when is_boolean(Bool) ->
+    persistent_term:put({?MODULE, gc_enabled}, Bool).
+
+get_cached_enabled_status() ->
+    persistent_term:get({?MODULE, gc_enabled}).
 
 config() ->
     Trees = get_trees(),

--- a/apps/aecore/src/aec_events.erl
+++ b/apps/aecore/src/aec_events.erl
@@ -33,6 +33,7 @@
                | peers
                | metric
                | chain_sync
+               | gc
                | oracle_query_tx_created
                | oracle_response_tx_created
                | {tx_event, any()}.

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -33,6 +33,7 @@ prep_stop(State) ->
 
 stop(_State) ->
     lager:info("Stopping aecore app", []),
+    aec_db_gc:cleanup(),
     aec_db:cleanup(),
     ok.
 

--- a/apps/aecore/test/aec_test_utils.erl
+++ b/apps/aecore/test/aec_test_utils.erl
@@ -332,6 +332,7 @@ start_chain_db(ram) ->
     ok = aec_db:initialize_db(ram),
     Tabs = [Tab || {Tab, _} <- aec_db:tables(ram)],
     ok = mnesia:wait_for_tables(Tabs, 5000),
+    aec_db_gc:install_test_env(),
     ok;
 
 start_chain_db(disc) ->
@@ -344,8 +345,10 @@ start_chain_db(disc) ->
 stop_chain_db() ->
     stop_chain_db(persistent_term:get({?MODULE, db_mode})).
 stop_chain_db(ram) ->
+    aec_db_gc:cleanup(),
     application:stop(mnesia);
 stop_chain_db({disc, Persist}) ->
+    aec_db_gc:cleanup(),
     application:stop(mnesia),
     application:set_env(aecore, persist, Persist),
     ok = mnesia:delete_schema([node()]).

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -470,6 +470,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "410":
+          description: State data at the requested height has been garbage-collected
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   "/accounts/{pubkey}/hash/{hash}":
     get:
       tags:
@@ -657,6 +663,12 @@ paths:
                 $ref: "#/components/schemas/Error"
         "404":
           description: Transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: State data at the requested height has been garbage-collected
           content:
             application/json:
               schema:
@@ -2002,6 +2014,12 @@ paths:
                 $ref: "#/components/schemas/TokenSupply"
         "400":
           description: Height not available
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: State data at the requested height has been garbage-collected
           content:
             application/json:
               schema:

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -388,7 +388,9 @@ handle_request_('GetAccountByPubkeyAndHeight', Params, _Context) ->
                 none ->
                     {404, [], #{reason => <<"Account not found">>}};
                 {error, chain_too_short} ->
-                    {404, [], #{reason => <<"Height not available">>}}
+                    {404, [], #{reason => <<"Height not available">>}};
+                {error, garbage_collected} ->
+                    {410, [], #{reason => <<"State data at the requested height has been garbage-collected">>}}
             end;
         {error, _} ->
             {400, [], #{reason => <<"Invalid public key">>}}

--- a/apps/aehttp/src/aehttp_dispatch_int.erl
+++ b/apps/aehttp/src/aehttp_dispatch_int.erl
@@ -217,7 +217,9 @@ handle_request_('GetTokenSupplyByHeight', Req, _Context) ->
         {ok, Result} ->
             {200, [], Result};
         {error, chain_too_short} ->
-            {400, [], #{reason => <<"Chain too short">>}}
+            {400, [], #{reason => <<"Chain too short">>}};
+        {error, garbage_collected} ->
+            {410, [], #{reason => <<"State data at the requested height has been garbage-collected">>}}
     end;
 
 handle_request_('GetCrashRequest', Req, _Context) ->

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -324,6 +324,8 @@ get_info_object_from_tx(TxKey, TypeKey, CallKey) ->
                             %% {ok, maps:put(TypeKey, TxType, maps:put(CallKey, atom_to_binary(TxType, utf8), State))};
                             %% That is not backward compatible, but consistent with inner Txs
                             {error, {400, [], #{<<"reason">> => <<"Tx has no info">>}}};
+                        {error, garbage_collected} ->
+                            {error, {410, [], #{<<"reason">> => <<"State data at the requested height has been garbage-collected">>}}};
                         {error, Why} ->
                             Msg = atom_to_binary(Why, utf8),
                             {error, {400, [], #{<<"reason">> => Msg}}}

--- a/docs/release-notes/next/GH-4096-retrieving-state-beyond-GC-height.md
+++ b/docs/release-notes/next/GH-4096-retrieving-state-beyond-GC-height.md
@@ -1,0 +1,3 @@
+* API requests that try to retrieve state from heights below the latest GC height will now receive a 410 ("gone")
+  return code, instead of a 500 ("internal error"). **Potential incompatibility**: applications that depended on
+  the past behavior will need to adapt.


### PR DESCRIPTION
See issue #4096 

This implementation assumes that if GC is enabled and the requested state is at a height lower than the height of the last GC switch, then the state may be either fully or partially deleted, and we don't even try to retrieve it. The return code `410` means `gone`, i.e. the data has been deleted.

The PR is based on PR #4106 (not yet merged)