### PR TITLE
Temporarily disable HC tests in aehttp_stake_contract_SUITE

### DIFF
--- a/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
+++ b/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
@@ -128,9 +128,10 @@
 
 -define(GENESIS_BENFICIARY, <<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0>>).
 
-all() -> [{group, pos},
-          {group, hc},
-          {group, hc_btc}
+all() -> [{group, pos}
+          %% These tests are currently not stable enough (CI!) - let's disable for now.
+          %% {group, hc},
+          %% {group, hc_btc}
          ].
 
 groups() ->


### PR DESCRIPTION
These tests take too long (4 minutes +) and fail intermittently - let's disable until they can be improved?!

This PR is supported by the Æternity Foundation
