### PR TITLE
Use foreground mode in docker container, not console -noinput

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ EXPOSE 3013 3014 3015 3113 3213 3413
 COPY ./docker/healthcheck.sh /healthcheck.sh
 HEALTHCHECK --timeout=3s CMD /healthcheck.sh
 
-CMD ["bin/aeternity", "console", "-noinput"]
+CMD ["bin/aeternity", "foreground"]


### PR DESCRIPTION
This makes the beam process terminate directly on SIGINT as expected of a docker process, instead of bringing up the interactive Break Menu.