### PR TITLE
Safe access DB mode

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -623,7 +623,7 @@ bypass_on_commit(R) ->
             R
     end.
 
-walk_tstore(TStore, Ref) ->                                          
+walk_tstore(TStore, Ref) ->
     ets:foldl(fun walk_tstore_/2, Ref, TStore).
 
 walk_tstore_({{locks, _, _}, _}, Acc) -> Acc;
@@ -1311,7 +1311,10 @@ lookup_tree_node(Hash, #tree_gc{ primary   = Prim
 
 lookup_tree_node_(Hash, T, Rec) ->
     case read(T, Hash) of
-        [Obj] -> {value, get_tree_value(Rec, Obj)};
+        [Obj] ->
+            Value = get_tree_value(Rec, Obj),
+            Hash = aec_hash:hash(header, aeser_rlp:encode(Value)),
+            {value, Value};
         []    -> none
     end.
 

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1314,7 +1314,11 @@ lookup_tree_node_(Hash, T, Rec) ->
         [Obj] ->
             Value = get_tree_value(Rec, Obj),
             case db_safe_access() of
-                true  -> Hash = aec_hash:hash(header, aeser_rlp:encode(Value));
+                true  -> case aec_hash:hash(header, aeser_rlp:encode(Value)) of
+                             Hash -> ok;
+                             Hash1 ->
+                                 error({corrupted_db_node, {expected, Hash, got, Hash1}})
+                         end;
                 false -> ok
             end,
             {value, Value};

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1313,7 +1313,10 @@ lookup_tree_node_(Hash, T, Rec) ->
     case read(T, Hash) of
         [Obj] ->
             Value = get_tree_value(Rec, Obj),
-            Hash = aec_hash:hash(header, aeser_rlp:encode(Value)),
+            case db_safe_access() of
+                true  -> Hash = aec_hash:hash(header, aeser_rlp:encode(Value));
+                false -> ok
+            end,
             {value, Value};
         []    -> none
     end.
@@ -1560,6 +1563,18 @@ prepare_mnesia_bypass() ->
                             lager:debug("NOT enabling bypass logic for rocksdb", [])
                     end
             end
+    end.
+
+db_safe_access() ->
+    case persistent_term:get({?MODULE, db_safe_access}, undefined) of
+        Value when is_boolean(Value) ->
+            Value;
+        undefined ->
+            {ok, SafeAccess} = aeu_env:find_config([<<"chain">>, <<"db_safe_access">>],
+                                                   [user_config, schema_default, {value, false}]),
+            lager:info("Safe DB-access mode is ~s", [if SafeAccess -> "ON"; true -> "OFF" end]),
+            persistent_term:put({?MODULE, db_safe_access}, SafeAccess),
+            SafeAccess
     end.
 
 can_enable_direct_access() ->

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -621,19 +621,19 @@ db_safe_access_scan(Tree) ->
     {ok, Hash} = aec_blocks:hash_internal_representation(Block),
     case get_mpt(Tree, Hash) of
         empty ->
-            ?DBG("Tree ~p empty at height ~p - no scan needed", [Tree, Height]),
+            lager:info("Tree ~p empty at height ~p - no scan needed", [Tree, Height]),
             {ok, 0};
         MPT ->
-            ?DBG("DB safe access FULL_SCAN for ~p at height ~p from root hash ~w",
+            lager:info("DB safe access FULL_SCAN for ~p at height ~p from root hash ~w",
                  [Tree, Height, aeu_mp_trees:root_hash(MPT)]),
             OldDBSafeAccess = persistent_term:get({aec_db, db_safe_access}, undefined),
             [ persistent_term:put({aec_db, db_safe_access}, true) || OldDBSafeAccess /= true ],
             try
                 N = visit_reachable(MPT),
-                ?DBG("DB safe access FULL_SCAN for ~p completed, checked ~p nodes", [Tree, N]),
+                lager:info("DB safe access FULL_SCAN for ~p completed, checked ~p nodes", [Tree, N]),
                 {ok, N}
             catch E:{Reason, _S} ->
-                ?DBG("DB safe access FULL_SCAN on ~p failed ~p:~p", [Tree, E, Reason]),
+                lager:info("DB safe access FULL_SCAN on ~p failed ~p:~p", [Tree, E, Reason]),
                 {error, Reason}
             after
                 case OldDBSafeAccess of

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -35,6 +35,7 @@
         , info/1
         , enable/0
         , disable/0
+        , gc_enabled/0
         ]).
 
 -export([maybe_garbage_collect/3]).
