### PR TITLE
Use better hyperchain configuration names 

### DIFF
--- a/apps/aecore/src/aec_consensus_smart_contract.erl
+++ b/apps/aecore/src/aec_consensus_smart_contract.erl
@@ -82,8 +82,8 @@ can_be_turned_off() -> false.
 assert_config(_Config) -> ok.
 
 start(Config, _) ->
-    #{<<"stakers">> := StakersEncoded} = Config,
-    Stakers =
+    #{<<"pinning_accounts">> := PinningAccountsEncoded} = Config,
+    PinningAccounts =
         lists:map(
             fun(#{<<"pub">> := EncodedPubkey, <<"priv">> := EncodedPrivkey}) ->
                 {ok, Pubkey} = aeser_api_encoder:safe_decode(account_pubkey,
@@ -95,14 +95,14 @@ start(Config, _) ->
                 end,
                 {Pubkey, Privkey}
             end,
-            StakersEncoded),
-    StakersMap = maps:from_list(Stakers),
+            PinningAccountsEncoded),
+    PinningAccountsMap = maps:from_list(PinningAccounts),
     %% TODO: ditch this after we move beyond OTP24
     Mod = aec_preset_keys,
     OldSpec =
-        {Mod, {Mod, start_link, [StakersMap]}, permanent, 3000, worker, [Mod]},
+        {Mod, {Mod, start_link, [PinningAccountsMap]}, permanent, 3000, worker, [Mod]},
     aec_consensus_sup:start_child(OldSpec),
-    lager:debug("Stakers: ~p", [StakersMap]),
+    lager:debug("PinningAccounts: ~p", [PinningAccountsMap]),
     ok.
 
 stop() -> ok.

--- a/apps/aehttp/src/aehttpc_aeternity.erl
+++ b/apps/aehttp/src/aehttpc_aeternity.erl
@@ -40,9 +40,9 @@ get_commitment_tx_at_height(NodeSpec, _Seed, Height, ParentHCAccountPubKey) ->
     end.
 
 %% @doc Post commitment to AE parent chain.
-post_commitment(NodeSpec, StakerPubkey, HCCollectPubkey, Amount, Fee, Commitment,
+post_commitment(NodeSpec, PinningAccountPubkey, HCCollectPubkey, Amount, Fee, Commitment,
                 NetworkId, SignModule) ->
-    post_commitment_tx(NodeSpec, StakerPubkey, HCCollectPubkey, Amount,
+    post_commitment_tx(NodeSpec, PinningAccountPubkey, HCCollectPubkey, Amount,
                        Fee, Commitment,
                        NetworkId, SignModule).
 
@@ -130,8 +130,8 @@ get_hc_commitments(NodeSpec, MB, ParentHCAccountPubKey) ->
                           <<"sender_id">> := _SenderId,
                           <<"payload">> := CommitmentEnc} ->
                                 {ok, Commitment} = aeser_api_encoder:safe_decode(bytearray, CommitmentEnc),
-                                {btc, Signature, StakerHash, TopKeyHash} = aec_parent_chain_block:decode_commitment(Commitment),
-                                [{Signature, StakerHash, TopKeyHash} | Acc];
+                                {btc, Signature, PinningAccountHash, TopKeyHash} = aec_parent_chain_block:decode_commitment(Commitment),
+                                [{Signature, PinningAccountHash, TopKeyHash} | Acc];
                         _ ->
                             Acc
                     end

--- a/apps/aehttp/src/aehttpc_btc.erl
+++ b/apps/aehttp/src/aehttpc_btc.erl
@@ -72,8 +72,8 @@ get_commitment_tx_at_height(NodeSpec, Seed, Height, ParentHCAccountPubKey) ->
 %% 3. Apply signatures using signrawtransaction
 %% 4. Submit it using sendrawtransaction
 
-post_commitment(NodeSpec, StakerPubkey, HCCollectPubkey, Amount, Fee, Commitment, _NetworkId, _SignModule) ->
-    post_commitment(NodeSpec, StakerPubkey, HCCollectPubkey, Amount, Fee, Commitment).
+post_commitment(NodeSpec, PinningAccountPubkey, HCCollectPubkey, Amount, Fee, Commitment, _NetworkId, _SignModule) ->
+    post_commitment(NodeSpec, PinningAccountPubkey, HCCollectPubkey, Amount, Fee, Commitment).
 
 post_commitment(NodeSpec, BTCAcc, HCCollectPubkey, Amount, Fee, Commitment) ->
     {ok, Unspent} = listunspent(NodeSpec),
@@ -327,8 +327,8 @@ parse_vout(Vout) when length(Vout) == 3 ->
             case CommitmentBTC of
                 <<Commitment:80/binary>> ->
                     case aec_parent_chain_block:decode_commitment(Commitment) of
-                        {btc, Signature, StakerHash, TopKeyHash} ->
-                            {ok, {Signature, StakerHash, TopKeyHash}};
+                        {btc, Signature, PinningAccountHash, TopKeyHash} ->
+                            {ok, {Signature, PinningAccountHash, TopKeyHash}};
                         _ ->
                             {error, not_btc_commitment}
                     end;

--- a/apps/aehttp/src/aehttpc_doge.erl
+++ b/apps/aehttp/src/aehttpc_doge.erl
@@ -60,9 +60,9 @@ get_commitment_tx_at_height(NodeSpec, Seed, Height, ParentHCAccountPubKey) ->
 %% 3. Apply signatures using signrawtransaction
 %% 4. Submit it using sendrawtransaction
 
-post_commitment(NodeSpec, StakerPubkey, HCCollectPubkey, Amount, Fee, Commitment,
+post_commitment(NodeSpec, PinningAccountPubkey, HCCollectPubkey, Amount, Fee, Commitment,
                 _NetworkId, _SignModule) ->
-        post_commitment(NodeSpec, StakerPubkey, HCCollectPubkey, Amount, Fee, Commitment).
+        post_commitment(NodeSpec, PinningAccountPubkey, HCCollectPubkey, Amount, Fee, Commitment).
 
 post_commitment(NodeSpec, BTCAcc, HCCollectPubkey, Amount, Fee, Commitment) ->
     {ok, Unspent} = listunspent(NodeSpec),

--- a/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
+++ b/apps/aehttp/test/aehttp_stake_contract_SUITE.erl
@@ -1517,11 +1517,11 @@ build_json_files(ElectionContract, NodeConfigs) ->
          }),
     ok.
 
-node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensus) ->
-    node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensus, false, 0).
+node_config(NetworkId,Node, CTConfig, PotentialPinningAccounts, ReceiveAddress, Consensus) ->
+    node_config(NetworkId,Node, CTConfig, PotentialPinningAccounts, ReceiveAddress, Consensus, false, 0).
 
