### PR TITLE
Multiple epochs in contract

### DIFF
--- a/apps/aecore/src/aec_chain_hc.erl
+++ b/apps/aecore/src/aec_chain_hc.erl
@@ -1,0 +1,79 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% API for hyperchain chain related information.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aec_chain_hc).
+
+%%% Hyperchain API
+-export([ epoch/0
+        , epoch/1
+        , epoch_length/0
+        , epoch_length/1
+        , block_producer/0
+        , block_producer/1
+        %, prev_epoch_last_hash/0
+        %, prev_epoch_last_hash/1
+        , epoch_start_height/1
+        ]).
+
+-define(ELECTION_CONTRACT, election).
+-define(STAKING_CONTRACT, staking).
+-define(REWARDS_CONTRACT, rewards).
+
+-spec epoch() -> 'undefined' | {ok, non_neg_integer()} | {error, chain_too_short}.
+epoch() ->
+    case aec_chain:top_height() of
+        undefined -> undefined;
+        Height -> epoch(Height)
+    end.
+
+-spec epoch_length() -> 'undefined' | {ok, non_neg_integer()} | {error, chain_too_short}.
+epoch_length() ->
+    case aec_chain:top_height() of
+        undefined -> undefined;
+        Height -> epoch_length(Height)
+    end.
+
+-spec block_producer() -> 'undefined' | {ok, aec_keys:pubkey()} | {error, chain_too_short}.
+block_producer() ->
+    case aec_chain:top_height() of
+        undefined -> undefined;
+        Height -> block_producer(Height)
+    end.
+
+-spec epoch(non_neg_integer()) -> {ok, non_neg_integer()} | {error, chain_too_short}.
+epoch(Height) ->
+    call_consensus_contract_at_height(?ELECTION_CONTRACT, Height, "epoch", []).
+
+-spec epoch_length(non_neg_integer()) -> {ok, non_neg_integer()} | {error, chain_too_short}.
+epoch_length(Height) ->
+    call_consensus_contract_at_height(?ELECTION_CONTRACT, Height, "epoch_length", []).
+
+-spec block_producer(non_neg_integer()) -> {ok, aec_keys:pubkey()} | {error, chain_too_short}.
+block_producer(Height) ->
+    call_consensus_contract_at_height(?ELECTION_CONTRACT, Height, "leader", []).
+
+-spec epoch_start_height(non_neg_integer()) -> {ok, non_neg_integer()} | {error, chain_too_short}.
+epoch_start_height(Epoch) ->
+    case epoch() of
+        {ok, TopEpoch} when TopEpoch >= Epoch ->
+            epoch_start_height(Epoch, TopEpoch, aec_chain:top_height());
+        _ ->
+            {error, chain_too_short}
+    end.
+
+epoch_start_height(Epoch, _EpochAtHeight, _Height) ->
+  {ok, Epoch}.
+
+
+%%% --- internal
+
+call_consensus_contract_at_height(Contract, Height, Endpoint, Args) when is_integer(Height), Height >= 0 ->
+    case aec_chain_state:get_key_block_hash_at_height(Height) of
+        error -> {error, chain_too_short};
+        {ok, Hash} ->
+           {TxEnv, Trees} = aetx_env:tx_env_and_trees_from_hash(aetx_transaction, Hash),
+           aec_consensus_hc:call_consensus_contract_result(Contract, TxEnv, Trees, Endpoint, Args)
+    end.
+

--- a/apps/aecore/src/aec_chain_hc.erl
+++ b/apps/aecore/src/aec_chain_hc.erl
@@ -10,10 +10,10 @@
         , epoch/1
         , epoch_length/0
         , epoch_length/1
+        , epoch_info/0
+        , epoch_info/1
         , block_producer/0
         , block_producer/1
-        %, prev_epoch_last_hash/0
-        %, prev_epoch_last_hash/1
         , epoch_start_height/1
         ]).
 
@@ -21,25 +21,34 @@
 -define(STAKING_CONTRACT, staking).
 -define(REWARDS_CONTRACT, rewards).
 
--spec epoch() -> 'undefined' | {ok, non_neg_integer()} | {error, chain_too_short}.
+-spec epoch() -> {ok, non_neg_integer()} | {error, chain_too_short}.
 epoch() ->
     case aec_chain:top_height() of
