### PR TITLE
Cache core schema as persistent_term

### DIFF
--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -218,14 +218,22 @@ lists_map_key_find(_, []) ->
     error.
 
 schema() ->
-    case setup:get_env(aeutils, '$schema', undefined) of
+    case pt_get_schema(undefined) of
         undefined ->
             load_schema(),
-            {ok, S} = setup:get_env(aeutils, '$schema'),
-            S;
+            pt_get_schema();
         S ->
             S
     end.
+
+pt_get_schema() ->
+    persistent_term:get({?MODULE, '$schema'}).
+
+pt_get_schema(Default) ->
+    persistent_term:get({?MODULE, '$schema'}, Default).
+
+pt_set_schema(Schema) ->
+    persistent_term:put({?MODULE, '$schema'}, Schema).
 
 schema(Key) ->
     schema(Key, schema()).
@@ -835,5 +843,5 @@ load_schema() ->
 
 load_schema(F) ->
     [Schema] = jsx:consult(F, [return_maps]),
-    application:set_env(aeutils, '$schema', Schema),
+    pt_set_schema(Schema),
     Schema.


### PR DESCRIPTION
Profiling indicates that schema default lookup when checking config values is inordinately expensive.

This PR caches the parsed schema as a persistent term rather than in ets.
This brings down schema default lookup time from ca 4 ms to ca 4 us.

(Plugin schemas were already cached as persistent terms)

This affects calls like:
```erlang
aeu_env:find_config( [<<"sync">>, <<"peer_analytics">>],
                     [user_config, schema_default, {value,false}]).
```

If the key is not present in the user config, the schema default will be returned. This is actually quite a common pattern.