### PR TITLE
Fix mainline packaging

### DIFF
--- a/.circleci/config/workflows/commit.yml
+++ b/.circleci/config/workflows/commit.yml
@@ -228,15 +228,6 @@ jobs:
             - /releases\/.*/
             - << pipeline.parameters.master_branch >>
 
-  - ubuntu_package:
-      requires: []
-      context: ae-slack
-      filters:
-        branches:
-          only:
-            - /releases\/.*/
-            - << pipeline.parameters.master_branch >>
-
   - upload-artifacts-s3:
       name: upload-artifacts-s3
       bucket: << pipeline.parameters.s3_builds_bucket >>
@@ -284,16 +275,6 @@ jobs:
       name: macos-tarball-bundle
       package_name: aeternity-bundle-$CIRCLE_SHA1-macos-x86_64.tar.gz
       aeplugin_devmode: true
-      context: ae-slack
-      filters:
-        branches:
-          only:
-            - /releases\/.*/
-            - << pipeline.parameters.master_branch >>
-
-  - publish-build-packages:
-      requires:
-        - ubuntu_package
       context: ae-slack
       filters:
         branches:

--- a/.circleci/config/workflows/commit.yml
+++ b/.circleci/config/workflows/commit.yml
@@ -16,10 +16,10 @@ jobs:
 
   - build_nix:
       context: ae-slack
-      filters:
-        branches:
-          only:
-            - << pipeline.parameters.master_branch >>
+      # filters:
+      #   branches:
+      #     only:
+      #       - << pipeline.parameters.master_branch >>
 
   - test:
       context: ae-slack
@@ -231,11 +231,11 @@ jobs:
   - ubuntu_package:
       requires: []
       context: ae-slack
-      filters:
-        branches:
-          only:
-            - /releases\/.*/
-            - << pipeline.parameters.master_branch >>
+      # filters:
+      #   branches:
+      #     only:
+      #       - /releases\/.*/
+      #       - << pipeline.parameters.master_branch >>
 
   - upload-artifacts-s3:
       name: upload-artifacts-s3

--- a/.circleci/config/workflows/commit.yml
+++ b/.circleci/config/workflows/commit.yml
@@ -16,10 +16,10 @@ jobs:
 
   - build_nix:
       context: ae-slack
-      # filters:
-      #   branches:
-      #     only:
-      #       - << pipeline.parameters.master_branch >>
+      filters:
+        branches:
+          only:
+            - << pipeline.parameters.master_branch >>
 
   - test:
       context: ae-slack
@@ -231,11 +231,11 @@ jobs:
   - ubuntu_package:
       requires: []
       context: ae-slack
-      # filters:
-      #   branches:
-      #     only:
-      #       - /releases\/.*/
-      #       - << pipeline.parameters.master_branch >>
+      filters:
+        branches:
+          only:
+            - /releases\/.*/
+            - << pipeline.parameters.master_branch >>
 
   - upload-artifacts-s3:
       name: upload-artifacts-s3

--- a/.circleci/config/workflows/release.yml
+++ b/.circleci/config/workflows/release.yml
@@ -32,14 +32,6 @@ jobs:
         tags:
           only: << pipeline.parameters.tag_regex >>
 
-  - ubuntu_package:
-      context: ae-slack
-      filters:
-        branches:
-          ignore: /.*/
-        tags:
-          only: << pipeline.parameters.tag_regex >>
-
   - macos-tarball:
       name: macos-release-tarball
       package_name: aeternity-$CIRCLE_TAG-macos-x86_64.tar.gz
@@ -262,19 +254,6 @@ jobs:
         - ae-vault-node
       requires:
         - upload-release-tarballs-s3
-        - hodl_latest
-      filters:
-        branches:
-          ignore: /.*/
-        tags:
-          only: << pipeline.parameters.tag_regex >>
-
-  - publish-release-packages:
-      context: ae-slack
-      requires:
-        - linux-release-tarball
-        - macos-release-tarball
-        - ubuntu_package
         - hodl_latest
       filters:
         branches:

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Aeternity Team <info@aeternity.com>
 Build-Depends: debhelper, ncurses-dev, libssl-dev, git, curl,
 	       autoconf, build-essential,
-	       esl-erlang ( >=1:21.3-1)
-Build-Conflicts: esl-erlang ( >=1:24.0)
+	       erlang ( >=1:24.3.4.15)
+Build-Conflicts: erlang ( >=1:27.0)
 
 Package: aeternity-node
 Architecture: any

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 let
-  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/860b56be91fb874d48e23a950815969a7b832fbc.tar.gz") {};
+  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-23.11") {};
 in {
   aeternityEnv = pkgs.stdenv.mkDerivation {
     name = "aeternity";
@@ -10,7 +10,7 @@ in {
       ## base
       pkgs.stdenv
       ## erlang
-      pkgs.erlangR23 # OTP 23.3.4.4
+      pkgs.erlang_26 # OTP 26.1.2
       ## crypto
       pkgs.libsodium
       ## rocksdb build deps

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,6 @@
 This document describes how to install an Aeternity node using a release binary either by:
 
 * [Quick install](#quick-install);
-* [Install from a package manager](#package-install);
 * [Install from a tarball](#tarball-install).
 
 ## Quick install
@@ -15,32 +14,6 @@ bash <(curl -s https://install.aeternity.io/install.sh)
 ```
 
 While this method is the easiest one it is not recommended for production systems.
-
-## Package Install
-
-Installing from a package manager is the recommended way of installing the aeternity node,
-as it also automatically installs the additional requirements and makes the updates much more simple.
-
-### Ubuntu
-
-The only supported version so far is 18.04 Bionic (x86-64).
-
-```bash
-sudo apt-get install software-properties-common
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D18ABB45C5AF91A0D835367E2106A773A40AFAEB
-sudo apt-add-repository 'deb https://apt.aeternity.io bionic main'
-sudo apt-get install aeternity-node
-sudo service aeternity-node start
-```
-
-### macOS
-
-Minimum required version is macOS Big Sur 11.6.2 (x86-64).
-
-```bash
-brew tap aeternity/aeternity
-brew install aeternity-node
-```
 
 ## Tarball Install
 


### PR DESCRIPTION
- fix NixOS builds
- remove .deb and brew packages

Since we switched to OTP26 (and other versions) we can't use anymore Erlang ESL repository (lack of versions and architectures). The most recent Ubuntu LTS (22.04) includes erlang `24.2.1`, while our minimum required version is `24.3.4.15`. Also the current builder images doesn't support 22.04 because of build issue that has to be fixed first (https://github.com/aeternity/docker-builder/issues/52)

Once the builder supports 22.04 we can try lowering the erlang requirement to 24.2.1 and build a .deb, however that would mean we're stuck with that minimum version until next Ubuntu LTS.

An alternative approach would be trying to package the erlang runtime in the .deb package, although   that sounds very wrong and abusive (isn't it? 🤔 )

fixes #4267