### PR TITLE
Sync default colors with brandguide

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1673,12 +1673,12 @@
                         "primary_colour": {
                             "description": "Primary colour for branding.",
                             "type": "string",
-                            "default": "#f5274e"
+                            "default": "#f7296e"
                         },
                         "secondary_colour" : {
                             "description" : "Secondary colour for branding.",
                             "type" : "string",
-                            "default" : "#242424"
+                            "default" : "#1e1e1e"
                         },
                         "network_name": {
                             "description" : "The display name of the network id, if not set defaults to Mainnet for ae_mainnet, Testnet for ae_uat otherwise network id",


### PR DESCRIPTION
The current primary default looks more [red](https://www.color-hex.com/color/f5274e) than [magenta](https://www.color-hex.com/color/f7296e).

https://docs.aeternity.com/brandguide/#color-swatches

This PR fixes values defined in https://github.com/aeternity/aeternity/pull/4179

This PR is supported by the Æternity Foundation

