### PR TITLE
Use `oneOf` instead of `anyOf` in oas3.yaml

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3287,7 +3287,7 @@ components:
           required:
             - version
             - type
-        - anyOf:
+        - oneOf:
             - $ref: "#/components/schemas/SpendTx"
             - $ref: "#/components/schemas/ChannelCreateTx"
             - $ref: "#/components/schemas/ChannelDepositTx"
@@ -3893,7 +3893,7 @@ components:
         - fee
         - tx
     Header:
-      anyOf:
+      oneOf:
         - $ref: "#/components/schemas/KeyBlock"
         - $ref: "#/components/schemas/MicroBlockHeader"
     SignedTxs:


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

> [anyOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#anyof) – validates the value against any (one or more) of the subschemas

https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

As I understand, it is better to use `oneOf` instead of `anyOf` for both transaction parameters and key/micro blocks because there are no use case when the value would comply with multiple schemas:
- in the case of transactions each item has its own `type` value;
- keyblock and microblock have their own unique fields, so the node can't return both at once.