### PR TITLE
Fix typo in aeternity config schema

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1858,7 +1858,7 @@
                     "items" : {
                         "description" : "Public keys belonging to protocol maintainers with reward shares (100 is 10%), optionally a protocol version can be specified from and/or to this account will be rewarded, e.g. ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109:6: specifies from Ceres onwards, ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8:109::5 specifies to Iris. If not set testnet or mainnet beneficiaries and shares will be used based on network_id configuration value. IMPORTANT: The value of this setting is under governance, thus it should not be changed without previous agreement within the configured network on doing so.",
                         "pattern": "^ak_[1-9A-HJ-NP-Za-km-z]*:[0-9]+(:[0-9]*:[0-9]*){0,1}$"
-                    },
+                    }
                 },
                 "garbage_collection" : {
                     "type" : "object",


### PR DESCRIPTION
Otherwise it can't be parsed by a tool I'm using to validate against json schema.

This PR is supported by the Æternity Foundation