### PR TITLE
Fix typo in aect_contracts.erl

### DIFF
--- a/apps/aecontract/src/aect_contracts.erl
+++ b/apps/aecontract/src/aect_contracts.erl
@@ -188,7 +188,7 @@ is_legal_version_at_protocol_(create, #{vm := ?VM_FATE_SOPHIA_2, abi := ?ABI_FAT
     end;
 is_legal_version_at_protocol_(create, #{vm := ?VM_FATE_SOPHIA_3, abi := ?ABI_FATE_SOPHIA_1}, Protocol) ->
     case Protocol of
-        P when P < ?IRIS_PROTOCOL_VSN  -> false;
+        P when P < ?CERES_PROTOCOL_VSN -> false;
         ?CERES_PROTOCOL_VSN            -> true;
         P when P > ?CERES_PROTOCOL_VSN -> true
     end;

--- a/apps/aega/src/aega_attach_tx.erl
+++ b/apps/aega/src/aega_attach_tx.erl
@@ -141,7 +141,7 @@ is_legal_version_at_protocol(#{vm := VMVersion, abi := ABIVersion}, Protocol) ->
         P when P == ?IRIS_PROTOCOL_VSN, ABIVersion == ?ABI_FATE_SOPHIA_1 ->
             VMVersion == ?VM_FATE_SOPHIA_2;
         P when P >= ?CERES_PROTOCOL_VSN, ABIVersion == ?ABI_FATE_SOPHIA_1 ->
-            VMVersion >= ?VM_FATE_SOPHIA_2;
+            VMVersion >= ?VM_FATE_SOPHIA_3;
         _ ->
             false
     end.


### PR DESCRIPTION
No practical consequence - creating a contract with `VM_FATE_SOPHIA_3` will fail on all protocols pre-Ceres in both code variants... Though crashing is less nice than `false` 😅 

This PR is supported by Æternity Foundation