### PR TITLE
Parent connector return chain type

### DIFF
--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -40,7 +40,8 @@
         %% internal state getters
         get_network_id/0,
         get_parent_conn_mod/0,
-        get_sign_module/0
+        get_sign_module/0,
+        get_parent_chain_type/0
         ]).
 
 %% Callbacks
@@ -154,6 +155,9 @@ handle_call(get_sign_module, _From, #state{sign_module = SM} = State) ->
     {reply, SM, State};
 handle_call(get_parent_conn_mod, _From, #state{parent_conn_mod = ParentConnMod} = State) ->
     {reply, ParentConnMod, State};
+handle_call(get_parent_chain_type, _From, #state{parent_conn_mod = ParentConnMod} = State) ->
+    Reply = ParentConnMod:get_chain_type(),
+    {reply, Reply, State};
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
@@ -318,3 +322,7 @@ get_parent_conn_mod() ->
 
 get_sign_module() ->
     gen_server:call(?SERVER, get_sign_module).
+
+-spec get_parent_chain_type() -> {ok, atom()}.
+get_parent_chain_type() ->
+    gen_server:call(?SERVER, get_parent_chain_type).

--- a/apps/aecore/src/aec_pinning_agent.erl
+++ b/apps/aecore/src/aec_pinning_agent.erl
@@ -28,12 +28,12 @@ get_pinning_data() ->
     }} = aec_chain_hc:epoch_info(),
     {ok, BlockHash} = aec_chain_state:get_key_block_hash_at_height(First-1),
     ConMod = aec_parent_connector:get_parent_conn_mod(),
-    {_,Type} = lists:split(8,atom_to_list(ConMod)), % split off "aehttpc_" from mod name to get type
+    {ok,ChainType} = ConMod:get_chain_type(), % split off "aehttpc_" from mod name to get type
     
     #{epoch             => Epoch-1,
       height            => First-1,
       block_hash        => BlockHash,
-      parent_type       => Type,
+      parent_type       => ChainType,
       parent_network_id => aec_parent_connector:get_network_id()}.
 
 

--- a/apps/aecore/src/aec_pinning_agent.erl
+++ b/apps/aecore/src/aec_pinning_agent.erl
@@ -27,8 +27,7 @@ get_pinning_data() ->
            length := _Length
     }} = aec_chain_hc:epoch_info(),
     {ok, BlockHash} = aec_chain_state:get_key_block_hash_at_height(First-1),
-    ConMod = aec_parent_connector:get_parent_conn_mod(),
-    {ok,ChainType} = ConMod:get_chain_type(), % split off "aehttpc_" from mod name to get type
+    {ok, ChainType} = aec_parent_connector:get_parent_chain_type(),
     
     #{epoch             => Epoch-1,
       height            => First-1,

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -899,7 +899,7 @@ handle_request_('GetPinningTx', _Params, _Context) ->
     {200, [], #{<<"epoch">> => Epoch,
                 <<"height">> => CCHeight,
                 <<"block_hash">> => aeser_api_encoder:encode(key_block_hash, EpochBlockHash),
-                <<"parent_type">> => list_to_binary(Type),
+                <<"parent_type">> => atom_to_binary(Type),
                 <<"parent_network_id">> => Id        
         }};
 

--- a/apps/aehttp/src/aehttpc.erl
+++ b/apps/aehttp/src/aehttpc.erl
@@ -20,6 +20,7 @@
 -type height() :: non_neg_integer().
 -type time() :: non_neg_integer().
 -type pubkey() :: binary().
+-type chain() :: aeternity | btc | doge.
 
 -export_type([ node_spec/0 ]).
 
@@ -32,6 +33,8 @@
 -callback get_header_by_height(height(), node_spec(), seed()) ->
     {ok, hash(), hash(), height(), time()} | {error, term()}.
 
+-callback get_chain_type() ->
+    {ok, chain()}.
 
 -spec parse_node_url(string()) -> node_spec().
 parse_node_url(NodeURL) ->

