### PR TITLE
WIP make changes BW compatible

### DIFF
--- a/apps/aecore/src/aec_fork_block_settings.erl
+++ b/apps/aecore/src/aec_fork_block_settings.erl
@@ -35,11 +35,14 @@
 -spec dir(aec_hard_forks:protocol_vsn()) -> string().
 dir(ProtocolVsn) ->
     ProtocolBin = integer_to_binary(ProtocolVsn),
-    case aeu_env:user_map_or_env([<<"chain">>, <<"hard_forks">>, ProtocolBin, <<"directory">>], aecore, [hard_forks, ProtocolVsn, directory], undefined) of
+    case aeu_env:config_value([<<"chain">>, <<"hard_forks">>, ProtocolBin, <<"directory">>],
+                              aecore, [hard_forks, ProtocolVsn, directory],
+                              undefined) of
         undefined ->
             case not is_custom_fork() orelse
-                  aeu_env:user_map_or_env([<<"chain">>, <<"hard_forks">>, ProtocolBin, <<"use_hardcoded_directory">>], aecore,
-                                          [hard_forks, ProtocolVsn, use_hardcoded_directory], false) of
+                  aeu_env:config_value([<<"chain">>, <<"hard_forks">>, ProtocolBin, <<"use_hardcoded_directory">>],
+                                       aecore, [hard_forks, ProtocolVsn, use_hardcoded_directory],
+                                       false) of
                 true ->
                     hardcoded_dir(ProtocolVsn);
                 _ ->

--- a/apps/aecore/src/aec_hard_forks.erl
+++ b/apps/aecore/src/aec_hard_forks.erl
@@ -177,7 +177,9 @@ protocols_from_network_id(_ID) ->
              };
         M when is_map(M) ->
             maps:fold(fun(K, #{<<"height">> := V}, Acc) ->
-                              Acc#{binary_to_integer(K) => V}
+                              Acc#{binary_to_integer(K) => V};
+                         (K, Height, Acc) when is_integer(Height) ->
+                              Acc#{binary_to_integer(K) => Height}
                       end, #{}, M)
     end.
 

--- a/apps/aecore/test/aec_fork_block_settings_tests.erl
+++ b/apps/aecore/test/aec_fork_block_settings_tests.erl
@@ -78,6 +78,9 @@ release_based(Dir, ForkConfig, ReadAccountsFun, ReadContractsFun, CMissingErr, A
                                 ForkConfig end),
                 meck:expect(aeu_env, user_map_or_env,
                             fun([<<"chain">>, <<"hard_forks">>, Protocol, Key], aecore, [hard_forks, _, _], Default) ->
+                                maps:get(Key, maps:get(Protocol, ForkConfig, #{}), Default) end),
+                meck:expect(aeu_env, config_value,
+                            fun([<<"chain">>, <<"hard_forks">>, Protocol, Key], aecore, [hard_forks, _, _], Default) ->
                                 maps:get(Key, maps:get(Protocol, ForkConfig, #{}), Default) end)
          end,
          ok

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1556,25 +1556,35 @@
                     "type" : "object",
                     "additionalProperties" : false,
                     "patternProperties" : {
-                        "^[1-9][0-9]*$": {
+                        "^[1-9][0-9]*$" : {
                             "description" : "Configuration for the hardfork",
-                            "type" : "object",
-                            "required" : ["height"],
-                            "properties": {
-                                "height" :{
-                                    "description" : "Minimum height at which protocol is effective",
-                                    "type" : "integer",
-                                    "minimum" : 0
-                                },
-                                "directory" :{
-                                    "description" : "Directory where accounts are stored",
-                                    "type" : "string"
-                                },
-                                "use_hardcoded_directory" :{
-                                    "description" : "Use the hardcoded directory of the protocol to facilitate testing old protocols",
-                                    "type" : "boolean"
-                                }                                
-                            }                                
+                            "oneOf" : [
+                            {
+                                "description" : "Minimum height at which protocol is effective (legacy format)",
+                                "type" : "integer",
+                                "minimum" : 0
+                            },
+                            {
+                                "description" : "Configuration for the hardfork (new format)",
+                                "type" : "object",
+                                "required" : ["height"],
+                                "properties" : {
+                                    "height" : {
+                                        "description" : "Minimum height at which protocol is effective",
+                                        "type" : "integer",
+                                        "minimum" : 0
+                                    },
+                                    "directory" : {
+                                        "description" : "Directory where accounts are stored",
+                                        "type" : "string"
+                                    },
+                                    "use_hardcoded_directory" : {
+                                        "description" : "Use the hardcoded directory of the protocol to facilitate testing old protocols",
+                                        "type" : "boolean",
+                                        "default" : false
+                                    }
+                                }
+                            }]
                         }
                     }
                 },

--- a/apps/aeutils/src/aeu_env.erl
+++ b/apps/aeutils/src/aeu_env.erl
@@ -185,15 +185,19 @@ nested_map_get([], V) ->
     {ok, V};
 nested_map_get([H|T], M) when is_map(M) ->
     case maps:find(H, M) of
-        {ok, M1} ->
+        {ok, M1} when is_map(M1) ->
             nested_map_get(T, M1);
-        error ->
+        {ok, V} when T == [] ->
+            {ok, V};
+        _ ->
             undefined
     end;
 nested_map_get([H|T], L) when is_list(L) ->
     case lists_map_key_find(H, L) of
-        {ok, V} ->
+        {ok, V} when is_map(V) ->
             nested_map_get(T, V);
+        {ok, V} when T == [] ->
+            {ok, V};
         error ->
             undefined
     end.


### PR DESCRIPTION
The idea is to make the schema changes backward-compatible, by supporting both the legacy format and the new format through the use of `oneOf`. Some additional code changes needed to also detect the use of the legacy format.

The function `aeu_env:config_value(Key, App, Env, Default)` is very similar to `aeu_env:user_map_or_env/4`, but also checks for schema defaults (before using the provided default). Having a schema default seems reasonable esp. for the property `use_hardcoded_directory`, which would be assumed `true` when using the legacy format, and `false` by default when using the new.