### PR TITLE
Define `pattern` for some schemas in OpenApi

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3037,7 +3037,7 @@ components:
         tx:
           $ref: "#/components/schemas/EncodedTx"
         tx_hash:
-          $ref: "#/components/schemas/EncodedHash"
+          $ref: "#/components/schemas/EncodedTxHash"
         stateful:
           description: This call will have effects on the next call in this dry-run (or not)
           type: boolean
@@ -3090,7 +3090,7 @@ components:
         tx:
           $ref: "#/components/schemas/EncodedTx"
         tx_hash:
-          $ref: "#/components/schemas/EncodedHash"
+          $ref: "#/components/schemas/EncodedTxHash"
         call_req:
           $ref: "#/components/schemas/DryRunCallReq"
     DryRunResult:
@@ -3151,6 +3151,11 @@ components:
       type: string
       example: tx_+E8hAaEB4TK48d23oE5jt/qWR5pUu8UlpTGn8bwM5JISGQMGf7ABoQOvDVCf43V7alNbsUvTarXaCf7rjtWX36YLS4+JTa4jn4YPHaUyOAAAxRZ6Sg==
       pattern: ^tx_\w+$
+    EncodedTxHash:
+      description: Base58Check encoded transaction hash
+      type: string
+      example: th_2Zfo2ALfRkKQxEaUj3HhcUGyMrTqYpDMgr2u15fPanYD1d55kz
+      pattern: ^th_\w{38,50}$
     EncodedValue:
       description: Base58Check encoded tagged value
       type: string
@@ -3961,7 +3966,7 @@ components:
       type: object
       properties:
         tx_hash:
-          $ref: "#/components/schemas/EncodedHash"
+          $ref: "#/components/schemas/EncodedTxHash"
       required:
         - tx_hash
     Pow:
@@ -4031,7 +4036,7 @@ components:
         block_hash:
           $ref: "#/components/schemas/EncodedHash"
         hash:
-          $ref: "#/components/schemas/EncodedHash"
+          $ref: "#/components/schemas/EncodedTxHash"
         encoded_tx:
           $ref: "#/components/schemas/EncodedTx"
         signatures:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1214,12 +1214,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                tx:
-                  $ref: "#/components/schemas/EncodedTx"
-              required:
-                - tx
+              $ref: "#/components/schemas/EncodedTx"
         description: The new transaction
         required: true
       responses:
@@ -2569,7 +2564,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedTx"
+          $ref: "#/components/schemas/EncodedTxByteArray"
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -2653,7 +2648,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedTx"
+          $ref: "#/components/schemas/EncodedTxByteArray"
         round:
           $ref: "#/components/schemas/UInt64"
         update:
@@ -2696,7 +2691,7 @@ components:
         round:
           $ref: '#/components/schemas/UInt64'
         payload:
-          $ref: '#/components/schemas/EncodedTx'
+          $ref: '#/components/schemas/EncodedTxByteArray'
         ttl:
           $ref: '#/components/schemas/UInt64'
         fee:
@@ -2744,7 +2739,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedTx"
+          $ref: "#/components/schemas/EncodedTxByteArray"
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -2767,7 +2762,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedTx"
+          $ref: "#/components/schemas/EncodedTxByteArray"
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -3033,7 +3028,7 @@ components:
       type: object
       properties:
         tx:
-          $ref: "#/components/schemas/EncodedTx"
+          $ref: "#/components/schemas/EncodedTxByteArray"
         tx_hash:
           $ref: "#/components/schemas/EncodedTxHash"
         stateful:
@@ -3086,7 +3081,7 @@ components:
       type: object
       properties:
         tx:
-          $ref: "#/components/schemas/EncodedTx"
+          $ref: "#/components/schemas/EncodedTxByteArray"
         tx_hash:
           $ref: "#/components/schemas/EncodedTxHash"
         call_req:
@@ -3145,6 +3140,13 @@ components:
       description: Base58Check encoded tagged pubkey
       type: string
     EncodedTx:
