### PR TITLE
- hyperchain/contract-pubkeys endpoint

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -483,7 +483,7 @@ staking_contract_pubkey() ->
                   _ -> erlang:error({contract_owner_not_valid_contract, EncContractId})
               end
           end,
-    aeu_ets_cache:get(?ETS_CACHE_TABLE, rewards_contract_pubkey, Fun).
+    aeu_ets_cache:get(?ETS_CACHE_TABLE, staking_contract_pubkey, Fun).
 
 pc_start_height() ->
     Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"start_height">>], 0) end,

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -83,6 +83,7 @@
         , call_consensus_contract_result/5
         , entropy_height/1
         , get_entropy_hash/1
+        , get_contract_pubkey/1
         ]).
 
 -ifdef(TEST).
@@ -474,6 +475,16 @@ rewards_contract_pubkey() ->
           end,
     aeu_ets_cache:get(?ETS_CACHE_TABLE, rewards_contract_pubkey, Fun).
 
+staking_contract_pubkey() ->
+    Fun = fun() ->
+              EncContractId = get_consensus_config_key([<<"staking_contract">>]),
+              case aeser_api_encoder:safe_decode(contract_pubkey, EncContractId) of
+                  {ok, Pubkey} -> Pubkey;
+                  _ -> erlang:error({contract_owner_not_valid_contract, EncContractId})
+              end
+          end,
+    aeu_ets_cache:get(?ETS_CACHE_TABLE, rewards_contract_pubkey, Fun).
+
 pc_start_height() ->
     Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"start_height">>], 0) end,
     aeu_ets_cache:get(?ETS_CACHE_TABLE, pc_start_height, Fun).
@@ -697,14 +708,17 @@ call_consensus_contract_result(ContractType, TxEnv, Trees, ContractFun, Args) ->
     lager:debug("Call result ~p", [Result]),
     {ok, Result}.
 
+-spec get_contract_pubkey(election | rewards | staking) -> binary().
+get_contract_pubkey(ContractType) ->
+    case ContractType of
+        ?ELECTION_CONTRACT -> election_contract_pubkey();
+        ?REWARDS_CONTRACT -> rewards_contract_pubkey();
+        ?STAKING_CONTRACT -> staking_contract_pubkey()
+    end.
+
 call_consensus_contract_(ContractType, TxEnv, Trees, EncodedCallData, Keyword, Amount) ->
     log_consensus_call(TxEnv, Keyword, EncodedCallData, Amount),
-    ContractPubkey =
-        case ContractType of
-            ?ELECTION_CONTRACT -> election_contract_pubkey();
-            ?REWARDS_CONTRACT -> rewards_contract_pubkey();
-            ?STAKING_CONTRACT -> rewards_contract_pubkey()
-        end,
+    ContractPubkey = get_contract_pubkey(ContractType),
     OwnerPubkey = contract_owner(),
     Contract = aect_state_tree:get_contract(ContractPubkey,
                                             aec_trees:contracts(Trees)),

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -535,6 +535,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /hyperchain/contract-pubkeys:
+    get:
+      tags:
+        - external
+        - hyperchain
+      operationId: GetHyperchainContractPubkeys
+      description: Get the pubkeys for the configured hyperchain contracts for staking, election and rewards
+      parameters:
+      responses:
+        "200":
+          description: succesful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#components/schemas/HCContractPubkeys"
+        "404":
+          description: Cannot find the contract pubkeys for some reason, e.g. HC consensus not started, or misconfigured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /key-blocks/current:
     get:
       tags:
@@ -3102,6 +3123,15 @@ components:
           type: string
       required:
         - hash
+    HCContractPubkeys:
+      type: object
+      properties:
+        staking:
+          $ref: "#/components/schemas/EncodedPubkey" 
+        election:
+          $ref: "#/components/schemas/EncodedPubkey" 
+        rewards:
+          $ref: "#/components/schemas/EncodedPubkey" 
     Header:
       anyOf:
         - $ref: "#/components/schemas/KeyBlock"

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -535,7 +535,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /hyperchain/contract-pubkeys:
+  /hyperchain/contracts:
     get:
       tags:
         - external

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -115,6 +115,7 @@ queue('GetPeerKey')                             -> ?READ_Q;
 queue('GetChainEnds')                           -> ?READ_Q;
 queue('GetRecentGasPrices')                     -> ?READ_Q;
 queue('GetPinningTx')                           -> ?READ_Q;
+queue('GetHyperchainContractPubkeys')           -> ?READ_Q;
 %% update transactions (default to update in catch-all)
 queue('PostTransaction')                        -> ?WRITE_Q;
 queue(_)                                        -> ?WRITE_Q.
