### PR TITLE
Small sync improvements

### DIFF
--- a/apps/aecore/src/aec_peers.erl
+++ b/apps/aecore/src/aec_peers.erl
@@ -68,6 +68,7 @@
 
 %=== MACROS ====================================================================
 
+-define(RAND_CONN_DELAY,                      50).
 -define(MIN_CONNECTION_INTERVAL,             100).
 -define(MAX_CONNECTION_INTERVAL,       30 * 1000). % 30 seconds
 
@@ -911,11 +912,15 @@ next_connect_delay(State) ->
                     #state{ last_connect_time = LastTime, outbound = Outbound } = State,
                     ExpDelay = floor(math:pow(2, Outbound - 1)) * 1000,
                     BoundDelay = min(ExpDelay, ?MAX_CONNECTION_INTERVAL),
-                    max(?MIN_CONNECTION_INTERVAL, BoundDelay - (timestamp() - LastTime));
+                    max(min_connection_interval(), BoundDelay - (timestamp() - LastTime));
                 %% If this is a monitoring node then aggressively connect to peers
-                true -> ?MIN_CONNECTION_INTERVAL
+                true ->
+                    min_connection_interval()
             end
     end.
+
+min_connection_interval() ->
+    ?MIN_CONNECTION_INTERVAL + rand:uniform(?RAND_CONN_DELAY).
 
 %% Gives the node some time to receive peers and establish outbound connections
 %% before it starts TCP probes of verified and unverified peers.


### PR DESCRIPTION
Made two minor improvments.

1. replaced the random work allocation for generation download with a structured but still robust allocation algorithm (we fetch the next generation first, but once out of work everyone attempts the missing pieces).
2. we (try to) pre-fetch the description of the next batch of work - previously all workers ended up repeating the fetch.

Also made some (long overdue) improvements to logging in `aec_peers`.

My non-scientific experiment shows this:
```
Before:
2024-03-20 08:57:45.979 [info] <0.2044.0>@aec_sync_stats:log_agg_stats:198 Synced 10000 generations: 3.27 ms/gen (12113 mblock(s), 77022 tx(s)) - Walltime: 134.90s CPU: 32.73s efficiency 24.27%
After:
2024-03-20 09:07:42.108 [info] <0.2044.0>@aec_sync_stats:log_agg_stats:198 Synced 10000 generations: 3.46 ms/gen (12113 mblock(s), 77022 tx(s)) - Walltime: 88.06s CPU: 34.56s efficiency 39.24%
```
But these numbers fluctuate quite a bit so take them with a pinch of salt.

This PR is supported by the Æterenity Foundation. 