+      type: object
+      properties:
+        tx:
+          $ref: "#/components/schemas/EncodedTxByteArray"
+      required:
+        - tx
+    EncodedTxByteArray:
       description: Base64Check encoded transaction
       type: string
       example: tx_+E8hAaEB4TK48d23oE5jt/qWR5pUu8UlpTGn8bwM5JISGQMGf7ABoQOvDVCf43V7alNbsUvTarXaCf7rjtWX36YLS4+JTa4jn4YPHaUyOAAAxRZ6Sg==
@@ -4061,7 +4063,7 @@ components:
         hash:
           $ref: "#/components/schemas/EncodedTxHash"
         encoded_tx:
-          $ref: "#/components/schemas/EncodedTx"
+          $ref: "#/components/schemas/EncodedTxByteArray"
         signatures:
           description: At least one signature is required unless for Generalized Account Meta transactions
           type: array
@@ -4321,12 +4323,7 @@ components:
           maximum: 18446744073709552000
         - type: string
     UnsignedTx:
-      type: object
-      properties:
-        tx:
-          $ref: "#/components/schemas/EncodedTx"
-      required:
-        - tx
+      $ref: "#/components/schemas/EncodedTx"
   parameters:
     accountPubkey:
       in: path

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2493,7 +2493,7 @@ components:
       type: object
       properties:
         bytecode:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
       required:
         - bytecode
     Channel:
@@ -2579,7 +2579,7 @@ components:
         nonce:
           $ref: "#/components/schemas/UInt64"
         poi:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedProofOfInclusion"
       required:
         - channel_id
         - from_id
@@ -2669,7 +2669,7 @@ components:
         nonce:
           $ref: "#/components/schemas/UInt64"
         offchain_trees:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedStateTrees"
       required:
         - channel_id
         - from_id
@@ -2754,7 +2754,7 @@ components:
         nonce:
           $ref: "#/components/schemas/UInt64"
         poi:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedProofOfInclusion"
       required:
         - channel_id
         - from_id
@@ -2842,7 +2842,7 @@ components:
           items:
             $ref: "#/components/schemas/Event"
         return_value:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
         return_type:
           description: The status of the call 'ok | error | revert'.
           type: string
@@ -2882,7 +2882,7 @@ components:
         gas_price:
           $ref: "#/components/schemas/UInt"
         call_data:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
       required:
         - caller_id
         - contract_id
@@ -2900,7 +2900,7 @@ components:
         nonce:
           $ref: "#/components/schemas/UInt64"
         code:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
         vm_version:
           $ref: "#/components/schemas/UInt16"
         abi_version:
@@ -2918,7 +2918,7 @@ components:
         ttl:
           $ref: "#/components/schemas/UInt64"
         call_data:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
       required:
         - owner_id
         - code
@@ -3045,7 +3045,7 @@ components:
       type: object
       properties:
         calldata:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
         contract:
           $ref: "#/components/schemas/EncodedPubkey"
         amount:
@@ -3123,8 +3123,23 @@ components:
       required:
         - results
     EncodedByteArray:
-      description: Base64Check encoded tagged byte array
+      description: Base64Check encoded byte array
       type: string
+      example: ba_AAAAAfy4hFE=
+      pattern: ^ba_\w+$
+    EncodedContractByteArray:
+      description: Base64Check encoded contract byte array
+      type: string
+      example: cb_AAAAAfy4hFE=
+      pattern: ^cb_\w+$
+    EncodedProofOfInclusion:
+      description: Base64Check encoded proof of inclusion
+      type: string
+      pattern: ^pi_\w+$
+    EncodedStateTrees:
+      description: Base64Check encoded state trees
+      type: string
+      pattern: ^ss_\w+$
     EncodedHash:
       description: Base58Check encoded tagged hash
       type: string
@@ -3159,7 +3174,7 @@ components:
           items:
             $ref: "#/components/schemas/UInt"
         data:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
       required:
         - address
         - topics
