### PR TITLE
Gh4157 control when mempool sync starts

### DIFF
--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -96,6 +96,11 @@
                          micro_blocks := [aec_blocks:micro_block()],
                          dir := backward | forward }.
 
+%% Preferred activity type is dirty for read functions.
+%% If called from within an activity, the activity type is inherited.
+activity(F) when is_function(F, 0) ->
+    aec_db:ensure_activity(async_dirty, F).
+
 %%%===================================================================
 %%% Accounts
 %%%===================================================================
@@ -497,6 +502,9 @@ top_header_hash_and_state() ->
 
 -spec top_key_block() -> 'error' | {ok, aec_blocks:block()}.
 top_key_block() ->
+    activity(fun top_key_block_/0).
+
+top_key_block_() ->
     case aec_db:get_top_block_hash() of
         Hash when is_binary(Hash) ->
             {ok, Block} = get_block(Hash),
@@ -510,12 +518,15 @@ top_key_block() ->
 
 -spec top_key_block_hash() -> 'undefined' | binary().
 top_key_block_hash() ->
+    activity(fun top_key_block_hash_/0).
+
+top_key_block_hash_() ->
     case aec_db:get_top_block_hash() of
         Hash when is_binary(Hash) ->
-            {ok, Block} = get_block(Hash),
-            case aec_blocks:type(Block) of
+            Header = aec_db:get_header(Hash),
+            case aec_headers:type(Header) of
                 key -> Hash;
-                micro -> aec_blocks:prev_key_hash(Block)
+                micro -> aec_headers:prev_key_hash(Header)
             end;
         undefined ->
             undefined
@@ -523,6 +534,9 @@ top_key_block_hash() ->
 
 -spec top_block_with_state() -> 'undefined' | {aec_blocks:block(), aec_trees:trees()}.
 top_block_with_state() ->
+    activity(fun top_block_with_state_/0).
+
+top_block_with_state_() ->
     case top_block_hash() of
         undefined -> undefined;
         Hash -> {aec_db:get_block(Hash), aec_db:get_block_state(Hash)}

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -100,6 +100,11 @@
                    "type" : "integer",
                    "default" : 1800000
                 },
+                "sync_start" : {
+                    "description" : "When to start syncing the mempool. A negative number indicates distance from the remote top; a positive number denotes absolute local height",
+                    "type" : "integer",
+                    "default" : -100
+                },
                 "nonce_offset" : {
                     "description" : "Maximum nonce offset accepted",
                     "type" : "integer",

--- a/docs/release-notes/next/GH4157-control-mempool-sync-start.md
+++ b/docs/release-notes/next/GH4157-control-mempool-sync-start.md
@@ -1,0 +1,5 @@
+* A config option, `mempool:sync_start` (integer) has been introduced to control when syncing of the mempool
+  starts during chain sync. A positive number denotes the height at which to begin syncing; a negative number
+  denotes how far from the network top height (best guess by the sync logic) to start. Default is `-500`, i.e.
+  start syncing the mempool 500 blocks from the top. A mempool sync is always triggered when chain sync is done,
+  and if a negative value greater than the top height is given, sync starts from `0`, i.e. from the beginning.


### PR DESCRIPTION
See #4157. From the release notes:
> A config option, `mempool:sync_start` (integer) has been introduced to control when syncing of the mempool
  starts during chain sync. A positive number denotes the height at which to begin syncing; a negative number
  denotes how far from the network top height (best guess by the sync logic) to start. Default is `-500`, i.e.
  start syncing the mempool 500 blocks from the top. A mempool sync is always triggered when chain sync is done,
  and if a negative value greater than the top height is given, sync starts from `0`, i.e. from the beginning.

This PR was sponsored by the ACF