### PR TITLE
Use dev_mode plugin version 0.6.0

### DIFF
--- a/.circleci/config/parameters/@parameters.yml
+++ b/.circleci/config/parameters/@parameters.yml
@@ -4,7 +4,7 @@ docker_repo:
 
 aeplugin_devmode_version:
   type: string
-  default: "0.5.2"
+  default: "0.6.0"
 
 tag_regex:
   type: string


### PR DESCRIPTION
Use the latest release of the dev_mode plugin (0.6.0), which implements PR aeternity/aeplugin_dev_mode#26