-        undefined -> undefined;
+        undefined -> {error, chain_too_short};
         Height -> epoch(Height)
     end.
 
--spec epoch_length() -> 'undefined' | {ok, non_neg_integer()} | {error, chain_too_short}.
+-spec epoch_length() -> {ok, non_neg_integer()} | {error, chain_too_short}.
 epoch_length() ->
     case aec_chain:top_height() of
-        undefined -> undefined;
+        undefined -> {error, chain_too_short};
         Height -> epoch_length(Height)
     end.
 
--spec block_producer() -> 'undefined' | {ok, aec_keys:pubkey()} | {error, chain_too_short}.
+-spec block_producer() -> {ok, aec_keys:pubkey()} | {error, chain_too_short}.
 block_producer() ->
     case aec_chain:top_height() of
-        undefined -> undefined;
+        undefined -> {error, chain_too_short};
         Height -> block_producer(Height)
+    end.
+
+-spec epoch_info() -> {ok, #{first => non_neg_integer(),
+                             at => non_neg_integer(),
+                             length => non_neg_integer()}} | {error, chain_too_short}.
+epoch_info() ->
+    case aec_chain:top_height() of
+        undefined -> {error, chain_too_short};
+        Height -> epoch_info(Height)
     end.
 
 -spec epoch(non_neg_integer()) -> {ok, non_neg_integer()} | {error, chain_too_short}.
@@ -54,18 +63,36 @@ epoch_length(Height) ->
 block_producer(Height) ->
     call_consensus_contract_at_height(?ELECTION_CONTRACT, Height, "leader", []).
 
+-spec epoch_info(non_neg_integer()) -> {ok, #{first => non_neg_integer(),
+                                              at => non_neg_integer(),
+                                              length => non_neg_integer()}}.
+epoch_info(Height) ->
+    {ok, LeftToFill} = call_consensus_contract_at_height(?ELECTION_CONTRACT, Height, "blocks_to_fill_epoch", []),
+    {ok, Length} =  epoch_length(Height),
+    HeightInEpoch = Length - LeftToFill,
+    {ok, #{first => Height - HeightInEpoch,
+           at => Height + HeightInEpoch,
+           length => Length}}.
+
 -spec epoch_start_height(non_neg_integer()) -> {ok, non_neg_integer()} | {error, chain_too_short}.
 epoch_start_height(Epoch) ->
-    case epoch() of
-        {ok, TopEpoch} when TopEpoch >= Epoch ->
-            epoch_start_height(Epoch, TopEpoch, aec_chain:top_height());
+    case aec_chain:top_height() of
+        undefined -> {error, chain_too_short};
+        Height ->
+           {ok, #{first := StartHeight}} = epoch_info(Height),
+           epoch_start_height(Epoch, StartHeight)
+    end.
+
+epoch_start_height(Epoch, EStartHeight) ->
+    case epoch(EStartHeight) of
+        {ok, EpochNum} when EpochNum == Epoch ->
+            {ok, EStartHeight};
+        {ok, EpochNum} when EpochNum > Epoch ->
+            {ok, Length} = epoch_length(EStartHeight - 1),
+            epoch_start_height(Epoch, EStartHeight - Length);
         _ ->
             {error, chain_too_short}
     end.
-
-epoch_start_height(Epoch, _EpochAtHeight, _Height) ->
-  {ok, Epoch}.
-
 
 %%% --- internal
 

--- a/apps/aecore/src/aec_chain_hc.erl
+++ b/apps/aecore/src/aec_chain_hc.erl
@@ -46,7 +46,7 @@ block_producer() ->
 
 -spec epoch_info() -> {ok, #{first => non_neg_integer(),
                              at => non_neg_integer(),
-                             length => non_neg_integer()}} | {error, chain_too_short}.
+                             last => non_neg_integer()}} | {error, chain_too_short}.
 epoch_info() ->
     case aec_chain:top_height() of
         undefined -> {error, chain_too_short};
