### PR TITLE
Added DIR (--dir) option to ct-latest target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,11 @@ CT_TEST_FLAGS += --group=$(GROUP)
 unexport GROUP
 endif
 
+ifdef DIR
+CT_TEST_FLAGS += --dir=$(DIR)
+unexport DIR
+endif
+
 ifdef TEST
 CT_TEST_FLAGS += --case=$(TEST)
 EUNIT_TEST_FLAGS += --module=$(TEST)


### PR DESCRIPTION
Added `DIR=...` option to `ct-latest` make target. Allows you to run all test in a particular directory/ies.

Supported by  Aeternity Foundation