### PR TITLE
GC follows top and automatically picks up siblings

### DIFF
--- a/apps/aecore/include/aec_block_insertion.hrl
+++ b/apps/aecore/include/aec_block_insertion.hrl
@@ -10,6 +10,7 @@
 -record(node, { header :: aec_headers:header()
               , hash   :: binary()
               , type   :: key | micro
+              , txs    :: undefined | list(aetx_sign:signed_tx())
               }).
 
 %% Metadata about the given fork

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1396,7 +1396,7 @@ handle_successfully_added_block(Block, Hash, true, PrevKeyHeader, Events, State,
     maybe_publish_tx_events(Events, Hash, Origin),
     maybe_publish_block(Origin, Block),
     State1 = maybe_consensus_change(State, Block),
-    ConsensusModule = consensus_module(State),
+    ConsensusModule = consensus_module(State1),
     case preempt_on_new_top(State1, Block, Hash, Origin) of
         {micro_changed, State2 = #state{ consensus = Cons }} ->
             {ok, setup_loop(State2, false, Cons#consensus.leader, Origin)};

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1390,6 +1390,7 @@ handle_successfully_added_block(Block, Hash, false, _, Events, State, Origin) ->
     maybe_publish_tx_events(Events, Hash, Origin),
     maybe_publish_block(Origin, Block),
     State1 = maybe_consensus_change(State, Block),
+    [ maybe_garbage_collect(Block, Hash, false) || aec_blocks:type(Block) == key ],
     {ok, State1};
 handle_successfully_added_block(Block, Hash, true, PrevKeyHeader, Events, State, Origin) ->
     maybe_publish_tx_events(Events, Hash, Origin),
@@ -1403,7 +1404,8 @@ handle_successfully_added_block(Block, Hash, true, PrevKeyHeader, Events, State,
             (BlockType == key) andalso
                 aec_metrics:try_update(
                   [ae,epoch,aecore,blocks,key,info], info_value(NewTopBlock)),
-            [ maybe_garbage_collect(NewTopBlock) || BlockType == key ],
+            [ maybe_garbage_collect(NewTopBlock, Hash, true)
+              || BlockType == key ],
             IsLeader = is_leader(NewTopBlock, PrevKeyHeader, ConsensusModule),
             case IsLeader of
                 true ->
@@ -1506,15 +1508,15 @@ get_pending_key_block(TopHash, State) ->
 %%
 %% To avoid starting of the GC process just for EUNIT
 -ifdef(EUNIT).
-maybe_garbage_collect(_) -> nop.
+maybe_garbage_collect(_, _, _) -> nop.
 -else.
 
 %% This should be called when there are no processes modifying the block state
 %% (e.g. aec_conductor on specific places)
-maybe_garbage_collect(Block) ->
+maybe_garbage_collect(Block, Hash, TopChange) ->
     T0 = erlang:system_time(microsecond),
     Header = aec_blocks:to_header(Block),
-    Res = aec_db_gc:maybe_garbage_collect(Header),
+    Res = aec_db_gc:maybe_garbage_collect(Header, Hash, TopChange),
     T1 = erlang:system_time(microsecond),
     lager:debug("Result -> ~p (time: ~p us)", [Res, T1-T0]),
     Res.

--- a/apps/aecore/src/aec_db_backends.erl
+++ b/apps/aecore/src/aec_db_backends.erl
@@ -30,6 +30,7 @@
 %% Callbacks for aeu_mp_trees_db
 -export([ mpt_db_drop_cache/1
         , mpt_db_get/2
+        , mpt_db_get/3
         , mpt_db_put/3
         ]).
 
@@ -124,6 +125,11 @@ mpt_db_get(Key, {gb_trees, Tree}) ->
     gb_trees:lookup(Key, Tree);
 mpt_db_get(Key, Handle) ->
     aec_db:lookup_tree_node(Key, Handle).
+
+mpt_db_get(Key, {gb_trees, Tree}, Map) when is_map(Map) ->
+    Map#{result => gb_trees:lookup(Key, Tree)};
+mpt_db_get(Key, Handle, Map) when is_map(Map) ->
+    aec_db:lookup_tree_node(Key, Handle, Map).
 
 mpt_db_put(Key, Val, {gb_trees, Tree}) ->
     {gb_trees, gb_trees:enter(Key, Val, Tree)};

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -485,7 +485,7 @@ scan_tree(Name, Height, Hash, Parent) ->
     T0 = erlang:system_time(millisecond),
     {ok, Count} = collect_reachable_hashes_fullscan(Name, Height, Hash),
     T1 = erlang:system_time(millisecond),
-    ?INFO("GC scan done at ~p (~p), Count = ~p, Time = ~p, hash = ~p",
+    ?INFO("GC scan done at ~p (~-13w), Count: ~-9w, Time (ms): ~-8w, hash: ~p",
           [Height, Name, Count, T1 - T0, aeu_debug:pp(Hash)]),
     gen_server:cast(Parent, #scanner_done{ tree = Name
                                          , height = Height

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -483,7 +483,10 @@ start_scanner(Name, Height, Hash, Attempt) ->
             , pid = S
             , attempt = Attempt}.
 
-scan_tree(Name, Height, Hash, Parent) ->
+scan_tree(Name, Height, Hash, Parent) when is_atom(Name)
+                                         , is_integer(Height)
+                                         , is_binary(Hash)
+                                         , is_pid(Parent) ->
     T0 = erlang:system_time(millisecond),
     {ok, Count} = collect_reachable_hashes_fullscan(Name, Height, Hash),
     T1 = erlang:system_time(millisecond),
@@ -494,7 +497,7 @@ scan_tree(Name, Height, Hash, Parent) ->
                                          , block_hash = Hash }),
     ok.
 
-pp_hash(Hash) ->
+pp_hash(Hash) when is_binary(Hash) ->
     Enc = enc_keyblock_hash(Hash),
     Start = binary:part(Enc, 0, 8),
     End = binary:part(Enc, byte_size(Enc), -4),
@@ -601,7 +604,7 @@ update_current_scan(Hash, Scanners, #st{current_scan = #{hashes := Hashes} = Sca
 %%                 [aec_blocks:height(MicroBlock), N, Res]),
 %%     Res.
 
--spec get_mpt(tree_name(), non_neg_integer()) -> aeu_mp_trees:tree() | empty.
+-spec get_mpt(tree_name(), block_hash()) -> aeu_mp_trees:tree() | empty.
 get_mpt(Tree, Hash) ->
     get_mpt_from_hash(Tree, Hash).
 

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1628,12 +1628,6 @@
                             "minimum" : 50,
                             "default" : 15000
                         },
-                        "depth" : {
-                            "description" : "How far below the top to perform collection scans (default: 0 = fork resistance depth)",
-                            "type" : "integer",
-                            "minimum" : 0,
-                            "default" : 0
-                        },
                         "trees" : {
                             "description": "Which state trees to scan. Default: all of them",
                             "type" : "array",

--- a/apps/aeutils/src/aeu_mp_trees_db.erl
+++ b/apps/aeutils/src/aeu_mp_trees_db.erl
@@ -14,6 +14,7 @@
 -module(aeu_mp_trees_db).
 
 -export([ get/2
+        , get/3
         , put/3
         , cache_get/2
         , drop_cache/1
@@ -89,6 +90,15 @@ get(Key, DB0) ->
         {value, _} = Res -> Res
     end.
 
+get(Key, DB0, Map) when is_map(Map) ->
+    DB = to_new_db(DB0),
+    case int_cache_get(Key, DB) of
+        'none' -> int_db_get(Key, DB, Map);
+        {value, _} = Res ->
+            Map#{result => Res,
+                 source => cache}
+    end.
+
 -spec cache_get(key(), db()) -> {'value', value()} | 'none'.
 cache_get(Key, DB0) ->
     DB = to_new_db(DB0),
@@ -153,6 +163,9 @@ int_drop_cache(#db{cache = Cache, module = M} = DB) ->
 
 int_db_get(Key, #db{handle = Handle, module = M}) ->
     M:mpt_db_get(Key, Handle).
+
+int_db_get(Key, #db{handle = Handle, module = M}, Map) ->
+    M:mpt_db_get(Key, Handle, Map).
 
 int_db_put(Key, Val, #db{handle = Handle, module = M} = DB) ->
     DB#db{handle = M:mpt_db_put(Key, Val, Handle)}.

--- a/apps/aeutils/src/aeu_mtrees.erl
+++ b/apps/aeutils/src/aeu_mtrees.erl
@@ -48,6 +48,7 @@
 -behavior(aeu_mp_trees_db).
 -export([ mpt_db_drop_cache/1
         , mpt_db_get/2
+        , mpt_db_get/3
         , mpt_db_put/3
         ]).
 
@@ -271,19 +272,22 @@ new_proof_db() ->
     aeu_mp_trees_db:new(proof_db_spec()).
 
 proof_db_spec() ->
-    #{ handle => dict:new()
-     , cache  => dict:new()
+    #{ handle => #{}
+     , cache  => #{}
      , module => ?MODULE
      }.
 
 mpt_db_get(Key, Proof) ->
-    {value, dict:fetch(Key, Proof)}.
+    {value, maps:get(Key, Proof)}.
+
+mpt_db_get(Key, Proof, Map) when is_map(Map) ->
+    Map#{result => {value, maps:get(Key, Proof)}}.
 
 mpt_db_put(Key, Val, Proof) ->
-    dict:store(Key, Val, Proof).
+    Proof#{Key => Val}.
 
 mpt_db_drop_cache(_Cache) ->
-    dict:new().
+    #{}.
 
 %%%===================================================================
 %%% serialization

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -109,6 +109,15 @@
                ]}
              ]}
            ]},
+          {ae_db_gc_lager_event, [
+             {handlers, [
+                {lager_console_backend, [{level, info}]},
+                {lager_file_backend, [
+                  {file, "aeternity_db_gc.log"}, {level, debug},
+                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                 ]}
+              ]}
+           ]},
            {aestratum_lager_event, [
              {handlers, [
                 {lager_file_backend, [

--- a/config/dev1/sys.config
+++ b/config/dev1/sys.config
@@ -114,7 +114,9 @@
                 {lager_console_backend, [{level, info}]},
                 {lager_file_backend, [
                   {file, "aeternity_db_gc.log"}, {level, debug},
-                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                  {size, 4194303}, {date, "$D0"}, {count, 3},
+                  {formatter, lager_default_formatter},
+                  {formatter_config, [time, " ", message, "\n"]}
                  ]}
               ]}
            ]},

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -112,7 +112,9 @@
                 {lager_console_backend, [{level, info}]},
                 {lager_file_backend, [
                   {file, "aeternity_db_gc.log"}, {level, debug},
-                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                  {size, 4194303}, {date, "$D0"}, {count, 3},
+                  {formatter, lager_default_formatter},
+                  {formatter_config, [time, " ", message, "\n"]}
                  ]}
               ]}
            ]},