-node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensus, ProducingCommitments, GenesisStartTime) ->
-    Stakers =
+node_config(NetworkId,Node, CTConfig, PotentialPinningAccounts, ReceiveAddress, Consensus, ProducingCommitments, GenesisStartTime) ->
+    PinningAccounts =
         case Consensus of
             ?CONSENSUS_POS ->
                 lists:map(
@@ -1530,7 +1530,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                         Priv = list_to_binary(aeu_hex:bin_to_hex( privkey(Who))), %% TODO: discuss key management
                         #{<<"pub">> => Pub, <<"priv">> => Priv}
                     end,
-                    PotentialStakers);
+                    PotentialPinningAccounts);
             ?CONSENSUS_HC ->
                 lists:map(
                     fun({HCWho, PCWho}) ->
@@ -1539,7 +1539,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                         #{  <<"hyper_chain_account">> =>#{<<"pub">> => encoded_pubkey(HCWho), <<"priv">> => HCPriv},
                             <<"parent_chain_account">> =>#{<<"pub">> => encoded_pubkey(PCWho), <<"priv">> => PCPriv}}
                     end,
-                    PotentialStakers);
+                    PotentialPinningAccounts);
             _ when Consensus == ?CONSENSUS_HC_BTC; Consensus == ?CONSENSUS_HC_DOGE ->
                 lists:map(
                     fun({HCWho, PCWho}) ->
@@ -1547,7 +1547,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                         #{  <<"hyper_chain_account">> => #{<<"pub">> => encoded_pubkey(HCWho), <<"priv">> => HCPriv},
                             <<"parent_chain_account">> => #{<<"pub">> => PCWho} }
                     end,
-                    PotentialStakers)
+                    PotentialPinningAccounts)
         end,
     ConsensusType =
         case Consensus of
@@ -1569,7 +1569,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                         <<"consensus">> =>
                             #{  <<"type">> => <<"AE2AE">>,
                                 <<"network_id">> => ?PARENT_CHAIN_NETWORK_ID,
-                                <<"spend_address">> => ReceiveAddress,
+                                <<"pinning_recipient">> => ReceiveAddress,
                                 <<"fee">> => 100000000000000,
                                 <<"amount">> => 9700
                             },
@@ -1598,7 +1598,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                         <<"consensus">> =>
                             #{  <<"type">> => PCType,
                                 <<"network_id">> => <<"regtest">>,
-                                <<"spend_address">> => ReceiveAddress,
+                                <<"pinning_recipient">> => ReceiveAddress,
                                 <<"fee">> => 95000,
                                 <<"amount">> => 7500
                             },
@@ -1632,7 +1632,7 @@ node_config(NetworkId,Node, CTConfig, PotentialStakers, ReceiveAddress, Consensu
                                         <<"rewards_contract">> => aeser_api_encoder:encode(contract_pubkey, staking_contract_address()),
                                         <<"contract_owner">> => aeser_api_encoder:encode(account_pubkey,?OWNER_PUBKEY),
                                         <<"expected_key_block_rate">> => 2000,
-                                        <<"stakers">> => Stakers},
+                                        <<"pinning_accounts">> => PinningAccounts},
                                     SpecificConfig)
                                     }}},
         <<"fork_management">> =>

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1787,7 +1787,7 @@
                                                             "type": "string",
                                                             "default": "ae_mainnet"
                                                         },
-                                                        "spend_address": {
+                                                        "pinning_recipient": {
                                                             "description" : "The address on the parent chain where commitment transactions will be sent. e.g. for a bitcoin parent chain this might start 'bcrt1'...",
                                                             "type": "string",
                                                             "default": ""
@@ -1833,8 +1833,8 @@
                                                 }
                                             }
                                         },
-                                        "stakers": {
-                                            "description" : "List of hyperchain accounts and associated parent chain accounts that this node should post commitments for",
+                                        "pinning_accounts": {
+                                            "description" : "List of hyperchain accounts and associated parent chain accounts that this node should use for pinning",
                                             "type" : "array",
                                             "items" : {
                                                 "type" : "object",


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

Use pinning_accounts instead of stakers and pinning_recipient instead of spend_address

See https://github.com/aeternity/aeternity/issues/4388