### PR TITLE
Improve HC tests by some "caching"

### DIFF
--- a/apps/aecontract/test/aect_test_utils.erl
+++ b/apps/aecontract/test/aect_test_utils.erl
@@ -717,7 +717,7 @@ generate_json_aci(Vsn, Code) ->
 
 generate_json_aci_(Vsn, Backend, Code) when Vsn >= ?SOPHIA_CERES_FATE ->
     try
-        {ok, JAci} = aeso_aci:contract_interface(json, to_str(Code), [{backend, Backend}]),
+        {ok, JAci} = aeso_aci:contract_interface(json, to_str(Code), [{backend, Backend}, {no_code, true}]),
         aeaci_aci:from_string(jsx:encode(JAci), #{backend => Backend})
     catch Err:Reason:Stack ->
         ct:log("Aci generation failed ~p ~p ~p\n", [Err, Reason, Stack]),

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -854,13 +854,18 @@ mine_blocks_loop(Blocks, BlocksToMine, Type) when is_integer(BlocksToMine), Bloc
 wait_for_new_block_mined() ->
     wait_for_new_block_mined(30000).
 
+td(B) ->
+    aeu_time:now_in_msecs() - aec_blocks:time_in_msecs(B).
+
 wait_for_new_block_mined(T) when is_integer(T), T >= 0 ->
     receive
         {gproc_ps_event, block_created, Info} ->
             #{info := Block, test_node := Node} = Info,
+            ct:log("~p produced a key-block at ~p (time-diff: ~p)", [Node, aec_blocks:height(Block), td(Block)]),
             {ok, Node, Block};
         {gproc_ps_event, micro_block_created, Info} ->
             #{info := Block, test_node := Node} = Info,
+            ct:log("~p produced a micro-block at ~p (time-diff ~p)", [Node, aec_blocks:height(Block), td(Block)]),
             {ok, Node, Block}
     after
         T ->

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -200,9 +200,9 @@ init_per_suite(Config0) ->
             {ok, MSBinSrc} = aect_test_utils:read_contract(?MAIN_STAKING_CONTRACT),
             {ok, EBinSrc} = aect_test_utils:read_contract(?HC_CONTRACT),
             [{staking_contract, StakingContract}, {election_contract, ElectionContract},
-             {contract_src, #{"StakingValidator" => binary_to_list(SVBinSrc),
-                              ?MAIN_STAKING_CONTRACT => binary_to_list(MSBinSrc),
-                              ?HC_CONTRACT => binary_to_list(EBinSrc)
+             {contract_src, #{"StakingValidator" => create_stub(binary_to_list(SVBinSrc)),
+                              ?MAIN_STAKING_CONTRACT => create_stub(binary_to_list(MSBinSrc)),
+                              ?HC_CONTRACT => create_stub(binary_to_list(EBinSrc))
                               }} | Config1]
     end.
 
@@ -1143,3 +1143,11 @@ key_reward_provided() ->
 key_reward_provided(RewardHeight) ->
   {get_block_producer(?NODE1, RewardHeight),
    rpc(?NODE1, aec_governance, block_mine_reward, [RewardHeight])}.
+
+create_stub(ContractFile) ->
+    create_stub(ContractFile, []).
+
+create_stub(ContractFile, Opts) ->
+    {ok, Enc}  = aeso_aci:contract_interface(json, ContractFile, Opts ++ [{no_code, true}]),
+    {ok, Stub} = aeso_aci:render_aci_json(Enc),
+    binary_to_list(Stub).


### PR DESCRIPTION
Speed up the contract calls in the tests by computing (and re-using) contract stubs - these are much smaller than the full code base which makes encode/decode go faster!

This PR is supported by Æternity Foundation