### PR TITLE
aeplugin_devmode_version -> 0.5.2

### DIFF
--- a/.circleci/config/parameters/@parameters.yml
+++ b/.circleci/config/parameters/@parameters.yml
@@ -4,7 +4,7 @@ docker_repo:
 
 aeplugin_devmode_version:
   type: string
-  default: "0.5.1"
+  default: "0.5.2"
 
 tag_regex:
   type: string


### PR DESCRIPTION
See issue #4163 

While the plugin uses the node's emitter by default, the plugin-local emitter has also been updated to match.

This PR is sponsored by the Aeternity Crypto Foundation