### PR TITLE
Remove continuation application during execution stack unwinding

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -178,6 +178,7 @@
         , sophia_higher_order_state/1
         , sophia_clone/1
         , sophia_create/1
+        , sophia_create_init_fail/1
         , sophia_bytecode_hash/1
         , sophia_factories/1
         , sophia_bignum/1
@@ -485,6 +486,7 @@ groups() ->
                                  sophia_higher_order_state,
                                  sophia_clone,
                                  sophia_create,
+                                 sophia_create_init_fail,
                                  sophia_bytecode_hash,
                                  sophia_factories,
                                  sophia_use_memory_gas,
@@ -1906,6 +1908,15 @@ sophia_create(_Cfg) ->
     Ct  = ?call(create_contract, Acc, create_test, {}, #{gas => 1000000000000}),
     R1  = ?call(call_contract, Acc, Ct, increaseByThree, word, {2137}, #{gas => 1000000000000, amount => 1000000}),
     ?assertEqual(2140, R1),
+    ok.
+
+sophia_create_init_fail(_Cfg) ->
+    ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, create_not_pre_iris),
+    init_new_state(),
+    Acc = ?call(new_account, 1000000000000000000000 * aec_test_utils:min_gas_price()),
+    Ct  = ?call(create_contract, Acc, create_crash, {}, #{gas => 1000000000000}),
+    R1  = ?call(call_contract, Acc, Ct, throw_and_catch, bool, {}, #{gas => 1000000000000}),
+    ?assertEqual(true, R1),
     ok.
 
 sophia_bytecode_hash(_Cfg) ->

--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -1911,7 +1911,7 @@ sophia_create(_Cfg) ->
     ok.
 
 sophia_create_init_fail(_Cfg) ->
-    ?skipRest(vm_version() < ?VM_FATE_SOPHIA_2, create_not_pre_iris),
+    ?skipRest(vm_version() < ?VM_FATE_SOPHIA_3, create_init_crash_uncatchable_in_iris),
     init_new_state(),
     Acc = ?call(new_account, 1000000000000000000000 * aec_test_utils:min_gas_price()),
     Ct  = ?call(create_contract, Acc, create_crash, {}, #{gas => 1000000000000}),

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -373,7 +373,7 @@ catch_protected(Err, ES) ->
                     catch_protected(Err, Cont(ES1));
                 true ->
                     %% During the unwinding process the continuation should not be applied.
-                    catch_protected(Err, ES1);
+                    catch_protected(Err, ES1)
                 end;
         {return_check, _, protected, _, Stores, API, ES1} ->
             ES2 = aefa_engine_state:set_accumulator(make_none(),

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -352,7 +352,7 @@ step([I|Is], EngineState0) ->
 catch_protected(Err, ES) ->
     case aefa_engine_state:pop_call_stack(ES) of
         {empty, _} -> throw(Err);
-        {modify, Cont, ES1} -> catch_protected(Err, Cont(ES1));
+        {modify, _Cont, ES1} -> catch_protected(Err, ES1);  % The continuation is not applied during unwinding
         {return_check, _, protected, _, Stores, API, ES1} ->
             ES2 = aefa_engine_state:set_accumulator(make_none(),
                   aefa_engine_state:set_stores(Stores,

--- a/apps/aefate/src/aefa_fate.erl
+++ b/apps/aefate/src/aefa_fate.erl
@@ -352,7 +352,29 @@ step([I|Is], EngineState0) ->
 catch_protected(Err, ES) ->
     case aefa_engine_state:pop_call_stack(ES) of
         {empty, _} -> throw(Err);
-        {modify, _Cont, ES1} -> catch_protected(Err, ES1);  % The continuation is not applied during unwinding
+        {modify, Cont, ES1} ->
+            case aefa_engine_state:vm_version(ES1) >= ?VM_FATE_SOPHIA_3 of
+                false ->
+                    %% TODO: after Ceres this branch can be safely removed along with the entire
+                    %% version switch. In Iris, the only situation in which this is not an identity
+                    %% is when there was a crash in `init`. In that case, the only option is for
+                    %% this function to replace the top of the accumulator stack. There are two
+                    %% consequences possible:
+                    %%
+                    %% (1) The stack is empty, and the VM crashes
+                    %% (2) The stack had its top element which is replaced, after which stack rewind
+                    %%     proceeds.
+                    %%
+                    %% (1) Is not observable on chain, so we will not have to be concerned about
+                    %% it. The change introduced in (2) shall be either ignored if the entire call
+                    %% reverts, or wiped by a protected return check which sets the accumulator to
+                    %% [None]. In either case, consequences of this Cont are not going to be
+                    %% observable after Ceres comes to power, even for syncing nodes.
+                    catch_protected(Err, Cont(ES1));
+                true ->
+                    %% During the unwinding process the continuation should not be applied.
+                    catch_protected(Err, ES1);
+                end;
         {return_check, _, protected, _, Stores, API, ES1} ->
             ES2 = aefa_engine_state:set_accumulator(make_none(),
                   aefa_engine_state:set_stores(Stores,

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -1565,24 +1565,18 @@ deploy_contract(CodeOrPK, InitArgsTypes, Value, GasCap, Prot, ES0) ->
           end,
 
     {ContractPK, ES2} = put_contract(CodeOrPK, Value, ES1),
-    ReplaceInitResult
-        = fun(ES0_) ->
-                  %% init returns unit, so we get rid of it if the call was protected, rewrap the
-                  %% result
-                  {Res, ES1_} =
-                      case aefa_engine_state:accumulator(ES0_) of
-                          [] ->
-                              %% We deliberately crash the machine to preserve the original
-                              %% unfortunate Iris behavior, but with a slightly better error
-                              %% message. There should be no transaction on the chain which has
-                              %% reached this point, however.
-                              %%
-                              %% TODO: After the Ceres hard fork, it should be safe to remove this
-                              %% check.
-                              error({init_crashed_miserably, CodeOrPK});
-                          _ ->
-                              get_op_arg({stack, 0}, ES0_)
-                      end,
+    ReplaceInitResult =
+        %% init returns unit, so we get rid of it if the call was protected, rewrap the
+        %% result
+        fun(ES0_) ->
+                  [aefa_engine_state:accumulator(ES0_) == [] ||
+                      %% We deliberately crash the machine to preserve the original unfortunate Iris
+                      %% behavior, but with a slightly better error message. There should be no
+                      %% transaction on the chain which has reached this point, however.
+                      %%
+                      %% TODO: After the Ceres hard fork, it should be safe to remove this check.
+                      error({init_crashed_miserably, CodeOrPK})],
+
                   case Protected of
                       unprotected ->
                           {{tuple, {}}, ES1_} = get_op_arg({stack, 0}, ES0_),

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -1569,31 +1569,31 @@ deploy_contract(CodeOrPK, InitArgsTypes, Value, GasCap, Prot, ES0) ->
         %% init returns unit, so we get rid of it if the call was protected, rewrap the
         %% result
         fun(ES0_) ->
-                  [aefa_engine_state:accumulator(ES0_) == [] ||
+                [ error({init_crashed_miserably, CodeOrPK}) ||
                       %% We deliberately crash the machine to preserve the original unfortunate Iris
                       %% behavior, but with a slightly better error message. There should be no
                       %% transaction on the chain which has reached this point, however.
                       %%
                       %% TODO: After the Ceres hard fork, it should be safe to remove this check.
-                      error({init_crashed_miserably, CodeOrPK})],
+                    aefa_engine_state:accumulator(ES0_) == [] ],
 
-                  case Protected of
-                      unprotected ->
-                          {{tuple, {}}, ES1_} = get_op_arg({stack, 0}, ES0_),
-                          write({stack, 0}, ?FATE_CONTRACT(ContractPK), ES1_);
-                      protected ->
-                          case get_op_arg({stack, 0}, ES0_) of
-                              {{variant,[0, 1], 1, {{tuple, {}}}}, ES1_} ->
-                                  write( {stack, 0}, make_some(?FATE_CONTRACT(ContractPK))
-                                       , ES1_
-                                       );
-                              {{variant, [0, 1], 0, {}}, ES1_} ->
-                                  %% Call to `init` failed due to runtime error
-                                  ES2_ = unput_contract(ContractPK, Value, ES1_),
-                                  write({stack, 0}, make_none(), ES2_)
-                          end
-                  end
-          end,
+                case Protected of
+                    unprotected ->
+                        {{tuple, {}}, ES1_} = get_op_arg({stack, 0}, ES0_),
+                        write({stack, 0}, ?FATE_CONTRACT(ContractPK), ES1_);
+                    protected ->
+                        case get_op_arg({stack, 0}, ES0_) of
+                            {{variant,[0, 1], 1, {{tuple, {}}}}, ES1_} ->
+                                write( {stack, 0}, make_some(?FATE_CONTRACT(ContractPK))
+                                     , ES1_
+                                     );
+                            {{variant, [0, 1], 0, {}}, ES1_} ->
+                                %% Call to `init` failed due to runtime error
+                                ES2_ = unput_contract(ContractPK, Value, ES1_),
+                                write({stack, 0}, make_none(), ES2_)
+                        end
+                end
+        end,
 
     ES3 = aefa_engine_state:set_chain_api(
             begin

--- a/test/contracts/create_crash.aes
+++ b/test/contracts/create_crash.aes
@@ -1,0 +1,14 @@
+contract Remote =  
+  stateful entrypoint init() =
+    abort("ERROR")
+
+contract Exposer =
+  stateful entrypoint expose(): Remote =
+    Chain.create(): Remote
+
+main contract Catcher =
+  stateful entrypoint throw_and_catch() : bool =
+    let e = Chain.create() : Exposer
+    switch(e.expose(protected=true))
+      None => true
+      Some(_) => false


### PR DESCRIPTION
fixes: #4165 

When init is called through create or clone, a continuation is added to the execution stack. This continuation alters the VM state by replacing the normal result of init (which is ()) with the newly created contract address. This is done by popping () from the accumulator stack an pushing the address afterwards:

https://github.com/aeternity/aeternity/blob/5bec2f9cfc48acf88a98ef31036ff3dc1cf65bab/apps/aefate/src/aefa_fate_op.erl#L1517-L1524

However, when init crashes this continuation is still on the execution stack. The crash is done through an Erlang throw which is caught in the main execution loop here:

https://github.com/aeternity/aeternity/blob/5bec2f9cfc48acf88a98ef31036ff3dc1cf65bab/apps/aefate/src/aefa_fate.erl#L340-L348

This follows to catch_protected which figures out whether the execution should really crash or be continued with None on the accumulator stack. This also unwinds the stack removing all entities until it's emptied or a protected return check is encountered. However, continuations are still executed:

https://github.com/aeternity/aeternity/blob/5bec2f9cfc48acf88a98ef31036ff3dc1cf65bab/apps/aefate/src/aefa_fate.erl#L351-L354

So the story is:

1. Contract calls create
2. A "fix init result" continuation is added to the e-stack
3. init is called
4. init crashes, putting nothing onto the a-stack
5. The abort gets caught and stack is unwound
6. The continuation is applied
7. A non-existent () is popped from the stack

Fix: Just don't call that continuation in line 354. The stack is being destroyed anyway.