### PR TITLE
Add extra env var required for macos build when lzo package is installed

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -52,6 +52,7 @@ If building on an m1 Mac homebrew does not automatically set up symlinks to syst
 ```bash
 export PATH=/opt/homebrew/bin:$PATH
 export CFLAGS="-I/opt/homebrew/include"
+export CXXFLAGS="-I/opt/homebrew/include"
 export LDFLAGS="-L/opt/homebrew/lib"
 ```
 


### PR DESCRIPTION
This PR was sponsored by the ACF