### PR TITLE
Don't crash on which_applications in test proxy

### DIFF
--- a/apps/aecore/test/aec_test_app_checker.erl
+++ b/apps/aecore/test/aec_test_app_checker.erl
@@ -19,4 +19,8 @@ check_and_report(Parent, KnownApps) ->
     check_and_report(Parent, NewApps ++ KnownApps).
 
 check_new_apps(KnownApps) ->
-    [A || {A,_,_} <- application:which_applications(), not lists:member(A, KnownApps)].
+    try
+        [A || {A,_,_} <- application:which_applications(), not lists:member(A, KnownApps)]
+    catch _:_ ->
+        []
+    end.


### PR DESCRIPTION
Erlang OTP-26.2.5 changed how application_controller behave during shutdown: erlang/otp#8422

This PR is supported by Æternity Foundation