### PR TITLE
only last leader in epoch can pin

### DIFF
--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -98,11 +98,12 @@ int_create(PrevBlock, KeyBlock) ->
     MBEnv = #{prev_hash := PrevBlockHash} = create_micro_block_env(PrevBlock, KeyBlock),
     case aec_chain:get_block_state(PrevBlockHash) of
         {ok, Trees} ->
-            TxEnv = create_tx_env(MBEnv),
+            TxEnv0 = create_tx_env(MBEnv),
             MaxGas = aec_governance:block_gas_limit(),
             %% Height is relative to last key-block.
             ConsensusModule = aec_blocks:consensus_module(KeyBlock),
             Height = ConsensusModule:micro_block_height_relative_previous_block(key, aec_blocks:height(KeyBlock)),
+            TxEnv = aetx_env:set_height(TxEnv0, Height),
             PrevNode = aec_chain_state:wrap_block(PrevBlock),
             Trees1 = ConsensusModule:state_pre_transform_micro_node(Height, PrevNode, Trees),
             int_pack_block(Height, MaxGas, [], [], MBEnv, TxEnv, Trees1, []);

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1050,8 +1050,9 @@ apply_micro_block_transactions(Node, FeesIn, Trees) ->
               Txs1      -> Txs1
           end,
     KeyHeader = db_get_header(node_prev_key_hash(Node)),
-    Env = aetx_env:tx_env_from_key_header(KeyHeader, node_prev_key_hash(Node),
-                                          node_time(Node), node_prev_hash(Node)),
+    Env0 = aetx_env:tx_env_from_key_header(KeyHeader, node_prev_key_hash(Node),
+                                           node_time(Node), node_prev_hash(Node)),
+    Env = aetx_env:set_height(Env0, node_height(Node)),
     case timer:tc(aec_block_micro_candidate, apply_block_txs_strict, [Txs, Trees, Env]) of
         {Time, {ok, _, NewTrees, Events}} ->
             aec_metrics:try_update([ae, epoch, aecore, blocks, micro, txs_execution_time, success], Time),

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -885,11 +885,11 @@ validate_pin(TxEnv, Trees, CurEpochInfo) ->
 add_pin_reward(Trees, TxEnv, Leader) ->
     #{cur_pin_reward := Reward} = aec_chain_hc:pin_reward_info({TxEnv, Trees}),
     aec_events:publish(pin, {pin_accepted}),
-    LeaderAcc = aec_accounts_trees:get(Leader, aec_trees:accounts(Trees)),
+    ATrees = aec_trees:accounts(Trees),
+    LeaderAcc = aec_accounts_trees:get(Leader, ATrees),
     {ok, LeaderAcc1} = aec_accounts:earn(LeaderAcc, Reward),
-    Trees1 = aec_trees:set_accounts(Trees,
-                                    aec_accounts_trees:enter(LeaderAcc1, aec_trees:accounts(Trees))),
-    Trees1.
+    ATrees1 = aec_accounts_trees:enter(LeaderAcc1, ATrees),
+    aec_trees:set_accounts(Trees, ATrees1).
 
 create_contracts([], _TxEnv, Trees) -> Trees;
 create_contracts([Contract | Tail], TxEnv, TreesAccum) ->

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -863,7 +863,7 @@ handle_pinning(TxEnv, Trees, EpochInfo, Leader ) ->
 validate_pin(TxEnv, Trees, CurEpochInfo) ->
     case aec_chain_hc:pin_info({TxEnv, Trees}) of
         undefined -> pin_missing;
-        EncTxHash ->
+        {bytes, EncTxHash} ->
             % TODO make this code much more robust - incorrect EncTxHash, bad value from PC, incorrect hash etc.etc
             lager:debug("PINNING: EncHash: ~p", [EncTxHash]),
             try

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1121,7 +1121,7 @@ last_leader_validates_pin_and_post_to_contract(Config) ->
     ct:log("First Spend: ~p", [FirstSpend]),
 
     %% call contract with PC pin tx hash
-    ok = pin_contract_call_tx(Config, "pin", [FirstSpend], 0, LastLeader),
+    ok = pin_contract_call_tx(Config, FirstSpend, LastLeader),
 
     {value, Account} = rpc(?NODE1, aec_chain, get_account, [LastLeader]),
     ct:log("Leader Account: ~p", [Account]),
@@ -1170,7 +1170,9 @@ last_leader_validates_pin_and_post_to_contract(Config) ->
 
     % post bad hash to contract
 
