### PR TITLE
[Ceres] Make NamePreclaim optional

### DIFF
--- a/apps/aens/test/aens_SUITE.erl
+++ b/apps/aens/test/aens_SUITE.erl
@@ -633,7 +633,12 @@ claim_negative2_(Cfg) ->
     TxSpec = aens_test_utils:claim_tx_spec(PubKey, Name, 0, namefee(Name, Cfg), S1),
     {ok, Tx0} = aens_claim_tx:new(TxSpec),
     Env0 = aetx_env:tx_env(Height),
-    {error, illegal_salt_value} = aetx:process(Tx0, Trees, Env0),
+    case aec_hard_forks:protocol_effective_at_height(1) of
+        P when P > ?FORTUNA_PROTOCOL_VSN ->
+            {error, illegal_salt_value} = aetx:process(Tx0, Trees, Env0);
+        _ ->
+            {error, name_not_preclaimed} = aetx:process(Tx0, Trees, Env0)
+    end,
 
     ok.
 

--- a/apps/aeprimop/src/aeprimop_state.erl
+++ b/apps/aeprimop/src/aeprimop_state.erl
@@ -281,7 +281,7 @@ put_commitment(Object, S) ->
 
 %%----------
 
--spec find_name_auction(channel_key(), state()) -> {term(), state()} | none.
+-spec find_name_auction(auction_hash(), state()) -> {object(), state()} | none.
 find_name_auction(Hash, S) ->
     find_x(name_auction, Hash, S).
 

--- a/docs/release-notes/next-ceres/aens_preclaim_optional.md
+++ b/docs/release-notes/next-ceres/aens_preclaim_optional.md
@@ -1,0 +1,5 @@
+* Make NamePreclaimTx optional. Since the introduction of auctions, the
+  front-running protection offered by the 'PreClaim -> Claim' flow is no
+  longer as important. To simplify name registrations (or the start of a
+  name auction) we now allow NameClaimTx without a previous NamePreclaimTx.
+  In this case we set the `NameSalt` to `0`.


### PR DESCRIPTION
Fixes #4174 

Make NamePreclaimTx optional. Since the introduction of auctions, the front-running protection offered by the 'PreClaim -> Claim' flow is no longer as important. To simplify name registrations (or the start of a name auction) we now allow NameClaimTx without a previous NamePreclaimTx. In this case we set the `NameSalt` to `0`.

This PR is supported by the Æternity Crypto Foundation
