### PR TITLE
More robust caching of validator schedules

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -705,16 +705,25 @@ leader_for_height(Height, RunEnv) ->
     end.
 
 cache_validators_for_epoch(RunEnv, Epoch) ->
-    case aec_chain_hc:epoch_info_for_epoch(RunEnv, Epoch) of
+    case epoch_info_for_epoch(RunEnv, Epoch) of
         {ok, EpochInfo} -> cache_validators_for_epoch_info(RunEnv, EpochInfo);
         _Err            -> error
     end.
 
 cache_validators_for_epoch(RunEnv, Hash, Epoch) ->
-    case aec_chain_hc:epoch_info_for_epoch(RunEnv, Epoch) of
+    case epoch_info_for_epoch(RunEnv, Epoch) of
         {ok, EpochInfo} -> cache_validators_for_epoch_info_(RunEnv, Hash, EpochInfo);
         _Err            -> error
     end.
+
+epoch_info_for_epoch(RunEnv, Epoch) ->
+    try
+        aec_chain_hc:epoch_info_for_epoch(RunEnv, Epoch)
+    catch _:_ ->
+        %% Not sure this is possible...
+        error
+    end.
+
 
 cache_validators_for_epoch_info(RunEnv, EpochInfo) ->
     case get_seed(EpochInfo) of

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -265,7 +265,7 @@ state_pre_transform_key_node(Node, PrevNode, Trees) ->
             {ok, Leader} = leader_for_height(Height, {TxEnv, Trees}),
             case Height == maps:get(last, EpochInfo) of
                 true ->
-                    {ok, Seed} = get_entropy_hash(Epoch + 1),
+                    {ok, Seed} = get_entropy_hash(Epoch + 2),
                     cache_validators_for_epoch({TxEnv, Trees}, Seed, Epoch + 2),
                     step_eoe(TxEnv, Trees, Leader, Seed, 0);
                 false ->
