### PR TITLE
HC/FATE: fix issue when calling Chain.blockhash on a competing key-block

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -691,7 +691,7 @@ init_per_testcase(TC, Config) when TC == aevm_version_interaction;
 init_per_testcase(fate_environment, Config) ->
     meck:new(aefa_chain_api, [passthrough]),
     meck:expect(aefa_chain_api, blockhash,
-                fun(N, S) when is_integer(N) ->
+                fun(N, _, S) when is_integer(N) ->
                         %% Just to ensure the arg format
                         _ = aefa_chain_api:generation(S),
                         aeb_fate_data:make_hash(<<N:256>>)

--- a/apps/aefate/src/aefa_fate_op.erl
+++ b/apps/aefate/src/aefa_fate_op.erl
@@ -1405,7 +1405,7 @@ blockhash(Arg0, Arg1, ES) ->
                 true ->
                     write(Arg0, make_none(), ES1);
                 false ->
-                    FateHash = aefa_chain_api:blockhash(N, API),
+                    FateHash = aefa_chain_api:blockhash(N, VMVsn, API),
                     write(Arg0, make_some(FateHash), ES1)
             end;
         {Value, ES1} ->

--- a/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
+++ b/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
@@ -753,7 +753,15 @@ change_leaders(Config) ->
     {ok, _B} = wait_same_top(),
     ok.
 
-empty_parent_block(_Config) ->
+empty_parent_block(Config) ->
+    case aect_test_utils:latest_protocol_version() < ?CERES_PROTOCOL_VSN of
+        true ->
+            {skip, lazy_leader_sync_broken_on_iris};
+        false ->
+            empty_parent_block_(Config)
+    end.
+
+empty_parent_block_(_Config) ->
     TopHeight = rpc(?LAZY_NODE, aec_chain, top_height, []),
     %% Remove the posted commitments to create a parent generation without commitments
     aecore_suite_utils:flush_mempool(?PARENT_CHAIN_NODE1_NAME),
@@ -1099,6 +1107,14 @@ block_difficulty(Config) ->
     ok.
 
 elected_leader_did_not_show_up(Config) ->
+    case aect_test_utils:latest_protocol_version() < ?CERES_PROTOCOL_VSN of
+        true ->
+            {skip, lazy_leader_sync_broken_on_iris};
+        false ->
+            elected_leader_did_not_show_up_(Config)
+    end.
+
+elected_leader_did_not_show_up_(Config) ->
     aecore_suite_utils:stop_node(?NODE1, Config), %% stop the block producer
     TopHeader0 = rpc(?NODE2, aec_chain, top_header, []),
     {TopHeader0, TopHeader0} = {rpc(?LAZY_NODE, aec_chain, top_header, []), TopHeader0},


### PR DESCRIPTION
Calling blockhash on a competing/forked key-block, when the height you ask for is part of the fork, will crash. 

Fixed from Ceres. This is mainly an issue with HC where you compute using `Chain.blockhash(current_height)` - this will fail on a competing block resulting in blocks not validating properly.

This PR is supported by Æternity Foundation