### PR TITLE
Add endpoint to get recent gas prices

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1028,6 +1028,21 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/EncodedHash"
+  /recent-gas-prices:
+    get:
+      tags:
+        - external
+        - transaction
+      operationId: GetRecentGasPrices
+      description: 'Get minimum gas prices in recent blocks'
+      parameters: []
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GasPrices"
   ###
   ## Internal endpoints
   ###
@@ -3766,6 +3781,20 @@ components:
           type: string
       required:
         - status
+    GasPrices:
+      type: array
+      items:
+        type: object
+        properties:
+          min_gas_price:
+            description: Minimum gas price in the block range
+            $ref: "#/components/schemas/UInt"
+          blocks:
+            description: Amount of blocks from top
+            $ref: "#/components/schemas/UInt64"
+        required:
+          - min_gas_price
+          - blocks
   parameters:
     intAsString:
       in: query

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1035,6 +1035,21 @@ paths:
             type: array
             items:
               $ref: '#/definitions/EncodedHash'
+  /recent-gas-prices:
+    get:
+      tags:
+        - external
+        - transaction
+      operationId: GetRecentGasPrices
+      description: 'Get minimum gas prices in recent blocks'
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/GasPrices'
   /debug/network:
     get:
       tags:
@@ -3718,6 +3733,20 @@ definitions:
     oneOf:
       - $ref: '#/definitions/DelegatesList'
       - $ref: '#/definitions/DelegatesObject'
+  GasPrices:
+    type: array
+    items:
+      type: object
+      properties:
+        min_gas_price:
+          description: Minimum gas price in the block range
+          $ref: '#/definitions/UInt'
+        blocks:
+          description: Amount of blocks from top
+          $ref: '#/definitions/UInt64'
+      required:
+        - min_gas_price
+        - blocks
 
 externalDocs:
   description: Find out more about Aeternity

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -731,6 +731,14 @@ handle_request_('ProtectedDryRunTxs', #{ 'DryRunInput' := Req }, _Context) ->
                   do_dry_run()],
     process_request(ParseFuns, Req);
 
+handle_request_('GetRecentGasPrices', _Params, _Context) ->
+    GasPrices = aehttp_logic:get_top_blocks_gas_price_summary(),
+    {200, [], lists:map(
+        fun([BlockAmount, GasPrice]) ->
+            #{ <<"blocks">> => BlockAmount, <<"min_gas_price">> => GasPrice }
+        end,
+        GasPrices)};
+
 handle_request_(OperationID, Req, Context) ->
     error_logger:error_msg(
       ">>> Got not implemented request to process: ~p~n",

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -150,6 +150,8 @@
     get_transaction/1,
     check_transaction_in_pool/1,
 
+    get_recent_gas_prices/1,
+
     % sync gossip
     pending_transactions/1,
     post_correct_tx/1,
@@ -459,6 +461,8 @@ groups() ->
 
         get_transaction,
         check_transaction_in_pool,
+
+        get_recent_gas_prices,
 
         % sync gossip
         pending_transactions,
@@ -1995,6 +1999,25 @@ get_status_sut(IntAsString) ->
     Host = external_address(),
     Parameters = case IntAsString of true -> "?int-as-string"; false -> "" end,
     http_request(Host, get, "status" ++ Parameters, []).
+
+%% /recent-gas-prices
+
+get_recent_gas_prices(_Config) ->
+    Host = external_address(),
+    {ok, 200, [
+        #{ <<"blocks">> := 1, <<"min_gas_price">> := MinGasPrice1 },
+        #{ <<"blocks">> := 5, <<"min_gas_price">> := MinGasPrice5 },
+        #{ <<"blocks">> := 20, <<"min_gas_price">> := MinGasPrice20 },
+        #{ <<"blocks">> := 120, <<"min_gas_price">> := MinGasPrice120 },
+        #{ <<"blocks">> := 480, <<"min_gas_price">> := MinGasPrice480 }
+    ]} = http_request(Host, get, "recent-gas-prices", []),
+    MinGasPrice = 1000000000,
+    ?assertMatch(X when is_integer(X) andalso X == MinGasPrice, MinGasPrice1),
+    ?assertMatch(X when is_integer(X) andalso X == MinGasPrice, MinGasPrice5),
+    ?assertMatch(X when is_integer(X) andalso X == MinGasPrice, MinGasPrice20),
+    ?assertMatch(X when is_integer(X) andalso X == MinGasPrice, MinGasPrice120),
+    ?assertMatch(X when is_integer(X) andalso X == MinGasPrice, MinGasPrice480),
+    ok.
 
 prepare_tx(TxType, Args, SignHash) ->
     %assert_required_tx_fields(TxType, Args),


### PR DESCRIPTION
needed to implement https://github.com/aeternity/aepp-sdk-js/issues/1786

At some point, we would have a such blockchain load that won't allow us to mine all submitted transactions with the minimum fee. Then the gas price used to build a transaction would matter. To be able to estimate a reasonable gas price I'm proposing to implement an endpoint on the node side exposing the minimum gas price among the last blocks.

<img width="514" alt="Screenshot 2023-08-23 at 20 01 14" src="https://github.com/aeternity/aeternity/assets/9007851/e83132a7-7d4c-40b9-ae0b-24298d69efd0">

This PR is supported by the Æternity Crypto Foundation