@@ -664,7 +664,7 @@ get_seed(#{seed := Hash}) when is_binary(Hash) ->
 
 get_entropy_hash(ChildEpoch) ->
     EntropyHeight = entropy_height(ChildEpoch),
-    lager:debug("Entropy from PC block at height ~p", [EntropyHeight]),
+    lager:debug("Entropy for epoch ~p from PC block at height ~p", [ChildEpoch, EntropyHeight]),
     case aec_parent_chain_cache:get_block_by_height(EntropyHeight, 1000) of
         {ok, Block} ->
             {ok, aec_parent_chain_block:hash(Block)};
@@ -684,10 +684,9 @@ is_block_producer_() ->
 
     StakersConfig /= [].
 
-%% We start at parent epoch 1
-%% We take first hash of parent epoch (hence -1)
+%% See whitepaper for details, but corresponding parent epoch is max(0, n-3)
 entropy_height(ChildEpoch) ->
-    (max(1, (ChildEpoch - 2)) - 1) * parent_epoch_length() + pc_start_height().
+    max(0, (ChildEpoch - 3)) * parent_epoch_length() + pc_start_height().
 
 %% -- Validator schedule (cached) -----------------------------------------
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -21,7 +21,6 @@
          produce_some_epochs/1,
          respect_schedule/1,
          entropy_impact_schedule/1,
-         mine_and_sync/1,
          spend_txs/1,
          simple_withdraw/1,
          empty_parent_block/1,
@@ -146,7 +145,6 @@ groups() ->
           [ start_two_child_nodes
           , produce_first_epoch
           , verify_fees
-          , mine_and_sync
           , spend_txs
           , simple_withdraw
           , sync_third_node
@@ -362,13 +360,6 @@ contract_call(ContractPubkey, Src, Fun, Args, Amount, From, Nonce) ->
     {ok, Tx} = aect_call_tx:new(TxSpec),
     Tx.
 
-%% This test is trivially true, since we already check in
-%% sync when producting the blocks.
-mine_and_sync(Config) ->
-    {ok, _KBs} = produce_cc_blocks(Config, 3),
-    {ok, _KB} = wait_same_top([ Node || {Node, _, _} <- ?config(nodes, Config)]),
-    ok.
-
 wait_same_top(Nodes) ->
     wait_same_top(Nodes, 3).
 
@@ -387,18 +378,34 @@ wait_same_top(Nodes, Attempts) ->
 
 spend_txs(Config) ->
     produce_cc_blocks(Config, 1),
-    Top0 = rpc(?NODE1, aec_chain, top_header, []),
-    ct:log("Top before posting spend txs: ~p", [aec_headers:height(Top0)]),
-    NetworkId = ?config(network_id, Config),
+
+    %% First, seed ALICE, BOB and LISA, they need tokens in later tests
     {ok, []} = rpc:call(?NODE1_NAME, aec_tx_pool, peek, [infinity]),
+    NetworkId = ?config(network_id, Config),
     seed_account(pubkey(?ALICE), 100000001 * ?DEFAULT_GAS_PRICE, NetworkId),
     seed_account(pubkey(?BOB), 100000002 * ?DEFAULT_GAS_PRICE, NetworkId),
     seed_account(pubkey(?LISA), 100000003 * ?DEFAULT_GAS_PRICE, NetworkId),
 
     produce_cc_blocks(Config, 1),
     {ok, []} = rpc:call(?NODE1_NAME, aec_tx_pool, peek, [infinity]),
-    %% TODO check that the actors got their share
-    ok.
+
+    %% Make spends until we've passed an epoch boundary
+    spend_txs_(Config).
+
+
+spend_txs_(Config) ->
+    {ok, #{first := First}} = rpc(?NODE1, aec_chain_hc, epoch_info, []),
+    Top = rpc(?NODE1, aec_chain, top_header, []),
+
+    case aec_headers:height(Top) == First of
+        true  -> ok;
+        false ->
+            NetworkId = ?config(network_id, Config),
+            seed_account(pubkey(?EDWIN), 1, NetworkId),
+            produce_cc_blocks(Config, 1),
+            {ok, []} = rpc:call(?NODE1_NAME, aec_tx_pool, peek, [infinity]),
+            spend_txs_(Config)
+    end.
 
 check_blocktime(_Config) ->
     {ok, TopBlock} = rpc(?NODE1, aec_chain, top_key_block, []),
@@ -767,7 +774,6 @@ first_leader_next_epoch(Config) ->
     {ok, #{last := Last, epoch := Epoch}} = rpc(Node, aec_chain_hc, epoch_info, [StartHeight]),
     ct:log("Checking leader for first block next epoch ~p (height ~p)", [Epoch+1, Last+1]),
     ?assertMatch({ok, _}, rpc(Node, aec_consensus_hc, leader_for_height, [Last + 1])).
-
 
 %% Demonstrate that child chain start signalling epoch length adjustment upward
 %% When parent blocks are produced too slowly, we need to lengthen child epoch

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -770,6 +770,7 @@ elected_leader_did_not_show_up_(Config) ->
 
 first_leader_next_epoch(Config) ->
     [{Node, _, _} | _] = ?config(nodes, Config),
+    produce_cc_blocks(Config, 1),
     StartHeight = rpc(Node, aec_chain, top_height, []),
     {ok, #{last := Last, epoch := Epoch}} = rpc(Node, aec_chain_hc, epoch_info, [StartHeight]),
     ct:log("Checking leader for first block next epoch ~p (height ~p)", [Epoch+1, Last+1]),

--- a/apps/aeutils/src/aeu_ets_cache.erl
+++ b/apps/aeutils/src/aeu_ets_cache.erl
@@ -9,6 +9,7 @@
 -export([get/3,
          put/3,
          lookup/2,
+         lookup/3,
          reinit/3]).
 
 -spec lookup(atom(), term()) -> {ok, term()} | error.
@@ -19,6 +20,16 @@ lookup(TableName, EtsKey) ->
     catch
         _:_ ->
             error
+    end.
+
+-spec lookup(atom(), term(), term()) -> term().
+lookup(TableName, EtsKey, Default) ->
+    try
+        [{EtsKey, Result}] = ets:lookup(TableName, EtsKey),
+        Result
+    catch
+        _:_ ->
+            Default
     end.
 
 -spec get(atom(), term(), fun(() -> term())) -> term().


### PR DESCRIPTION
Main observation, at the point where we call `step_eoe` we _know_ the seed/hash (and thus in effect the schedule) for next-next Epoch. No point in not caching that schedule right away.

Second issue is bootstrapping after restart, that should be handled by the current code, but there are no tests for it.

This PR also adds a test that puts microblocks in all positions in an epoch.

Finally it aligns `entropy_height` with the Whitepaper.

This PR is supported by Æternity Foundation.