### PR TITLE
Add return_type enums to ContractCallObject, GAObject

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3351,6 +3351,10 @@ components:
         return_type:
           description: The status of the call 'ok | error | revert'.
           type: string
+          enum:
+            - ok
+            - error
+            - revert
       required:
         - caller_id
         - caller_nonce
@@ -3377,6 +3381,9 @@ components:
         return_type:
           description: The status of the call 'ok | error'.
           type: string
+          enum:
+            - ok
+            - error
         inner_object:
           $ref: "#/components/schemas/TxInfoObject"
       required:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -3247,6 +3247,10 @@ definitions:
       return_type:
         description: The status of the call 'ok | error | revert'.
         type: string
+        enum:
+          - ok
+          - error
+          - revert
     required:
       - caller_id
       - caller_nonce
@@ -3273,6 +3277,9 @@ definitions:
       return_type:
         description: The status of the call 'ok | error'.
         type: string
+        enum:
+          - ok
+          - error
       inner_object:
         $ref: '#/definitions/TxInfoObject'
     required:


### PR DESCRIPTION
Replaces PR #3953 

Instead of only having the return string in the description, we also provide it as enum type.