### PR TITLE
Review and update uses of time functions in the system.

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -363,10 +363,10 @@ migrate_tables_(Tabs0, Rpt) ->
                all -> [T || T <- all_standalone_tables()];
                _ when is_list(Tabs0) -> Tabs0
            end,
-    T0 = erlang:localtime(),
+    T0 = erlang:monotonic_time(second),
     Res = mnesia_rocksdb_admin:migrate_standalone(rocksdb_copies, Tabs, Rpt),
-    T1 = erlang:localtime(),
-    {ok, {calendar:time_difference(T0, T1), Res}}.
+    T1 = erlang:monotonic_time(second),
+    {ok, {calendar:seconds_to_daystime(T1 - T0), Res}}.
 
 all_standalone_tables() ->
     maps:fold(

--- a/apps/aecore/src/aec_db_gc.erl
+++ b/apps/aecore/src/aec_db_gc.erl
@@ -498,9 +498,9 @@ scan_tree(Name, Height, Hash, Parent) when is_atom(Name)
                                          , is_integer(Height)
                                          , is_binary(Hash)
                                          , is_pid(Parent) ->
-    T0 = erlang:system_time(millisecond),
+    T0 = erlang:monotonic_time(millisecond),
     {ok, Count} = collect_reachable_hashes_fullscan(Name, Height, Hash),
-    T1 = erlang:system_time(millisecond),
+    T1 = erlang:monotonic_time(millisecond),
     ?INFO("GC scan done at ~p (~-13w), Count: ~-9w, Time (ms): ~-8w, hash: ~s",
           [Height, Name, Count, T1 - T0, pp_hash(Hash)]),
     gen_server:cast(Parent, #scanner_done{ tree = Name

--- a/apps/aecore/src/aec_peer_analytics.erl
+++ b/apps/aecore/src/aec_peer_analytics.erl
@@ -182,7 +182,7 @@ log_ping(#{stats := Stats} = St, Pub, Host, Port, GHash, THash, Diff) ->
     St#{stats => Stats#{ Pub => PS }}.
 
 unix_time() ->
-    erlang:monotonic_time(second) + erlang:time_offset(second).
+    erlang:system_time(second).  %% Erlang system view of POSIX time
 
 maybe_schedule_version_probe(#{stats := Stats, probes_pids := PPids, probes_mref := MRefs} = St, Pub) ->
     #{first_seen := First, last_seen := Last, info := Info} = maps:get(Pub, Stats),

--- a/apps/aecore/src/aec_sync_stats.erl
+++ b/apps/aecore/src/aec_sync_stats.erl
@@ -161,7 +161,7 @@ set_sync_stat(Id, SyncStat, State) ->
     lists:keystore(Id, #sync_stat.id, State, touch(SyncStat)).
 
 touch(SyncStat) ->
-    SyncStat#sync_stat{ last_update = now_ms() }.
+    SyncStat#sync_stat{ last_update = erlang:system_time(millisecond) }.
 
 %% -- Stats and aggregation -----------------------------------------------
 empty_agg(Step, Limit) ->
@@ -200,8 +200,3 @@ log_agg_stats(#{t0 := T0, t1 := T1, t := T, gs := Gs, mbs := MBs, txs := Txs}) -
                     [Gs, T / (1000 * Gs), MBs, Txs, TWall / 1_000_000, T / 1_000_000, (T * 100) / TWall]);
 log_agg_stats(_Incomplete) ->
     ok.
-
-%% ------------------------------------------------------------------------
-%% -- Misc helpers
-%% ------------------------------------------------------------------------
-now_ms() -> erlang:system_time(millisecond).

--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -39,7 +39,7 @@ time_since_last_dispatch(HandlerPid) ->
         {_, Dict} ->
             case lists:keyfind(timestamp_key(), 1, Dict) of
                 {_, TS} ->
-                    Now = erlang:monotonic_time(),
+                    Now = timestamp_now(),
                     erlang:convert_time_unit(Now - TS, native, millisecond);
                 _ ->
                     undefined
@@ -51,10 +51,15 @@ time_since_last_dispatch(HandlerPid) ->
 %% Called from websocket_handle()
 %%
 put_timestamp() ->
-    put(timestamp_key(), erlang:monotonic_time()).
+    put(timestamp_key(), timestamp_now()).
 
 timestamp_key() ->
     {?MODULE, last_dispatch}.
+
+timestamp_now() ->
+    %% Use monotonically increasing timestamps (not guaranteed distinct).
+    %% Can be used for time deltas, but not compared between systems.
+    erlang:monotonic_time().
 
 %% ===========================================================================
 

--- a/apps/aemon/src/aemon_publisher.erl
+++ b/apps/aemon/src/aemon_publisher.erl
@@ -68,7 +68,7 @@ balance() ->
     end.
 
 post_tx() ->
-    Timestamp = os:system_time(seconds),
+    Timestamp = os:system_time(second),
     {Height, Protocol, HashKey, HashTop} = top_info(),
     Payload = to_payload(Height, HashKey, HashTop, Timestamp),
 

--- a/apps/aestratum/src/aestratum.erl
+++ b/apps/aestratum/src/aestratum.erl
@@ -270,7 +270,7 @@ format_status(_Opt, Status) ->
 push_payment(#aestratum_payment{id = Id} = P, S) ->
     try ?TXN(send_payment(P, S#aestratum_state.height, S#aestratum_state.protocol)) of
         {Pid, TxHash, PayoutTxArgs, AbsMap} ->
-            Date = calendar:now_to_datetime(erlang:timestamp()),
+            Date = erlang:universaltime(),
             P1   = ok_val_err(?TXN(aestratum_db:update_payment(P, AbsMap, TxHash, Date))),
             log_push_tx(P1, PayoutTxArgs),
             S#aestratum_state{tx_push_pid = Pid,

--- a/apps/aeutils/src/aeu_time.erl
+++ b/apps/aeutils/src/aeu_time.erl
@@ -6,12 +6,12 @@
          msecs_to_secs/1]).
 
 now_in_msecs() ->
-    {Megasecs, Secs, Microsecs} = os:timestamp(),
-    Megasecs * 1000000000 + Secs * 1000 + Microsecs div 1000.
+    os:system_time(millisecond).
+
 
 now_in_secs() ->
-    {Megasecs, Secs, _} = os:timestamp(),
-    Megasecs * 1000000 + Secs.
+    os:system_time(second).
+
 
 msecs_to_secs(Msecs) ->
     Msecs div 1000.

--- a/system_test/common/aest_sync_SUITE.erl
+++ b/system_test/common/aest_sync_SUITE.erl
@@ -210,23 +210,23 @@ new_node_joins_network(Cfg) ->
     %% Starts a chain with two nodes
     start_node(old_node1, Cfg),
     start_node(old_node2, Cfg),
-    T0 = erlang:system_time(seconds),
+    T0 = erlang:system_time(second),
     wait_for_startup([old_node1, old_node2], 4, Cfg),
     #{network_id := <<"ae_system_test">>} = aest_nodes:get_status(old_node1), %% Check node picked user config
     #{network_id := <<"ae_system_test">>} = aest_nodes:get_status(old_node2), %% Check node picked user config
-    StartupTime = erlang:system_time(seconds) - T0,
+    StartupTime = erlang:system_time(second) - T0,
 
     Length = max(30, 5 + proplists:get_value(blocks_per_second, Cfg) * StartupTime),
 
     %% Mines for 20 blocks and calculate the average mining time
-    StartTime = erlang:system_time(seconds),
+    StartTime = erlang:system_time(second),
 
 
     inject_spend_txs(old_node1, patron(), 5, 1, 100),
     inject_spend_txs(old_node2, patron(), 5, 6, 100),
 
     wait_for_value({height, Length + 1}, [old_node1, old_node2], Length * ?MINING_TIMEOUT, Cfg),
-    EndTime = erlang:system_time(seconds),
+    EndTime = erlang:system_time(second),
     %% Average mining time per block
     MiningTime = ((EndTime - StartTime) * 1000) div Length,
     ct:log("Mining time per block ~p ms for ~p blocks", [MiningTime, Length]),
@@ -274,9 +274,9 @@ docker_keeps_data(Cfg) ->
     wait_for_startup([standalone_node], 0, Cfg),
 
     %% Mines for 20 blocks and calculate the average mining time
-    StartTime = erlang:system_time(seconds),
+    StartTime = erlang:system_time(second),
     wait_for_value({height, Length}, [standalone_node], Length * ?MINING_TIMEOUT, Cfg),
-    EndTime = erlang:system_time(seconds),
+    EndTime = erlang:system_time(second),
     %% Average mining time per block
     MiningTime = ((EndTime - StartTime) * 1000) div Length,
 

--- a/system_test/only_local/aest_heavy_sync_SUITE.erl
+++ b/system_test/only_local/aest_heavy_sync_SUITE.erl
@@ -146,7 +146,7 @@ many_spend_txs(Cfg) ->
     %% Start 2nd node and let it sync with node1 and node3
     start_node(node2, Cfg),
 
-    FoundNode3 = find_txs(node3, TxHashes, #{}, erlang:system_time(seconds) + 120),
+    FoundNode3 = find_txs(node3, TxHashes, #{}, erlang:system_time(second) + 120),
     ct:log("MicroBlock distribution ~p", [FoundNode3]),
 
     %% It's to be expected that at least one micro block contains almost max nr of transactions
@@ -155,7 +155,7 @@ many_spend_txs(Cfg) ->
     %% If we have synced one more key block, all transactions are present!
     wait_for_startup([node2], Height, Cfg),
 
-    FoundNode2 = find_txs(node2, TxHashes, #{}, erlang:system_time(seconds) + 200),  %% around 10 micro blocks
+    FoundNode2 = find_txs(node2, TxHashes, #{}, erlang:system_time(second) + 200),  %% around 10 micro blocks
     case FoundNode2 == FoundNode3 of
         true -> ok;
         false ->
@@ -169,7 +169,7 @@ many_spend_txs(Cfg) ->
 find_txs(_Node, [], Found, _Deadline) ->
     Found;
 find_txs(Node, [TxHash | TxHashes], Found, Deadline) ->
-    case Deadline - erlang:system_time(seconds) > 0 of
+    case Deadline - erlang:system_time(second) > 0 of
         true ->
              case aest_nodes:request(Node, 'GetTransactionByHash', #{hash => TxHash}) of
                  {ok, 200, #{ block_hash := MBHash}} ->


### PR DESCRIPTION
Use modern time API everywhere. Do not do time conversions manually when there are standard functions available. Don't use the deprecated time units. Prefer to use monotonic time for plain time delta measurements.