@@ -3172,7 +3187,7 @@ components:
         nonce:
           $ref: "#/components/schemas/UInt64"
         code:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
         vm_version:
           $ref: "#/components/schemas/UInt16"
         abi_version:
@@ -3186,7 +3201,7 @@ components:
         ttl:
           $ref: "#/components/schemas/UInt64"
         call_data:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
         auth_fun:
           description: Contract authorization function hash (hex encoded)
           type: string
@@ -3217,7 +3232,7 @@ components:
         ttl:
           $ref: "#/components/schemas/UInt64"
         auth_data:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
         tx:
           $ref: "#/components/schemas/SignedTx"
       required:
@@ -3240,7 +3255,7 @@ components:
         gas_used:
           $ref: "#/components/schemas/UInt64"
         return_value:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
         return_type:
           description: The status of the call 'ok | error'.
           type: string
@@ -3356,7 +3371,7 @@ components:
         version:
           $ref: "#/components/schemas/UInt32"
         info:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedContractByteArray"
       required:
         - hash
         - height
@@ -3459,7 +3474,7 @@ components:
         key:
           type: string
         encoded_key:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedByteArray"
         id:
           $ref: "#/components/schemas/EncodedPubkey"
       required:
@@ -3576,7 +3591,7 @@ components:
             gas_price:
               $ref: "#/components/schemas/UInt"
             call_data:
-              $ref: "#/components/schemas/EncodedByteArray"
+              $ref: "#/components/schemas/EncodedContractByteArray"
           required:
             - caller
             - contract
@@ -3613,7 +3628,7 @@ components:
             deposit:
               $ref: "#/components/schemas/UInt"
             call_data:
-              $ref: "#/components/schemas/EncodedByteArray"
+              $ref: "#/components/schemas/EncodedContractByteArray"
           required:
             - owner
             - vm_version
@@ -3939,7 +3954,7 @@ components:
       type: object
       properties:
         poi:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedProofOfInclusion"
       required:
         - poi
     PostTxResponse:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2819,7 +2819,7 @@ components:
       type: object
       properties:
         commitment_id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedCommitmentId"
       required:
         - commitment_id
     ContractCallObject:
@@ -3166,6 +3166,11 @@ components:
       type: string
       example: nm_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
       pattern: ^nm_\w{38,50}$
+    EncodedCommitmentId:
+      description: Base58Check encoded AENS commitment
+      type: string
+      example: cm_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
+      pattern: ^cm_\w{38,50}$
     EncodedValue:
       description: Base58Check encoded tagged value
       type: string
@@ -3499,7 +3504,7 @@ components:
       type: object
       properties:
         commitment_id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedCommitmentId"
         fee:
           $ref: "#/components/schemas/UInt"
         ttl:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3156,6 +3156,11 @@ components:
       type: string
       example: th_2Zfo2ALfRkKQxEaUj3HhcUGyMrTqYpDMgr2u15fPanYD1d55kz
       pattern: ^th_\w{38,50}$
+    EncodedSignature:
+      description: Base58Check encoded signature
+      type: string
+      example: sg_8hhU15cVMbukFj4FbdrFwwYnbzXYPnstu9PDnWZGbfQNpeHcB6tK1F3wvG1MPYySARgDRJYUh3YPJD3HctFwg6Y4rUGSR
+      pattern: ^sg_\w+$
     EncodedValue:
       description: Base58Check encoded tagged value
       type: string
@@ -3408,7 +3413,7 @@ components:
         txs_hash:
           $ref: "#/components/schemas/EncodedHash"
         signature:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedSignature"
         time:
           $ref: "#/components/schemas/UInt64"
         version:
@@ -4044,7 +4049,7 @@ components:
           type: array
           minItems: 0
           items:
-            $ref: "#/components/schemas/EncodedValue"
+            $ref: "#/components/schemas/EncodedSignature"
       required:
         - tx
     SignedTxs:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1216,7 +1216,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EncodedTx"
+              type: object
+              properties:
+                tx:
+                  $ref: "#/components/schemas/EncodedTx"
+              required:
+                - tx
         description: The new transaction
         required: true
       responses:
