### PR TITLE
Add ability to dry-run endpoint to run transactions from the mempool 

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3478,6 +3478,8 @@ components:
       properties:
         tx:
           $ref: "#/components/schemas/EncodedByteArray"
+        tx_hash:
+          $ref: "#/components/schemas/EncodedHash"
         call_req:
           $ref: "#/components/schemas/DryRunCallReq"
     DryRunCallReq:

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -3376,6 +3376,8 @@ definitions:
     properties:
       tx:
         $ref: '#/definitions/EncodedByteArray'
+        tx_hash:
+          $ref: "#/components/schemas/EncodedHash"        
       call_req:
         $ref: '#/definitions/DryRunCallReq'
   DryRunCallReq:

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -853,6 +853,14 @@ handle_request_('ProtectedDryRunTxs', #{ 'DryRunInput' := Req }, _Context) ->
                                   catch _:_ ->
                                       0 %% this is handled later on
                                   end;
+                                 (#{<<"tx_hash">> := TxHash}) ->
+                                  try {ok, TxHashInternal} = aeser_api_encoder:safe_decode(tx_hash, TxHash),
+                                      {mempool, SignedTx} = aec_chain:find_tx_with_location(TxHashInternal),
+                                      Tx = aetx_sign:tx(SignedTx),
+                                      aetx:gas_limit(Tx, Height, Protocol)
+                                  catch _:_ ->
+                                      0 %% this is handled later on
+                                  end;                                    
                                  (#{<<"call_req">> := CallReq}) ->
                                     maps:get(<<"gas">>, CallReq, ?DEFAULT_CALL_REQ_GAS_LIMIT)
                               end,

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -736,7 +736,7 @@ dry_run_tx_hash(TxHash) ->
                 {mempool, SignedTx} ->
                     Tx = aetx_sign:tx(SignedTx),
                     {Type, _} = aetx:specialize_type(Tx),
-                    case not lists:member(Type, [paying_for_tx, offchain_tx, ga_meta_tx]) of
+                    case not lists:member(Type, [offchain_tx, ga_meta_tx]) of
                         true  -> {ok, Tx};
                         false -> {error, lists:concat(["Unsupported transaction type ", Type])}
                     end;
@@ -822,6 +822,7 @@ ok_err({error, _}) -> <<"error">>;
 ok_err(_)          -> <<"ok">>.
 
 type(spend_tx)                  -> <<"spend">>;
+type(paying_for_tx)             -> <<"paying_for_tx">>;
 type(oracle_register_tx)        -> <<"oracle_register">>;
 type(oracle_extend_tx)          -> <<"oracle_extend">>;
 type(oracle_query_tx)           -> <<"oracle_query">>;

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -741,7 +741,6 @@ dry_run_tx_hash(TxHash) ->
                         false -> {error, lists:concat(["Unsupported transaction type ", Type])}
                     end;
                 _ ->
-                    %% TODO what to do about transaction that have already succeeded 
                     {error, "Transaction not found in mempool"}
             end;
         Err = {error, _Reason} ->

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -736,7 +736,7 @@ dry_run_tx_hash(TxHash) ->
                 {mempool, SignedTx} ->
                     Tx = aetx_sign:tx(SignedTx),
                     {Type, _} = aetx:specialize_type(Tx),
-                    case not lists:member(Type, [offchain_tx, ga_meta_tx]) of
+                    case not lists:member(Type, [offchain_tx]) of
                         true  -> {ok, Tx};
                         false -> {error, lists:concat(["Unsupported transaction type ", Type])}
                     end;
@@ -823,6 +823,7 @@ ok_err(_)          -> <<"ok">>.
 
 type(spend_tx)                  -> <<"spend">>;
 type(paying_for_tx)             -> <<"paying_for_tx">>;
+type(ga_meta_tx)                -> <<"ga_meta_tx">>;
 type(oracle_register_tx)        -> <<"oracle_register">>;
 type(oracle_extend_tx)          -> <<"oracle_extend">>;
 type(oracle_query_tx)           -> <<"oracle_query">>;

--- a/apps/aehttp/test/aehttp_dryrun_SUITE.erl
+++ b/apps/aehttp/test/aehttp_dryrun_SUITE.erl
@@ -487,6 +487,13 @@ mempool_ga_tx(Config) ->
     {ok, 200, #{ <<"results">> := [#{ <<"result">> := <<"ok">> }, #{ <<"result">> := <<"ok">> }] }} =
         dry_run(Config, Txs([TxHash1, TxHash2])),
 
+    SFailMetaTx = create_ga_meta_tx(["42"], EPub, EPrivKey, SpendTx, 100000 * aec_test_utils:min_gas_price(), 10000),
+    EncodedSFailMetaTx = aeser_api_encoder:encode(transaction, aetx_sign:serialize_to_binary(SFailMetaTx)),
+    {ok, 200, #{ <<"tx_hash">> := TxHash3}} = post_tx(EncodedSFailMetaTx),
+
+    {ok, 200, #{ <<"results">> := [#{ <<"result">> := <<"ok">> }, #{ <<"result">> := <<"error">> }] }} =
+        dry_run(Config, Txs([TxHash1, TxHash3])),
+
     ok.
 
 %% --- Internal functions ---


### PR DESCRIPTION
This is to solve the following issue: https://github.com/aeternity/aeternity/issues/4283

This PR is supported by Æternity Foundation