### PR TITLE
`GetRecentGasPrices` fixes

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3957,6 +3957,7 @@ components:
         required:
           - min_gas_price
           - minutes
+          - utilization
   parameters:
     intAsString:
       in: query

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1106,7 +1106,8 @@ paths:
         - transaction
       operationId: GetRecentGasPrices
       description: 'Get minimum gas prices in recent blocks'
-      parameters: []
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
       responses:
         '200':
           description: 'Successful operation'
@@ -3948,9 +3949,11 @@ components:
             $ref: "#/components/schemas/UInt"
           utilization:
             description: Percent of available gas used
-            type: integer
-            minimum: 0
-            maximum: 100
+            oneOf:
+              - type: integer
+                minimum: 0
+                maximum: 100
+              - type: string
           minutes:
             description: Number of minutes from the top
             $ref: "#/components/schemas/UInt64"

--- a/apps/aehttp/src/aehttp_logic.erl
+++ b/apps/aehttp/src/aehttp_logic.erl
@@ -194,6 +194,9 @@ get_min_gas_price_since([{Ms, CutOff} | CutOffs] = COs, Hash, AccStats, Data) ->
             {error, block_not_found}
     end.
 
+stats_to_data(Minutes, {MinGasPrice, 0, 0}) ->
+    stats_to_data(Minutes, {MinGasPrice, 0, 1});
+
 stats_to_data(Minutes, {MinGasPrice, UsedGas, TotGas}) ->
     {Minutes, min_gas_price(MinGasPrice), round((100 * UsedGas) / TotGas)}.
 


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

I'm not sure I like how `int-as-string` works, but would be consistent to support it as far as `min_gas_price` is an amount to coins. 