### PR TITLE
Update to released Sophia compiler 8.0.0

### DIFF
--- a/apps/aecontract/test/aecontract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_SUITE.erl
@@ -5935,7 +5935,7 @@ sophia_compiler_version(_Cfg) ->
     {code, Code} = aect_contracts:code(C),
     CMap = aeser_contract_code:deserialize(Code),
     ?assertMatchProtocol(maps:get(compiler_version, CMap, undefined),
-                         undefined, <<"2.1.0">>, <<"3.2.0">>, <<"unknown">>, <<"6.1.0">>, <<"8.0.0-rc1">>),
+                         undefined, <<"2.1.0">>, <<"3.2.0">>, <<"unknown">>, <<"6.1.0">>, <<"8.0.0">>),
     ok.
 
 sophia_protected_call(_Cfg) ->

--- a/rebar.config
+++ b/rebar.config
@@ -219,7 +219,7 @@
                     {dist_node, [{setcookie, 'aeternity_cookie'},
                                  {sname, 'aeternity_ct@localhost'}]},
                     {deps, [{meck, "0.8.12"},
-                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"3130191"}}},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"ffdd4ec"}}},
                             {aesophia_cli, {git, "https://github.com/aeternity/aesophia_cli", {ref,"e0a1730"}}},
                             {aestratum_client, {git, "https://github.com/aeternity/aestratum_client", {ref, "cfd406a"}}},
                             {websocket_client, {git, "https://github.com/aeternity/websocket_client", {ref, "506d8e2"}}},


### PR DESCRIPTION
We test with most recently released Sophia compiler version.

This PR is supported by Æternity Foundation.