### PR TITLE
New required dependencies just to build the node

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -44,7 +44,7 @@ The easiest way to install package on MacOS is Homebrew, it can be installed by 
 Then install the build dependencies using the `brew` command:
 ```
 brew update
-brew install erlang@23 openssl libsodium autoconf gmp cmake
+brew install erlang@23 openssl libsodium autoconf gmp cmake automake googletest
 ```
 
 If building on an m1 Mac homebrew does not automatically set up symlinks to system directories, so before running `make` set up the build path with:

--- a/docs/build.md
+++ b/docs/build.md
@@ -44,7 +44,7 @@ The easiest way to install package on MacOS is Homebrew, it can be installed by 
 Then install the build dependencies using the `brew` command:
 ```
 brew update
-brew install erlang@23 openssl libsodium autoconf gmp cmake automake googletest
+brew install erlang@23 openssl libsodium autoconf gmp cmake automake
 ```
 
 If building on an m1 Mac homebrew does not automatically set up symlinks to system directories, so before running `make` set up the build path with:


### PR DESCRIPTION
These packages now seem to be required just in order to build the node and run test cases locally on Mac OS aarch64 (at least). Seems to be caused by the rocksdb C dependencies.

This PR is sponsored by the ACF