### PR TITLE
Deprecate UAT seed node (eu-central-1)

### DIFF
--- a/apps/aeutils/test/data/epoch_full.yaml
+++ b/apps/aeutils/test/data/epoch_full.yaml
@@ -3,7 +3,6 @@
 peers:
     # TestNet seed peers
     - "aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015" # us-west-2
-    - "aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015" # eu-central-1
     - "aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015" # ap-southeast-1
     - "aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015" # eu-north
 

--- a/apps/aeutils/test/data/epoch_no_newline.yaml
+++ b/apps/aeutils/test/data/epoch_no_newline.yaml
@@ -3,7 +3,6 @@
 peers:
     # TestNet seed peers
     - "aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015" # us-west-2
-    - "aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015" # eu-central-1
     - "aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015" # ap-southeast-1
     - "aenode://pp_2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3015" # eu-east
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -64,7 +64,6 @@
       ]},
       {testnet_peers, [
         <<"aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015">>,
-        <<"aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015">>,
         <<"aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015">>,
         <<"aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015">>
       ]},

--- a/docs/release-notes/RELEASE-NOTES-0.25.0.md
+++ b/docs/release-notes/RELEASE-NOTES-0.25.0.md
@@ -90,7 +90,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.0.0-rc2.md
+++ b/docs/release-notes/RELEASE-NOTES-1.0.0-rc2.md
@@ -96,7 +96,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.0.0-rc3.md
+++ b/docs/release-notes/RELEASE-NOTES-1.0.0-rc3.md
@@ -63,7 +63,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.0.0-rc4.md
+++ b/docs/release-notes/RELEASE-NOTES-1.0.0-rc4.md
@@ -60,7 +60,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.0.0-rc5.md
+++ b/docs/release-notes/RELEASE-NOTES-1.0.0-rc5.md
@@ -59,7 +59,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.0.0-rc6.md
+++ b/docs/release-notes/RELEASE-NOTES-1.0.0-rc6.md
@@ -62,7 +62,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.0.0.md
+++ b/docs/release-notes/RELEASE-NOTES-1.0.0.md
@@ -85,7 +85,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7@18.130.148.7:3015
 
@@ -95,7 +94,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.0.1.md
+++ b/docs/release-notes/RELEASE-NOTES-1.0.1.md
@@ -85,7 +85,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7@18.130.148.7:3015
 
@@ -95,7 +94,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.1.0.md
+++ b/docs/release-notes/RELEASE-NOTES-1.1.0.md
@@ -94,7 +94,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7@18.130.148.7:3015
 
@@ -104,7 +103,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.2.0.md
+++ b/docs/release-notes/RELEASE-NOTES-1.2.0.md
@@ -99,7 +99,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7@18.130.148.7:3015
 
@@ -109,7 +108,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.3.0.md
+++ b/docs/release-notes/RELEASE-NOTES-1.3.0.md
@@ -101,7 +101,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7@18.130.148.7:3015
 
@@ -111,7 +110,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-1.4.0.md
+++ b/docs/release-notes/RELEASE-NOTES-1.4.0.md
@@ -87,7 +87,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_nt5N7fwae3DW8Mqk4kxkGAnbykRDpEZq9dzzianiMMPo4fJV7@18.130.148.7:3015
 
@@ -97,7 +96,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://18.130.148.7:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-2.0.0-rc.1.md
+++ b/docs/release-notes/RELEASE-NOTES-2.0.0-rc.1.md
@@ -164,7 +164,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -174,7 +173,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-2.0.0.md
+++ b/docs/release-notes/RELEASE-NOTES-2.0.0.md
@@ -97,7 +97,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -107,7 +106,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-2.1.0.md
+++ b/docs/release-notes/RELEASE-NOTES-2.1.0.md
@@ -90,7 +90,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -100,7 +99,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-2.2.0.md
+++ b/docs/release-notes/RELEASE-NOTES-2.2.0.md
@@ -104,7 +104,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -114,7 +113,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-2.3.0.md
+++ b/docs/release-notes/RELEASE-NOTES-2.3.0.md
@@ -93,7 +93,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -103,7 +102,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-2.4.0.md
+++ b/docs/release-notes/RELEASE-NOTES-2.4.0.md
@@ -85,7 +85,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -95,7 +94,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-2.5.0.md
+++ b/docs/release-notes/RELEASE-NOTES-2.5.0.md
@@ -83,7 +83,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -93,7 +92,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-3.0.0-rc.1.md
+++ b/docs/release-notes/RELEASE-NOTES-3.0.0-rc.1.md
@@ -140,7 +140,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -150,7 +149,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-3.0.0.md
+++ b/docs/release-notes/RELEASE-NOTES-3.0.0.md
@@ -90,7 +90,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -100,7 +99,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-3.0.1.md
+++ b/docs/release-notes/RELEASE-NOTES-3.0.1.md
@@ -82,7 +82,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -92,7 +91,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-3.1.0.md
+++ b/docs/release-notes/RELEASE-NOTES-3.1.0.md
@@ -95,7 +95,6 @@ For running a node as part of the testnet by using the Docker image, please cons
 In order to join testnet reconfigure seed nodes in the release package:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -105,7 +104,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-3.2.0.md
