### PR TITLE
[HC]: configuration cleanup/overhaul

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -112,19 +112,7 @@ start(Config, #{block_production := BlockProduction}) ->
         false -> ok
     end,
     CacheSize = maps:get(<<"cache_size">>, Polling, 200),
-    ParentHosts =
-        lists:map(
-            fun(#{<<"host">> := Host,
-                  <<"port">> := Port,
-                  <<"user">> := User,
-                  <<"password">> := Pass
-                }) ->
-                #{host => Host,
-                  port => Port,
-                  user => User,
-                  password => Pass}
-            end,
-            Nodes0),
+    ParentHosts = lists:map(fun aehttpc:parse_node_url/1, Nodes0),
     {ParentConnMod, PCSpendPubkey, HCPCPairs, SignModule} =
         case PCType of
             <<"AE2AE">> -> start_ae(StakersEncoded, PCSpendAddress);
@@ -858,4 +846,3 @@ elect_lazy_leader(Beneficiary, TxEnv, Trees) ->
         {error, What} ->
             aec_conductor:throw_error({failed_to_elect_new_leader, What})
     end.
-

--- a/apps/aehttp/src/aehttpc.erl
+++ b/apps/aehttp/src/aehttpc.erl
@@ -1,0 +1,63 @@
+%%% -*- erlang-indent-level:4; indent-tabs-mode: nil -*-
+%%% -------------------------------------------------------------------
+%%% @copyright (C) 2024, Aeternity Anstalt
+%%% @doc Parent chain connector behavior
+%%%
+%%% @end
+-module(aehttpc).
+
+-export([ parse_node_url/1
+        , url/1 ]).
+
+
+-type node_spec() :: #{ host     := string()
+                      , scheme   := string()
+                      , port     => non_neg_integer()
+                      , user     => binary()
+                      , password => binary()}.
+-type seed() :: binary().
+-type hash() :: binary().
+-type height() :: non_neg_integer().
+-type pubkey() :: binary().
+
+-export_type([ node_spec/0 ]).
+
+-callback get_latest_block(node_spec(), seed()) ->
+    {ok, hash(), hash(), height()} | {error, term()}.
+
+-callback get_header_by_hash(hash(), node_spec(), seed()) ->
+    {ok, hash(), hash(), height()} | {error, term()}.
+
+-callback get_header_by_height(height(), node_spec(), seed()) ->
+    {ok, hash(), hash(), height()} | {error, term()}.
+
+-callback get_commitment_tx_in_block(node_spec(), seed(), hash(), hash(), pubkey()) ->
+    {ok, [term()]} | {error, term()}.
+
+-callback get_commitment_tx_at_height(node_spec(), seed(), height(), pubkey()) ->
+    {ok, [term()]} | {error, term()}.
+
+-callback post_commitment(node_spec(), pubkey(), pubkey(), non_neg_integer(), non_neg_integer(), binary(), binary(), term()) ->
+    {ok, term()} | {error, term()} | {error, non_neg_integer(), term()}.
+
+
+-spec parse_node_url(string()) -> node_spec().
+parse_node_url(NodeURL) ->
+    URIMap = uri_string:parse(NodeURL),
+    maps:from_list(
+      [ {host, maps:get(host, URIMap, "localhost")}
+      , {scheme, maps:get(scheme, URIMap, "http")} ] ++
+      [ {port, maps:get(port, URIMap)} || maps:is_key(port, URIMap) ] ++
+      parse_userinfo(maps:get(userinfo, URIMap, ""))
+     ).
+
+parse_userinfo("") -> [];
+parse_userinfo(UserInfo) ->
+    [User, Password] = string:split(UserInfo, ":"),
+    [{user, iolist_to_binary(User)}, {password, iolist_to_binary(Password)}].
+
+-spec url(node_spec()) -> string().
+url(#{scheme := Scheme, host := Host, port := Port}) ->
+    lists:flatten(io_lib:format("~s://~s:~p", [Scheme, Host, Port]));
+url(#{scheme := Scheme, host := Host}) ->
+    lists:flatten(io_lib:format("~s://~s", [Scheme, Host])).

--- a/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
+++ b/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
@@ -1533,6 +1533,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
         case Consensus of
             ?CONSENSUS_POS -> #{};
             ?CONSENSUS_HC ->
+                Port = aecore_suite_utils:external_api_port(?PARENT_CHAIN_NODE1),
                 #{  <<"parent_chain">> =>
                     #{  <<"start_height">> => ?CHILD_START_HEIGHT,
                         <<"confirmations">> => ?CHILD_CONFIRMATIONS,
@@ -1545,12 +1546,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                             },
                         <<"polling">> =>
                             #{  <<"fetch_interval">> => 100,
-                                <<"nodes">> =>
-                                    [   #{  <<"host">> => <<"127.0.0.1">>,
-                                            <<"port">> => aecore_suite_utils:external_api_port(?PARENT_CHAIN_NODE1),
-                                            <<"user">> => <<"test">>,
-                                            <<"password">> => <<"Pass">>}
-                                    ]
+                                <<"nodes">> => [ iolist_to_binary(io_lib:format("http://test:Pass@127.0.0.1:~p", [Port])) ]
                             },
                         <<"producing_commitments">> => ProducingCommitments
                         },
@@ -1574,12 +1570,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                             },
                         <<"polling">> =>
                             #{  <<"fetch_interval">> => 100,
-                                <<"nodes">> =>
-                                    [   #{  <<"host">> => <<"127.0.0.1">>,
-                                            <<"port">> => ?BTC_PARENT_CHAIN_PORT,
-                                            <<"user">> => <<"test">>,
-                                            <<"password">> => <<"Pass">>}
-                                    ]
+                                <<"nodes">> => [ iolist_to_binary(io_lib:format("http://test:Pass@127.0.0.1:~p", [?BTC_PARENT_CHAIN_PORT])) ]
                             },
                         <<"producing_commitments">> => ProducingCommitments
                         },