@@ -2566,7 +2571,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -2650,7 +2655,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
         round:
           $ref: "#/components/schemas/UInt64"
         update:
@@ -2693,7 +2698,7 @@ components:
         round:
           $ref: '#/components/schemas/UInt64'
         payload:
-          $ref: '#/components/schemas/EncodedByteArray'
+          $ref: '#/components/schemas/EncodedTx'
         ttl:
           $ref: '#/components/schemas/UInt64'
         fee:
@@ -2741,7 +2746,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -2764,7 +2769,7 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -3030,7 +3035,7 @@ components:
       type: object
       properties:
         tx:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
         tx_hash:
           $ref: "#/components/schemas/EncodedHash"
         stateful:
@@ -3083,7 +3088,7 @@ components:
       type: object
       properties:
         tx:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
         tx_hash:
           $ref: "#/components/schemas/EncodedHash"
         call_req:
@@ -3127,12 +3132,10 @@ components:
       description: Base58Check encoded tagged pubkey
       type: string
     EncodedTx:
-      type: object
-      properties:
-        tx:
-          $ref: "#/components/schemas/EncodedByteArray"
-      required:
-        - tx
+      description: Base64Check encoded transaction
+      type: string
+      example: tx_+E8hAaEB4TK48d23oE5jt/qWR5pUu8UlpTGn8bwM5JISGQMGf7ABoQOvDVCf43V7alNbsUvTarXaCf7rjtWX36YLS4+JTa4jn4YPHaUyOAAAxRZ6Sg==
+      pattern: ^tx_\w+$
     EncodedValue:
       description: Base58Check encoded tagged value
       type: string
@@ -4015,7 +4018,7 @@ components:
         hash:
           $ref: "#/components/schemas/EncodedHash"
         encoded_tx:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
         signatures:
           description: At least one signature is required unless for Generalized Account Meta transactions
           type: array
@@ -4278,7 +4281,7 @@ components:
       type: object
       properties:
         tx:
-          $ref: "#/components/schemas/EncodedByteArray"
+          $ref: "#/components/schemas/EncodedTx"
       required:
         - tx
   parameters:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2474,7 +2474,7 @@ components:
       type: object
       properties:
         id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedNameId"
         started_at:
           $ref: "#/components/schemas/UInt64"
         ends_at:
@@ -3161,6 +3161,11 @@ components:
       type: string
       example: sg_8hhU15cVMbukFj4FbdrFwwYnbzXYPnstu9PDnWZGbfQNpeHcB6tK1F3wvG1MPYySARgDRJYUh3YPJD3HctFwg6Y4rUGSR
       pattern: ^sg_\w+$
+    EncodedNameId:
+      description: Base58Check encoded AENS name hash
+      type: string
+      example: nm_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
+      pattern: ^nm_\w{38,50}$
     EncodedValue:
       description: Base58Check encoded tagged value
       type: string
@@ -3455,7 +3460,7 @@ components:
       type: object
       properties:
         id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedNameId"
         owner:
           $ref: "#/components/schemas/EncodedPubkey"
         ttl:
@@ -3475,7 +3480,7 @@ components:
       type: object
       properties:
         name_id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedNameId"
       required:
         - name_id
     NamePointer:
@@ -3511,7 +3516,7 @@ components:
       type: object
       properties:
         name_id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedNameId"
         fee:
           $ref: "#/components/schemas/UInt"
         ttl:
@@ -3528,7 +3533,7 @@ components:
       type: object
       properties:
         name_id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedNameId"
         recipient_id:
           $ref: "#/components/schemas/EncodedPubkey"
         fee:
@@ -3548,7 +3553,7 @@ components:
       type: object
       properties:
         name_id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedNameId"
         name_ttl:
           $ref: "#/components/schemas/UInt64"
         pointers:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3174,9 +3174,11 @@ components:
       type: string
       example: cm_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
       pattern: ^cm_\w{38,50}$
