### PR TITLE
fail gracefully on signed tx in /dry-run

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -581,7 +581,7 @@ paths:
         - external
         - dry-run
       operationId: ProtectedDryRunTxs
-      description: Dry-run transactions on top of a given block. Supports all TXs except GAMetaTx, PayingForTx and OffchainTx. The maximum gas limit of all calls is capped. The maximum gas limit per request is a global node setting. Since DryRunCallReq object do not have a mandatory gas field, if not set a default value of 1000000 is being used instead.
+      description: Dry-run unsigned transactions on top of a given block. Supports all TXs except GAMetaTx, PayingForTx and OffchainTx. The maximum gas limit of all calls is capped. The maximum gas limit per request is a global node setting. Since DryRunCallReq object do not have a mandatory gas field, if not set a default value of 1000000 is being used instead.
       parameters:
         - $ref: '#/components/parameters/intAsString'
       requestBody:

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -844,11 +844,11 @@ handle_request_('ProtectedDryRunTxs', #{ 'DryRunInput' := Req }, _Context) ->
                       TxGasLimit= lists:sum(
                           lists:map(
                               fun(#{<<"tx">> := ETx}) ->
-                                  case aeser_api_encoder:safe_decode(transaction, ETx) of
-                                      {ok, DTx} ->
-                                          Tx = aetx:deserialize_from_binary(DTx),
-                                          aetx:gas_limit(Tx, Height, Protocol);
-                                      {error, _Err} -> 0 %% this is handled later on
+                                  try {ok, DTx} = aeser_api_encoder:safe_decode(transaction, ETx),
+                                      Tx = aetx:deserialize_from_binary(DTx),
+                                      aetx:gas_limit(Tx, Height, Protocol)
+                                  catch _:_ ->
+                                      0 %% this is handled later on
                                   end;
                                  (#{<<"call_req">> := CallReq}) ->
                                     maps:get(<<"gas">>, CallReq, ?DEFAULT_CALL_REQ_GAS_LIMIT)

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -729,7 +729,7 @@ dry_run_tx(ETx) ->
                 true  -> {ok, Tx};
                 false -> {error, lists:concat(["Unsupported transaction type ", Type])}
             end;
-         Err = {error, _Reason} ->
+        Err = {error, _Reason} ->
             Err
     end.
 

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -710,19 +710,29 @@ dry_run_accounts_([Account | Accounts], Acc) ->
 dry_run_txs_([], Txs) ->
     {ok, lists:reverse(Txs)};
 dry_run_txs_([#{ <<"tx">> := ETx } | Txs], Acc) ->
+    try dry_run_tx(ETx) of
+        {ok, Tx} -> dry_run_txs_(Txs, [{tx, Tx} | Acc]);
+        Err = {error, _Reason} ->
+            Err
+    catch
+        _:_ -> {error, "malformed transaction"}
+    end;
+dry_run_txs_([#{ <<"call_req">> := CallReq } | Txs], Acc) ->
+    dry_run_txs_(Txs, [{call_req, CallReq} | Acc]).
+
+dry_run_tx(ETx) ->
     case aeser_api_encoder:safe_decode(transaction, ETx) of
         {ok, DTx} ->
             Tx = aetx:deserialize_from_binary(DTx),
             {Type, _} = aetx:specialize_type(Tx),
             case not lists:member(Type, [paying_for_tx, offchain_tx, ga_meta_tx]) of
-                true  -> dry_run_txs_(Txs, [{tx, Tx} | Acc]);
+                true  -> {ok, Tx};
                 false -> {error, lists:concat(["Unsupported transaction type ", Type])}
             end;
-        Err = {error, _Reason} ->
+         Err = {error, _Reason} ->
             Err
-    end;
-dry_run_txs_([#{ <<"call_req">> := CallReq } | Txs], Acc) ->
-    dry_run_txs_(Txs, [{call_req, CallReq} | Acc]).
+    end.
+
 
 
 dry_run_results({Rs, Events}) ->


### PR DESCRIPTION
fixes #4286 

If any of the provided transactions in dry-run has wrong format, we fail with a 400 instead of 500.

dry-run transactions shall not be signed, which is now also documented in the OpenAPI spec.

This PR is supported by Æternity Foundation 