@@ -67,7 +67,7 @@ block_producer(Height) ->
 
 -spec epoch_info(non_neg_integer()) -> {ok, #{first => non_neg_integer(),
                                               at => non_neg_integer(),
-                                              length => non_neg_integer()}}.
+                                              last => non_neg_integer()}}.
 epoch_info(Height) ->
     {ok, LeftToFill} = call_consensus_contract_at_height(?ELECTION_CONTRACT, Height, "blocks_to_fill_epoch", []),
     {ok, Length} = epoch_length(Height),
@@ -76,7 +76,7 @@ epoch_info(Height) ->
     {ok, #{first => Height - HeightInEpoch,
            epoch => Epoch,
            at => Height + HeightInEpoch,
-           length => Length}}.
+           last => Height - HeightInEpoch + Length - 1}}.
 
 -spec epoch_start_height(non_neg_integer()) -> {ok, non_neg_integer()} | {error, chain_too_short}.
 epoch_start_height(Epoch) ->

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -589,7 +589,13 @@ set_mode(State) ->
             end;
         pos ->
             %% TODO actually check whether node is a producing node
-            State#state{mode = pos, has_beneficiary = true}
+            case ConsensusModule of
+                aec_consensus_hc ->
+                    IsBlockProducer = aec_consensus_hc:is_block_producer(),
+                    State#state{mode = pos, has_beneficiary = IsBlockProducer};
+                _ ->
+                    set_beneficiary_configured(State#state{mode = pos}, ConsensusModule)
+            end
     end.
 
 set_stratum_mode(State) ->

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -449,9 +449,9 @@ parent_generation() ->
     Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"parent_generation">>]) end,
     aeu_ets_cache:get(?ETS_CACHE_TABLE, parent_generation, Fun).
 
-acceptable_sync_offset() ->
-    Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"acceptable_sync_offset">>], 60000) end,
-    aeu_ets_cache:get(?ETS_CACHE_TABLE, acceptable_sync_offset, Fun).
+%acceptable_sync_offset() ->
+%    Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"acceptable_sync_offset">>], 60000) end,
+%    aeu_ets_cache:get(?ETS_CACHE_TABLE, acceptable_sync_offset, Fun).
 
 
 get_child_epoch_length(TxEnv, Trees) ->

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -441,10 +441,6 @@ get_child_epoch(TxEnv, Trees) ->
     {ok, Result} = call_consensus_contract_result(?ELECTION_CONTRACT, TxEnv, Trees, "epoch", []),
     Result.
 
