### PR TITLE
Adding Block Production Time config. Fix #4459

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1730,7 +1730,7 @@
                                             "defult": 3000,
                                             "type": "integer"
                                         },
-                                        "hc_block_production_time": {
+                                        "child_block_production_time": {
                                             "description": "The maximum time (in ms) given produce both a micro block and a keyblock from a given transaction mempool.",
                                             "defult": 500,
                                             "type": "integer"

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1726,7 +1726,13 @@
                                             "type": "integer"
                                         },
                                         "child_block_time": {
-                                            "description": "The time in milliseconds to produce a child block",
+                                            "description": "The average time in milliseconds between two key blocks on the child chain",
+                                            "defult": 3000,
+                                            "type": "integer"
+                                        },
+                                        "hc_block_production_time": {
+                                            "description": "The maximum time (in ms) given produce both a micro block and a keyblock from a given transaction mempool.",
+                                            "defult": 500,
                                             "type": "integer"
                                         },
                                         "child_epoch_length": {


### PR DESCRIPTION
Should the config be called child_block_production_time as with other configs or hc_block_production_time as we want to rename all references from child to hs later?

This PR is supported by the Aeternity foundation.