### PR TITLE
Improve HC sync stability

### DIFF
--- a/apps/aecore/src/aec_parent_chain_cache.erl
+++ b/apps/aecore/src/aec_parent_chain_cache.erl
@@ -108,10 +108,11 @@ get_commitments(Hash) ->
     end.
 
 
+-ifdef(TEST).
 -spec get_state() -> {ok, map()}.
 get_state() ->
     gen_server:call(?SERVER, get_state).
-
+-endif.
 
 
 %%%=============================================================================

--- a/apps/aecore/test/aec_parent_chain_cache_tests.erl
+++ b/apps/aecore/test/aec_parent_chain_cache_tests.erl
@@ -661,9 +661,10 @@ child_new_top(CachePid, Height) ->
 
 assert_child_cache_consistency(#{ child_start_height := StartHeight,
                                   child_top_height   := ChildTop,
-                                  blocks             := Blocks,
+                                  blocks             := Blocks0,
                                   max_size           := CacheMaxSize,
                                   top_height         := TopHeight}) ->
+    Blocks = maps:filter(fun(_, V) -> is_tuple(V) end, Blocks0),
     ?assertEqual(CacheMaxSize, map_size(Blocks)),
     CacheExpectedStart = min(ChildTop + StartHeight, TopHeight - CacheMaxSize + 1),
     ?assertEqual(CacheExpectedStart, lists:min(maps:keys(Blocks))),


### PR DESCRIPTION
Fixes #4373

The parent cache does/did not really cater for the sync case. It filled up in a rather ad hoc way. This change aims to do the (pre-)filling in a more structured way. It also adds a more specific sync-test; though that one passed even before these changes. 

What _really should be done_ is to introduce a worker pool like the node sync has; and this pool should synchronize with the child chain sync progress. But since the epochs and periodically sync is coming structural changes will probably be required, so let's kick that one further down the road 😅.

This PR is supported by the Æternity Foundation.