### PR TITLE
Fix devmode accounts by changing `data/aeplugin_dev_mode` permissions (second attempt)

### DIFF
--- a/.circleci/config/commands/@install.yml
+++ b/.circleci/config/commands/@install.yml
@@ -6,7 +6,6 @@ aeplugin_install_devmode:
           export PLUGIN_VERSION=<< pipeline.parameters.aeplugin_devmode_version >>
           curl -fsSLOJ https://github.com/aeternity/aeplugin_dev_mode/releases/download/v$PLUGIN_VERSION/aeplugin_dev_mode.ez
           cp aeplugin_dev_mode.ez plugins/
-          mkdir -p data/aeplugin_dev_mode
 
 install_os_deps:
   steps:


### PR DESCRIPTION
The previous fix #4307 didn't worked for some reason
```
$ docker run -it aeternity/aeternity:master-bundle@sha256:eca00bafac4b397147af7f868ce17e436ac22a21230b4d7ca7b66cbb9549a853 /bin/bash
aeternity@ff14b1c6df06:~/node$ ls data -l
total 152
drwxr-xr-x 1 aeternity aeternity   4096 Mar 28 10:59 aecore
-rw-rw-r-- 1 aeternity aeternity 147021 Mar 28 10:57 aeternity_config_schema.json
drwxr-xr-x 2 aeternity aeternity   4096 Mar 28 11:00 mnesia
```
I don't know how to run .circleci locally, so somebody needs to figure out why the previous fix didn't work or ensure that this one is working 🙏 

This PR is supported by the Æternity Foundation