-%get_blocks_upto_child_epoch(TxEnv, Trees) ->
-%    {ok, NrBlocks} = call_consensus_contract_result(?ELECTION_CONTRACT, TxEnv, Trees, "blocks_to_fill_epoch", []),
-%    NrBlocks.
-
 set_child_epoch_length(Length, TxEnv, Trees) ->
     {ok, CD} = aeb_fate_abi:create_calldata("set_next_epoch_length",
                                             [

--- a/apps/aecore/test/aec_parent_chain_cache_tests.erl
+++ b/apps/aecore/test/aec_parent_chain_cache_tests.erl
@@ -226,7 +226,7 @@ configurable_confirmation_height() ->
 %%%===================================================================
 
 start_cache(StartHeight, MaxSize) ->
-    Args = [StartHeight, 1000, fun(Height) -> [Height + StartHeight, Height + StartHeight + ?EPOCH] end, MaxSize, true],
+    Args = [StartHeight, 1000, fun(Height) -> [Height + StartHeight, Height + StartHeight + ?EPOCH] end, MaxSize],
     gen_server:start_link({local, ?TEST_MODULE}, ?TEST_MODULE, Args, []).
 
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -632,6 +632,10 @@ verify_fees(Config) ->
     {ok, _SignedTx} = seed_account(PatronPub, 1, NetworkId),
     Test(), %% fees are generated
 
+    %% key blocks are in sync, but give gossip time to sync micro block
+    %% This won't be needed if micro blocks come before key blocks
+    timer:sleep(?CHILD_BLOCK_TIME div 2),
+
     ct:log("Test with no transaction", []),
     [ Test() || _ <- lists:seq(0, ?REWARD_DELAY) ],
     ok.

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -440,7 +440,7 @@ respect_schedule(Config) ->
     ct:log("Validating schedule for Epoch ~p from height ~p", [PrevChildEpoch, StartHeight]),
     Hash = <<"12">>,
     ct:log("Entropy from height ~p: block hash ~p", [EntropyHeight, Hash]),
-    {ok, Schedule} = rpc(?NODE1, aec_chain_hc, validator_schedule_at_height, [StartHeight]),
+    {ok, Schedule} = rpc(?NODE1, aec_chain_hc, validator_schedule_at_height, [Hash, StartHeight]),
     ct:log("Validating schedule ~p", [Schedule]),
     ok.
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -669,7 +669,7 @@ epoch_with_slow_parent(Config) ->
     %% ensure start at a new epoch boundary
     ChildTopHeight = rpc(?NODE1, aec_chain, top_height, []),
     BlocksLeftToBoundary = ?CHILD_EPOCH_LENGTH - (ChildTopHeight rem ?CHILD_EPOCH_LENGTH),
-    {ok, StartEpoch} = inspect_election_contract(?ALICE, epoch, Config),
+    {ok, StartEpoch} = rpc(?NODE1, aec_chain_hc, epoch, []),
     ct:log("Starting at CC epoch ~p: producing ~p cc blocks", [StartEpoch, BlocksLeftToBoundary]),
     %% some block production including parent blocks
     produce_cc_blocks(Config, BlocksLeftToBoundary),
@@ -687,7 +687,7 @@ epoch_with_slow_parent(Config) ->
     ?assertEqual(ParentStartHeight, ParentTopHeight),
 
     ?assertException(error, timeout_waiting_for_block, produce_cc_blocks(Config, ?CHILD_EPOCH_LENGTH, none)),
-    {ok, EndEpoch} = inspect_election_contract(?ALICE, epoch, Config),
+    {ok, EndEpoch} = rpc(?NODE1, aec_chain_hc, epoch, []),
     ct:log("Ending at CC epoch ~p", [EndEpoch]),
     ok.
 
@@ -793,10 +793,7 @@ inspect_election_contract(OriginWho, WhatToInspect, Config) ->
 inspect_election_contract(OriginWho, WhatToInspect, Config, TopHash) ->
     {Fun, Args} =
         case WhatToInspect of
-            current_leader -> {"leader", []};
-            current_added_staking_power -> {"added_stake", []};
-            validators -> {"sorted_validators", []};
-            epoch -> {"epoch", []}
+            current_added_staking_power -> {"added_stake", []}
         end,
     ContractPubkey = ?config(election_contract, Config),
     do_contract_call(ContractPubkey, src(?HC_CONTRACT, Config), Fun, Args, OriginWho, TopHash).

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -1,5 +1,6 @@
 include "List.aes"
 include "Pair.aes"
+include "Option.aes"
 
 contract interface MainStaking =
   entrypoint sorted_validators : () => list((address * int))
@@ -8,109 +9,105 @@ contract interface MainStaking =
   stateful entrypoint post_elect : () => unit
 
 main contract HCElection =
+  record epoch_info =
+    { start                : int,
+      length               : int,
+      seed                 : option(hash),
+      staking_distribution : option(list(address * int))
+    }
+
   record state =
     { main_staking_ct       : MainStaking,
-      entropy               : string,
       leader                : address,
       added_stake           : int,
       epoch                 : int,
-      epoch_length          : int,
-      blocks_to_fill_epoch  : int,
-      next_epoch_length     : int
+      epochs                : map(int, epoch_info)
     }
 
-  record get_state_response =
-    { main_staking_ct       : MainStaking,
-      entropy               : string,
-      leader                : address,
-      added_stake           : int,
-      epoch                 : int,
-      epoch_length          : int
-    }
+  // record get_state_response =
+  //   { main_staking_ct       : MainStaking,
+  //     entropy               : string,
+  //     leader                : address,
+  //     added_stake           : int,
+  //     epoch                 : int,
+  //     epoch_length          : int
+  //   }
 
-  entrypoint init(main_staking_ct : MainStaking, entropy_str : string, epoch_length : int) =
+  entrypoint init(main_staking_ct : MainStaking) =
     { main_staking_ct       = main_staking_ct,
       leader                = Contract.address,
-      entropy               = entropy_str,
       added_stake           = 0,
-      epoch                 = 1,
-      epoch_length          = epoch_length,
-      blocks_to_fill_epoch  = epoch_length,
-      next_epoch_length     = epoch_length
-      }
+      epoch                 = 0,
+      epochs                = {} }
 
-  stateful entrypoint set_next_epoch_length(len : int) =
+  stateful entrypoint init_epochs(epoch_length : int) =
     assert_protocol_call()
-    put(state{epoch_length = len})
+    require(Chain.block_height == 0, "Only in genesis")
+    put(state{ epochs = { [0] = mk_epoch_info(0, 1, None, None),
+                          [1] = mk_epoch_info(1, epoch_length, None, Some(state.main_staking_ct.sorted_validators())),
+                          [2] = mk_epoch_info(epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.sorted_validators())),
+                          [3] = mk_epoch_info(2 * epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.sorted_validators()))
+                        },
+               epoch  = 1
+             })
 
