### PR TITLE
Add missed timer initialization in aedevmode_emitter:init

### DIFF
--- a/apps/aedevmode/src/aedevmode_emitter.erl
+++ b/apps/aedevmode/src/aedevmode_emitter.erl
@@ -77,9 +77,12 @@ init([]) ->
         _ ->
             ok
     end,
-    {ok, #st{ keyblock_interval   = cfg(<<"keyblock_interval">>)
+    St = #st{ keyblock_interval   = cfg(<<"keyblock_interval">>)
             , microblock_interval = cfg(<<"microblock_interval">>)
-            , auto_emit           = cfg(<<"auto_emit_microblocks">>) }}.
+            , auto_emit           = cfg(<<"auto_emit_microblocks">>) },
+    St1 = restart_keyblock_timer(St),
+    St2 = restart_microblock_timer(St1),
+    {ok, St2}.
 
 cfg(K) ->
     {ok, V} = aeu_env:find_config([<<"dev_mode">>, K], [user_config, schema_default]),


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

The problem I had: in tests of aepp-sdk I needed more accurate intervals between keyblocks, and I decided to use devmode instead of pow miner. The config I used:
```yaml
dev_mode:
    keyblock_interval: 5
    microblock_interval: 1
    auto_emit_microblocks: false
```
this way, node was generating keyblocks, but no microblocks, also I wasn't able to mine transactions.

As I understand, keyblock timer was working because something generating 1st block and this triggers the event that restarts a timer
https://github.com/aeternity/aeternity/blob/b0a7140abdb6b6df79ebbb2a8b75e6397cbb6eae/apps/aedevmode/src/aedevmode_emitter.erl#L144-L145
but nothing was creating a microblock, so that timer wasn't working.