### PR TITLE
DB might contain dict MP trees, convert them in from_db_format

### DIFF
--- a/apps/aeutils/src/aeu_mp_trees.erl
+++ b/apps/aeutils/src/aeu_mp_trees.erl
@@ -158,11 +158,11 @@ has_backend(#mpt{ db = DB }) ->
     ?MODULE =/= aeu_mp_trees_db:get_module(DB).
 
 -spec from_db_format(tree() | tuple()) -> tree().
-from_db_format(Tree = #mpt{}) -> Tree;
+from_db_format(Tree = #mpt{ db = DB }) -> Tree#mpt{ db = aeu_mp_trees_db:from_db_format(DB) };
 from_db_format(Tuple) ->
     case setelement(1, Tuple, db_mpt) of
         #db_mpt{ hash = RootHash, db = DB } ->
-            #mpt{ hash = RootHash, db = DB, node_cache = none };
+            #mpt{ hash = RootHash, db = aeu_mp_trees_db:from_db_format(DB), node_cache = none };
         _ ->
             error(illegal_db_format)
     end.

--- a/apps/aeutils/src/aeu_mp_trees_db.erl
+++ b/apps/aeutils/src/aeu_mp_trees_db.erl
@@ -28,6 +28,8 @@
 
 -export([record_fields/1]).
 
+-export([from_db_format/1]).
+
 -export_type([ db/0
              , db_spec/0
              ]).
@@ -144,6 +146,11 @@ get_module(DB) ->
     #db{module = Module} = to_new_db(DB),
     Module.
 
+-spec from_db_format(db()) -> db().
+from_db_format(DB = #db{handle = H, cache = C}) ->
+    DB#db{ handle = ensure_map(H), cache = ensure_map(C) }.
+
+
 %%%===================================================================
 %%% Cache
 %%%===================================================================
@@ -175,7 +182,7 @@ to_new_db(#db{} = DB) -> DB;
 to_new_db({db, _, _, _, _, _} = OldDB) ->
     case setelement(1, OldDB, old_db) of
         #old_db{ handle = Handle
-               , cache  = Cache 
+               , cache  = Cache
                , drop_cache = {Module, _}
                , get        = {Module, _}
                , put        = {Module, _} } ->
@@ -184,4 +191,8 @@ to_new_db({db, _, _, _, _, _} = OldDB) ->
                 , handle  => Handle});
         _ -> not_db
     end.
-    
+
+-spec ensure_map(map() | dict:dict()) -> map().
+ensure_map(Map) when is_map(Map) -> Map;
+ensure_map(Dict) ->
+    maps:from_list(dict:to_list(Dict)).


### PR DESCRIPTION
Fixes #4236. The problem is that we might have terms in the (local) DB using the old format, they need to be converted to the new format when they are read.

This PR is supported by Æternity Foundation