-    EncodedValue:
-      description: Base58Check encoded tagged value
+    EncodedOracleQueryId:
+      description: Base58Check encoded oracle query id
       type: string
+      example: oq_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
+      pattern: ^oq_\w{38,50}$
     Error:
       type: object
       properties:
@@ -3728,7 +3730,7 @@ components:
       type: object
       properties:
         id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedOracleQueryId"
         sender_id:
           $ref: "#/components/schemas/EncodedPubkey"
         sender_nonce:
@@ -3816,7 +3818,7 @@ components:
       type: object
       properties:
         query_id:
-          $ref: "#/components/schemas/EncodedValue"
+          $ref: "#/components/schemas/EncodedOracleQueryId"
         response:
           type: string
         response_ttl:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3416,7 +3416,10 @@ components:
         height:
           $ref: "#/components/schemas/UInt64"
         pof_hash:
-          $ref: "#/components/schemas/EncodedHash"
+          description: \"no_fraud\" or Base58Check encoded Proof of Fraud hash
+          type: string
+          pattern: ^no_fraud|bf_\w{38,50}$
+          example: no_fraud
         prev_hash:
           $ref: "#/components/schemas/EncodedHash"
         prev_key_hash:

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -250,7 +250,8 @@ paths:
           description: The name key of the name entry
           required: true
           schema:
-            $ref: "#/components/schemas/Name"
+            type: string
+            example: "dimitar.chain"
       responses:
         "200":
           description: Successful operation
@@ -911,7 +912,8 @@ paths:
           description: The name key of the name entry
           required: true
           schema:
-            $ref: "#/components/schemas/Name"
+            type: string
+            example: "dimitar.chain"
       responses:
         "200":
           description: Successful operation
@@ -2564,7 +2566,12 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedTxByteArray"
+          description: Base64Check encoded byte array. Accepted on input as a
+            plain 'ba_'-prefixed byte array (see aehttp_dispatch_int.erl's
+            produce_tx(channel_close_solo_tx, ...)), but returned by the
+            node as a 'tx_'-prefixed transaction (see
+            aesc_close_solo_tx.erl) -- no single prefix pattern covers both.
+          type: string
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -2691,7 +2698,13 @@ components:
         round:
           $ref: '#/components/schemas/UInt64'
         payload:
-          $ref: '#/components/schemas/EncodedTxByteArray'
+          description: Base64Check encoded byte array. Accepted on input as a
+            plain 'ba_'-prefixed byte array (see aehttp_dispatch_int.erl's
+            produce_tx(channel_set_delegates_tx, ...)), but returned by the
+            node as a 'tx_'-prefixed transaction (see
+            aesc_set_delegates_tx.erl) -- no single prefix pattern covers
+            both.
+          type: string
         ttl:
           $ref: '#/components/schemas/UInt64'
         fee:
@@ -2739,7 +2752,12 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedTxByteArray"
+          description: Base64Check encoded byte array. Accepted on input as a
+            plain 'ba_'-prefixed byte array (see aehttp_dispatch_int.erl's
+            produce_tx(channel_slash_tx, ...)), but returned by the node as
+            a 'tx_'-prefixed transaction (see aesc_slash_tx.erl) -- no
+            single prefix pattern covers both.
+          type: string
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -2762,7 +2780,13 @@ components:
         from_id:
           $ref: "#/components/schemas/EncodedPubkey"
         payload:
-          $ref: "#/components/schemas/EncodedTxByteArray"
+          description: Base64Check encoded byte array. Accepted on input as a
+            plain 'ba_'-prefixed byte array (see aehttp_dispatch_int.erl's
+            produce_tx(channel_snapshot_solo_tx, ...)), but returned by the
+            node as a 'tx_'-prefixed transaction (see
+            aesc_snapshot_solo_tx.erl) -- no single prefix pattern covers
+            both.
+          type: string
         ttl:
           $ref: "#/components/schemas/UInt64"
         fee:
@@ -3119,20 +3143,20 @@ components:
       description: Base64Check encoded byte array
       type: string
       example: ba_AAAAAfy4hFE=