--- a/apps/aehttp/src/aehttpc_aeternity.erl
+++ b/apps/aehttp/src/aehttpc_aeternity.erl
@@ -12,7 +12,8 @@
 %% Util exports
 -export([get_generation/2,
 get_generation_by_height/2,
-post_request/4]).
+post_request/4,
+get_chain_type/0]).
 
 -behavior(aehttpc).
 
@@ -25,6 +26,9 @@ get_header_by_hash(Hash, NodeSpec, _Seed) ->
 
 get_header_by_height(Height, NodeSpec, _Seed) ->
     get_key_block_header_by_height(Height, NodeSpec).
+
+get_chain_type() ->
+    {ok, aeternity}.
 
 hash_to_integer(Hash) ->
     {_, HashBin} = aeser_api_encoder:decode(Hash),

--- a/apps/aehttp/src/aehttpc_btc.erl
+++ b/apps/aehttp/src/aehttpc_btc.erl
@@ -10,7 +10,8 @@
         %  get_commitment_tx_in_block/5,
         %  get_commitment_tx_at_height/4,
         %  post_commitment/8,
-         hash_to_integer/1]).
+         hash_to_integer/1,
+         get_chain_type/0]).
 
 %% Temporary exports for keeping useful chain utils around
 -export([select_utxo/2,
@@ -63,6 +64,9 @@ get_header_by_height(Height, NodeSpec, Seed) ->
 
 hash_to_integer(Hash) ->
     binary_to_integer(Hash, 16).
+
+get_chain_type() ->
+    {ok, btc}.
 
 select_utxo([#{<<"spendable">> := true, <<"amount">> := Amount} = Unspent | _Us], Needed) when Amount >= Needed ->
     %% For now just pick first spendable UTXO with enough funds. There is no end to how fancy this can get

--- a/apps/aehttp/src/aehttpc_doge.erl
+++ b/apps/aehttp/src/aehttpc_doge.erl
@@ -10,7 +10,8 @@
         %  get_commitment_tx_in_block/5,
         %  get_commitment_tx_at_height/4,
         %  post_commitment/8,
-         hash_to_integer/1]).
+         hash_to_integer/1,
+         get_chain_type/0]).
 
 %% Temporary exports for keeping useful chain utils around
 -export([select_utxo/2,
@@ -53,6 +54,9 @@ get_header_by_height(Height, NodeSpec, Seed) ->
 
 hash_to_integer(Hash) ->
     binary_to_integer(Hash, 16).
+
+get_chain_type() ->
+    {ok, doge}.
 
 % get_commitment_tx_in_block(NodeSpec, Seed, BlockHash, _PrevHash, ParentHCAccountPubKey) ->
 %     {ok, {_Height, _Hash, __PrevHash, Txs}}

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -832,7 +832,7 @@ get_pin(Config) ->
 
     %% note: the pins are for the last block in previous epoch
     Repl1 = aecore_suite_utils:http_request(aecore_suite_utils:external_address(), get, "hyperchain/pin-tx", []),
-    {ok, 200, #{<<"epoch">> := PrevEpoch, <<"height">> := Height1, <<"block_hash">> := BH1}} = Repl1,
+    {ok, 200, #{<<"epoch">> := PrevEpoch, <<"height">> := Height1, <<"block_hash">> := BH1, <<"parent_type">> := <<"aeternity">>}} = Repl1,
     {ok, BH1Dec} = aeser_api_encoder:safe_decode(key_block_hash, BH1),
     ?assertEqual({epoch, Epoch - 1}, {epoch, PrevEpoch}),
     ?assertEqual(maps:get(first, EpochInfo1) - 1, Height1),


### PR DESCRIPTION
- aehttpc type define get_chain_type()- implemented by ae/btc/doge impls
- pinning agent updated to use get_chain_type
- disaptcher updated to handle atom() instead of binary() type
- test case updated to check for type aeternity