### PR TITLE
HC: Don't crash if there are no local stakers

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -675,9 +675,15 @@ pick_lazy_leader(TopHash) ->
         {ok, AllStakers} ->
             SignModule = get_sign_module(),
             LocalStakers = lists:filter(fun SignModule:is_key_present/1, AllStakers),
-            Staker = lists:nth(rand:uniform(length(LocalStakers)), LocalStakers),
-            SignModule:set_candidate(Staker),
-            {ok, Staker};
+            case LocalStakers of
+              [] ->
+                  timer:sleep(1000),
+                  error;
+              _ ->
+                  Staker = lists:nth(rand:uniform(length(LocalStakers)), LocalStakers),
+                  SignModule:set_candidate(Staker),
+                  {ok, Staker}
+            end;
         _ ->
             timer:sleep(1000),
             error


### PR DESCRIPTION
Don't try to elect a "lazy" leader if there are no local stakers...

This PR is supported by Æternity foundation