-      pattern: ^ba_\w+$
+      pattern: ^ba_[0-9A-Za-z+/=]+$
     EncodedContractByteArray:
       description: Base64Check encoded contract byte array
       type: string
       example: cb_AAAAAfy4hFE=
-      pattern: ^cb_\w+$
+      pattern: ^cb_[0-9A-Za-z+/=]+$
     EncodedProofOfInclusion:
       description: Base64Check encoded proof of inclusion
       type: string
-      pattern: ^pi_\w+$
+      pattern: ^pi_[0-9A-Za-z+/=]+$
     EncodedStateTrees:
       description: Base64Check encoded state trees
       type: string
-      pattern: ^ss_\w+$
+      pattern: ^ss_[0-9A-Za-z+/=]+$
     EncodedHash:
       description: Base58Check encoded tagged hash
       type: string
@@ -3150,37 +3174,32 @@ components:
       description: Base64Check encoded transaction
       type: string
       example: tx_+E8hAaEB4TK48d23oE5jt/qWR5pUu8UlpTGn8bwM5JISGQMGf7ABoQOvDVCf43V7alNbsUvTarXaCf7rjtWX36YLS4+JTa4jn4YPHaUyOAAAxRZ6Sg==
-      pattern: ^tx_\w+$
+      pattern: ^tx_[0-9A-Za-z+/=]+$
     EncodedTxHash:
       description: Base58Check encoded transaction hash
       type: string
       example: th_2Zfo2ALfRkKQxEaUj3HhcUGyMrTqYpDMgr2u15fPanYD1d55kz
-      pattern: ^th_\w{38,50}$
+      pattern: ^th_\w+$
     EncodedSignature:
       description: Base58Check encoded signature
       type: string
       example: sg_8hhU15cVMbukFj4FbdrFwwYnbzXYPnstu9PDnWZGbfQNpeHcB6tK1F3wvG1MPYySARgDRJYUh3YPJD3HctFwg6Y4rUGSR
       pattern: ^sg_\w+$
-    Name:
-      description: AENS name
-      type: string
-      example: dimitar.chain
-      pattern: ^\w+\.chain$
     EncodedNameId:
       description: Base58Check encoded AENS name hash
       type: string
       example: nm_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
-      pattern: ^nm_\w{38,50}$
+      pattern: ^nm_\w+$
     EncodedCommitmentId:
       description: Base58Check encoded AENS commitment
       type: string
       example: cm_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
-      pattern: ^cm_\w{38,50}$
+      pattern: ^cm_\w+$
     EncodedOracleQueryId:
       description: Base58Check encoded oracle query id
       type: string
       example: oq_psy8tRXPzGxh6975H7K6XQcMFVsdrxJMt7YkzMY8oUTevutzw
-      pattern: ^oq_\w{38,50}$
+      pattern: ^oq_\w+$
     Error:
       type: object
       properties:
@@ -3422,7 +3441,7 @@ components:
         pof_hash:
           description: \"no_fraud\" or Base58Check encoded Proof of Fraud hash
           type: string
-          pattern: ^no_fraud|bf_\w{38,50}$
+          pattern: ^(no_fraud|bf_\w+)$
           example: no_fraud
         prev_hash:
           $ref: "#/components/schemas/EncodedHash"
@@ -4095,7 +4114,7 @@ components:
         nonce:
           $ref: "#/components/schemas/UInt64"
         payload:
-          $ref: "#/components/schemas/EncodedByteArray"
+          description: Base64Check encoded byte array, or a raw string
       required:
         - recipient_id
         - amount

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -250,8 +250,7 @@ paths:
           description: The name key of the name entry
           required: true
           schema:
-            type: string
-            example: "dimitar.chain"
+            $ref: "#/components/schemas/Name"
       responses:
         "200":
           description: Successful operation
@@ -912,8 +911,7 @@ paths:
           description: The name key of the name entry
           required: true
           schema:
-            type: string
-            example: "dimitar.chain"
+            $ref: "#/components/schemas/Name"
       responses:
         "200":
           description: Successful operation