+  function mk_epoch_info(start : int,
+                         length : int,
+                         seed : option(hash),
+                         staking_distribution : option(list(address * int))) =
+    {start = start, length = length, seed = seed, staking_distribution = staking_distribution}
 
-  stateful entrypoint elect(entropy_str : string, network_id : bytes(15)) =
+  stateful entrypoint step(leader : address) =
     assert_protocol_call()
-    require(state.blocks_to_fill_epoch > 0, "End of epoch reached")
-    let (new_leader, added_staking_power) = elect_(entropy_str, network_id)
-    state.main_staking_ct.post_elect()
-    if (state.blocks_to_fill_epoch > 1)
-       put(state{blocks_to_fill_epoch = state.blocks_to_fill_epoch - 1})
-    else
-       put(state{blocks_to_fill_epoch = state.next_epoch_length,
-                 epoch = state.epoch + 1,
-                 epoch_length = state.next_epoch_length})
-    put(state{ leader = new_leader, entropy = entropy_str, added_stake = added_staking_power})
-    (new_leader, added_staking_power)
+    put(state{ leader = leader })
 
-  stateful entrypoint tick() =
+  stateful entrypoint step_eoe(leader : address, seed : bytes(), epoch_adjust : int) =
     assert_protocol_call()
-    require(state.blocks_to_fill_epoch > 0, "End of epoch reached")
-    if (state.blocks_to_fill_epoch > 1)
-       put(state{blocks_to_fill_epoch = state.blocks_to_fill_epoch - 1})
-    else
-       put(state{blocks_to_fill_epoch = state.next_epoch_length,
-                 epoch = state.epoch + 1,
-                 epoch_length = state.next_epoch_length})
-
-  stateful entrypoint elect_after_lazy_leader(new_leader : address) =
-    assert_protocol_call()
-    let known_validator = state.main_staking_ct.is_validator(new_leader)
-    require(known_validator == true, "Must be a validator")
-    put(state{ leader = new_leader, entropy = "lazy_leader", added_stake = 0})
-    (new_leader, 0)
-
-
-  entrypoint elect_next(entropy_str : string, network_id : bytes(15)) =
-    let (leader, staking_power) = elect_(entropy_str, network_id)
-    (leader, staking_power)
-
-  function elect_(entropy_str : string, network_id) =
-    let Some(current_hash : hash) = Chain.block_hash(Chain.block_height) // current hash!
-    let entropy : hash = Crypto.sha256(entropy_str)
-    let sorted0 = state.main_staking_ct.sorted_validators()
-    // Further filter based on prefix of the hash of the staker pubkey being somewhere in sorted0 and the signature being correct
-    let (sorted, total_stake, _, _)  = List.foldl(accum_stake, ([], 0, current_hash, network_id), sorted0)
-
-    let shot = Bytes.to_int(entropy) mod total_stake
-    switch(find_validator(sorted, shot))
-      None => abort("NO CANDIDATE") // should not be possible
-      Some(new_leader) => (new_leader, total_stake)
+    let epoch = state.epoch
+    let ei = state.epochs[epoch]
+    // require(ei.start + ei.length - 1 == Chain.block_height, "This is not the end")
+    let ei2 = state.epochs[epoch + 2]
+    let new_epochs = { [epoch] = state.epochs[epoch],
+                       [epoch + 1] = state.epochs[epoch + 1]{ seed = Some(Crypto.blake2b(seed)) },
+                       [epoch + 2] = state.epochs[epoch + 2],
+                       [epoch + 3] = mk_epoch_info(ei2.start + ei2.length + 1, ei2.length + epoch_adjust, None,
+                                                   Some(state.main_staking_ct.sorted_validators()))
+                     }
+    put(state{ leader = leader,
+               epoch  = epoch + 1,
+               epochs = new_epochs })
 
   entrypoint leader() =
     state.leader
 