@@ -128,6 +129,10 @@ start_link() ->
 
 cleanup() ->
     erase_cached_enabled_status().
+
+-spec gc_enabled() -> boolean().
+gc_enabled() ->
+    gen_server:call(?MODULE, is_enabled).
 
 -spec maybe_garbage_collect(Header, Hash, TopChange) -> ok | nop
               when Header :: aec_headers: header()
@@ -378,6 +383,8 @@ handle_call(#maybe_garbage_collect{}, _From, St) ->
     {reply, nop, St};
 handle_call({set_enabled, Bool}, _From, #st{enabled = Enabled} = St) ->
     {reply, Enabled, set_gc_enabled(Bool, St)};
+handle_call(is_enabled, _From, #st{enabled = Enabled} = St) ->
+    {reply, Enabled, St};
 handle_call({info, Keys}, _, St) ->
     {reply, info_(Keys, St), St}.
 

--- a/apps/aecore/test/aec_db_safe_access_SUITE.erl
+++ b/apps/aecore/test/aec_db_safe_access_SUITE.erl
@@ -166,6 +166,8 @@ safe_access_test(Config, PK, PKKey, NodeHash) ->
     aecore_suite_utils:start_node(dev1, Config, [{"AE__CHAIN__DB_SAFE_ACCESS", "true"}]),
 
     {badrpc, _} = rpc:call(N1, aec_chain, get_account, [PK]),
+
+    timer:sleep(2000), %% Wait for node to fully get up to speed?!
     error = rpc:call(N1, aec_db_gc, db_safe_access_scan, []),
 
     ok.

--- a/apps/aecore/test/aec_db_safe_access_SUITE.erl
+++ b/apps/aecore/test/aec_db_safe_access_SUITE.erl
@@ -1,0 +1,232 @@
+-module(aec_db_safe_access_SUITE).
+
+%% common_test exports
+-export([all/0, groups/0, suite/0,
+         init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2]).
+
+%% test case exports
+-export([ main_test/1
+        ]).
+
+-include_lib("common_test/include/ct.hrl").
+
+-define(MAX_MINED_BLOCKS, 20).
+-define(NUM_ACCOUNTS, 3).
+-define(DUMMY_HASH, <<0:256>>).
+
+all() ->
+    [{group, one_node}].
+
+groups() ->
+    [{one_node, [sequence],
+      [ main_test
+      ]}].
+
+suite() ->
+    [].
+
+init_per_suite(Config0) ->
+    Config1 = aec_metrics_test_utils:make_port_map([dev1], Config0),
+    Forks = aecore_suite_utils:forks(),
+    DefCfg = #{<<"chain">> =>
+                   #{<<"persist">> => true,
+                     <<"hard_forks">> => Forks},
+               <<"mining">> => #{<<"micro_block_cycle">> => 100,
+                                 <<"expected_mine_rate">> => 100}},
+    Accounts = [new_pubkey() || _ <- lists:seq(1, ?NUM_ACCOUNTS)],
+    Config2 = aecore_suite_utils:init_per_suite([dev1],
+                                                DefCfg,
+                                                [{add_peers, true}],
+                                                [{instant_mining, true},
+                                                 {symlink_name, "latest.db_safe_access"},
+                                                 {test_module, ?MODULE},
+                                                 {accounts, Accounts} | Config1]),
+    aecore_suite_utils:start_node(dev1, Config2),
+    aecore_suite_utils:connect(aecore_suite_utils:node_name(dev1)),
+    ok = aecore_suite_utils:check_for_logs([dev1], Config2),
+    N1 = aecore_suite_utils:node_name(dev1),
+
+    node_log_details(N1, up),
+
+    aecore_suite_utils:mock_mempool_nonce_offset(N1, 200),
+    Fee   = 1500000 * aec_test_utils:min_gas_price(),
+    Txs = lists:foldl(
+      fun ({Nonce, PK}, Acc) ->
+              {ok, Tx} = add_spend_tx(N1, 10, Fee, Nonce, 100, PK),
+              [Tx|Acc]
+      end, [], lists:zip(lists:seq(1, length(Accounts)), Accounts)),
+    aecore_suite_utils:mine_blocks_until_txs_on_chain(N1, Txs, ?MAX_MINED_BLOCKS),
+    aecore_suite_utils:unmock_mempool_nonce_offset(N1),
+    check_accounts(Config2),
+
+    node_log_details(N1, accounts_on_chain),
+
+    Config2.
+
+end_per_suite(Config) ->
+    catch begin
+               {ok, DbCfg} = node_db_cfg(dev1),
+               aecore_suite_utils:stop_node(dev1, Config),
+               aecore_suite_utils:delete_node_db_if_persisted(DbCfg)
+          end.
+
+init_per_group(Group, Config) when Group =:= one_node ->
+    Config1 = config(Config),
+    InitialApps = {aec_test_utils:running_apps(), aec_test_utils:loaded_apps()},
+    {ok, _} = application:ensure_all_started(exometer_core),
+    ok = aec_metrics_test_utils:start_statsd_loggers(aec_metrics_test_utils:port_map(Config1)),
+    [{initial_apps, InitialApps} | Config1];
+init_per_group(all_nodes, Config) ->
+    Config.
+
+end_per_group(Group, Config) when Group =:= one_node ->
+    ct:log("Metrics: ~p", [aec_metrics_test_utils:fetch_data()]),
+    ok = aec_metrics_test_utils:stop_statsd_loggers(),
+    {_, {OldRunningApps, OldLoadedApps}} = proplists:lookup(initial_apps, Config),
+    ok = aec_test_utils:restore_stopped_and_unloaded_apps(OldRunningApps, OldLoadedApps);
+end_per_group(all_nodes, _Config) ->
+   ok.
+
+
+init_per_testcase(_Case, Config) ->
+    ct:log("testcase pid: ~p", [self()]),
+    [{tc_start, os:timestamp()}|Config].
+
+end_per_testcase(_Case, Config) ->
+    Ts0 = ?config(tc_start, Config),
+    ct:log("Events during TC: ~p", [[{N, aecore_suite_utils:all_events_since(N, Ts0)}
+                                     || {_,N} <- ?config(nodes, Config)]]),
+    ok.
+
+%% ============================================================
+%% Test cases
+%% ============================================================
+
+main_test(Config) ->
+    N1 = aecore_suite_utils:node_name(dev1),
+    H1 = aec_headers:height(rpc:call(N1, aec_chain, top_header, [])),
+    ct:log("Height = ~p", [H1]),
+
+    PKs = ?config(accounts, Config),
+
+    %% Depending on how the bitpatterns of the PKs overlap we might not be able
+    %% to find a MPT node, but let's try some clever heuristic...
+
+    {ok, PK, PKKey, NodeHash} = find_tree_node(N1, PKs),
+    safe_access_test(Config, PK, PKKey, NodeHash).
+
+find_tree_node(_, []) ->
+    ct:log("Couldn't find tree node - no test :sadpanda:", []),
+    {error, no_tree_node};
+find_tree_node(N, [PK | PKs]) ->
+    {value, Acc} = rpc:call(N, aec_chain, get_account, [PK]),
+
+    SerAcc = aec_accounts:serialize(Acc),
+    PrimaryAccounts = primary(N),
+
+    <<X:8, PKTail/binary>> = PK,
+    case find_tree_node(N, PrimaryAccounts, PKTail, SerAcc, [X | lists:seq(32, 63)]) of
+        {ok, PKKey, NodeHash} -> {ok, PK, PKKey, NodeHash};
+        _ -> find_tree_node(N, PKs)
+    end.
+
+find_tree_node(_, _, _, _, []) ->
+    none;
+find_tree_node(N, PAccs, PKTail, SerAcc, [X | Xs]) ->
+    PKKey = <<X:8, PKTail/binary>>,
+    NodeHash = aec_hash:hash(header, aeser_rlp:encode([PKKey, SerAcc])),
+
+    case has_key(N, NodeHash, PAccs) of
+        true -> {ok, PKKey, NodeHash};
+        _ -> find_tree_node(N, PAccs, PKTail, SerAcc, Xs)
+    end.
+
+safe_access_test(Config, PK, PKKey, NodeHash) ->
+    ct:log("Testing with ~p (hash: ~p)", [PK, NodeHash]),
+    N1 = aecore_suite_utils:node_name(dev1),
+
+    {value, Acc} = rpc:call(N1, aec_chain, get_account, [PK]),
+    {ok, Acc1} = aec_accounts:earn(Acc, 100000000000000),
+    SerAcc = aec_accounts:serialize(Acc1),
+
+    Ctxt = rpc:call(N1, aec_db, new_tree_context, [dirty, accounts]),
+    ok = rpc:call(N1, aec_db, enter_tree_node, [NodeHash, [PKKey, SerAcc], Ctxt]),
+
+    {value, Acc1} = rpc:call(N1, aec_chain, get_account, [PK]),
+
+    aecore_suite_utils:stop_node(dev1, Config),
+
+    aecore_suite_utils:start_node(dev1, Config, [{"AE__CHAIN__DB_SAFE_ACCESS", "true"}]),
+
+    {badrpc, _} = rpc:call(N1, aec_chain, get_account, [PK]),
+
+    ok.
+
+%% ==================================================
+%% Private functions
+%% ==================================================
+
+primary(N) ->
+    rpc:call(N, aec_db, primary_state_tab, [accounts]).
+
+has_key(N, Key, Tab) ->
+    case rpc:call(N, mnesia, dirty_read, [Tab, Key]) of
+        [_|_] -> true;
+        _     -> false
+    end.
+
+node_log_details(N, Prefix) ->
+    ct:log("////////// ~p | ~p S = ~p~n", [N, Prefix, catch rpc:call(N, sys, get_state, [aec_db_gc])]),
+    ct:log("////////// ~p | ~p H = ~p~n", [N, Prefix, catch rpc:call(N, aec_chain, top_header, [])]),
+    ok.
+
+check_accounts(Config) ->
+    N1 = aecore_suite_utils:node_name(dev1),
+    lists:foreach(
+      fun (PK) ->
+              {value, _} = rpc:call(N1, aec_chain, get_account, [PK])
+      end, ?config(accounts, Config)),
+    ok.
+
+config(Config) ->
+    [{devs, [dev1]}, {nodes, [aecore_suite_utils:node_tuple(dev1)]} | Config].
+
+node_db_cfg(Node) ->
+    {ok, DbCfg} = aecore_suite_utils:get_node_db_config(
+                    fun (M, F, A)->
+                            rpc:call(aecore_suite_utils:node_name(Node), M, F, A, 5000)
+                    end),
+    {ok, DbCfg}.
+
+add_spend_tx(Node, Amount, Fee, Nonce, TTL, Recipient) ->
+    Sender = aecore_suite_utils:patron(),
+    add_spend_tx(Node, Amount, Fee, Nonce, TTL, Recipient,
+                 maps:get(pubkey, Sender),
+                 maps:get(privkey, Sender)).
+
+add_spend_tx(Node, Amount, Fee, Nonce, TTL, Recipient, SenderPubkey,
+             SenderPrivkey) ->
+    add_spend_tx(Node, Amount, Fee, Nonce, TTL, Recipient, SenderPubkey,
+                SenderPrivkey, <<>>).
+
+add_spend_tx(Node, Amount, Fee, Nonce, TTL, Recipient, SenderPubkey,
+             SenderPrivkey, Payload) ->
+    SenderId = aeser_id:create(account, SenderPubkey),
+    RecipientId = aeser_id:create(account, Recipient),
+    Params = #{ sender_id    => SenderId,
+                recipient_id => RecipientId,
+                amount       => Amount,
+                nonce        => Nonce,
+                ttl          => TTL,
+                payload      => Payload,
+                fee          => Fee },
+    {ok, Tx} = aec_spend_tx:new(Params),
+    STx = aec_test_utils:sign_tx(Tx, SenderPrivkey),
+    Res = rpc:call(Node, aec_tx_pool, push, [STx]),
+    {Res, aeser_api_encoder:encode(tx_hash, aetx_sign:hash(STx))}.
+
+new_pubkey() ->
+    #{public := PubKey} = enacl:sign_keypair(),
+    PubKey.

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1576,6 +1576,11 @@
 		    "type" : "boolean",
 		    "default" : true
 		},