@@ -1592,7 +1583,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
     {ok, AccountFileName} = aecore_suite_utils:hard_fork_filename(Node, CTConfig, integer_to_list(Protocol), binary_to_list(NetworkId) ++ "_accounts.json"),
     #{<<"chain">> =>
             #{  <<"persist">> => false,
-                <<"hard_forks">> => #{integer_to_binary(Protocol) => #{<<"height">> => 0, 
+                <<"hard_forks">> => #{integer_to_binary(Protocol) => #{<<"height">> => 0,
                                                                        <<"contracts_file">> => ContractFileName,
                                                                        <<"accounts_file">> => AccountFileName}},
                 <<"consensus">> =>

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1624,22 +1624,29 @@
                                     "properties": {
                                         "contract_owner": {
                                             "description": "Owner of the smart contracts that controls the consensus.",
-                                            "default": "ak_11111111111111111111111111111115rHyByZ",
                                             "type": "string"
                                         },
                                         "election_contract": {
                                             "description": "The address of the smart contract that will be used for leader elections. For a new chain this contract should be loaded at genesis",
-                                            "default": "",
                                             "type": "string"
                                         },
                                         "rewards_contract": {
                                             "description": "The address of the smart contract that will be used for reward distributions. For a new chain this contract should be loaded at genesis",
-                                            "default": "",
                                             "type": "string"
                                         },
                                         "expected_key_block_rate": {
                                             "description": "Something about rates.. FIXME",
                                             "default": 2000,
+                                            "type": "integer"
+                                        },
+                                        "genesis_start_time": {
+                                            "description": "Timestamp for genesis",
+                                            "default": 0,
+                                            "type": "integer"
+                                        },
+                                        "lazy_leader_trigger_time": {
+                                            "description": "Graze period until lazy leader is triggered (in ms)",
+                                            "default": 10000,
                                             "type": "integer"
                                         },
                                         "parent_chain": {
@@ -1656,6 +1663,11 @@
                                                     "description": "Height on the parent chain that this hyperchain will start posting commitments and start creating blocks",
                                                     "default": 0,
                                                     "type": "integer"
+                                                },
+                                                "producing_commitments": {
+                                                    "description": "Enable/Disable commitment production",
+                                                    "default": false,
+                                                    "type": "boolean"
                                                 },
                                                 "consensus": {
                                                     "description" : "Details of the parent chain.",
@@ -1699,6 +1711,11 @@
                                                             "description" : "The interval between polls of the parent chain looking for a new block (millisec)",
                                                             "type": "integer",
                                                             "default": 500
+                                                        },
+                                                        "cache_size": {
+                                                            "description" : "Size of local cache for parent chain",
+                                                            "type": "integer",
+                                                            "default": 200
                                                         },
                                                         "nodes": {
                                                             "description" : "List of parent chain nodes to poll for new blocks",

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -152,7 +152,7 @@
                                 "crash" : {
                                     "description" : "Something went really wrong, clean up.",
                                     "type" : "integer",
-                                    "default" : 1 
+                                    "default" : 1
                                 },
                                 "not_a_generalized_account" : {
                                     "description" : "If the transaction is being authenticated as a GA but the account is still basic. We provide a grace period in a number of generations for the account to be upgraded.",
@@ -1140,7 +1140,7 @@
                 "whitelist_file" : {
                     "description" : "The name of a block hash whitelist file (JSON format)",
                     "type" : "string",
-                    "default" : ".block_whitelist.json" 
+                    "default" : ".block_whitelist.json"
                 },
                 "log_peer_connection_count_interval" : {
                     "description": "Time (milliseconds) between logging info about connected peers",
@@ -1199,7 +1199,7 @@
                 "provide_node_info" : {
                     "description": "Provide node version to peers",
                     "type" : "boolean",
-                    "default": true 
+                    "default": true
                 },
                 "peer_analytics" : {
                     "description": "If enabled aggregates info about remote peers and exposes them via HTTP. Overrides max_inbound and max_outbound",
@@ -1704,31 +1704,8 @@
                                                             "description" : "List of parent chain nodes to poll for new blocks",
                                                             "type" : "array",
                                                             "items" : {
-                                                                "type" : "object",
-                                                                "description" : "Host name and login details",
-                                                                "additionalProperties" : false,
-                                                                "properties": {
-                                                                    "host": {
-                                                                        "description": "Host name of IP address",
-                                                                        "type": "string",
-                                                                        "default": "localhost"
-                                                                    },
-                                                                    "port": {
-                                                                        "description": "Port number of HTTP API server on parent node",
-                                                                        "type": "integer",
-                                                                        "default": 3013
-                                                                    },
-                                                                    "user": {
-                                                                        "description": "Username for HTTP API login if needed",
-                                                                        "type": "string",
-                                                                        "default": ""
-                                                                    },
-                                                                    "password": {
-                                                                        "description": "Password for HTTP API login if needed",
-                                                                        "type": "string",
-                                                                        "default": ""
-                                                                    }
-                                                                }
+                                                                "type" : "string",
+                                                                "description" : "URL address of the API - <protocol>://<user>:<password>@<hostname>:<port>"
                                                             },
                                                             "default": []
                                                         }


### PR DESCRIPTION
- Making the transport protocol configurable - fixing #4224.
- Refactor code to avoid lots of repeated parameters.
- Make sure default values are considered, when applicable - fixing #4225.
- Harmonize code and config schema - fixing #4230.

This PR is supported by Æternity Foundation.