@@ -908,6 +909,14 @@ handle_request_('GetPinningTx', _Params, _Context) ->
         {error, _} ->
            {404, [], #{reason => <<"No pin data available">>}}
     end;
+
+handle_request_('GetHyperchainContractPubkeys', _Params, _Context) ->
+    % TODO handle not in HC at all or consensus not initialized?
+    lager:debug("HyperchainsGetContract"),
+    {200, [], #{<<"staking">> => aeser_api_encoder:encode(contract_pubkey, aec_consensus_hc:get_contract_pubkey(staking)),
+                <<"election">> => aeser_api_encoder:encode(contract_pubkey, aec_consensus_hc:get_contract_pubkey(election)),
+                <<"rewards">> => aeser_api_encoder:encode(contract_pubkey, aec_consensus_hc:get_contract_pubkey(rewards))
+            }};
 
 handle_request_(OperationID, Req, Context) ->
     error_logger:error_msg(

--- a/apps/aehttp/src/aehttpc.erl
+++ b/apps/aehttp/src/aehttpc.erl
@@ -19,7 +19,7 @@
 -type hash() :: binary().
 -type height() :: non_neg_integer().
 -type time() :: non_neg_integer().
--type pubkey() :: binary().
+%-type pubkey() :: binary().
 -type chain() :: aeternity | btc | doge.
 
 -export_type([ node_spec/0 ]).

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -845,9 +845,8 @@ get_contract_pubkeys(Config) ->
     StakingContractPK = rpc(Node, aec_consensus_hc, get_contract_pubkey, [staking]),
     ElectionContractPK = rpc(Node, aec_consensus_hc, get_contract_pubkey, [election]),
     RewardsContractPK = rpc(Node, aec_consensus_hc, get_contract_pubkey, [rewards]),
-    %% note: the pins are for the last block in previous epoch
-    ct:log("Calling hyperchain/contract-pubkeys at ~p", [aecore_suite_utils:external_address()]),
-    {ok, 200, Repl1} = aecore_suite_utils:http_request(aecore_suite_utils:external_address(), get, "hyperchain/contract-pubkeys", []),
+    ct:log("Calling hyperchain/contracts at ~p", [aecore_suite_utils:external_address()]),
+    {ok, 200, Repl1} = aecore_suite_utils:http_request(aecore_suite_utils:external_address(), get, "hyperchain/contracts", []),
     #{<<"staking">> := Staking,
       <<"election">> := Election,
       <<"rewards">> := Rewards

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -34,6 +34,7 @@
          get_pin/1,
          wallet_post_pin_to_pc/1,
          post_pin_to_pc/1,
+         get_contract_pubkeys/1,
          first_leader_next_epoch/1
         ]).
 
@@ -151,6 +152,7 @@ groups() ->
           , produce_some_epochs
           , respect_schedule
           , check_blocktime
+          , get_contract_pubkeys
           ]}
     , {epochs, [sequence],
           [ start_two_child_nodes
@@ -831,6 +833,33 @@ epochs_with_fast_parent(Config) ->
     ok.
 
 %%%=============================================================================
+%%% HC Endpoints
+%%%=============================================================================
+
+get_contract_pubkeys(Config) ->
+    [{Node, _, _} | _] = ?config(nodes, Config),
+    %% Verify that endpoint is available
+    {ok, IsChildChain} = rpc(Node, aeu_env, find_config,
+                             [[<<"http">>, <<"endpoints">>, <<"hyperchain">>], [user_config, schema_default]]),
+    ?assert(IsChildChain),
+    StakingContractPK = rpc(Node, aec_consensus_hc, get_contract_pubkey, [staking]),
+    ElectionContractPK = rpc(Node, aec_consensus_hc, get_contract_pubkey, [election]),
+    RewardsContractPK = rpc(Node, aec_consensus_hc, get_contract_pubkey, [rewards]),
+    %% note: the pins are for the last block in previous epoch
+    ct:log("Calling hyperchain/contract-pubkeys at ~p", [aecore_suite_utils:external_address()]),
+    {ok, 200, Repl1} = aecore_suite_utils:http_request(aecore_suite_utils:external_address(), get, "hyperchain/contract-pubkeys", []),
+    #{<<"staking">> := Staking,
+      <<"election">> := Election,
+      <<"rewards">> := Rewards
+    } = Repl1,
+    ?assertEqual({ok, StakingContractPK}, aeser_api_encoder:safe_decode(contract_pubkey, Staking)),
+    ?assertEqual({ok, ElectionContractPK}, aeser_api_encoder:safe_decode(contract_pubkey, Election)),
+    ?assertEqual({ok, RewardsContractPK}, aeser_api_encoder:safe_decode(contract_pubkey, Rewards)),
+
+    ok.
+    
+
+%%%=============================================================================
 %%% Pinning
 %%%=============================================================================
 
@@ -1378,6 +1407,7 @@ node_config(Node, CTConfig, PotentialStakers, ReceiveAddress, ProducingCommitmen
                                 maps:merge(
                                     #{  <<"election_contract">> => aeser_api_encoder:encode(contract_pubkey, election_contract_address()),
                                         <<"rewards_contract">> => aeser_api_encoder:encode(contract_pubkey, staking_contract_address()),
+                                        <<"staking_contract">> => aeser_api_encoder:encode(contract_pubkey, staking_contract_address()),
                                         <<"contract_owner">> => aeser_api_encoder:encode(account_pubkey,?OWNER_PUBKEY),
                                         <<"expected_key_block_rate">> => 2000,
                                         <<"stakers">> => Stakers},


### PR DESCRIPTION
- endpoint implemented
- method to get contract pubkeys from HC consensus module (which also considers the staking contract - change from before
- updated HC test suite to configure all contracts (rewards == staking)

- ATM endpoint fails completely if any of the contracts are not configured. The consensus modeul probably shouldn't even start if this is the case. Right now this is actually due to the ETS cache failing if the contracts aren't there, so there needs to be some fixing around there to handle this in a good way if allowed.


This PR is supported by the Aeternity foundation