### PR TITLE
Fix typo in "block not found" message

### DIFF
--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -248,7 +248,7 @@ handle_request_('GetKeyBlockByHash', Params, _Context) ->
                                         error_code => <<"no_key_block">>}}
                     end;
                 error ->
-                    {404, [], #{reason => <<"Block not fond">>}}
+                    {404, [], #{reason => <<"Block not found">>}}
             end
     end;
 


### PR DESCRIPTION
This can be a breaking change 🙃 

This PR is supported by the Æternity Foundation