### PR TITLE
Implement ad_hoc_listen_ports functionality

### DIFF
--- a/apps/aechannel/src/aesc_checks.erl
+++ b/apps/aechannel/src/aesc_checks.erl
@@ -9,6 +9,7 @@
         , account/2
         , accounts/3
         , lock_period/1
+        , port/2
         ]).
 
 -include("aesc_codec.hrl").
@@ -87,6 +88,27 @@ amounts(#{ initiator_amount   := InitiatorAmount0
         {true,  false} -> {error, insufficient_responder_amount};
         {false, false} -> {error, insufficient_amounts}
     end.
+
+port(Port, responder) ->
+    case aeu_env:find_config([<<"channels">>, <<"ad_hoc_listen_ports">>], [user_config, schema_default]) of
+        {ok,true} ->
+            ok;
+        _ ->
+            case aeu_env:find_config([<<"channels">>, <<"listeners">>], [user_config, {value, []}]) of
+                {ok, Listeners} ->
+                    case lists:any(fun(#{<<"port">> := P}) -> P == Port end, Listeners) of
+                        true ->
+                            ok;
+                        _ ->
+                            {error, responder_port_not_allowed}
+                    end;
+                _ ->
+                    ok
+            end
+    end;
+port(_, _) ->
+    ok.
+
 
 %% ==================================================================
 %% Internal functions

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -229,7 +229,7 @@ handler_init_error(Err, Handler) ->
                     , {invalid_fsm_id                , invalid_fsm_id}
                     , {bad_signature                 , bad_signature}
                     , {failed_noise_session_start    , failed_noise_session_start}
-                    , {responder_port_not_allowed     , responder_port_not_allowed}
+                    , {responder_port_not_allowed    , responder_port_not_allowed}
                     ],
     case proplists:get_value(Err, HandledErrors, not_handled_error) of
         not_handled_error ->

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -229,6 +229,7 @@ handler_init_error(Err, Handler) ->
                     , {invalid_fsm_id                , invalid_fsm_id}
                     , {bad_signature                 , bad_signature}
                     , {failed_noise_session_start    , failed_noise_session_start}
+                    , {responder_port_not_allowed     , responder_port_not_allowed}
                     ],
     case proplists:get_value(Err, HandledErrors, not_handled_error) of
         not_handled_error ->


### PR DESCRIPTION
Fixes https://github.com/aeternity/aeternity/issues/4327

Most of the functionality is already implemented in https://github.com/aeternity/aeternity/pull/4051

All that is missing is the functionality to disallow adhoc ports if ad_hoc_listen_ports is set to false.

This PR is supported by Æternity Foundation