### PR TITLE
Ping v2 and automatic ping vsn upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,7 @@ system-test-deps:
 	docker pull "aeternity/aeternity:v2.3.0"
 	docker pull "aeternity/aeternity:v4.0.0"
 	docker pull "aeternity/aeternity:v4.2.0"
+	docker pull "aeternity/aeternity:v6.9.0"
 	docker pull "aeternity/aeternity:latest"
 
 system-test: KIND=system_test

--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,7 @@ smoke-test-run: internal-build
 system-smoke-test-deps:
 	$(MAKE) docker
 	docker pull "aeternity/aeternity:v1.4.0"
+	docker pull "aeternity/aeternity:v6.9.0"
 
 local-system-test: KIND=system_test
 local-system-test: internal-build
@@ -301,7 +302,6 @@ system-test-deps:
 	docker pull "aeternity/aeternity:v2.3.0"
 	docker pull "aeternity/aeternity:v4.0.0"
 	docker pull "aeternity/aeternity:v4.2.0"
-	docker pull "aeternity/aeternity:v6.9.0"
 	docker pull "aeternity/aeternity:latest"
 
 system-test: KIND=system_test

--- a/apps/aecore/include/aec_peer_messages.hrl
+++ b/apps/aecore/include/aec_peer_messages.hrl
@@ -1,3 +1,6 @@
+
+-define(P2P_PROTOCOL_VSN, 1).
+
 -define(REQUEST_TIMEOUT, 30000).
 
 -define(MSG_FRAGMENT, 0).
@@ -27,7 +30,8 @@
 
 
 -define(RESPONSE_VSN, 1).
--define(PING_VSN, 1).
+-define(PING_VSN_1, 1).
+-define(PING_VSN_2, 2).
 -define(GET_MEMPOOL_VSN, 1).
 -define(MEMPOOL_VSN, 1).
 -define(GET_HEADER_BY_HASH_VSN, 1).

--- a/apps/aecore/src/aec_capabilities.erl
+++ b/apps/aecore/src/aec_capabilities.erl
@@ -36,8 +36,8 @@ delete_capability(Key) ->
 get_capabilities() ->
     call(get_capabilities).
 
-register_peer(Peer, Capabilities) ->
-    call({register_peer, Peer, Capabilities}).
+register_peer(Peer, Capabilities) when is_list(Capabilities) ->
+    call({register_peer, Peer, maps:from_list(Capabilities)}).
 
 remove_peer(Peer) ->
     call({remove_peer, Peer}).

