### PR TITLE
In hyperchains test suite, fail if any helper node logs contained errors

### DIFF
--- a/apps/aecore/test/aecore_errorfree_SUITE.erl
+++ b/apps/aecore/test/aecore_errorfree_SUITE.erl
@@ -5,7 +5,7 @@
 %% common_test exports
 -export(
    [
-    all/0, 
+    all/0,
     init_per_suite/1, end_per_suite/1,
     init_per_testcase/2, end_per_testcase/2
    ]).

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -263,6 +263,9 @@ end_per_group(_Group, Config) ->
     Config1 = with_saved_keys([nodes], Config),
     [ aecore_suite_utils:stop_node(Node, Config1)
       || {Node, _, _} <- proplists:get_value(nodes, Config1, []) ],
+
+    aecore_suite_utils:assert_no_errors_in_logs(Config1, ["{handled_abort,parent_chain_not_synced}"]),
+
     Config1.
 
 %% Here we decide which nodes are started/running


### PR DESCRIPTION
Closes #4436 

A CT end group call which extracts current nodes in the test group and verifies each node logs for errors
Will report via `ct:fail` with node name and file name

![console log](https://github.com/user-attachments/assets/bbcbd633-f406-4575-9e77-c88ccf389c0e)

This PR is supported by Æternity Foundation.