### PR TITLE
Improve startup error when keys_dir is not available

### DIFF
--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -511,11 +511,18 @@ p_gen_new_peer(Pwd, PubFile, PrivFile) ->
 ensure_dir(KeysDir) ->
     case filelib:is_dir(KeysDir) of
         false ->
-            KeysDirFile = filename:join(KeysDir, "keyfile"),
-            ok = filelib:ensure_dir(KeysDirFile);
+            case ensure_dir_(KeysDir) of
+                ok  -> ok;
+                Err -> error({could_not_ensure_key_dir, KeysDir, Err})
+            end;
         true ->
             ok
     end.
+
+%% Note: `filelib:ensure_path/1` was introduced in OTP-25
+ensure_dir_(KeysDir) ->
+    KeysDirFile = filename:join(KeysDir, "keyfile"),
+    filelib:ensure_dir(KeysDirFile).
 
 from_local_dir(NewFile) ->
     file:read_file(NewFile).

--- a/apps/aecore/src/aec_keys.erl
+++ b/apps/aecore/src/aec_keys.erl
@@ -59,7 +59,8 @@
 -export([check_peer_keys/2,
          encrypt_key/2,
          sign_privkey/0,
-         start_link/1
+         start_link/1,
+         ensure_dir/1
         ]).
 -endif.
 

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -71,4 +71,28 @@ all_test_() ->
                 end}]
       end]}.
 
+ensure_dir_test_() ->
+    {foreach,
+     fun() -> meck:new(filelib, [passthrough, unstick]) end,
+     fun(_) -> meck:unload(filelib) end,
+     [{"OK case 1",
+       fun() ->
+           meck:expect(filelib, is_dir, fun(_Dir) -> true end),
+           meck:expect(filelib, ensure_dir, fun(_Dir) -> ok end),
+           ?assertEqual(ok, aec_keys:ensure_dir("/testdir"))
+       end},
+      {"OK case 2",
+       fun() ->
+           meck:expect(filelib, is_dir, fun(_Dir) -> false end),
+           meck:expect(filelib, ensure_dir, fun(_Dir) -> ok end),
+           ?assertEqual(ok, aec_keys:ensure_dir("/testdir"))
+       end},
+      {"Bad dir",
+       fun() ->
+           meck:expect(filelib, is_dir, fun(_Dir) -> false end),
+           meck:expect(filelib, ensure_dir, fun(_Dir) -> {error, erofs} end),
+           ?assertError({could_not_ensure_key_dir, "/testdir", _}, aec_keys:ensure_dir("/testdir"))
+       end}
+     ]}.
+
 -endif.

--- a/apps/aecore/test/aec_keys_tests.erl
+++ b/apps/aecore/test/aec_keys_tests.erl
@@ -71,27 +71,4 @@ all_test_() ->
                 end}]
       end]}.
 
-start_test_() ->
-    TF =
-        fun() ->
-                ?_test(
-                   aec_test_utils:aec_keys_bare_cleanup(
-                     aec_test_utils:aec_keys_bare_setup()))
-        end,
-    {setup,
-     fun() -> ok = application:ensure_started(crypto) end,
-     fun(_) -> ok = application:stop(crypto) end,
-     lazy_gen(100, TF)}.
-
-lazy_gen(N, TF) ->
-    {generator,
-     fun () ->
-             if N > 0 ->
-                     [TF()
-                      | lazy_gen(N-1, TF)];
-                true ->
-                     []
-             end
-     end}.
-
 -endif.


### PR DESCRIPTION
Fixes #4346 

This PR is supported by the Æternity Foundation