### PR TITLE
[Ceres] Adjust cost for reading stored value

### DIFF
--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -538,7 +538,7 @@ spend_gas_for_new_cells1(NewCells, #es{ created_cells = Cells } = ES) ->
 spend_gas_for_store_values(StoreValues, ES) ->
     case consensus_version(ES) < ?CERES_PROTOCOL_VSN of
         true  -> ES;
-        false -> spend_gas(StoreValues * 20000, ES)
+        false -> spend_gas(StoreValues * 5000, ES)
     end.
 
 -define(GAS_DENOMINATOR, 1000).


### PR DESCRIPTION
Fixes #4197. Reading from the contract store is expensive, we introduced a read cache to avoid the worst cases - still the first time reading an element is expensive (accessing the MPT). We set an approximate cost of 20000 gas; here we adjust to 5000 gas - it should be enough to deflect misuse, but not too big making normal usage overly expensive.

This PR is supported by Æternity Foundation 