--- a/config/dev2/sys.config
+++ b/config/dev2/sys.config
@@ -107,6 +107,15 @@
                ]}
              ]}
            ]},
+          {ae_db_gc_lager_event, [
+             {handlers, [
+                {lager_console_backend, [{level, info}]},
+                {lager_file_backend, [
+                  {file, "aeternity_db_gc.log"}, {level, debug},
+                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                 ]}
+              ]}
+           ]},
            {aestratum_lager_event, [
              {handlers, [
                 {lager_file_backend, [

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -111,7 +111,9 @@
                 {lager_console_backend, [{level, info}]},
                 {lager_file_backend, [
                   {file, "aeternity_db_gc.log"}, {level, debug},
-                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                  {size, 4194303}, {date, "$D0"}, {count, 3},
+                  {formatter, lager_default_formatter},
+                  {formatter_config, [time, " ", message, "\n"]}
                  ]}
               ]}
            ]},

--- a/config/dev3/sys.config
+++ b/config/dev3/sys.config
@@ -106,6 +106,15 @@
                ]}
              ]}
            ]},
+          {ae_db_gc_lager_event, [
+             {handlers, [
+                {lager_console_backend, [{level, info}]},
+                {lager_file_backend, [
+                  {file, "aeternity_db_gc.log"}, {level, debug},
+                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                 ]}
+              ]}
+           ]},
            {aestratum_lager_event, [
               {handlers, [
                {lager_file_backend, [

--- a/config/sys.config
+++ b/config/sys.config
@@ -134,7 +134,9 @@
                 {lager_console_backend, [{level, info}]},
                 {lager_file_backend, [
                   {file, "aeternity_db_gc.log"}, {level, info},
-                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                  {size, 4194303}, {date, "$D0"}, {count, 3},
+                  {formatter, lager_default_formatter},
+                  {formatter_config, [time, " ", message, "\n"]}
                  ]}
               ]}
            ]},

--- a/config/sys.config
+++ b/config/sys.config
@@ -129,6 +129,15 @@
                ]}
              ]}
            ]},
+          {ae_db_gc_lager_event, [
+             {handlers, [
+                {lager_console_backend, [{level, info}]},
+                {lager_file_backend, [
+                  {file, "aeternity_db_gc.log"}, {level, info},
+                  {size, 4194303}, {date, "$D0"}, {count, 3}
+                 ]}
+              ]}
+           ]},
           {aestratum_lager_event, [
              {handlers, [
                {lager_file_backend, [

--- a/rebar.config
+++ b/rebar.config
@@ -23,6 +23,7 @@
             {lager_extra_sinks, [epoch_mining,
                                  epoch_metrics,
                                  epoch_sync,
+                                 ae_db_gc,
                                  aestratum]}]}.
 
 %% NOTE: When possible deps are referenced by Git ref to ensure consistency between builds.


### PR DESCRIPTION
The GC follows the top, and extends the fullsweep scan at switch height to include any sibling block that might appear
(GC switch will trigger for the very first block at the given height, so siblings will appear after.)

The branch also includes some initial code for diagnosing and repairing state trees.