--- a/apps/aecore/src/aec_capabilities.erl
+++ b/apps/aecore/src/aec_capabilities.erl
@@ -1,0 +1,90 @@
+-module(aec_capabilities).
+
+-behavior(gen_server).
+
+
+-export([ set_capability/2
+        , get_capability/1
+        , delete_capability/1
+        , get_capabilities/0
+        , register_peer/2
+        , remove_peer/1
+        , peers_with_capability/1 ]).
+
+%% Gen_server stuff
+-export([ start_link/0 ]).
+
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3 ]).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+get_capability(Key) ->
+    call({get_capability, Key}).
+
+set_capability(Key, Value) ->
+    call({set_capability, Key, Value}).
+
+delete_capability(Key) ->
+    call({delete_capability, Key}).
+
+get_capabilities() ->
+    call(get_capabilities).
+
+register_peer(Peer, Capabilities) ->
+    call({register_peer, Peer, Capabilities}).
+
+remove_peer(Peer) ->
+    call({remove_peer, Peer}).
+
+peers_with_capability(Key) ->
+    call({peers_with_capability, Key}).
+
+call(Req) ->
+    gen_server:call(?MODULE, Req).
+
+
+init([]) ->
+    {ok, #{ peers => #{}
+          , capabilities => #{} }}.
+
+handle_call({get_capability, Key}, _From, #{capabilities := Cs} = St) ->
+    {reply, maps:find(Key, Cs), St};
+handle_call({set_capability, Key, Value}, _From, #{capabilities := Cs} = St) ->
+    {reply, ok, St#{capabilities := Cs#{Key => Value}}};
+handle_call({delete_capability, Key}, _From, #{capabilities := Cs} = St) ->
+    {reply, ok, St#{capabilities := maps:remove(Key, Cs)}};
+handle_call(get_capabilities, _From, #{capabilities := Cs} = St) ->
+    {reply, maps:to_list(Cs), St};
+handle_call({register_peer, PeerId, Capabilities}, _From, #{peers := Peers} = St) ->
+    {reply, ok, St#{peers := Peers#{PeerId => Capabilities}}};
+handle_call({peers_with_capability, Key}, _From, #{peers := Peers} = St) ->
+    Result = maps:fold(fun(P, Cs, Acc) ->
+                               peers_with_cap_(P, Key, Cs, Acc)
+                       end, [], Peers),
+    {reply, Result, St}.
+
+handle_cast(_, St) ->
+    {noreply, St}.
+
+handle_info(_, St) ->
+    {noreply, St}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_FromVsn, St, _Extra) ->
+    {ok, St}.
+
+peers_with_cap_(PeerId, Key, PeerCaps, Acc) ->
+    case maps:find(Key, PeerCaps) of
+        {ok, Value} ->
+            [{PeerId, Value} | Acc];
+        error ->
+            Acc
+    end.

--- a/apps/aecore/src/aec_capabilities.erl
+++ b/apps/aecore/src/aec_capabilities.erl
@@ -64,8 +64,9 @@ handle_call(get_capabilities, _From, #{capabilities := Cs} = St) ->
 handle_call({register_peer, PeerId, Capabilities}, _From, #{peers := Peers} = St) ->
     {reply, ok, St#{peers := Peers#{PeerId => Capabilities}}};
 handle_call({peers_with_capability, Key}, _From, #{peers := Peers} = St) ->
-    Result = maps:fold(fun(P, Cs, Acc) ->
-                               peers_with_cap_(P, Key, Cs, Acc)
+    Result = maps:fold(fun(PeerId, #{Key := Caps}, Acc) ->
+                            [{PeerId, Caps}|Acc];
+                           (_,_, Acc) -> Acc
                        end, [], Peers),
     {reply, Result, St}.
 
@@ -80,11 +81,3 @@ terminate(_Reason, _State) ->
 
 code_change(_FromVsn, St, _Extra) ->
     {ok, St}.
-
-peers_with_cap_(PeerId, Key, PeerCaps, Acc) ->
-    case maps:find(Key, PeerCaps) of
-        {ok, Value} ->
-            [{PeerId, Value} | Acc];
-        error ->
-            Acc
-    end.

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -475,8 +475,11 @@ handle_general_error(S) ->
             connect_fail(S1)
     end.
 
-request_key(Kind, Vsn) ->
-    {Kind,Vsn}.
+%% Ping needs to support concurrent pings of different versions
+request_key(ping, Vsn) ->
+    {ping, Vsn};
+request_key(Kind, _Vsn) ->
+    Kind.
 
 get_request(S, Kind, Vsn) ->
     maps:get(request_key(map_request(Kind), Vsn), maps:get(requests, S, #{}), none).
@@ -487,7 +490,7 @@ set_request(S, Kind, Vsn, From) ->
 set_request(S, Kind, Vsn, From, Timeout) ->
     Rs = maps:get(requests, S, #{}),
     TRef = erlang:start_timer(Timeout, self(), {request, Kind, Vsn}),
-    S#{ requests => Rs#{ {Kind, Vsn} => {Kind, From, TRef} } }.
+    S#{ requests => Rs#{ request_key(Kind, Vsn) => {Kind, From, TRef} } }.
 
 remove_request_fld(S, Kind, Vsn) ->
     Rs = maps:get(requests, S, #{}),

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -763,9 +763,10 @@ use_latest_common_ping_version(S, PingObj) ->
     S#{use_ping_vsn => Pick}.
 
 remote_vsns_supported(Type, PingObj, S) ->
+    TypeBin = atom_to_binary(Type, utf8),
     AllVsns = maps:get(versions, PingObj, []),
-    case lists:keyfind(atom_to_binary(Type, utf8), 1, AllVsns) of
-        {_, Vsns} ->
+    case lists:filter(fun(#{protocol := Protocol})  -> Protocol == TypeBin end, AllVsns) of
+        [#{vsns := Vsns}] ->
             Vsns;
         _ ->
             %% assume our hard-coded vsn
@@ -955,7 +956,7 @@ ping_obj(PingObj, Exclude, Vsn) ->
 
 vsn_upgrade(ping, Obj, ?PING_VSN_2) ->
     MyCaps = aec_capabilities:get_capabilities(),
-    Vsns = aec_peer_messages:all_msg_versions(),
+    Vsns = aec_peer_messages:supported_msg_versions(),
     Obj#{ versions => Vsns, capabilities => MyCaps };
 vsn_upgrade(_T, Obj, _V) ->
     Obj.

--- a/apps/aecore/src/aec_peer_messages.erl
+++ b/apps/aecore/src/aec_peer_messages.erl
@@ -105,11 +105,11 @@ serialize(txps_get, TxpsGet, Vsn = ?TX_POOL_SYNC_GET_VSN) ->
 serialize(txps_finish, TxpsFinish, Vsn = ?TX_POOL_SYNC_FINISH_VSN) ->
     #{ done := Done } = TxpsFinish,
     serialize_flds(txps_finish, Vsn, [{done, Done}]);
-serialize(peers, Peers, Vsn = ?VSN_1) ->
+serialize(peers, Peers, Vsn = ?PEER_VSN) ->
     [ serialize(peer, Peer, Vsn) || Peer <- Peers ];
-serialize(peer, Peer, ?VSN_1) ->
+serialize(peer, Peer, ?PEER_VSN) ->
     %% Don't pollute the encoding with lots of Vsn-fields...
-    Template = serialization_template(peer, ?VSN_1),
+    Template = serialization_template(peer, ?PEER_VSN),
     Flds = [ {host,   maps:get(host, Peer)}
            , {port,   maps:get(port, Peer)}
            , {pubkey, maps:get(pubkey, Peer)} ],

--- a/apps/aecore/src/aec_peer_messages.erl
+++ b/apps/aecore/src/aec_peer_messages.erl
@@ -13,7 +13,7 @@
         , tag/1]).
 
 -export([ msg_versions/1
-        , all_msg_versions/0
+        , supported_msg_versions/0
         , latest_vsn/2 ]).
 
 -export([serialize_capabilities/2,
@@ -234,7 +234,7 @@ msg_versions(ping) ->
 msg_versions(_Msg) ->
     undefined.
 
-all_msg_versions() ->
+supported_msg_versions() ->
     [#{protocol => atom_to_binary(T, utf8), vsns => msg_versions(T)} || T <- [ping]].
 
 deserialize(ping, Vsn, PingFlds) when Vsn == ?PING_VSN_2 ->

--- a/apps/aecore/src/aec_peer_messages.erl
+++ b/apps/aecore/src/aec_peer_messages.erl
@@ -261,14 +261,14 @@ deserialize(ping, Vsn, PingFlds) when Vsn == ?PING_VSN_1 ->
         [ {port, _Port}
         , {share, _Share}
         , {genesis_hash, _GenHash}
-        , {difficulty, Difficulty}
+        , {difficulty, _Difficulty}
         , {best_hash, _TopHash}
         , {sync_allowed, _SyncAllowed}
         , {peers, PeersBin} ] = aeserialization:decode_fields(
                                     serialization_template(ping, Vsn),
                                     PingFlds),
     Peers = deserialize(peers, ?PEER_VSN, PeersBin),
-    PingData1 = replace_keys(PingData, [{peers, Peers}, {difficulty, Difficulty}]),
+    PingData1 = replace_keys(PingData, [{peers, Peers}]),
     {ping, Vsn, maps:from_list(PingData1)};
 deserialize(get_header_by_hash, Vsn, GetHeaderFlds) when Vsn == ?GET_HEADER_BY_HASH_VSN ->
     [{hash, Hash}] = aeserialization:decode_fields(

--- a/apps/aecore/src/aec_peer_messages.erl
+++ b/apps/aecore/src/aec_peer_messages.erl
@@ -9,32 +9,53 @@
 -export([ deserialize/2
         , serialize/2
         , serialize/3
-        , serialize_response/2
+        , serialize_response/3
         , tag/1]).
+
+-export([ msg_versions/1
+        , all_msg_versions/0
+        , latest_vsn/2 ]).
+
+-export([serialize_capabilities/2,
+	 deserialize_capabilities/2]).
 
 -include("aec_peer_messages.hrl").
 
-serialize_response(Type, {ok, Object}) ->
-    SerObj = serialize(Type, Object),
+serialize_response(Type, Vsn, {ok, Object}) ->
+    SerObj = serialize(Type, Object, Vsn),
     serialize(response, #{ result => true,
                            type   => tag(Type),
                            object => SerObj });
-serialize_response(Type, {error, Reason}) ->
+serialize_response(Type, _Vsn, {error, Reason}) ->
     serialize(response, #{ result => false,
                            type   => tag(Type),
                            reason => to_binary(Reason) }).
 
 serialize(Msg, Data) ->
-    serialize(Msg, Data, latest_vsn(Msg)).
+    serialize(Msg, Data, latest_vsn(Msg, ?P2P_PROTOCOL_VSN)).
 
-serialize(ping, Ping, Vsn = ?PING_VSN) ->
+serialize(ping, Ping, Vsn = ?PING_VSN_2) ->
+    lager:debug("ping vsn ~p: ~p", [?PING_VSN_2, Ping]),
+    Caps = serialize_capabilities(?PING_VSN_2, maps:get(capabilities, Ping, [])),
+    Flds = [ {versions, maps:get(versions, Ping)}
+           , {port, maps:get(port, Ping)}
+           , {share, maps:get(share, Ping)}
+           , {genesis_hash, maps:get(genesis_hash, Ping)}
+           , {height, maps:get(height, Ping)}
+           , {difficulty, maps:get(difficulty, Ping)}
+           , {best_hash, maps:get(best_hash, Ping)}
+           , {sync_allowed, maps:get(sync_allowed, Ping)}
+           , {capabilities, Caps}
+           , {peers, serialize(peers, maps:get(peers, Ping), ?PEER_VSN)} ],
+    serialize_flds(ping, Vsn, Flds);
+serialize(ping, Ping, Vsn = ?PING_VSN_1) ->
     Flds = [ {port, maps:get(port, Ping)}
            , {share, maps:get(share, Ping)}
            , {genesis_hash, maps:get(genesis_hash, Ping)}
            , {difficulty, maps:get(difficulty, Ping)}
            , {best_hash, maps:get(best_hash, Ping)}
            , {sync_allowed, maps:get(sync_allowed, Ping)}
-           , {peers, serialize(peers, maps:get(peers, Ping), ?VSN_1)} ],
+           , {peers, serialize(peers, maps:get(peers, Ping), ?PEER_VSN)} ],
     serialize_flds(ping, Vsn, Flds);
 serialize(get_header_by_hash, GetHeader, Vsn = ?GET_HEADER_BY_HASH_VSN) ->
     #{ hash := Hash } = GetHeader,
@@ -88,7 +109,7 @@ serialize(peers, Peers, Vsn = ?VSN_1) ->
     [ serialize(peer, Peer, Vsn) || Peer <- Peers ];
 serialize(peer, Peer, ?VSN_1) ->
     %% Don't pollute the encoding with lots of Vsn-fields...
-    Template = serialization_template(peer, ?PING_VSN),
+    Template = serialization_template(peer, ?VSN_1),
     Flds = [ {host,   maps:get(host, Peer)}
            , {port,   maps:get(port, Peer)}
            , {pubkey, maps:get(pubkey, Peer)} ],
@@ -177,7 +198,10 @@ rev_tag(?MSG_GET_NODE_INFO)        -> get_node_info;
 rev_tag(?MSG_NODE_INFO)            -> node_info;
 rev_tag(?MSG_CLOSE)                -> close.
 
-latest_vsn(ping)                 -> ?PING_VSN;
+latest_vsn(Request, ?P2P_PROTOCOL_VSN) ->
+    latest_vsn(Request).
+
+latest_vsn(ping)                 -> ?PING_VSN_2;
 latest_vsn(get_header_by_hash)   -> ?GET_HEADER_BY_HASH_VSN;
 latest_vsn(get_header_by_height) -> ?GET_HEADER_BY_HEIGHT_VSN;
 latest_vsn(header)               -> ?HEADER_VSN;
@@ -199,7 +223,40 @@ latest_vsn(get_node_info)        -> ?GET_NODE_INFO_VSN;
 latest_vsn(node_info)            -> ?NODE_INFO_VSN;
 latest_vsn(close)                -> ?CLOSE_VSN.
 
-deserialize(ping, Vsn, PingFlds) when Vsn == ?PING_VSN ->
+%% In cases where we support multiple message versions.
+%% Only add clauses for messages where multiple vsns are needed.
+%% Default is to support only the latest version.
+msg_versions(ping) ->
+    {ok, Min} = aeu_env:find_config([<<"sync">>, <<"minimum_ping_version">>],
+				    [user_config, schema_default]),
+    [V || V <- [?PING_VSN_1, ?PING_VSN_2],
+	  V >= Min];
+msg_versions(_Msg) ->
+    undefined.
+
+all_msg_versions() ->
+    [#{protocol => atom_to_binary(T, utf8), vsns => msg_versions(T)} || T <- [ping]].
+
+deserialize(ping, Vsn, PingFlds) when Vsn == ?PING_VSN_2 ->
+    PingData =
+        [ {versions, _Versions}
+        , {port, _Port}
+        , {share, _Share}
+        , {genesis_hash, _GenHash}
+        , {height, _Height}
+        , {difficulty, _Difficulty}
+        , {best_hash, _TopHash}
+        , {sync_allowed, _SyncAllowed}
+        , {capabilities, CapBin}
+        , {peers, PeersBin} ] = aeserialization:decode_fields(
+                                  serialization_template(ping, Vsn),
+                                  PingFlds),
+    Peers = deserialize(peers, ?PEER_VSN, PeersBin),
+    Capabilities = deserialize_capabilities(Vsn, CapBin),
+    PingData1 = replace_keys(PingData, [{peers, Peers},
+                                        {capabilities, Capabilities}]),
+    {ping, Vsn, maps:from_list(PingData1)};
+deserialize(ping, Vsn, PingFlds) when Vsn == ?PING_VSN_1 ->
     PingData =
         [ {port, _Port}
         , {share, _Share}
@@ -210,7 +267,7 @@ deserialize(ping, Vsn, PingFlds) when Vsn == ?PING_VSN ->
         , {peers, PeersBin} ] = aeserialization:decode_fields(
                                     serialization_template(ping, Vsn),
                                     PingFlds),
-    Peers = deserialize(peers, Vsn, PeersBin),
+    Peers = deserialize(peers, ?PEER_VSN, PeersBin),
     PingData1 = replace_keys(PingData, [{peers, Peers}, {difficulty, Difficulty}]),
     {ping, Vsn, maps:from_list(PingData1)};
 deserialize(get_header_by_hash, Vsn, GetHeaderFlds) when Vsn == ?GET_HEADER_BY_HASH_VSN ->
@@ -341,7 +398,71 @@ deserialize(node_info, Vsn, NodeInfoFlds) ->
 deserialize(close, Vsn, _CloseFlds) when Vsn == ?CLOSE_VSN ->
     {close, Vsn, #{}}.
 
-serialization_template(ping, ?PING_VSN) ->
+serialize_capabilities(Vsn, Caps) ->
+    Transformed = lists:map(
+                    fun({Tag, L}) when is_atom(Tag), is_list(L) ->
+                            L1 = lists:map(
+                                   fun(M) when is_map(M) ->
+                                           {Tag, M}
+                                   end, L),
+                            {atom_to_binary(Tag, utf8), L1}
+                    end, Caps),
+    Template = [{data, [{binary, binary}]}],
+    Fields = [{K, serialize_capability(K, V, Vsn)} || {K, V} <- Transformed],
+    [List] = aeserialization:encode_fields(Template, [{data, Fields}]),
+    aeser_rlp:encode(List).
+
+serialize_capability(K, V, Vsn) ->
+    Template = capabilities_template(K, Vsn),
+    List = aeserialization:encode_fields(Template, V),
+    aeser_rlp:encode(List).
+
+deserialize_capabilities(Vsn, Caps) ->
+    try
+	Data = aeser_rlp:decode(Caps),
+	[{data, Fields}] = aeserialization:decode_fields([{data, [{binary, binary}]}], [Data]),
+	Deserialized = [{K, deserialize_capability(K, V, Vsn)} || {K, V} <- Fields],
+        lists:map(
+          fun({Kb, L}) ->
+                  KbA = binary_to_existing_atom(Kb, utf8),
+                  L1 = lists:map(
+                         fun({Ka, M}) when Ka == KbA, is_map(M) ->
+                                 M
+                         end, L),
+                  {KbA, L1}
+          end, Deserialized)
+    catch _:Reason ->
+	    {error, Reason}
+    end.
+
+deserialize_capability(K, Bin, Vsn) ->
+    Data = aeser_rlp:decode(Bin),
+    Template = capabilities_template(K, Vsn),
+    aeserialization:decode_fields(Template, Data).
+
+capabilities_template(<<"chain_poi">>, ?PING_VSN_2) ->
+    [{chain_poi, #{ items => [ {height, int}
+                             , {root_hash, binary}
+                             , {genesis, binary}
+                             , {top, binary}
+                             , {poi, binary} ]}
+     }].
+
+serialization_template(ping, ?PING_VSN_2) ->
+    [ {versions, [#{items => [ {protocol, binary}
+                             , {vsns, [int]}]
+                   }]
+      }
+    , {port, int}
+    , {share, int}
+    , {genesis_hash, binary}
+    , {height, int}                      % V2
+    , {difficulty, int}
+    , {best_hash, binary}
+    , {sync_allowed, bool}
+    , {capabilities, binary} % V2
+    , {peers, [binary]} ];
+serialization_template(ping, ?PING_VSN_1) ->
     [ {port, int}
     , {share, int}
     , {genesis_hash, binary}

--- a/apps/aecore/src/aec_worker_sup.erl
+++ b/apps/aecore/src/aec_worker_sup.erl
@@ -22,6 +22,7 @@ init([]) ->
             ?CHILD(aec_peer_analytics, 5000, worker),
             ?CHILD(aec_tx_pool_gc, 5000, worker),
             ?CHILD(aec_resilience, 5000, worker),
+            ?CHILD(aec_capabilities, 5000, worker),
             ?CHILD(aec_db_gc, 5000, worker) ],
 
     {ok, {{one_for_one, 5, 10}, ChildSpecs}}.

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -656,6 +656,8 @@ check_capabilities(Config) ->
     {ok, PeerInfo} = aec_peers:parse_peer_address(aecore_suite_utils:peer_info(Dev1)),
     PeerId = aec_peer:id(PeerInfo),
     Caps = default_capabilities(),
+    %% Wait for the ping capabailities to be propagated
+    timer:sleep(2000),
     PeersWithCap = rpc:call(N2, aec_capabilities, peers_with_capability, [chain_poi], 5000),
     ct:log("Peers with chain_poi on Dev2 = ~p", [ PeersWithCap ]),
     PeersWithCap = [{PeerId, Caps}],

--- a/apps/aecore/test/aecore_sync_SUITE.erl
+++ b/apps/aecore/test/aecore_sync_SUITE.erl
@@ -37,6 +37,8 @@
     check_metrics_logged/1,
     crash_syncing_worker/1,
     large_msgs/1,
+    set_capabilities/1,
+    check_capabilities/1,
     inject_long_chain/1,
     measure_second_node_sync_time/1,
     validate_default_peers/1,
@@ -75,6 +77,7 @@ groups() ->
                               {group, semantically_invalid_tx},
                               {group, mempool_sync},
                               {group, one_blocked},
+                              {group, capabilities},                              
                               {group, large_msgs},
                               {group, performance},
                               {group, config_overwrites_defaults},
@@ -137,6 +140,12 @@ groups() ->
        ensure_tx_pools_one_tx, %% for dev1 & dev2
        ensure_tx_pools_one_tx_third_node %% check mempool on dev3
       ]},
+     {capabilities, [sequence],
+      [start_first_node,
+       set_capabilities,
+       mine_on_first,
+       start_second_node,
+       check_capabilities]},
      {one_blocked, [sequence],
       [start_first_node,
        mine_on_first,
@@ -260,7 +269,7 @@ end_per_suite(Config) ->
 
 init_per_group(TwoNodes, Config) when
         TwoNodes =:= two_nodes; TwoNodes =:= semantically_invalid_tx;
-        TwoNodes =:= mempool_sync; TwoNodes =:= run_benchmark ->
+        TwoNodes =:= mempool_sync; TwoNodes =:= run_benchmark; TwoNodes =:= capabilities ->
     Config1 = config({devs, [dev1, dev2]}, Config),
     InitialApps = {running_apps(), loaded_apps()},
     {ok, _} = application:ensure_all_started(exometer_core),
@@ -349,6 +358,7 @@ end_per_group(Group, Config) when Group =:= two_nodes;
                                   Group =:= node_info;
                                   Group =:= peer_analytics;
                                   Group =:= semantically_invalid_tx;
+                                  Group =:= capabilities;
                                   Group =:= run_benchmark ->
     ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
     ok = aec_metrics_test_utils:stop_statsd_loggers(),
@@ -631,6 +641,28 @@ crash_syncing_worker(Config) ->
 
     {ok, B2} = rpc:call(N1, aec_chain, get_key_block_by_height, [H1], 5000),
     ok.
+
+set_capabilities(Config) ->
+    [ Dev1 | _ ] = proplists:get_value(devs, Config),
+    N1 = aecore_suite_utils:node_name(Dev1),
+    Caps = default_capabilities(),
+    ok = rpc:call(N1, aec_capabilities, set_capability, [chain_poi, Caps], 5000),
+    {ok, Caps} = rpc:call(N1, aec_capabilities, get_capability, [chain_poi], 5000),
+    ok.
+
+check_capabilities(Config) ->
+    [ Dev1, Dev2 | _ ] = proplists:get_value(devs, Config),
+    N2 = aecore_suite_utils:node_name(Dev2),
+    {ok, PeerInfo} = aec_peers:parse_peer_address(aecore_suite_utils:peer_info(Dev1)),
+    PeerId = aec_peer:id(PeerInfo),
+    Caps = default_capabilities(),
+    PeersWithCap = rpc:call(N2, aec_capabilities, peers_with_capability, [chain_poi], 5000),
+    ct:log("Peers with chain_poi on Dev2 = ~p", [ PeersWithCap ]),
+    PeersWithCap = [{PeerId, Caps}],
+    ok.
+
+default_capabilities() ->
+    [#{height => 0, root_hash => <<>>, genesis => <<>>, top => <<>>, poi => <<>>}].
 
 kill_sync_worker(N, PeerId) ->
     case rpc:call(N, aec_sync, worker_for_peer, [PeerId], 5000) of

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1042,6 +1042,11 @@
                     "type" : "integer",
                     "default" : 120000
                 },
+		"minimum_ping_version" : {
+		    "description" : "The lowest version of ping object that peers have to support",
+		    "type" : "integer",
+		    "default" : 1
+		},
                 "external_port" : {
                     "description" : "Listen port for external sync connections. This must be the WAN-facing port number (depending on NAT configuration this may be different from 'port' value above).",
                     "type" : "integer",

--- a/system_test/common/aest_peers_SUITE.erl
+++ b/system_test/common/aest_peers_SUITE.erl
@@ -132,7 +132,7 @@ test_old_peer_discovery(Cfg) ->
     StartupTimeout = proplists:get_value(node_startup_time, Cfg),
 
 
-    CompatibleVersion = "v6.12.0", %% Latest version it should be compatible with
+    CompatibleVersion = "v6.9.0", %% Latest version it should be compatible with
     Compatible = lists:concat(["aeternity/aeternity:", CompatibleVersion]),
     OldBaseSpec = #{
                     peers   => [old_node1],


### PR DESCRIPTION
See issue #4175 

This PR implements the suggestion given in the issue description.

The v2 ping object adds a `versions` and a `capabilities` attribute.

```erlang
serialization_template(ping, ?PING_VSN_2) ->
    [ {versions, [#{items => [ {protocol, binary}
                             , {vsns, [int]}]
                   }]
      }
    , {port, int}
    , {share, int}
    , {genesis_hash, binary}
    , {height, int}                      % V2
    , {difficulty, int}
    , {best_hash, binary}
    , {sync_allowed, bool}
    , {capabilities, binary} % V2
    , {peers, [binary]} ];
```
The `versions` attribute relies on newly added encoding template support. Once serialized, the type is `[[binary, int]]`, but this notation wasn't supported. The `capabilities` payload needs context-sensitive serialization. An example is given with `chain_poi` (capability not yet implemented).