-    ok = pin_contract_call_tx(Config, "pin", [<<"THIS IS A BAD TX HASH">>], 0, LastLeader),
+    {ok, #{last := Last3}} = rpc(Node, aec_chain_hc, epoch_info, []),
+    {ok, LastLeader3} = rpc(Node, aec_consensus_hc, leader_for_height, [Last3]),
+    ok = pin_contract_call_tx(Config, <<"THIS IS A BAD TX HASH">>, LastLeader3),
 
     {ok, _} = produce_cc_blocks(Config, 2),
     {ok, #{info := {incorrect_proof_posted}}} = wait_for_ps(pin),
@@ -1193,7 +1195,7 @@ last_leader_validates_pin_and_post_to_contract(Config) ->
 
     % post bad hash to contract
     LeaderBalance4A = account_balance(LastLeader4),
-    ok = pin_contract_call_tx(Config, "pin", [EncTxHash4], 0, LastLeader4),
+    ok = pin_contract_call_tx(Config, EncTxHash4, LastLeader4),
 
     {ok, _} = produce_cc_blocks(Config, 2),
     {ok, #{info := {incorrect_proof_posted}}} = wait_for_ps(pin),
@@ -1222,7 +1224,7 @@ last_leader_validates_pin_and_post_to_contract(Config) ->
     aecore_suite_utils:subscribe(NodeName, pin),
 
     % post bad hash to contract
-    ok = pin_contract_call_tx(Config, "pin", [EncTxHash5], 0, LastLeader5),
+    ok = pin_contract_call_tx(Config, EncTxHash5, LastLeader5),
 
     {ok, _} = produce_cc_blocks(Config, 2),
     {ok, #{info := {incorrect_proof_posted}}} = wait_for_ps(pin),
@@ -1249,23 +1251,15 @@ mine_to_last_block_in_epoch(Node, Config) ->
     DistToBeforeLast = Last - CH - 1,
     {ok, _} = produce_cc_blocks(Config, DistToBeforeLast).
 
+bytes_literal(Bin) ->
+    [_, _ | PinLit] = binary_to_list(aeu_hex:hexstring_encode(Bin)),
+    "#" ++ PinLit.
+
 % PINREFAC
-pin_contract_call_tx(Config, Fun, Args, Amount, FromPubKey) ->
-    ContractPubkey = ?config(election_contract, Config),
-    Nonce = next_nonce(?NODE1, FromPubKey),
-    {ok, CallData} = aeb_fate_abi:create_calldata(Fun, Args),
-    ABI = aect_test_utils:abi_version(),
-    TxSpec =
-        #{  caller_id   => aeser_id:create(account, FromPubKey)
-          , nonce       => Nonce
-          , contract_id => aeser_id:create(contract, ContractPubkey)
-          , abi_version => ABI
-          , fee         => 1000000 * ?DEFAULT_GAS_PRICE
-          , amount      => Amount
-          , gas         => 1000000
-          , gas_price   => ?DEFAULT_GAS_PRICE
-          , call_data   => CallData},
-    {ok, Tx} = aect_call_tx:new(TxSpec),
+pin_contract_call_tx(Config, PinProof, FromPubKey) ->
+    Tx = contract_call(?config(election_contract, Config), src(?HC_CONTRACT, Config),
+                       "pin", [bytes_literal(PinProof)], 0, FromPubKey),
+
     NetworkId = ?config(network_id, Config),
     SignedTx = sign_tx(Tx, privkey(who_by_pubkey(FromPubKey)), NetworkId),
     rpc:call(?NODE1_NAME, aec_tx_pool, push, [SignedTx, tx_received]),

--- a/rebar.config
+++ b/rebar.config
@@ -223,7 +223,7 @@
                             {aesophia_cli, {git, "https://github.com/aeternity/aesophia_cli", {ref,"e0a1730"}}},
                             {aestratum_client, {git, "https://github.com/aeternity/aestratum_client", {ref, "cfd406a"}}},
                             {websocket_client, {git, "https://github.com/aeternity/websocket_client", {ref, "506d8e2"}}},
-                            {aesophia_aci_encoder, {git, "https://github.com/aeternity/aesophia_aci_encoder", {ref, "f4d60c2"}}}
+                            {aesophia_aci_encoder, {git, "https://github.com/aeternity/aesophia_aci_encoder", {ref, "1f55ee5"}}}
                            ]}
                    ]},
             {prod, [{relx, [{dev_mode, false},

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -27,7 +27,7 @@ main contract HCElection =
       added_stake           : int,
       epoch                 : int,
       epochs                : map(int, epoch_info),
-      pin                   : option(string),
+      pin                   : option(bytes()),
       pin_reward            : pin_reward_info
     }
 
@@ -101,9 +101,6 @@ main contract HCElection =
     require(Chain.block_height == last, "Only in last block")
     require(Call.caller == state.leader, "Must be called by the last leader of epoch")
     put(state{pin = Some(proof)})
-
-  entrypoint pin_info() =
-    state.pin
 
   entrypoint leader() =
     state.leader

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -95,6 +95,16 @@ main contract HCElection =
                pin = None,
                pin_reward = pr})
 
+  stateful entrypoint pin(proof : bytes()) =
+    let epoch = state.epoch
+    let last = state.epochs[epoch].start + state.epochs[epoch].length - 1
+    require(Chain.block_height == last, "Only in last block")
+    require(Call.caller == state.leader, "Must be called by the last leader of epoch")
+    put(state{pin = Some(proof)})
+
+  entrypoint pin_info() =
+    state.pin
+
   entrypoint leader() =
     state.leader
 
@@ -121,11 +131,6 @@ main contract HCElection =
     let total_stake = List.foldl((+), 0, List.map(Pair.snd, validators))
     // One extra hash operation to convert from bytes() to bytes(32)/hash
     validator_schedule_(Crypto.blake2b(seed), (s) => Bytes.to_int(s) mod total_stake, validators, length, [])
-
-  stateful entrypoint pin(s : string) =
-    // PINTODO: determine that caller is "correct"
-    // PINTODO: simplify to single bytes() arg
-    put(state{pin = Some(s)})
 
   entrypoint pin_info() =
     state.pin


### PR DESCRIPTION
Fixes Issue #4448 in a particular way.

Instead of carrying around who the last leader is in the epochs (which resulted in rather complex code and unsatisfactory solution for first two epochs), decided to keep the contract simple and enforce pin call to be added to the last micro block. In that way, it is easy to check who the leader is.

Up to debate when to clear the PIN. If done in `step_eoe` then inspecting the last key block will not show it. Hence one needs to look before that. If done in `step` then extra check needed that this is first block of epoch or reset to NONE in each call (since one cannot set it anyway).

This PR is supported by the Aeternity foundation