### PR TITLE
Make the BRI optional per protocol version

### DIFF
--- a/apps/aecore/src/aec_dev_reward.erl
+++ b/apps/aecore/src/aec_dev_reward.erl
@@ -22,10 +22,9 @@
 %%% weighted avg BRI voting result of 1% to 20% (yes) votes is 10.89869526640124746202%, 109 of 1000 shares will be the protocol reward
 %%% for: "ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109"
 %%%%%%%%% TODO update with real values
--define(MAINNET_BENEFICIARIES, [{<<172,241,128,85,116,104,119,143,197,105,4,192,224,207,200,138,230,84,111,38,89,33,239,21,201,183,185,209,19,60,109,136>>, 109, undefined, ?IRIS_PROTOCOL_VSN},
-                                {<<172,241,128,85,116,104,119,143,197,105,4,192,224,207,200,138,230,84,111,38,89,33,239,21,201,183,185,209,19,60,109,136>>, 109, ?CERES_PROTOCOL_VSN, undefined}]).
+-define(MAINNET_BENEFICIARIES, [{<<172,241,128,85,116,104,119,143,197,105,4,192,224,207,200,138,230,84,111,38,89,33,239,21,201,183,185,209,19,60,109,136>>, 109, ?FORTUNA_PROTOCOL_VSN, ?IRIS_PROTOCOL_VSN}]).
 %%% for: "ak_2A3PZPfMC2X7ZVy4qGXz2xh2Lbh79Q4UvZ5fdH7QVFocEgcKzU:109"
--define(TESTNET_BENEFICIARIES, [{<<152,57,168,5,218,153,177,254,226,207,243,133,11,50,143,68,121,242,94,41,187,198,158,67,133,88,6,71,55,26,85,54>>, 109, undefined, undefined}]).
+-define(TESTNET_BENEFICIARIES, [{<<152,57,168,5,218,153,177,254,226,207,243,133,11,50,143,68,121,242,94,41,187,198,158,67,133,88,6,71,55,26,85,54>>, 109, ?FORTUNA_PROTOCOL_VSN, ?IRIS_PROTOCOL_VSN}]).
 
 ensure_env() ->
     Enabled = cfg(<<"protocol_beneficiaries_enabled">>, ?ENABLED),
@@ -54,9 +53,7 @@ allocated_shares_and_beneficiaries(BenefShares0) ->
     BenefShares = lists:sort(BenefShares0),
     {_, Shares} = lists:unzip(BenefShares),
     AllocShares = lists:sum(Shares),
-    if AllocShares == 0 ->
-            exit({invalid_protocol_beneficiaries, sum_shares_is_zero});
-       AllocShares > ?TOTAL_SHARES ->
+    if   AllocShares > ?TOTAL_SHARES ->
             exit({invalid_protocol_beneficiaries, sum_shares_too_large});
        AllocShares =< ?TOTAL_SHARES ->
             {AllocShares, BenefShares}
@@ -149,9 +146,7 @@ parse_beneficiary(BeneficiaryShareStr) ->
             error({invalid_format, BeneficiaryShareStr})
     end.
 
-parse_beneficiaries([]) ->
-    {error, no_beneficiaries};
-parse_beneficiaries([_|_] = BeneficiarySharesProtocolsStrs) ->
+parse_beneficiaries(BeneficiarySharesProtocolsStrs) ->
     try lists:filtermap(fun parse_beneficiary/1, BeneficiarySharesProtocolsStrs) of
         BeneficiarySharesProtocols ->
             {ok, [{ProtocolVsn, beneficiaries_at_protocol(ProtocolVsn, BeneficiarySharesProtocols)} ||

--- a/apps/aecore/src/aec_dev_reward.erl
+++ b/apps/aecore/src/aec_dev_reward.erl
@@ -203,7 +203,10 @@ protocols() ->
             Protocols
     end.
 
-
+split_int(BeneficiaryReward1, BeneficiaryReward2,
+          _AllocShares, _TotalShares,
+          []) ->
+    {{BeneficiaryReward1, BeneficiaryReward2}, []};
 split_int(BeneficiaryReward1, BeneficiaryReward2,
           AllocShares, TotalShares,
           Beneficiaries = [_|_]) when

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1859,7 +1859,6 @@
                         "description" : "Public keys belonging to protocol maintainers with reward shares (100 is 10%), optionally a protocol version can be specified from and/or to this account will be rewarded, e.g. ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109:6: specifies from Ceres onwards, ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109::5 specifies to Iris. If not set testnet or mainnet beneficiaries and shares will be used based on network_id configuration value. IMPORTANT: The value of this setting is under governance, thus it should not be changed without previous agreement within the configured network on doing so.",
                         "pattern": "^ak_[1-9A-HJ-NP-Za-km-z]*:[0-9]+(:[0-9]*:[0-9]*){0,1}$"
                     },
-                    "minItems": 0
                 },
                 "garbage_collection" : {
                     "type" : "object",

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1859,8 +1859,7 @@
                         "description" : "Public keys belonging to protocol maintainers with reward shares (100 is 10%), optionally a protocol version can be specified from and/or to this account will be rewarded, e.g. ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109:6: specifies from Ceres onwards, ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109::5 specifies to Iris. If not set testnet or mainnet beneficiaries and shares will be used based on network_id configuration value. IMPORTANT: The value of this setting is under governance, thus it should not be changed without previous agreement within the configured network on doing so.",
                         "pattern": "^ak_[1-9A-HJ-NP-Za-km-z]*:[0-9]+(:[0-9]*:[0-9]*){0,1}$"
                     },
-                    "minItems": 1,
-                    "default" : ["ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109"]
+                    "minItems": 0
                 },
                 "garbage_collection" : {
                     "type" : "object",


### PR DESCRIPTION
The BRI account should be optional per protocol version and optional in general.