+++ b/docs/release-notes/RELEASE-NOTES-3.2.0.md
@@ -92,7 +92,6 @@ To join the testnet by using the Docker image, please refer to the [docker docum
 The release package comes preconfigured with testnet seed nodes, this is the list:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -102,7 +101,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-3.3.0.md
+++ b/docs/release-notes/RELEASE-NOTES-3.3.0.md
@@ -94,7 +94,6 @@ To join the testnet by using the Docker image, please refer to the [docker docum
 The release package comes preconfigured with testnet seed nodes, this is the list:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -104,7 +103,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-4.0.0.md
+++ b/docs/release-notes/RELEASE-NOTES-4.0.0.md
@@ -115,7 +115,6 @@ To join the testnet by using the Docker image, please refer to the [docker docum
 The release package comes preconfigured with testnet seed nodes, this is the list:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -125,7 +124,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-4.1.0.md
+++ b/docs/release-notes/RELEASE-NOTES-4.1.0.md
@@ -98,7 +98,6 @@ To join the testnet by using the Docker image, please refer to the [docker docum
 The release package comes preconfigured with testnet seed nodes, this is the list:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -108,7 +107,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-4.2.0.md
+++ b/docs/release-notes/RELEASE-NOTES-4.2.0.md
@@ -92,7 +92,6 @@ To join the testnet by using the Docker image, please refer to the [docker docum
 The release package comes preconfigured with testnet seed nodes, this is the list:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -102,7 +101,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-4.2.1.md
+++ b/docs/release-notes/RELEASE-NOTES-4.2.1.md
@@ -89,7 +89,6 @@ To join the testnet by using the Docker image, please refer to the [docker docum
 The release package comes preconfigured with testnet seed nodes, this is the list:
 
 * aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-* aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 * aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 * aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 
@@ -99,7 +98,6 @@ The core nodes of the public test network are accessible from the Internet.
 
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the testnet can be obtained by opening in the browser any of the following URLs:
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 

--- a/docs/release-notes/RELEASE-NOTES-5.0.0.md
+++ b/docs/release-notes/RELEASE-NOTES-5.0.0.md
@@ -183,7 +183,6 @@ To join the **testnet** by using the Docker image, please refer to the [docker d
 The release package comes preconfigured with **testnet** seed nodes, this is the list:
 ```
 aenode://pp_QU9CvhAQH56a2kA15tCnWPRJ2srMJW8ZmfbbFTAy7eG4o16Bf@52.10.46.160:3015
-aenode://pp_2vhFb3HtHd1S7ynbpbFnEdph1tnDXFSfu4NGtq46S2eM5HCdbC@18.195.109.60:3015
 aenode://pp_27xmgQ4N1E3QwHyoutLtZsHW5DSW4zneQJ3CxT5JbUejxtFuAu@13.250.162.250:3015
 aenode://pp_DMLqy7Zuhoxe2FzpydyQTgwCJ52wouzxtHWsPGo51XDcxc5c8@13.53.161.215:3015
 ```
@@ -195,7 +194,6 @@ The core nodes of the public test network are accessible from the Internet.
 Information, e.g. height, of the top block of the longest chain as seen by these core nodes of the **testnet** can be obtained by opening in the browser any of the following URLs:
 
 * http://52.10.46.160:3013/v2/blocks/top
-* http://18.195.109.60:3013/v2/blocks/top
 * http://13.250.162.250:3013/v2/blocks/top
 * http://13.53.161.215:3013/v2/blocks/top
 


### PR DESCRIPTION
The node itself will be running for about 2-3 releases until we see there is no old UAT releases still in the wild.