### PR TITLE
Use the version of aesophia from ceres branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -217,7 +217,7 @@
                     {dist_node, [{setcookie, 'aeternity_cookie'},
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"99467db"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"32a9811"}}},
                             {aesophia_cli, {git, "https://github.com/aeternity/aesophia_cli", {ref,"5f03a89"}}},
                             {aestratum_client, {git, "https://github.com/aeternity/aestratum_client", {ref, "adb0993"}}},
                             {websocket_client, {git, "https://github.com/aeternity/websocket_client", {ref, "95ef9de"}}},


### PR DESCRIPTION
The build on master is failing because of a force push of `ceres` branch in `aesophia`.

This PR uses the latest commit of this branch https://github.com/aeternity/aesophia/commits/ceres