### PR TITLE
Add note that swagger is deprecated and little release note placeholder

### DIFF
--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  description: 'This is the [Aeternity](https://www.aeternity.com/) node API.'
+  description: 'This is the [Aeternity](https://www.aeternity.com/) compiler API. The swagger version of this API will be deprecated and replaced by an openAPI 3.x specification'
   version: x.y.z
   title: Aeternity node
   termsOfService: 'https://www.aeternity.com/terms/'

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  description: 'This is the [Aeternity](https://www.aeternity.com/) compiler API. The swagger version of this API will be deprecated and replaced by an openAPI 3.x specification'
+  description: 'This is the [Aeternity](https://www.aeternity.com/) node API. The swagger version of this API will be deprecated and replaced by an openAPI 3.x specification'
   version: x.y.z
   title: Aeternity node
   termsOfService: 'https://www.aeternity.com/terms/'

--- a/docs/release-notes/next-ceres/deprecate_swagger.md
+++ b/docs/release-notes/next-ceres/deprecate_swagger.md
@@ -1,0 +1,1 @@
+* Deprecate swagger API to be replaced by openAPI 3.x specification


### PR DESCRIPTION
Put notice in swagger file that in future swagger will be deprecated.
It's time to start using openAPI spec instead

This PR is supported by the Æternity Foundation