+		"db_safe_access" : {
+		    "description" : "Enable checksum check for data read from DB - only applies for state tree (Merkle Patricia Tree) data. Relevant when using untrusted DB snapshot. This lowers DB read performance with 3% - 7%.",
+		    "type" : "boolean",
+		    "default" : false
+		},
                 "db_write_max_retries" : {
                     "deprecated" : true,
                     "description" : "OBSOLETE/ignored: Maximum number of retries for failing database write operations.",

--- a/apps/aeutils/priv/db_safe_access_scan
+++ b/apps/aeutils/priv/db_safe_access_scan
@@ -28,11 +28,16 @@ main(Args) ->
     db_safe_access_scan(Node, Opts).
 
 db_safe_access_scan(Node, #{opts := Opts}) ->
-    case Opts of
-        #{tree := "all"} ->
-            db_safe_access_scan_(Node, [accounts, calls, contracts, oracles, channels, ns]);
-        #{tree := Tree} ->
-            db_safe_access_scan_(Node, [list_to_atom(Tree)])
+    case rpc:call(Node, aec_db_gc, gc_enabled, []) of
+        false ->
+            case Opts of
+                #{tree := "all"} ->
+                    db_safe_access_scan_(Node, [accounts, calls, contracts, oracles, channels, ns]);
+                #{tree := Tree} ->
+                    db_safe_access_scan_(Node, [list_to_atom(Tree)])
+            end;
+        _ ->
+            io:fwrite("Aborted! Scan is only available when Garbage Collect is OFF!\n", [])
     end.
 
 db_safe_access_scan_(_Node, []) ->

--- a/apps/aeutils/priv/db_safe_access_scan
+++ b/apps/aeutils/priv/db_safe_access_scan
@@ -1,0 +1,68 @@
+#!/usr/bin/env escript
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil -*-
+
+-mode(compile).
+
+%% See https://hexdocs.pm/argparse/
+%% Argparse supports a hierarchical structure of commands and subcommands, each
+%% with its own arguments. This spec (no command specified) describes the top level.
+%%
+%% We only provide the user-level arguments. The node connection arguments, which
+%% are automatically provided by the script wrappers, are specified in aeu_ext_scripts.erl
+spec() -> #{ arguments => args() }.
+
+args() ->
+    [ #{ name => tree
+       , short => $t
+       , long => "-tree"
+       , required => false
+       , type => {string, ["all", "accounts", "calls", "contracts", "oracles", "channels", "ns"]}
+       , help => "Tree to do a safe access scan on"
+       , default => "all"}
+    ].
+
+
+main(Args) ->
+    Opts = aeu_ext_scripts:parse_opts(Args, spec()),
+    {ok, Node} = aeu_ext_scripts:connect_node(Opts),
+    db_safe_access_scan(Node, Opts).
+
+db_safe_access_scan(Node, #{opts := Opts}) ->
+    case Opts of
+        #{tree := "all"} ->
+            db_safe_access_scan_(Node, [accounts, calls, contracts, oracles, channels, ns]);
+        #{tree := Tree} ->
+            db_safe_access_scan_(Node, [list_to_atom(Tree)])
+    end.
+
+db_safe_access_scan_(_Node, []) ->
+    io:fwrite("\nScan COMPLETE\n");
+db_safe_access_scan_(Node, [Tree | Trees]) ->
+    scan_tree(Node, Tree),
+    db_safe_access_scan_(Node, Trees).
+
+scan_tree(Node, Tree) ->
+    io:fwrite("Start scan of ~p\n.", [Tree]),
+    Self = self(),
+    spawn(fun() ->
+              Res = rpc:call(Node, aec_db_gc, db_safe_access_scan, [Tree]),
+              Self ! {res, Tree, Res}
+          end),
+    wait_for_scan(Tree, erlang:system_time(millisecond)).
+
+wait_for_scan(Tree, Start) ->
+    receive {res, Tree, Res} ->
+        case Res of
+            {ok, N} ->
+                io:fwrite("\nScan of ~p SUCCESSFUL took ~.1fs - checked ~p DB nodes\n",
+                          [Tree, elapsed(Start), N]);
+            {error, Reason} ->
+                io:fwrite("\nScan of ~p FAILED - reasons ~p\n", [Tree, Reason])
+        end
+    after 3000 ->
+        io:fwrite(".", []),
+        wait_for_scan(Tree, Start)
+    end.
+
+elapsed(Start) ->
+    (erlang:system_time(millisecond) - Start) / 1000.

--- a/apps/aeutils/priv/extensions/db_safe_access_scan.cmd
+++ b/apps/aeutils/priv/extensions/db_safe_access_scan.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+:: Wrapper to run db_safe_access_scan
+
+set "PATH=%BINDIR%;%PATH%"
+set "ERL_LIBS=%ROOTDIR%\lib"
+set "APPS_VSN=%REL_VSN%"
+
+"%ERTS_DIR%\bin\escript" "%ROOTDIR%\lib\aeutils-%APPS_VSN%\priv\db_safe_access_scan" "-%NAME_TYPE%" "%NAME%" --setcookie "%COOKIE%" %*

--- a/apps/aeutils/priv/extensions/db_safe_access_scan.sh
+++ b/apps/aeutils/priv/extensions/db_safe_access_scan.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Wrapper to run db_safe_access_scan
+
+PATH=$BINDIR:$PATH
+export ERL_LIBS=$ROOTDIR/lib
+APPS_VSN=${REL_VSN:?}
+
+relx_escript "lib/aeutils-${APPS_VSN:?}/priv/db_safe_access_scan" "$NAME_TYPE" "$NAME" -setcookie "$COOKIE" $*
+
+exit $?

--- a/rebar.config
+++ b/rebar.config
@@ -179,6 +179,7 @@
                    {copy, "apps/aeutils/priv/extensions/create_whitelist.sh", "bin/extensions/create_whitelist"},
                    {copy, "apps/aeutils/priv/extensions/db_rollback.sh", "bin/extensions/db_rollback"},
                    {copy, "apps/aeutils/priv/extensions/db_migrate.sh", "bin/extensions/db_migrate"},
+                   {copy, "apps/aeutils/priv/extensions/db_safe_access_scan.sh", "bin/extensions/db_safe_access_scan"},
                    {copy, "apps/aeutils/priv/extensions/maintenance.sh", "bin/extensions/maintenance"},
                    {copy, "apps/aeutils/priv/extensions/offline.sh", "bin/extensions/offline"},
                    {copy, "apps/aeutils/priv/extensions/admin.sh", "bin/extensions/admin"},

--- a/scripts/aeternity_bin
+++ b/scripts/aeternity_bin
@@ -150,6 +150,11 @@ relx_usage() {
             echo "  This can take a few hours and the node will be placed in maintenance mode during the migration"
             echo "  -s (-silent)    : Suppress progress reports"
             ;;
+        db_safe_access_scan)
+            echo "Usage: $REL_NAME db_safe_access_scan [-t Tree]"
+            echo "  Scan state tree DB for incorrect/tainted values - useful when running on an untrusted DB snapshot"
+            echo "  -t (--tree)  : State tree to scan, default all (accounts, calls, contracts, oracles, channels, ns)"
+            ;;
         maintenance)
             echo "Usage: $REL_NAME maintenance [on | off | status] [-t timeout]"
             echo "  Enable / disable / check status of maintenance mode"
@@ -202,6 +207,7 @@ Commands:
   create_whitelist        Export block hashes within a range of heights to json file
   db_rollback             Rollback blockchain to specified height, hash, or from whitelist file
   db_migrate              Migrate rocksdb database to column families
+  db_safe_access_scan     Run safe access scan for state tree DB(s)
   maintenance             Enable / disable maintenance mode
   offline                 Enable / disable offline mode
   admin                   Aeternity node administration commands

--- a/scripts/extensions.vars
+++ b/scripts/extensions.vars
@@ -1,1 +1,1 @@
-{extensions, "status|cli|check_config|keys_gen|peer_key|create_whitelist|db_rollback|db_migrate|maintenance|offline|admin|messages_hash|version"}.
+{extensions, "status|cli|check_config|keys_gen|peer_key|create_whitelist|db_rollback|db_migrate|db_safe_access_scan|maintenance|offline|admin|messages_hash|version"}.


### PR DESCRIPTION
Fixes #4361.

Implements a safe access mode for the state trees. Useful when running on an untrusted DB snapshot. Also introduces `bin/aeternity db_safe_access_scan` command. Enble by adding:

```
chain:
  db_safe_access: true
```

Example run of full scan (at height ~25000):
```
$ bin/aeternity db_safe_access_scan
Start scan of accounts
....
Scan of accounts SUCCESSFUL took 10.2s - checked 47757 DB nodes
Start scan of calls
.
Scan of calls SUCCESSFUL took 0.0s - checked 0 DB nodes
Start scan of contracts
.
Scan of contracts SUCCESSFUL took 0.1s - checked 541 DB nodes
Start scan of oracles
.
Scan of oracles SUCCESSFUL took 0.0s - checked 1 DB nodes
Start scan of channels
.
Scan of channels SUCCESSFUL took 0.0s - checked 115 DB nodes
Start scan of ns
..............
Scan of ns SUCCESSFUL took 40.5s - checked 192255 DB nodes

Scan COMPLETE
```

This PR is supported by the Æternity Foundation