### PR TITLE
Fix typo in release notes about int-as-string

### DIFF
--- a/docs/release-notes/RELEASE-NOTES-6.5.1.md
+++ b/docs/release-notes/RELEASE-NOTES-6.5.1.md
@@ -4,7 +4,7 @@
 
 It:
 
-* Fixes a bug in the OAS3 definition for endpoint "/accounts/{pubkey}/next-nonce" in a combination with `int-to-string` flag
+* Fixes a bug in the OAS3 definition for endpoint "/accounts/{pubkey}/next-nonce" in a combination with `int-as-string` flag
 
 Please join the **mainnet** by following the instructions in the documentation below,
 and let us know if you have any problems by [opening a ticket](https://github.com/aeternity/aeternity/issues).

--- a/docs/release-notes/RELEASE-NOTES-6.6.0.md
+++ b/docs/release-notes/RELEASE-NOTES-6.6.0.md
@@ -20,7 +20,7 @@ It:
 
 * Drop support of Ubuntu 16.04
 
-* Fixes a bug in the OAS3 definition for endpoint "/accounts/{pubkey}/next-nonce" in a combination with `int-to-string` flag
+* Fixes a bug in the OAS3 definition for endpoint "/accounts/{pubkey}/next-nonce" in a combination with `int-as-string` flag
 
 With regards of HyperChains it:
 


### PR DESCRIPTION
This PR is supported by the Æternity Crypto Foundation