### PR TITLE
Reverse key-block/micro-block order

### DIFF
--- a/apps/aecore/src/aec_block_insertion.erl
+++ b/apps/aecore/src/aec_block_insertion.erl
@@ -240,12 +240,20 @@ build_insertion_ctx_prev(Node, PrevKeyNode) ->
    end.
 
 build_insertion_ctx_check_prev_height(#node{type = key} = Node, PrevNode, PrevKeyNode) ->
-    case node_height(PrevNode) =:= (node_height(Node) - 1) of
+    ConsensusModule = node_consensus(Node),
+    ExpectedHeight =
+        ConsensusModule:key_block_height_relative_previous_block(node_type(PrevNode),
+                                                                 node_height(PrevNode)),
+    case ExpectedHeight =:= node_height(Node) of
         true -> {ok, PrevNode, PrevKeyNode};
         false -> {error, height_inconsistent_for_keyblock_with_previous_hash}
     end;
 build_insertion_ctx_check_prev_height(#node{type = micro} = Node, PrevNode, PrevKeyNode) ->
-    case node_height(PrevNode) =:= node_height(Node) of
+    ConsensusModule = node_consensus(Node),
+    ExpectedHeight =
+        ConsensusModule:micro_block_height_relative_previous_block(node_type(PrevNode),
+                                                                   node_height(PrevNode)),
+    case ExpectedHeight =:= node_height(Node) of
         true -> {ok, PrevNode, PrevKeyNode};
         false -> {error, height_inconsistent_for_microblock_with_previous_hash}
     end.

--- a/apps/aecore/src/aec_block_key_candidate.erl
+++ b/apps/aecore/src/aec_block_key_candidate.erl
@@ -12,7 +12,7 @@
 -include("blocks.hrl").
 
 %% -- API functions ----------------------------------------------------------
--spec create(BlockHash, Beneficiary, Miner) -> {ok, aec_blocks:block()} | {error, term()} 
+-spec create(BlockHash, Beneficiary, Miner) -> {ok, aec_blocks:block()} | {error, term()}
   when BlockHash :: aec_blocks:block() | aec_blocks:block_header_hash()
      , Beneficiary :: aec_keys:pubkey()
      , Miner :: aec_keys:pubkey().
@@ -25,45 +25,45 @@ create(BlockHash, Beneficiary, Miner) when is_binary(BlockHash) ->
     end;
 create(Block, Beneficiary, Miner) ->
     {ok, BlockHash} = aec_blocks:hash_internal_representation(Block),
-    Height = aec_blocks:height(Block) + 1,
+    ConsensusModule = aec_blocks:consensus_module(Block),
+    Height = ConsensusModule:key_block_height_relative_previous_block(aec_blocks:type(Block),
+                                                                      aec_blocks:height(Block)),
     Protocol = aec_hard_forks:protocol_effective_at_height(Height),
-    int_create(BlockHash, Block, Beneficiary, Miner, Protocol).
+    int_create(Height, BlockHash, Block, Beneficiary, Miner, Protocol).
 
 %% -- Internal functions -----------------------------------------------------
 
-int_create(BlockHash, Block, Beneficiary, Miner, Protocol) ->
-    H = aec_blocks:height(Block) + 1,
-    Consensus = aec_consensus:get_consensus_module_at_height(H),
+int_create(Height, BlockHash, Block, Beneficiary, Miner, Protocol) ->
+    Consensus = aec_consensus:get_consensus_module_at_height(Height),
     N = Consensus:keyblocks_for_target_calc() + 1,
     case aec_blocks:height(Block) < N of
         true  ->
-            int_create_(BlockHash, Block, Beneficiary, Miner, [], Protocol);
+            int_create_(Height, BlockHash, Block, Beneficiary, Miner, [], Protocol);
         false ->
             case N of
                 1 ->
-                    int_create_(BlockHash, Block, Beneficiary, Miner, [], Protocol);
+                    int_create_(Height, BlockHash, Block, Beneficiary, Miner, [], Protocol);
                 _ ->
                     case aec_chain:get_n_generation_headers_backwards_from_hash(BlockHash, N) of
                         {ok, Headers} ->
-                            int_create_(BlockHash, Block, Beneficiary, Miner, Headers, Protocol);
+                            int_create_(Height, BlockHash, Block, Beneficiary, Miner, Headers, Protocol);
                         error ->
                             {error, headers_for_target_adjustment_not_found}
                     end
             end
     end.
 
-int_create_(PrevBlockHash, PrevBlock, Beneficiary, Miner, AdjChain, Protocol) ->
-    {ok, Trees} =
-        aec_chain_state:calculate_state_for_new_keyblock(PrevBlockHash, Miner, Beneficiary, Protocol),
-    Block = int_create_block(PrevBlockHash, PrevBlock, Miner, Beneficiary, Trees, Protocol),
+int_create_(Height, PrevBlockHash, PrevBlock, Beneficiary, Miner, AdjChain, Protocol) ->
+    {ok, Trees} = aec_chain_state:calculate_state_for_new_keyblock(Height, PrevBlockHash,
+                                                                   Miner, Beneficiary, Protocol),
+    Block = int_create_block(Height, PrevBlockHash, PrevBlock, Miner, Beneficiary, Trees, Protocol),
     Consensus = aec_blocks:consensus_module(Block),
     case Consensus:keyblock_create_adjust_target(Block, AdjChain) of
         {ok, AdjBlock} -> {ok, AdjBlock};
         {error, Reason} -> {error, {failed_to_adjust_target, Reason}}
     end.
 
-int_create_block(PrevBlockHash, PrevBlock, Miner, Beneficiary, Trees, Protocol) ->
-    Height = aec_blocks:height(PrevBlock) + 1,
+int_create_block(Height, PrevBlockHash, PrevBlock, Miner, Beneficiary, Trees, Protocol) ->
     Consensus = aec_consensus:get_consensus_module_at_height(Height),
     PrevKeyHash = case aec_blocks:type(PrevBlock) of
                       micro -> aec_blocks:prev_key_hash(PrevBlock);

--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -143,7 +143,10 @@ int_create_block(MBEnv, TxEnv, Txs, Trees, Events) ->
       prev_block := PrevBlock, prev_hash := PrevBlockHash} = MBEnv,
     Time = aetx_env:time_in_msecs(TxEnv),
     Protocol = aec_blocks:version(KeyBlock),
-    Height = aec_blocks:height(KeyBlock),
+
+    %% Heigth is relative to last key-block.
+    ConsensusModule = aec_blocks:consensus_module(KeyBlock),
+    Height = ConsensusModule:micro_block_height_relative_previous_block(key, aec_blocks:height(KeyBlock)),
 
     TxsTree = aec_txs_trees:from_txs(Txs),
     TxsRootHash = aec_txs_trees:pad_empty(aec_txs_trees:root_hash(TxsTree)),

--- a/apps/aecore/src/aec_chain.erl
+++ b/apps/aecore/src/aec_chain.erl
@@ -723,76 +723,67 @@ get_key_block_by_height(Height) when is_integer(Height), Height >= 0 ->
 
 -spec get_current_generation() -> 'error' | {'ok', generation()}.
 get_current_generation() ->
-    get_generation_(top_block_node()).
-
-get_generation_(#{hash := Hash, header := Header}) ->
-    case aec_headers:type(Header) of
-        key ->
-            {ok, #{ key_block => aec_blocks:new_key_from_header(Header), micro_blocks => [], dir => forward }};
-        micro ->
-            Index = maps:from_list(aec_db:find_headers_and_hash_at_height(aec_headers:height(Header))),
-            get_generation_with_header_index(Hash, Index)
-    end;
-get_generation_(Hash) when is_binary(Hash) ->
-    case get_header(Hash) of
-        error -> error;
-        {ok, Header} ->
-            get_generation_(#{hash => Hash, header => Header})
-    end;
-get_generation_(_) ->
-    error.
-
-get_generation_with_header_index(TopHash, Index) ->
-    get_generation_with_header_index(TopHash, Index, []).
-
-get_generation_with_header_index(TopHash, Index, MBs) ->
-    H = maps:get(TopHash, Index),
-    case aec_headers:type(H) of
-        key -> {ok, #{ key_block => aec_blocks:new_key_from_header(H), micro_blocks => MBs, dir => forward }};
-        micro ->
-            Block = aec_db:get_block_from_micro_header(TopHash, H),
-            get_generation_with_header_index(aec_headers:prev_hash(H), Index, [Block | MBs])
-    end.
+    #{header := TopHeader} = top_block_node(),
+    get_generation_by_height(aec_headers:height(TopHeader), forward).
 
 -spec get_generation_by_hash(binary(), forward | backward) ->
         'error' | {'ok', generation()}.
 get_generation_by_hash(KeyBlockHash, Dir) ->
     case aec_db:find_key_block(KeyBlockHash) of
         none -> error;
-        {value, KeyBlock} when Dir == backward ->
-            case get_generation_(aec_blocks:prev_hash(KeyBlock)) of
-                error         -> error;
-                {ok, G = #{}} -> {ok, G#{ key_block => KeyBlock, dir => Dir }}
-            end;
-        {value, KeyBlock} when Dir == forward ->
-            case get_generation_by_height(aec_blocks:height(KeyBlock), forward) of
-                {ok, G = #{ key_block := KeyBlock }} -> {ok, G};
-                {ok, _G}                             -> error; %% KeyBlockHash not on chain!!
-                error                                -> error
-            end
+        {value, KeyBlock} -> get_generation_by_height(aec_blocks:height(KeyBlock), KeyBlock, Dir)
     end.
 
 -spec get_generation_by_height(aec_blocks:height(), forward | backward) ->
         'error' | {'ok', generation()}.
-get_generation_by_height(Height, backward) ->
+get_generation_by_height(Height, Dir) ->
     case get_key_block_by_height(Height) of
         {error, _Reason} -> error;
-        {ok, KeyBlock} ->
-            case get_generation_(aec_blocks:prev_hash(KeyBlock)) of
-                error         -> error;
-                {ok, G = #{}} -> {ok, G#{ key_block => KeyBlock, dir => backward }}
-            end
-    end;
-get_generation_by_height(Height, forward) ->
-    #{header := TopHeader} = TopNode = top_block_node(),
+        {ok, KeyBlock}   -> get_generation_by_height(Height, KeyBlock, Dir)
+    end.
+
+get_generation_by_height(Height, KeyBlock, backward) ->
+    get_generation_by_height(Height, KeyBlock, aec_blocks:prev_hash(KeyBlock), backward);
+get_generation_by_height(Height, KeyBlock, forward) ->
+    #{header := TopHeader, hash := TopHash} = top_block_node(),
     TopHeight = aec_headers:height(TopHeader),
-    if TopHeight < Height  -> error;
-       TopHeight == Height -> get_generation_(TopNode);
-       true                ->
-           case get_key_block_by_height(Height + 1) of
-               {error, _Reason} -> error;
-               {ok, KeyBlock}   -> get_generation_(aec_blocks:prev_hash(KeyBlock))
-           end
+    if  TopHeight < Height  -> error;
+        TopHeight == Height -> get_generation_by_height(Height, KeyBlock, TopHash, forward);
+        true                ->
+            case get_key_block_by_height(Height + 1) of
+                {error, _Reason} -> error;
+                {ok, KeyBlock1}  ->
+                    get_generation_by_height(Height, KeyBlock, aec_blocks:prev_hash(KeyBlock1), forward)
+            end
+    end.
+
+get_generation_by_height(Height, KeyBlock, LastMBHash, backward) ->
+    ConsensusModule = aec_blocks:consensus_module(KeyBlock),
+    MBHeight = ConsensusModule:micro_block_height_relative_previous_block(key, Height - 1),
+    get_generation(backward, KeyBlock, MBHeight, LastMBHash);
+get_generation_by_height(Height, KeyBlock, LastMBHash, forward) ->
+    ConsensusModule = aec_blocks:consensus_module(KeyBlock),
+    MBHeight = ConsensusModule:micro_block_height_relative_previous_block(key, Height),
+    get_generation(forward, KeyBlock, MBHeight, LastMBHash).
+
+get_generation(Dir, KeyBlock, MBHeight, LastMBHash) ->
+    {ok, MBs} = get_micro_blocks_at_height(MBHeight, LastMBHash),
+    {ok, #{ key_block => KeyBlock, micro_blocks => MBs, dir => Dir }}.
+
+get_micro_blocks_at_height(Height, LastMBHash) ->
+    Index = maps:from_list(aec_db:find_headers_and_hash_at_height(Height)),
+    get_micro_blocks_at_height(LastMBHash, Index, []).
+
+get_micro_blocks_at_height(Hash, Index, MBs) ->
+    case maps:get(Hash, Index, undefined) of
+        undefined -> {ok, MBs};
+        H ->
+            case aec_headers:type(H) of
+                key -> {ok, MBs};
+                micro ->
+                    Block = aec_db:get_block_from_micro_header(Hash, H),
+                    get_micro_blocks_at_height(aec_headers:prev_hash(H), Index, [Block | MBs])
+            end
     end.
 
 %%%===================================================================

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -75,7 +75,7 @@
 
 -module(aec_chain_state).
 
--export([ calculate_state_for_new_keyblock/4
+-export([ calculate_state_for_new_keyblock/5
         , find_common_ancestor/2
         , get_key_block_hash_at_height/1
         , key_block_hashes_at_height/1
@@ -271,16 +271,16 @@ hash_is_in_main_chain(Hash) ->
     end.
 
 -spec calculate_state_for_new_keyblock(
+        non_neg_integer(),
         binary(),
         aec_keys:pubkey(),
         aec_keys:pubkey(),
         aec_hard_forks:protocol_vsn()) -> {'ok', aec_trees:trees()} | 'error'.
-calculate_state_for_new_keyblock(PrevHash, Miner, Beneficiary, Protocol) ->
+calculate_state_for_new_keyblock(Height, PrevHash, Miner, Beneficiary, Protocol) ->
     aec_db:ensure_transaction(fun() ->
         case db_find_node(PrevHash) of
             error -> error;
             {ok, PrevNode} ->
-                Height = node_height(PrevNode) + 1,
                 Node  = fake_key_node(PrevNode, Height, Miner, Beneficiary, Protocol),
                 State = new_state_from_persistence(),
                 case get_state_trees_in(Node, true) of

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -505,9 +505,14 @@ get_key_block_hash_at_height(Height, State) when is_integer(Height), Height >= 0
             case Height > TopHeight of
                 true -> error;
                 false ->
+                    ConsensusModule = aec_block_insertion:node_consensus(TopNode),
                     case db_find_key_nodes_at_height(Height) of
-                        error        -> error({broken_chain, Height});
-                        {ok, [Node]} -> {ok, node_hash(Node)};
+                        error when ConsensusModule == aec_consensus_hc ->
+                            error;
+                        error ->
+                            error({broken_chain, Height});
+                        {ok, [Node]} ->
+                            {ok, node_hash(Node)};
                         {ok, [_|_] = Nodes} ->
                             {ok, {MaybeChokeNode, ChokePt}} = choke_point(Height, TopHeight, TopNode, TopHash),
                             keyblock_hash_in_main_chain(Nodes, MaybeChokeNode, ChokePt)

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1372,7 +1372,7 @@ hc_create_microblock(ConsensusModule, TopHash, Leader) ->
                     MBHash
             end;
         _ ->
-            epoch_mining:debug("Failed micro-block, top is still: ~p", [TopHash]),
+            epoch_mining:info("Failed micro-block, top is still: ~p", [TopHash]),
             TopHash
     end.
 

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1553,8 +1553,10 @@ is_leader(NewTopBlock, PrevKeyHeader, ConsensusModule) ->
     end.
 
 setup_loop(State = #state{ mode = pos,
-                           consensus = #consensus{ consensus_module = aec_consensus_hc } }, _, _, _) ->
-    State;
+                           consensus = #consensus{ consensus_module = aec_consensus_hc } }, Restart, _, _) ->
+    if not Restart -> create_key_block_candidate(State);
+       true        -> State
+    end;
 setup_loop(State = #state{ consensus = Cons }, RestartMining, IsLeader, Origin) ->
     State1 = State#state{ consensus = Cons#consensus{ leader = IsLeader } },
     State2 =

--- a/apps/aecore/src/aec_consensus.erl
+++ b/apps/aecore/src/aec_consensus.erl
@@ -162,6 +162,10 @@
 -callback dirty_validate_key_node_with_ctx(#node{}, aec_blocks:micro_block(), #insertion_ctx{}) -> ok | {error, term()}.
 -callback dirty_validate_micro_node_with_ctx(#node{}, aec_blocks:micro_block(), #insertion_ctx{}) -> ok | {error, term()}.
 
+%% Callbacks handling block structure differences between PoW and PoS/HC.
+-callback key_block_height_relative_previous_block(key | micro, non_neg_integer()) -> non_neg_integer().
+-callback micro_block_height_relative_previous_block(key | micro, non_neg_integer()) -> non_neg_integer().
+
 %% Customized state transitions - in case of keyblocks the callbacks are called with pruned state trees
 %% Those callbacks run in a DB context - to abort the execution please call aec_block_insertion:abort_state_transition(Reason)
 %% Performs initial state transformation when the previous block used a different consensus algorithm

--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -29,6 +29,9 @@
         %% Dirty validation before starting the state transition
         , dirty_validate_key_node_with_ctx/3
         , dirty_validate_micro_node_with_ctx/3
+        %% Block structure
+        , key_block_height_relative_previous_block/2
+        , micro_block_height_relative_previous_block/2
         %% State transition
         , state_pre_transform_key_node_consensus_switch/2
         , state_pre_transform_key_node/3
@@ -415,6 +418,15 @@ get_fraud_miner(Ctx) ->
 
 time_diff_greater_than_minimal(Node, PrevNode) ->
     aec_block_insertion:node_time(Node) >= aec_block_insertion:node_time(PrevNode) + aec_governance:micro_block_cycle().
+
+%% ------------------------------------------------------------------------
+%% -- Block structure
+%% ------------------------------------------------------------------------
+key_block_height_relative_previous_block(_Type, Height) ->
+    Height + 1.
+
+micro_block_height_relative_previous_block(_Type, Height) ->
+    Height.
 
 %% -------------------------------------------------------------------
 %% Custom state transitions

--- a/apps/aecore/src/aec_consensus_common_tests.erl
+++ b/apps/aecore/src/aec_consensus_common_tests.erl
@@ -35,6 +35,9 @@
         %% Dirty validation before starting the state transition
         , dirty_validate_key_node_with_ctx/3
         , dirty_validate_micro_node_with_ctx/3
+        %% Block structure
+        , key_block_height_relative_previous_block/2
+        , micro_block_height_relative_previous_block/2
         %% State transition
         , state_pre_transform_key_node_consensus_switch/2
         , state_pre_transform_key_node/3
@@ -170,6 +173,15 @@ dirty_validate_key_hash_at_height(_, _) -> ok.
 %% Don't waste CPU cycles when we are only interested in state transitions...
 dirty_validate_key_node_with_ctx(_Node, _Block, _Ctx) -> ok.
 dirty_validate_micro_node_with_ctx(_Node, _Block, _Ctx) -> ok.
+
+%% ------------------------------------------------------------------------
+%% -- Block structure
+%% ------------------------------------------------------------------------
+key_block_height_relative_previous_block(_Type, Height) ->
+    Height + 1.
+
+micro_block_height_relative_previous_block(_Type, Height) ->
+    Height.
 
 %% -------------------------------------------------------------------
 %% Custom state transitions

--- a/apps/aecore/src/aec_consensus_on_demand.erl
+++ b/apps/aecore/src/aec_consensus_on_demand.erl
@@ -34,6 +34,9 @@
         %% Dirty validation before starting the state transition
         , dirty_validate_key_node_with_ctx/3
         , dirty_validate_micro_node_with_ctx/3
+        %% Block structure
+        , key_block_height_relative_previous_block/2
+        , micro_block_height_relative_previous_block/2
         %% State transition
         , state_pre_transform_key_node_consensus_switch/2
         , state_pre_transform_key_node/3
@@ -187,6 +190,15 @@ dirty_validate_key_hash_at_height(_, _) -> ok.
 %% Don't waste CPU cycles when we are only interested in state transitions...
 dirty_validate_key_node_with_ctx(_Node, _Block, _Ctx) -> ok.
 dirty_validate_micro_node_with_ctx(_Node, _Block, _Ctx) -> ok.
+
+%% ------------------------------------------------------------------------
+%% -- Block structure
+%% ------------------------------------------------------------------------
+key_block_height_relative_previous_block(_Type, Height) ->
+    Height + 1.
+
+micro_block_height_relative_previous_block(_Type, Height) ->
+    Height.
 
 %% -------------------------------------------------------------------
 %% Custom state transitions

--- a/apps/aecore/src/aec_consensus_smart_contract.erl
+++ b/apps/aecore/src/aec_consensus_smart_contract.erl
@@ -39,6 +39,9 @@
         %% Dirty validation before starting the state transition
         , dirty_validate_key_node_with_ctx/3
         , dirty_validate_micro_node_with_ctx/3
+        %% Block structure
+        , key_block_height_relative_previous_block/2
+        , micro_block_height_relative_previous_block/2
         %% State transition
         , state_pre_transform_key_node_consensus_switch/2
         , state_pre_transform_key_node/3
@@ -126,6 +129,15 @@ dirty_validate_key_hash_at_height(_, _) -> ok.
 %% Don't waste CPU cycles when we are only interested in state transitions...
 dirty_validate_key_node_with_ctx(_Node, _Block, _Ctx) -> ok.
 dirty_validate_micro_node_with_ctx(_Node, _Block, _Ctx) -> ok.
+
+%% ------------------------------------------------------------------------
+%% -- Block structure
+%% ------------------------------------------------------------------------
+key_block_height_relative_previous_block(_Type, Height) ->
+    Height + 1.
+
+micro_block_height_relative_previous_block(_Type, Height) ->
+    Height.
 
 %% -------------------------------------------------------------------
 %% Custom state transitions

--- a/apps/aecore/src/aec_preset_keys.erl
+++ b/apps/aecore/src/aec_preset_keys.erl
@@ -7,6 +7,7 @@
          candidate_pubkey/0,
          promote_candidate/1,
          sign_micro_block/1,
+         sign_micro_block/2,
          produce_key_header_signature/2,
          is_ready/0,
          sign_binary/2,
@@ -82,9 +83,16 @@ set_random_candidate() ->
 
 -spec sign_micro_block(aec_blocks:block()) -> {ok, aec_blocks:block()} | {error, term()}.
 sign_micro_block(MicroBlock) ->
+    case get_pubkey() of
+        {ok, Active} -> sign_micro_block(MicroBlock, Active);
+        Err          -> Err
+    end.
+
+-spec sign_micro_block(aec_blocks:block(), aec_keys:pubkey()) -> {ok, aec_blocks:block()} | {error, term()}.
+sign_micro_block(MicroBlock, Signer) ->
     Header = aec_blocks:to_micro_header(MicroBlock),
     Bin = aec_headers:serialize_to_signature_binary(Header),
-    {ok, Signature} = gen_server:call(?MODULE, {sign, Bin}),
+    {ok, Signature} = gen_server:call(?MODULE, {sign, Bin, Signer}),
     {ok, aec_blocks:set_signature(MicroBlock, Signature)}.
 
 -spec sign_binary(Bin, Signer) -> {ok, Signature} | {error, Reason}
@@ -229,6 +237,6 @@ get_random_pubkey(#state{keys = Keys}) ->
     Pubkeys = maps:keys(Keys),
     case length(Pubkeys) of
         0 -> error;
-        Len -> 
+        Len ->
             {ok, lists:nth(rand:uniform(Len), Pubkeys)}
     end.

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -1188,8 +1188,11 @@ do_fetch_generation_ext(Hash, PeerId) ->
 gen_is_consecutive(backward, _KB, []) ->
     ok;
 gen_is_consecutive(backward, KB, [MB]) ->
+    ConsensusModule = aec_blocks:consensus_module(KB),
+    ExpectedHeight =
+        ConsensusModule:key_block_height_relative_previous_block(micro, aec_blocks:height(MB)),
     case
-        (aec_blocks:height(KB) =:= (1 + aec_blocks:height(MB)))
+        (aec_blocks:height(KB) =:= ExpectedHeight)
         andalso (aec_blocks:prev_hash(KB) =:= header_hash(MB))
     of
         false -> {error, {MB, KB}};

--- a/apps/aecore/test/aec_chain_tests.erl
+++ b/apps/aecore/test/aec_chain_tests.erl
@@ -969,9 +969,10 @@ fork_gen_key_candidate() ->
     %% The new key block candidate will have the same protocol version as the
     %% last block of hard chain.
     Protocol = aec_blocks:version(TopBlock),
+    Height   = aec_blocks:height(TopBlock) + 1,
     ?assertMatch({ok, _},
                  aec_chain_state:calculate_state_for_new_keyblock(
-                   TopBlockHash, Pubkey, Pubkey, Protocol)),
+                   Height, TopBlockHash, Pubkey, Pubkey, Protocol)),
     ok.
 
 %%%===================================================================

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -367,7 +367,8 @@ wait_same_top(Nodes) ->
     wait_same_top(Nodes, 3).
 
 wait_same_top(_Nodes, Attempts) when Attempts < 1 ->
-    {error, run_out_of_attempts};
+    %% {error, run_out_of_attempts};
+    throw({error, run_out_of_attempts});
 wait_same_top(Nodes, Attempts) ->
     KBs = [ rpc(Node, aec_chain, top_block, []) || Node <- Nodes ],
     case lists:usort(KBs) of
@@ -1156,7 +1157,7 @@ calc_rewards(RewardForHeight) ->
     {ok, #{key_block := PrevKB,
            micro_blocks := MBs}}
         = rpc(?NODE1, aec_chain, get_generation_by_height,
-              [RewardForHeight - 1, forward]),
+              [RewardForHeight, backward]),
     PrevGenProtocol = aec_blocks:version(PrevKB),
     Txs = lists:flatten(
             lists:map(
@@ -1445,11 +1446,11 @@ produce_to_cc_height(Config, TopHeight, GoalHeight, ParentProduce) ->
                          ct:log("CC ~p mined block: ~p", [N, Block]),
                          Block;
                     {ok, _Txs} ->
-                         {ok, [{N1, KB}, {N2, MB}]} = mine_cc_blocks(NodeNames, 2),
+                         {ok, [{N1, MB}, {N2, KB}]} = mine_cc_blocks(NodeNames, 2),
                          ?assertEqual(key, aec_blocks:type(KB)),
                          ?assertEqual(micro, aec_blocks:type(MB)),
-                         ct:log("CC ~p mined block: ~p", [N1, KB]),
-                         ct:log("CC ~p mined micro block: ~p", [N2, MB]),
+                         ct:log("CC ~p mined micro block: ~p", [N1, MB]),
+                         ct:log("CC ~p mined key block:   ~p", [N2, KB]),
                          KB
                 end,
             Producer = get_block_producer_name(?config(staker_names, Config), KeyBlock),


### PR DESCRIPTION
This is a complex operation - some of the existing tests for PoW should preferably be run also on this...

This change also taints the existing code (especially the rewrite of `get_generation_by_<height/hash` is invasive) but it is impossible to avoid as far as I can see. But let's see what the review can unravel.

This implements #4418.

This PR is supported by Æternity Foundation.   