@@ -3161,6 +3159,11 @@ components:
       type: string
       example: sg_8hhU15cVMbukFj4FbdrFwwYnbzXYPnstu9PDnWZGbfQNpeHcB6tK1F3wvG1MPYySARgDRJYUh3YPJD3HctFwg6Y4rUGSR
       pattern: ^sg_\w+$
+    Name:
+      description: AENS name
+      type: string
+      example: dimitar.chain
+      pattern: ^\w+\.chain$
     EncodedNameId:
       description: Base58Check encoded AENS name hash
       type: string

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -2219,21 +2219,35 @@ contract_transactions(_Config) ->    % miner has an account
     InvalidHex1 = <<"1234">>,
     InvalidHex2 = <<"0xXYZ">>,
 
+    %% Since oas3.yaml now declares a `pattern` for the contract byte-array
+    %% schemas, requests with a malformed value are now rejected by the OAS
+    %% schema-validation layer before ever reaching the handler code (and
+    %% its "Not byte array: <field>" error) -- still a 400, just a more
+    %% generic, earlier validation_error.
+    AssertInvalidByteArray =
+        fun(Field, Result) ->
+            ?assertMatch(
+               {ok, 400, #{<<"info">> := #{<<"error">> := <<"no_match">>,
+                                            <<"path">> := [Field]},
+                           <<"reason">> := <<"validation_error">>}},
+               Result)
+        end,
+
     % invalid code