-  entrypoint added_stake() =
-    state.added_stake
+  // entrypoint added_stake() =
+  //   state.added_stake
 
   entrypoint epoch() =
     state.epoch
 
   entrypoint epoch_length() =
-    state.epoch_length
+    state.epochs[state.epoch].length
 
-  entrypoint blocks_to_fill_epoch() =
-    state.blocks_to_fill_epoch
+  entrypoint epoch_info() =
+    (state.epoch, state.epochs[state.epoch])
 
-  entrypoint validator_schedule(seed : bytes(), validators : list(address * int), length : int) =
+  entrypoint epoch_info_epoch(epoch : int) =
+    require(epoch >= state.epoch - 1 && epoch =< state.epoch + 2, "Epoch not in scope")
+    state.epochs[epoch]
+
+  entrypoint get_validator_schedule() =
+    let ei = state.epochs[state.epoch]
+    validator_schedule(Option.force(ei.seed), Option.force(ei.staking_distribution), ei.length)
+
+  entrypoint get_validator_schedule_seed(seed : bytes()) =
+    let ei = state.epochs[state.epoch]
+    validator_schedule(Crypto.blake2b(seed), Option.force(ei.staking_distribution), ei.length)
+
+  entrypoint validator_schedule(seed : hash, validators : list(address * int), length : int) =
     let total_stake = List.foldl((+), 0, List.map(Pair.snd, validators))
     // One extra hash operation to convert from bytes() tp bytes(32)/hash
-    validator_schedule_(Crypto.blake2b(seed), (s) => Bytes.to_int(s) mod total_stake, validators, length, [])
+    validator_schedule_(seed, (s) => Bytes.to_int(s) mod total_stake, validators, length, [])
 
   function
     validator_schedule_(_, _, _, 0, schedule) = List.reverse(schedule)
@@ -123,26 +120,26 @@ main contract HCElection =
     pick_validator(n, (validator, stake) :: _) | n < stake = validator
     pick_validator(n, (_, stake) :: validators)            = pick_validator(n - stake, validators)
 
-  entrypoint get_state() : get_state_response =
-    { main_staking_ct   = state.main_staking_ct,
-      entropy           = state.entropy,
-      leader            = state.leader,
-      added_stake       = state.added_stake,
-      epoch             = state.epoch,
-      epoch_length      = state.epoch_length
-      }
+  // entrypoint get_state() : get_state_response =
+  //   { main_staking_ct   = state.main_staking_ct,
+  //     entropy           = state.entropy,
+  //     leader            = state.leader,
+  //     added_stake       = state.added_stake,
+  //     epoch             = state.epoch,
+  //     epoch_length      = state.epoch_length
+  //     }
 
-  function find_validator(validators, shot) =
-    switch(validators)
-      []   => None
-      (validator_addr, validator_stake : int)::t =>
-        if(validator_stake > shot) Some(validator_addr)
-        else find_validator(t, shot - validator_stake)
+  // function find_validator(validators, shot) =
+  //   switch(validators)
+  //     []   => None
+  //     (validator_addr, validator_stake : int)::t =>
+  //       if(validator_stake > shot) Some(validator_addr)
+  //       else find_validator(t, shot - validator_stake)
 
   function assert_protocol_call() =
       require(Call.caller == Contract.creator, "Must be called by the protocol")
 
-  function accum_stake((accum, total_s, current_hash, network_id), (addr, stake)) =
-    ((addr, stake) :: accum, stake + total_s, current_hash, network_id)
+  // function accum_stake((accum, total_s, current_hash, network_id), (addr, stake)) =
+  //   ((addr, stake) :: accum, stake + total_s, current_hash, network_id)
 
 


### PR DESCRIPTION
Extended the contract to keep track of the four cycles, i.e. four epochs.

Added `aec_chain_hc` as interface module (good for testing)
Added additional tests

This PR is supported by Æternity Foundation