### PR TITLE
Fix rollback and direct access issue 

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1472,7 +1472,7 @@ find_tx_with_location(STxHash) ->
 remove_tx(TxHash) ->
     ?t(begin
            remove_tx_location(TxHash),
-           mnesia:delete({aec_signed_tx, TxHash})
+           delete(aec_signed_tx, TxHash)
        end).
 
 add_tx(STx) ->


### PR DESCRIPTION
See #4376 for manifestation. This fixes #4376.

The problem is not related to dev_mode, rather it is an issue when using direct DB access. There was a direct call to `mnesia:delete` in the logic for removing a transaction (used by rollback) - this broke when the system expected direct access. The fix is trivial. In the best of worlds we should have tests finding this (the devmode rollback tests expose the issue - if run with rocksdb and persistence, but normally they are not).

This PR is supported by Æternity Foundation. 