-    {ok, 400, #{<<"reason">> := <<"Not byte array: code">>}} =
-        get_contract_create(maps:put(code, InvalidHex1, ValidEncoded)),
-    {ok, 400, #{<<"reason">> := <<"Not byte array: code">>}} =
-        get_contract_create(maps:put(code, InvalidHex2, ValidEncoded)),
+    AssertInvalidByteArray(<<"code">>,
+        get_contract_create(maps:put(code, InvalidHex1, ValidEncoded))),
+    AssertInvalidByteArray(<<"code">>,
+        get_contract_create(maps:put(code, InvalidHex2, ValidEncoded))),
     % invalid call data
-    {ok, 400, #{<<"reason">> := <<"Not byte array: call_data">>}} =
-        get_contract_create(maps:put(call_data, InvalidHex1, ValidEncoded)),
-    {ok, 400, #{<<"reason">> := <<"Not byte array: call_data">>}} =
-        get_contract_create(maps:put(call_data, InvalidHex2, ValidEncoded)),
+    AssertInvalidByteArray(<<"call_data">>,
+        get_contract_create(maps:put(call_data, InvalidHex1, ValidEncoded))),
+    AssertInvalidByteArray(<<"call_data">>,
+        get_contract_create(maps:put(call_data, InvalidHex2, ValidEncoded))),
     % invalid call data
-    {ok, 400, #{<<"reason">> := <<"Not byte array: call_data">>}} =
-        get_contract_call(maps:put(call_data, InvalidHex1, ContractCallEncoded)),
-    {ok, 400, #{<<"reason">> := <<"Not byte array: call_data">>}} =
-        get_contract_call(maps:put(call_data, InvalidHex2, ContractCallEncoded)),
+    AssertInvalidByteArray(<<"call_data">>,
+        get_contract_call(maps:put(call_data, InvalidHex1, ContractCallEncoded))),
+    AssertInvalidByteArray(<<"call_data">>,
+        get_contract_call(maps:put(call_data, InvalidHex2, ContractCallEncoded))),
 
     %% Call objects
     {ok, 200, #{<<"tx">> := SpendTx}} = post_spend_tx(MinerAddress, 1,
@@ -2571,25 +2585,47 @@ test_invalid_hash({PubKeyType, PubKey}, MapKey0, Encoded, APIFun) when is_atom(P
         end,
     CorrectAddress = aeser_api_encoder:encode(PubKeyType, PubKey),
     Msg = list_to_binary("Invalid hash: " ++ atom_to_list(Name)),
+    MapKeyBin = atom_to_binary(MapKey, utf8),
+    %% Fields whose schema now declares a `pattern` (e.g. commitment_id,
+    %% name/name_id) get malformed values rejected earlier, at the OAS
+    %% schema-validation layer, before ever reaching the handler's own
+    %% "Invalid hash: <field>" check -- still a 400, just a more generic,
+    %% earlier validation_error. Accept either shape: whichever layer
+    %% happens to catch a given malformed variant, it must still be
+    %% rejected with a 400.
+    AssertRejected =
+        fun(Result) ->
+            case Result of
+                {ok, 400, #{<<"reason">> := Msg}} ->
+                    ok;
+                {ok, 400, #{<<"info">> := #{<<"error">> := <<"no_match">>,
+                                             <<"path">> := [MapKeyBin]},
+                            <<"reason">> := <<"validation_error">>}} ->
+                    ok;
+                Other ->
+                    ?assertMatch({ok, 400, #{<<"reason">> := Msg}}, Other)
+            end
+        end,
     <<_, HashWithBrokenPrefix/binary>> = CorrectAddress,
-    {ok, 400, #{<<"reason">> := Msg}} = APIFun(maps:put(MapKey, HashWithBrokenPrefix, Encoded)),
+    AssertRejected(APIFun(maps:put(MapKey, HashWithBrokenPrefix, Encoded))),
 
     <<_Prefix:3/binary, HashWithNoPrefix/binary>> = CorrectAddress,
-    {ok, 400, #{<<"reason">> := Msg}} = APIFun(maps:put(MapKey, HashWithNoPrefix, Encoded)),
+    AssertRejected(APIFun(maps:put(MapKey, HashWithNoPrefix, Encoded))),
 
     case aeser_api_encoder:byte_size_for_type(PubKeyType) of
         not_applicable -> pass;
         _ ->
             <<ShortHash:10/binary, _Rest/binary>> = CorrectAddress,
-            {ok, 400, #{<<"reason">> := Msg}} = APIFun(maps:put(MapKey, ShortHash, Encoded)),
+            AssertRejected(APIFun(maps:put(MapKey, ShortHash, Encoded))),
 
             BS = byte_size(PubKey),
             HalfSize = BS div 2,
             <<FirstHalfKey:HalfSize/binary, _SecondHalfKey/binary>> = PubKey,
             HalfHash = aeser_api_encoder:encode(PubKeyType, FirstHalfKey),
-            {ok, 400, #{<<"reason">> := Msg}} = APIFun(maps:put(MapKey, HalfHash, Encoded))
+            AssertRejected(APIFun(maps:put(MapKey, HalfHash, Encoded)))
     end,
     ok.
+
 
 test_missing_address(Key, Encoded, APIFun) ->
     Msg = list_to_binary("Account of " ++ atom_to_list(Key) ++ " not found"),
@@ -3498,7 +3534,16 @@ post_broken_api_encoded_tx(_Config) ->
                     payload => <<"foo">>}),
             <<_, BrokenHash/binary>> =
                 aeser_api_encoder:encode(transaction, SignedBinTx),
-            {ok, 400, #{<<"reason">> := <<"Invalid api encoding">>}} = post_transactions_sut(BrokenHash)
+            %% oas3.yaml now declares a `pattern` for EncodedTxByteArray, so
+            %% a malformed 'tx' value is now rejected by the OAS schema-
+            %% validation layer before ever reaching the handler's own
+            %% "Invalid api encoding" check -- still a 400, just a more
+            %% generic, earlier validation_error.
+            ?assertMatch(
+               {ok, 400, #{<<"info">> := #{<<"error">> := <<"no_match">>,
+                                            <<"path">> := [<<"tx">>]},
+                           <<"reason">> := <<"validation_error">>}},
+               post_transactions_sut(BrokenHash))
         end,
         lists:seq(1, NumberOfChecks)), % number
     ok.


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

sdk uses the `pattern` property to generate more accurate TS types in https://github.com/aeternity/aepp-sdk-js/pull/2011