### PR TITLE
Update MacOS build dependancies

### DIFF
--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -78,8 +78,6 @@ macos-tarball:
     xcode: "13.4.1" # macOS 12.3.1
   resource_class: macos.x86.medium.gen2
   working_directory: /Users/distiller/aeternity
-  # environment:
-  #   HOMEBREW_NO_AUTO_UPDATE: 1
   steps:
     - fixed_checkout
     - when:

--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -78,8 +78,8 @@ macos-tarball:
     xcode: "13.4.1" # macOS 12.3.1
   resource_class: macos.x86.medium.gen2
   working_directory: /Users/distiller/aeternity
-  environment:
-    HOMEBREW_NO_AUTO_UPDATE: 1
+  # environment:
+  #   HOMEBREW_NO_AUTO_UPDATE: 1
   steps:
     - fixed_checkout
     - when:

--- a/.circleci/config/workflows/commit.yml
+++ b/.circleci/config/workflows/commit.yml
@@ -270,6 +270,7 @@ jobs:
           only:
             - /releases\/.*/
             - << pipeline.parameters.master_branch >>
+            - macos_build
 
   - macos-tarball:
       name: macos-tarball-bundle

--- a/.circleci/config/workflows/commit.yml
+++ b/.circleci/config/workflows/commit.yml
@@ -270,7 +270,6 @@ jobs:
           only:
             - /releases\/.*/
             - << pipeline.parameters.master_branch >>
-            - macos_build
 
   - macos-tarball:
       name: macos-tarball-bundle

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,7 +63,7 @@ The release binaries are published on [GitHub][releases] and are tested on the f
 
 Package dependencies are:
 
-* [Libsodium](https://download.libsodium.org/doc/) v1.0.16
+* [Libsodium](https://download.libsodium.org/doc/) v1.0.16/v1.0.19
 * [Openssl](https://www.openssl.org) v1.1
 
 #### Ubuntu dependencies
@@ -89,13 +89,13 @@ brew install openssl libsodium
 The macOS package has:
 
 * A hard dependency on OpenSSL v1.1 installed with [Homebrew](https://brew.sh/) in its default path `/usr/local/opt/openssl/lib/libcrypto.1.1.dylib`;
-* A hard dependency on libsodium v1.0.16 installed with [Homebrew](https://brew.sh/) in its default path `/usr/local/opt/libsodium/lib/libsodium.23.dylib`.
+* A hard dependency on libsodium v1.0.19 installed with [Homebrew](https://brew.sh/) in its default path `/usr/local/opt/libsodium/lib/libsodium.26.dylib`.
 
 In case you have installed either of them in a non-default path, you could use symlink(s) to work around the issue.
 You can create those symlinks by running the following commands:
 ```bash
 ln -s "$(brew --prefix openssl)"/lib/libcrypto.1.1.dylib /usr/local/opt/openssl/lib/libcrypto.1.1.dylib
-ln -s "$(brew --prefix libsodium)"/lib/libsodium.23.dylib /usr/local/opt/libsodium/lib/libsodium.23.dylib
+ln -s "$(brew --prefix libsodium)"/lib/libsodium.26.dylib /usr/local/opt/libsodium/lib/libsodium.26.dylib
 ```
 
 ### Deploy node


### PR DESCRIPTION
Latest libsodium of brew is v1.0.19 with runtime lib `libsodium.26.dylib`