### PR TITLE
Default to a safe last_gc height

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -84,6 +84,7 @@
         , secondary_state_tab/1
         , write_last_gc_switch/1
         , read_last_gc_switch/0
+        , read_last_gc_switch/1
         , write_last_gc_scan/1
         , read_last_gc_scan/0 ]).
 
@@ -956,9 +957,12 @@ write_last_gc_switch(Height) ->
     ?t(write(#aec_chain_state{key = last_gc_switch, value = Height})).
 
 read_last_gc_switch() ->
+    read_last_gc_switch(0).
+
+read_last_gc_switch(Default) ->
     R = ?t(case read(aec_chain_state, last_gc_switch) of
                [] ->
-                   0;
+                   Default;
                [#aec_chain_state{value = Height}] ->
                    Height
            end),
@@ -976,7 +980,7 @@ read_last_gc_scan() ->
                [#aec_chain_state{value = Height}] ->
                    Height
            end),
-    lager:debug("<-- last GC Height: ~p", [R]),
+    lager:debug("<-- last height of complete GC scan: ~p", [R]),
     R.
 
 -spec make_primary_state_tab(tree_name(), table_name()) -> ok.

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -180,7 +180,7 @@ init(#{ <<"enabled">>     := Enabled
                 aec_db:ensure_activity(
                   async_dirty,
                   fun() ->
-                          {aec_db:read_last_gc_switch(),
+                          {last_gc_switch(),
                            aec_db:read_last_gc_scan()}
                   end);
             false ->
@@ -200,6 +200,17 @@ init(#{ <<"enabled">>     := Enabled
                scanners     = Scanners,
                synced       = false},
     {ok, Data}.
+
+last_gc_switch() ->
+    case aec_db:read_last_gc_switch(undefined) of
+        undefined ->
+            case aec_chain:top_height() of
+                undefined -> 0;
+                TopHeight -> TopHeight
+            end;
+        Height ->
+            Height
+    end.
 
 maybe_restart_scanners(LastSwitch, LastScan, Trees) ->
     if LastSwitch > 0, LastScan < LastSwitch ->


### PR DESCRIPTION
The latest version of the GC logs its last sweep height persistently, but the previous (6.8.x) version didn't.
When starting up on an old db, we want to default to the safest switch height, which would be the top height.