### PR TITLE
AENSv2.DataPt should have type bytes() not string

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -6736,7 +6736,7 @@ sophia_aens_update_transaction(Cfg) ->
     ?assertEqual(23456, aens_names:ttl(Rec3)),
     ?assertEqual(23456, aens_names:client_ttl(Rec3)),
 
-    RawPointers = if VMVersion >= ?VM_FATE_SOPHIA_3 -> #{<<"raw_pointer">> => DataPointee(<<"data">>)};
+    RawPointers = if VMVersion >= ?VM_FATE_SOPHIA_3 -> #{<<"raw_pointer">> => DataPointee({bytes, <<"data">>})};
                      true                           -> #{}
                   end,
 
@@ -6756,7 +6756,7 @@ sophia_aens_update_transaction(Cfg) ->
                    [aens_pointer:new(<<(atom_to_binary(T, utf8))/binary, "_pubkey">>,
                                      aeser_id:create(T, <<A:256>>)) ||
                        {T, A} <- [{account, APubkey}, {oracle, OPubkey}, {contract, CPubkey}]]
-                   ++ [aens_pointer:new(K, V) || {K, {variant, _, _, {V}}} <- maps:to_list(RawPointers)]),
+                   ++ [aens_pointer:new(K, V) || {K, {variant, _, _, {{bytes, V}}}} <- maps:to_list(RawPointers)]),
                  lists:sort(aens_names:pointers(Rec4))),
 
     {} = ?call(call_contract, Acc, Ct, update, {tuple, []},
@@ -7347,7 +7347,7 @@ fate_vm_new_data_pointers(Cfg) ->
     CHash           = aens_hash:commitment_hash(NameAscii, Salt1),
 
     AccountPointeeV2 = fun (A) -> {variant, [1, 1, 1, 1, 1], 0, {A}} end,
-    PointeeV2Type = {variant_t, [{acc_pt, [word]}, {orc_pt, [word]}, {con_pt, [word]}, {cha_pt, [word]}, {dat_pt, [string]}]},
+    PointeeV2Type = {variant_t, [{acc_pt, [word]}, {orc_pt, [word]}, {con_pt, [word]}, {cha_pt, [word]}, {dat_pt, [{bytes, any}]}]},
 
     %%  A1 register a name N
     {} = ?call(call_contract, Acc, CtIris, reg, {tuple, []}, {Name1, ?hsh(CHash), Salt1, 1_000_000_000_000_000_000}, CallSpec),
@@ -7366,7 +7366,7 @@ fate_vm_new_data_pointers(Cfg) ->
     Res = ?call(call_contract, Acc, CtCeres, remote_lookup, PointeeV2Type, {?cid(CtIris), Name1, <<"key1">>}, CallSpec),
 
     %%  A2 add key2 -> data
-    {} = ?call(call_contract, Acc, CtCeres, add_data_ptr, {tuple, []}, {Name1, <<"key2">>, <<"ptr1">>}, CallSpec),
+    {} = ?call(call_contract, Acc, CtCeres, add_data_ptr, {tuple, []}, {Name1, <<"key2">>, {bytes, <<"ptr1">>}}, CallSpec),
 
     %%  A2 tries to lookup key2 through A1 -> fail
     {error,<<"Error in aens_lookup: data_pointer_not_in_fate_vm_2">>} =
@@ -7394,7 +7394,7 @@ fate_vm_new_data_pointers(Cfg) ->
 
     %%  A2 add key2 -> too long -> fail
     {error,<<"Error in aens_update: bad_pointer">>} =
-        ?call(call_contract, Acc, CtCeres, add_data_ptr, {tuple, []}, {Name1, <<"key2">>, <<0:(1025*8)>>}, CallSpec),
+        ?call(call_contract, Acc, CtCeres, add_data_ptr, {tuple, []}, {Name1, <<"key2">>, {bytes, <<0:(1025*8)>>}}, CallSpec),
 
     %%  A2 transfer N to A1
     {} = ?call(call_contract, Acc, CtCeres, trf, {tuple, []}, {Name1, CtIris}, CallSpec),

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -2246,7 +2246,7 @@ mk_pointer_id_v1(?FATE_VARIANT([1, 1, 1, 1], AddrTag, {?FATE_ADDRESS(Addr)})) ->
 
 mk_pointer_id_v2(?FATE_VARIANT([1, 1, 1, 1, 1], AddrTag, {?FATE_ADDRESS(Addr)})) ->
     mk_id(AddrTag, Addr);
-mk_pointer_id_v2(?FATE_VARIANT([1, 1, 1, 1, 1], 4, {?FATE_STRING(Data)})) ->
+mk_pointer_id_v2(?FATE_VARIANT([1, 1, 1, 1, 1], 4, {?FATE_BYTES(Data)})) ->
     Data.
 
 %% type pointee = Account | Oracle | Contract | Channel

--- a/rebar.config
+++ b/rebar.config
@@ -217,7 +217,7 @@
                     {dist_node, [{setcookie, 'aeternity_cookie'},
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"b5d77bc"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"a8d708c"}}},
                             {aesophia_cli, {git, "https://github.com/aeternity/aesophia_cli", {ref,"5f03a89"}}},
                             {aestratum_client, {git, "https://github.com/aeternity/aestratum_client", {ref, "adb0993"}}},
                             {websocket_client, {git, "https://github.com/aeternity/websocket_client", {ref, "95ef9de"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -217,7 +217,7 @@
                     {dist_node, [{setcookie, 'aeternity_cookie'},
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"8f50838"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"b5d77bc"}}},
                             {aesophia_cli, {git, "https://github.com/aeternity/aesophia_cli", {ref,"5f03a89"}}},
                             {aestratum_client, {git, "https://github.com/aeternity/aestratum_client", {ref, "adb0993"}}},
                             {websocket_client, {git, "https://github.com/aeternity/websocket_client", {ref, "95ef9de"}}},

--- a/test/contracts/aens_update.aes
+++ b/test/contracts/aens_update.aes
@@ -19,7 +19,7 @@ main contract AENSUpdate =
     let Some(pv1) = AENSCompat.pointee_from_V2(ptr)
     o.set(name, key, pv1)
 
-  stateful entrypoint add_data_ptr(name : string, key : string, data : string) =
+  stateful entrypoint add_data_ptr(name : string, key : string, data : bytes()) =
     set(name, key, AENSv2.DataPt(data))
 
   stateful entrypoint set(name : string, key : string, ptr : AENSv2.pointee) =


### PR DESCRIPTION
See #aeternity/aesophia#493

The new raw/data pointers should of course have type DataPt(bytes()) - when they were introduced string was the closest thing we had to an arbitrary sized byte array.

This PR is supported by the Æternity Foundation
