### PR TITLE
Add HCVoteTx

### DIFF
--- a/apps/aecore/src/aec_consensus.erl
+++ b/apps/aecore/src/aec_consensus.erl
@@ -195,7 +195,7 @@
 -callback allow_lazy_leader() -> false | {true, integer()}.
 -callback pick_lazy_leader(binary()) -> error | {ok, aec_keys:pubkey()}.
 -callback get_sign_module() -> sign_module().
--callback get_type() -> consensus_config().
+-callback get_type() -> consensus_type().
 -callback get_block_producer_configs() -> list().
 -callback is_leader_valid(#node{}, aec_trees:trees(), aetx_env:env(), #node{}) -> boolean().
 

--- a/apps/aecore/src/aec_consensus.erl
+++ b/apps/aecore/src/aec_consensus.erl
@@ -60,6 +60,7 @@
         , set_genesis_hash/0
         , get_consensus_module_at_height/1
         , get_consensus_config_at_height/1
+        , get_consensus_type/0
         , get_genesis_consensus_module/0
         , get_genesis_consensus_config/0
         , get_genesis_hash/0 %% Cached access to the genesis hash using persistent term :)
@@ -72,6 +73,7 @@
 -type consensus_module() :: atom().
 -type sign_module() :: atom().
 -type consensus_config() :: #{binary() => term()}.
+-type consensus_type() :: pow | pos.
 -type global_consensus_config() :: [{non_neg_integer(), {consensus_module(), consensus_config()}}].
 
 %% Block sealing
@@ -193,7 +195,7 @@
 -callback allow_lazy_leader() -> false | {true, integer()}.
 -callback pick_lazy_leader(binary()) -> error | {ok, aec_keys:pubkey()}.
 -callback get_sign_module() -> sign_module().
--callback get_type() -> pow | pos.
+-callback get_type() -> consensus_config().
 -callback get_block_producer_configs() -> list().
 -callback is_leader_valid(#node{}, aec_trees:trees(), aetx_env:env(), #node{}) -> boolean().
 
@@ -286,6 +288,23 @@ get_consensus() ->
 get_consensus_spec_at_height(Height) ->
     [{0,H}|R] = get_consensus(),
     consensus_at_height(H, R, Height).
+
+%% For now let's assume we don't change between 'pos' and 'pow' - if need be
+%% extend with get_consensus_type/1
+-spec get_consensus_type() -> consensus_type().
+get_consensus_type() ->
+    case persistent_term:get({?MODULE, consensus_type}, error) of
+        error ->
+            ConsensusType =
+                case get_consensus() of
+                    [{0, {aec_consensus_hc, _}} | _] -> pos;
+                    _ -> pow
+                end,
+            persistent_term:put({?MODULE, consensus_type}, ConsensusType),
+            ConsensusType;
+        ConsensusType ->
+            ConsensusType
+    end.
 
 %% This is a placeholder for later - the idea is that if at some point
 %% the network decides to change the configuration variables which are

--- a/apps/aecore/src/aec_hc_vote_pool.erl
+++ b/apps/aecore/src/aec_hc_vote_pool.erl
@@ -92,13 +92,10 @@ push_(STx, Event) ->
             gen_server:call(?SERVER, {push, STx, Event})
     end.
 
-%% The specified maximum number of transactions avoids requiring
-%% building in memory the complete list of all transactions in the
-%% pool.
 -spec peek(epoch() | {epoch(), vote_type()}) -> {ok, [vote()]}.
-peek(At) when is_integer(At) ->
-    gen_server:call(?SERVER, {peek, At});
-peek({H, B} = At) when is_integer(H), is_binary(B) ->
+peek(Epoch) when is_integer(Epoch) ->
+    gen_server:call(?SERVER, {peek, Epoch});
+peek({Epoch, Type} = At) when is_integer(Epoch), is_integer(Type) ->
     gen_server:call(?SERVER, {peek, At}).
 
 -spec size() -> {ok, non_neg_integer()}.

--- a/apps/aecore/src/aec_hc_vote_pool.erl
+++ b/apps/aecore/src/aec_hc_vote_pool.erl
@@ -1,0 +1,262 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2024, Aeternity Foundation
+%%% @doc
+%%%     Pool for HC votes (short lived transport Txs)
+%%% @end
+%%%-------------------------------------------------------------------
+-module(aec_hc_vote_pool).
+
+-behaviour(gen_server).
+-compile({no_auto_import, [size/1]}).
+
+%% API
+-export([ start_link/0
+        , stop/0
+        ]).
+
+-export([ peek/1
+        , push/1
+        , push/2
+        , size/0
+        ]).
+
+-include_lib("aecontract/include/hard_forks.hrl").
+
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
+
+-import(aeu_debug, [pp/1]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, { gc_height       :: height()
+               , hash_pool = #{} :: #{tx_hash() => vote()}
+               , h_cache   = #{} :: #{height() => tx_hash()}
+               , t_cache   = #{} :: #{{height(), binary()} => [vote()]} }).
+
+-type height() :: aec_blocks:height().
+
+-type event() :: tx_created | tx_received.
+
+-type vote()    :: aec_hc_vote_tx:tx().
+-type tx_hash() :: binary().
+
+-define(DEFAULT_TX_TTL, 5).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+stop() ->
+    %% implies also clearing the mempool
+    gen_server:stop(?SERVER).
+
+-define(PUSH_EVENT(E), Event =:= tx_created; Event =:= tx_received).
+
+-spec push(aetx_sign:signed_tx()) -> ok | {error, atom()}.
+push(Tx) ->
+    push(Tx, tx_created).
+
+-spec push(aetx_sign:signed_tx(), event()) -> ok | {error, atom()}.
+push(Tx, Event = tx_received) ->
+    TxHash = safe_tx_hash(Tx),
+    case aec_tx_gossip_cache:in_cache(TxHash) of
+        true ->
+            ok;
+        false ->
+            %% Transported through gossip, use 'tx_pool_push' job queue
+            aec_jobs_queues:run(tx_pool_push, fun() -> push_(Tx, Event) end)
+    end;
+push(Tx, Event = tx_created) ->
+    push_(Tx, Event).
+
+safe_tx_hash(Tx) ->
+    try
+        aetx_sign:hash(Tx)
+    catch _:_ ->
+        error({illegal_transaction, Tx})
+    end.
+
+push_(STx, Event) ->
+    case validate_vote_tx(STx) of
+        Err = {error, _} ->
+            lager:debub("Validation error ~p for HCVoteTx: ~p", [Err, STx]),
+            Err;
+        {ok, Vote} ->
+            gen_server:call(?SERVER, {push, Vote, STx, Event})
+    end.
+
+%% The specified maximum number of transactions avoids requiring
+%% building in memory the complete list of all transactions in the
+%% pool.
+-spec peek(height() | {height(), binary()}) -> {ok, [vote()]}.
+peek(At) when is_integer(At) ->
+    gen_server:call(?SERVER, {peek, At});
+peek({H, B} = At) when is_integer(H), is_binary(B) ->
+    gen_server:call(?SERVER, {peek, At}).
+
+-spec size() -> {ok, non_neg_integer()}.
+size() ->
+    gen_server:call(?SERVER, size).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    GCHeight = top_height(),
+    lager:debug("init: GCHeight = ~p", [GCHeight]),
+    aec_events:subscribe(top_changed),
+    {ok, #state{gc_height = GCHeight}}.
+
+handle_call({push, Vote, STx, Event}, _From, State) ->
+    State1 = do_add_vote(Vote, State),
+    aec_events:publish(Event, STx),
+    {reply, ok, State1};
+handle_call({peek, PeekAt}, _From, State) ->
+    Ts = do_pool_peek(PeekAt, State),
+    {reply, {ok, Ts}, State};
+handle_call(Request, From, State) ->
+    lager:warning("Ignoring unknown call request from ~p: ~p", [From, Request]),
+    {noreply, State}.
+
+handle_cast(Msg, State) ->
+    lager:warning("Ignoring unknown cast message: ~p", [Msg]),
+    {noreply, State}.
+
+handle_info({gproc_ps_event, top_changed, #{info := #{block_type := key, height := Height}}},
+            State) ->
+    {noreply, do_update_top(Height, State)};
+handle_info({gproc_ps_event, top_changed, #{info := #{block_type := micro}}}, State) ->
+    {noreply, State};
+handle_info(Info, State) ->
+    lager:warning("Ignoring unknown info: ~p", [Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+do_add_vote(Vote, #state{ hash_pool = HashPool
+                                  , t_cache   = TCache
+                                  , h_cache   = HCache } = State) ->
+    THash = aec_vote:hash(Vote),
+    BlockHash = aec_vote:block_hash(Vote),
+    case maps:is_key(THash, HashPool) of
+        true ->
+            lager:debug("Duplicate vote: ~p", [Vote]),
+            State;
+        false ->
+            HashPool1 = HashPool#{THash => Vote},
+            Height    = aec_vote:height(Vote),
+            T         = {Height, aec_vote:block_hash(Vote)},
+            TCache1   = TCache#{T => [THash | maps:get(T, TCache, [])]},
+            HCache1   = HCache#{Height => [THash | maps:get(Height, HCache, [])]},
+            State#state{ hash_pool = HashPool1
+                       , h_cache   = HCache1
+                       , t_cache   = TCache1 }
+    end.
+
+do_pool_peek(Height, #state{hash_pool = HPool, h_cache = HCache}) when is_integer(Height) ->
+    get_votes(maps:get(Height, HCache, []), HPool);
+do_pool_peek(T = {_, _}, #state{hash_pool = HPool, t_cache = TCache}) ->
+    get_votes(maps:get(T, TCache, []), HPool).
+
+get_votes(THs, HPool) ->
+    [ maps:get(TH, HPool) || TH <- THs ].
+
+top_height() ->
+    case aec_chain:dirty_top_header() of
+        undefined -> 0;
+        Header    -> aec_headers:height(Header)
+    end.
+
+do_update_top(_Height, State) ->
+    %% TODO: do some GC/cleanup
+    State.
+
+validate_vote_tx(STx) ->
+    {Block, _BlockHash, Trees} = get_onchain_env(),
+    Checks = [ fun check_tx_type/3
+             , fun check_valid_at_protocol/3
+             , fun check_signature/3
+             , fun check_ttl/3
+             ],
+    case aeu_validation:run(Checks, [STx, Block, Trees]) of
+        ok ->
+            extract_vote(STx);
+        Err = {error, _} ->
+            Err
+    end.
+
+check_tx_type(STx, _Block, _Trees) ->
+    case aetx:specialize_type(aetx_sign:tx(STx)) of
+        {vote_tx, _} ->
+            ok;
+        _ ->
+            lager:info("Only HCVoteTXs expected in vote_pool: ~p", [STx]),
+            {error, only_hc_vote_tx_allowed}
+    end.
+
+check_valid_at_protocol(STx, Block, _Trees) ->
+    Protocol = aec_blocks:version(Block),
+    aetx:check_protocol(aetx_sign:tx(STx), Protocol).
+
+check_signature(STx, Block, Trees) ->
+    Protocol = aec_blocks:version(Block),
+    case aetx_sign:verify(STx, Trees, Protocol) of
+        {error, _} = E ->
+            lager:info("Failed signature check on tx: ~p\n", [E]),
+            E;
+        ok ->
+            ok
+    end.
+
+check_ttl(STx, Block, _Trees) ->
+    Height = aec_blocks:height(Block),
+    Tx = aetx_sign:tx(STx),
+    case Height > aetx:ttl(Tx) of
+        true  -> {error, ttl_expired};
+        false -> ok
+    end.
+
+-spec extract_vote(aetx_sign:signed_tx()) -> {ok, vote()} | {error, term()}.
+extract_vote(STx) ->
+    {vote_tx, TTx} = aetx:specialize_type(aetx_sign:tx(STx)),
+    Height    = aec_vote_tx:height(TTx),
+    WitnessPK = aec_vote_tx:witness_pubkey(TTx),
+    BlockHash = aec_vote_tx:block_hash(TTx),
+    Signature = aec_vote_tx:signature(TTx),
+    Vote = aec_vote:new(Height, BlockHash, WitnessPK, Signature),
+
+    case aec_vote:validate(Vote) of
+        true ->
+            {ok, Vote};
+        false ->
+            {error, invalid_vote}
+    end.
+
+validate_vote(Vote) ->
+    %% TODO: Actually do check something more here!?
+    Top = aec_chain:top_block(),
+    case aec_vote:height(Vote) > aec_blocks:height(Top) of
+        true ->
+            {error, vote_from_the_future};
+        false ->
+            ok
+    end.

--- a/apps/aecore/src/aec_hc_vote_tx.erl
+++ b/apps/aecore/src/aec_hc_vote_tx.erl
@@ -169,5 +169,5 @@ version(_) ->
 
 -spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
 valid_at_protocol(_, _) ->
-    true.
+    aec_consensus:get_consensus_type() == pos.
 

--- a/apps/aecore/src/aec_hc_vote_tx.erl
+++ b/apps/aecore/src/aec_hc_vote_tx.erl
@@ -1,0 +1,158 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2024, Aeternity Foundation
+%%%-------------------------------------------------------------------
+
+-module(aec_hc_vote_tx).
+
+%% API
+-export([new/1,
+         type/0,
+         fee/1,
+         gas/1,
+         ttl/1,
+         nonce/1,
+         origin/1,
+         voter_id/1,
+         voter_pubkey/1,
+         recipient_id/1,
+         epoch/1,
+         check/3,
+         process/3,
+         signers/2,
+         version/1,
+         serialization_template/1,
+         serialize/1,
+         deserialize/2,
+         for_client/1,
+         valid_at_protocol/2
+        ]).
+
+-export([data/1]).
+
+-behavior(aetx).
+
+-include("blocks.hrl").
+
+-define(HC_VOTE_TX_VSN, 1).
+-define(HC_VOTE_TX_TYPE, hc_vote_tx).
+
+-record(hc_vote_tx,
+        { voter_id        :: aeser_id:id(),
+          epoch     = 0   :: non_neg_integer(),
+          data      = #{} :: #{binary() => binary()}
+        }).
+
+-opaque tx() :: #hc_vote_tx{}.
+
+-export_type([tx/0]).
+
+-spec new(map()) -> {ok, aetx:tx()}.
+new(#{voter_id := VoterId,
+      epoch    := Epoch,
+      data     := Data})
+  when is_integer(Epoch), Epoch >= 0,
+       is_map(Data) ->
+    account = aeser_id:specialize_type(VoterId),
+    Tx = #hc_vote_tx{voter_id = VoterId,
+                     epoch    = Epoch,
+                     data     = Data},
+    {ok, aetx:new(?MODULE, Tx)}.
+
+-spec type() -> atom().
+type() ->
+    ?HC_VOTE_TX_TYPE.
+
+-spec fee(tx()) -> integer().
+fee(#hc_vote_tx{}) ->
+    0.
+
+-spec gas(tx()) -> non_neg_integer().
+gas(#hc_vote_tx{}) ->
+    0.
+
+-spec ttl(tx()) -> aetx:tx_ttl().
+ttl(#hc_vote_tx{}) ->
+    0.
+
+-spec nonce(tx()) -> non_neg_integer().
+nonce(#hc_vote_tx{}) ->
+    0.
+
+-spec origin(tx()) -> aec_keys:pubkey().
+origin(#hc_vote_tx{} = Tx) ->
+    voter_pubkey(Tx).
+
+-spec voter_id(tx()) -> aeser_id:id().
+voter_id(#hc_vote_tx{voter_id = VoterId}) ->
+    VoterId.
+
+-spec voter_pubkey(tx()) -> aec_keys:pubkey().
+voter_pubkey(#hc_vote_tx{voter_id = VoterId}) ->
+    aeser_id:specialize(VoterId, account).
+
+-spec epoch(tx()) -> non_neg_integer().
+epoch(#hc_vote_tx{epoch = Epoch}) ->
+    Epoch.
+
+-spec data(tx()) -> #{binary() => binary()}.
+data(#hc_vote_tx{data = Data}) ->
+    Data.
+
+-spec check(tx(), aec_trees:trees(), aetx_env:env()) -> {ok, aec_trees:trees()} | {error, term()}.
+check(#hc_vote_tx{}, Trees,_Env) ->
+    {ok, Trees}.
+
+-spec signers(tx(), aec_trees:trees()) -> {ok, [aec_keys:pubkey()]}.
+signers(#hc_vote_tx{} = Tx, _) -> {ok, [voter_pubkey(Tx)]}.
+
+-spec process(tx(), aec_trees:trees(), aetx_env:env()) ->
+    {ok, aec_trees:trees(), aetx_env:env()} | {error, term()}.
+process(#hc_vote_tx{}, _Trees, _Env) ->
+    {error, hc_vote_tx_cant_be_processed}.
+
+serialize(#hc_vote_tx{voter_id = VoterId,
+                      epoch    = Epoch,
+                      data     = Data} = Tx) ->
+    {version(Tx),
+     [ {voter_id, VoterId}
+     , {epoch, Epoch}
+     , {data, serialize_data(Data)}
+     ]}.
+
+deserialize(?HC_VOTE_TX_VSN,
+            [ {voter_id, VoterId}
+            , {epoch, Epoch}
+            , {data, Data}]) ->
+    %% Asserts
+    account = aeser_id:specialize_type(VoterId),
+    #hc_vote_tx{voter_id = VoterId,
+                epoch    = Epoch,
+                data     = deserialize_data(Data)}.
+
+serialize_data(Data) ->
+    lists:sort(maps:to_list(Data)).
+
+deserialize_data(Data) ->
+    maps:from_list(Data).
+
+serialization_template(?HC_VOTE_TX_VSN) ->
+    [ {voter_id, id}
+    , {epoch, int}
+    , {data, [{binary, binary}]}
+    ].
+
+for_client(#hc_vote_tx{voter_id = VoterId,
+                       epoch    = Epoch,
+                       data     = Data}) ->
+    #{<<"voter_id">>    => aeser_api_encoder:encode(id_hash, VoterId),
+      <<"epoch">>       => Epoch,
+      <<"data">>        => Data}.
+
+-spec version(tx()) -> non_neg_integer().
+version(_) ->
+    ?HC_VOTE_TX_VSN.
+
+-spec valid_at_protocol(aec_hard_forks:protocol_vsn(), tx()) -> boolean().
+valid_at_protocol(_, _) ->
+    true.
+

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -1427,8 +1427,14 @@ handle_new_txs(S, Msg) ->
     S.
 
 tx_push(STx) ->
-    try aec_tx_pool:push(STx, tx_received)
-    catch _:_ -> rejected end.
+    case aetx:specialize_type(aetx_sign:tx(STx)) of
+        {hc_vote_tx, _Tx} ->
+            try aec_hc_vote_pool:push(STx, tx_received)
+            catch _:_ -> rejected end;
+        {_, _Tx} ->
+            try aec_tx_pool:push(STx, tx_received)
+            catch _:_ -> rejected end
+    end.
 
 %% -- Send message -----------------------------------------------------------
 send_msg(#{ status := {disconnecting, _ESock} }, _Type, _Msg) -> ok;

--- a/apps/aecore/src/aec_worker_sup.erl
+++ b/apps/aecore/src/aec_worker_sup.erl
@@ -19,12 +19,13 @@ init([]) ->
         ++ [?CHILD(aec_metrics_rpt_dest, 5000, worker),
             ?CHILD(aec_keys, 5000, worker),
             ?CHILD(aec_tx_pool, 5000, worker),
-            ?CHILD(aec_hc_vote_pool, 5000, worker),
             ?CHILD(aec_peer_analytics, 5000, worker),
             ?CHILD(aec_tx_pool_gc, 5000, worker),
             ?CHILD(aec_resilience, 5000, worker),
             ?CHILD(aec_capabilities, 5000, worker),
-            ?CHILD(aec_db_gc, 5000, worker) ],
+            ?CHILD(aec_db_gc, 5000, worker) ]
+        ++ maybe_vote_tx_pool(),
+
 
     {ok, {{one_for_one, 5, 10}, ChildSpecs}}.
 
@@ -37,4 +38,10 @@ maybe_upnp_worker() ->
     case aec_upnp:is_enabled() of
         true  -> [?CHILD(aec_upnp, 5000, worker)];
         false -> []
+    end.
+
+maybe_vote_tx_pool() ->
+    case aec_consensus:get_consensus_type() of
+        pos -> [?CHILD(aec_hc_vote_pool, 5000, worker)];
+        pow -> []
     end.

--- a/apps/aecore/src/aec_worker_sup.erl
+++ b/apps/aecore/src/aec_worker_sup.erl
@@ -19,6 +19,7 @@ init([]) ->
         ++ [?CHILD(aec_metrics_rpt_dest, 5000, worker),
             ?CHILD(aec_keys, 5000, worker),
             ?CHILD(aec_tx_pool, 5000, worker),
+            ?CHILD(aec_hc_vote_pool, 5000, worker),
             ?CHILD(aec_peer_analytics, 5000, worker),
             ?CHILD(aec_tx_pool_gc, 5000, worker),
             ?CHILD(aec_resilience, 5000, worker),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -672,7 +672,7 @@ empty_parent_block(_Config) ->
     end.
 
 sanity_check_vote_tx(Config) ->
-    [{Node1, _, _}, {Node2, _, _} | _] = ?config(nodes, Config),
+    [{Node1, _, _, _}, {Node2, _, _, _} | _] = ?config(nodes, Config),
 
     %% Push a vote tx onto node1 - then read on node2
     {ok, VoteTx1} = aec_hc_vote_tx:new(#{voter_id => aeser_id:create(account, pubkey(?ALICE)),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -38,7 +38,8 @@
          get_contract_pubkeys/1,
          correct_leader_in_micro_block/1,
          first_leader_next_epoch/1,
-         check_default_pin/1
+         check_default_pin/1,
+         sanity_check_vote_tx/1
         ]).
 
 -include_lib("stdlib/include/assert.hrl").
@@ -158,6 +159,7 @@ groups() ->
           , entropy_impact_schedule
           , check_blocktime
           , get_contract_pubkeys
+          , sanity_check_vote_tx
           ]}
     , {epochs, [sequence],
           [ start_two_child_nodes
@@ -668,6 +670,26 @@ empty_parent_block(_Config) ->
             %% empty_parent_block_(Config)
             {skip, todo}
     end.
+
+sanity_check_vote_tx(Config) ->
+    [{Node1, _, _}, {Node2, _, _} | _] = ?config(nodes, Config),
+
+    %% Push a vote tx onto node1 - then read on node2
+    {ok, VoteTx1} = aec_hc_vote_tx:new(#{voter_id => aeser_id:create(account, pubkey(?ALICE)),
+                                         epoch    => 42,
+                                         type     => 4,
+                                         data     => #{<<"key1">> => <<"value1">>,
+                                                       <<"key2">> => <<"value2">>}}),
+    {_, HCVoteTx1} = aetx:specialize_type(VoteTx1),
+
+    NetworkId = rpc(Node1, aec_governance, get_network_id, []),
+    SVoteTx1 = sign_tx(VoteTx1, privkey(?ALICE), NetworkId),
+
+    ok = rpc(Node1, aec_hc_vote_pool, push, [SVoteTx1]),
+    timer:sleep(10),
+    {ok, [HCVoteTx1]} = rpc(Node2, aec_hc_vote_pool, peek, [42]),
+
+    ok.
 
 verify_fees(Config) ->
     [{Node, NodeName, _, _} | _ ] = ?config(nodes, Config),

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -89,7 +89,8 @@
                  | channel_set_delegates_tx
                  | channel_offchain_tx
                  | channel_client_reconnect_tx
-                 | paying_for_tx.
+                 | paying_for_tx
+                 | hc_vote_tx.
 
 %% dialyzer chokes on the following type - 20+ opaque types in a
 %% union is too much apparently :-(
@@ -609,89 +610,92 @@ deserialize_from_binary(Bin) ->
     Fields = aeserialization:decode_fields(Template, RawFields),
     #aetx{cb = CB, type = Type, size = byte_size(Bin), tx = CB:deserialize(Vsn, Fields)}.
 
-type_to_cb(spend_tx)                    -> aec_spend_tx;
-type_to_cb(oracle_register_tx)          -> aeo_register_tx;
-type_to_cb(oracle_extend_tx)            -> aeo_extend_tx;
-type_to_cb(oracle_query_tx)             -> aeo_query_tx;
-type_to_cb(oracle_response_tx)          -> aeo_response_tx;
-type_to_cb(name_preclaim_tx)            -> aens_preclaim_tx;
-type_to_cb(name_claim_tx)               -> aens_claim_tx;
-type_to_cb(name_transfer_tx)            -> aens_transfer_tx;
-type_to_cb(name_update_tx)              -> aens_update_tx;
-type_to_cb(name_revoke_tx)              -> aens_revoke_tx;
-type_to_cb(contract_call_tx)            -> aect_call_tx;
-type_to_cb(contract_create_tx)          -> aect_create_tx;
-type_to_cb(ga_attach_tx)                -> aega_attach_tx;
-type_to_cb(ga_meta_tx)                  -> aega_meta_tx;
-type_to_cb(paying_for_tx)               -> aec_paying_for_tx;
-type_to_cb(channel_create_tx)           -> aesc_create_tx;
-type_to_cb(channel_deposit_tx)          -> aesc_deposit_tx;
-type_to_cb(channel_withdraw_tx)         -> aesc_withdraw_tx;
-type_to_cb(channel_force_progress_tx)   -> aesc_force_progress_tx;
-type_to_cb(channel_close_solo_tx)       -> aesc_close_solo_tx;
-type_to_cb(channel_close_mutual_tx)     -> aesc_close_mutual_tx;
-type_to_cb(channel_slash_tx)            -> aesc_slash_tx;
-type_to_cb(channel_settle_tx)           -> aesc_settle_tx;
-type_to_cb(channel_snapshot_solo_tx)    -> aesc_snapshot_solo_tx;
-type_to_cb(channel_set_delegates_tx)    -> aesc_set_delegates_tx;
-type_to_cb(channel_offchain_tx)         -> aesc_offchain_tx.
+type_to_cb(spend_tx)                  -> aec_spend_tx;
+type_to_cb(oracle_register_tx)        -> aeo_register_tx;
+type_to_cb(oracle_extend_tx)          -> aeo_extend_tx;
+type_to_cb(oracle_query_tx)           -> aeo_query_tx;
+type_to_cb(oracle_response_tx)        -> aeo_response_tx;
+type_to_cb(name_preclaim_tx)          -> aens_preclaim_tx;
+type_to_cb(name_claim_tx)             -> aens_claim_tx;
+type_to_cb(name_transfer_tx)          -> aens_transfer_tx;
+type_to_cb(name_update_tx)            -> aens_update_tx;
+type_to_cb(name_revoke_tx)            -> aens_revoke_tx;
+type_to_cb(contract_call_tx)          -> aect_call_tx;
+type_to_cb(contract_create_tx)        -> aect_create_tx;
+type_to_cb(ga_attach_tx)              -> aega_attach_tx;
+type_to_cb(ga_meta_tx)                -> aega_meta_tx;
+type_to_cb(paying_for_tx)             -> aec_paying_for_tx;
+type_to_cb(channel_create_tx)         -> aesc_create_tx;
+type_to_cb(channel_deposit_tx)        -> aesc_deposit_tx;
+type_to_cb(channel_withdraw_tx)       -> aesc_withdraw_tx;
+type_to_cb(channel_force_progress_tx) -> aesc_force_progress_tx;
+type_to_cb(channel_close_solo_tx)     -> aesc_close_solo_tx;
+type_to_cb(channel_close_mutual_tx)   -> aesc_close_mutual_tx;
+type_to_cb(channel_slash_tx)          -> aesc_slash_tx;
+type_to_cb(channel_settle_tx)         -> aesc_settle_tx;
+type_to_cb(channel_snapshot_solo_tx)  -> aesc_snapshot_solo_tx;
+type_to_cb(channel_set_delegates_tx)  -> aesc_set_delegates_tx;
+type_to_cb(channel_offchain_tx)       -> aesc_offchain_tx;
+type_to_cb(hc_vote_tx)                -> aec_hc_vote_tx.
 
-type_to_swagger_name(spend_tx)                    -> <<"SpendTx">>;
-type_to_swagger_name(oracle_register_tx)          -> <<"OracleRegisterTx">>;
-type_to_swagger_name(oracle_extend_tx)            -> <<"OracleExtendTx">>;
-type_to_swagger_name(oracle_query_tx)             -> <<"OracleQueryTx">>;
-type_to_swagger_name(oracle_response_tx)          -> <<"OracleRespondTx">>;
-type_to_swagger_name(name_preclaim_tx)            -> <<"NamePreclaimTx">>;
-type_to_swagger_name(name_claim_tx)               -> <<"NameClaimTx">>;
-type_to_swagger_name(name_transfer_tx)            -> <<"NameTransferTx">>;
-type_to_swagger_name(name_update_tx)              -> <<"NameUpdateTx">>;
-type_to_swagger_name(name_revoke_tx)              -> <<"NameRevokeTx">>;
-type_to_swagger_name(contract_call_tx)            -> <<"ContractCallTx">>;
-type_to_swagger_name(contract_create_tx)          -> <<"ContractCreateTx">>;
-type_to_swagger_name(ga_attach_tx)                -> <<"GAAttachTx">>;
-type_to_swagger_name(ga_meta_tx)                  -> <<"GAMetaTx">>;
-type_to_swagger_name(paying_for_tx)               -> <<"PayingForTx">>;
-type_to_swagger_name(channel_create_tx)           -> <<"ChannelCreateTx">>;
-type_to_swagger_name(channel_deposit_tx)          -> <<"ChannelDepositTx">>;
-type_to_swagger_name(channel_withdraw_tx)         -> <<"ChannelWithdrawTx">>;
-type_to_swagger_name(channel_force_progress_tx)   -> <<"ChannelForceProgressTx">>;
-type_to_swagger_name(channel_close_solo_tx)       -> <<"ChannelCloseSoloTx">>;
-type_to_swagger_name(channel_close_mutual_tx)     -> <<"ChannelCloseMutualTx">>;
-type_to_swagger_name(channel_slash_tx)            -> <<"ChannelSlashTx">>;
-type_to_swagger_name(channel_settle_tx)           -> <<"ChannelSettleTx">>;
-type_to_swagger_name(channel_snapshot_solo_tx)    -> <<"ChannelSnapshotSoloTx">>;
-type_to_swagger_name(channel_set_delegates_tx)    -> <<"ChannelSetDelegatesTx">>;
+type_to_swagger_name(spend_tx)                  -> <<"SpendTx">>;
+type_to_swagger_name(oracle_register_tx)        -> <<"OracleRegisterTx">>;
+type_to_swagger_name(oracle_extend_tx)          -> <<"OracleExtendTx">>;
+type_to_swagger_name(oracle_query_tx)           -> <<"OracleQueryTx">>;
+type_to_swagger_name(oracle_response_tx)        -> <<"OracleRespondTx">>;
+type_to_swagger_name(name_preclaim_tx)          -> <<"NamePreclaimTx">>;
+type_to_swagger_name(name_claim_tx)             -> <<"NameClaimTx">>;
+type_to_swagger_name(name_transfer_tx)          -> <<"NameTransferTx">>;
+type_to_swagger_name(name_update_tx)            -> <<"NameUpdateTx">>;
+type_to_swagger_name(name_revoke_tx)            -> <<"NameRevokeTx">>;
+type_to_swagger_name(contract_call_tx)          -> <<"ContractCallTx">>;
+type_to_swagger_name(contract_create_tx)        -> <<"ContractCreateTx">>;
+type_to_swagger_name(ga_attach_tx)              -> <<"GAAttachTx">>;
+type_to_swagger_name(ga_meta_tx)                -> <<"GAMetaTx">>;
+type_to_swagger_name(paying_for_tx)             -> <<"PayingForTx">>;
+type_to_swagger_name(channel_create_tx)         -> <<"ChannelCreateTx">>;
+type_to_swagger_name(channel_deposit_tx)        -> <<"ChannelDepositTx">>;
+type_to_swagger_name(channel_withdraw_tx)       -> <<"ChannelWithdrawTx">>;
+type_to_swagger_name(channel_force_progress_tx) -> <<"ChannelForceProgressTx">>;
+type_to_swagger_name(channel_close_solo_tx)     -> <<"ChannelCloseSoloTx">>;
+type_to_swagger_name(channel_close_mutual_tx)   -> <<"ChannelCloseMutualTx">>;
+type_to_swagger_name(channel_slash_tx)          -> <<"ChannelSlashTx">>;
+type_to_swagger_name(channel_settle_tx)         -> <<"ChannelSettleTx">>;
+type_to_swagger_name(channel_snapshot_solo_tx)  -> <<"ChannelSnapshotSoloTx">>;
+type_to_swagger_name(channel_set_delegates_tx)  -> <<"ChannelSetDelegatesTx">>;
 %% not exposed in HTTP API:
-type_to_swagger_name(channel_offchain_tx)         -> <<"ChannelOffchainTx">>.
+type_to_swagger_name(channel_offchain_tx)       -> <<"ChannelOffchainTx">>;
+type_to_swagger_name(hc_vote_tx)                -> <<"HCVoteTx">>.
 
--spec swagger_name_to_type(binary()) -> tx_type().
-swagger_name_to_type(<<"SpendTx">>)                   -> spend_tx;
-swagger_name_to_type(<<"OracleRegisterTx">>)          -> oracle_register_tx;
-swagger_name_to_type(<<"OracleExtendTx">>)            -> oracle_extend_tx;
-swagger_name_to_type(<<"OracleQueryTx">>)             -> oracle_query_tx;
-swagger_name_to_type(<<"OracleRespondTx">>)           -> oracle_response_tx;
-swagger_name_to_type(<<"NamePreclaimTx">>)            -> name_preclaim_tx;
-swagger_name_to_type(<<"NameClaimTx">>)               -> name_claim_tx;
-swagger_name_to_type(<<"NameTransferTx">>)            -> name_transfer_tx;
-swagger_name_to_type(<<"NameUpdateTx">>)              -> name_update_tx;
-swagger_name_to_type(<<"NameRevokeTx">>)              -> name_revoke_tx;
-swagger_name_to_type(<<"ContractCallTx">>)            -> contract_call_tx;
-swagger_name_to_type(<<"ContractCreateTx">>)          -> contract_create_tx;
-swagger_name_to_type(<<"GAAttachTx">>)                -> ga_attach_tx;
-swagger_name_to_type(<<"GAMetaTx">>)                  -> ga_meta_tx;
-swagger_name_to_type(<<"PayingForTx">>)               -> paying_for_tx;
-swagger_name_to_type(<<"ChannelCreateTx">>)           -> channel_create_tx;
-swagger_name_to_type(<<"ChannelDepositTx">>)          -> channel_deposit_tx;
-swagger_name_to_type(<<"ChannelWithdrawTx">>)         -> channel_withdraw_tx;
-swagger_name_to_type(<<"ChannelForceProgressTx">>)    -> channel_force_progress_tx;
-swagger_name_to_type(<<"ChannelCloseSoloTx">>)        -> channel_close_solo_tx;
-swagger_name_to_type(<<"ChannelCloseMutualTx">>)      -> channel_close_mutual_tx;
-swagger_name_to_type(<<"ChannelSlashTx">>)            -> channel_slash_tx;
-swagger_name_to_type(<<"ChannelSettleTx">>)           -> channel_settle_tx;
-swagger_name_to_type(<<"ChannelSnapshotSoloTx">>)     -> channel_snapshot_solo_tx;
-swagger_name_to_type(<<"ChannelSetDelegatesTx">>)     -> channel_set_delegates_tx;
+-spec swagger_name_to_type(binary())               -> tx_type().
+swagger_name_to_type(<<"SpendTx">>)                -> spend_tx;
+swagger_name_to_type(<<"OracleRegisterTx">>)       -> oracle_register_tx;
+swagger_name_to_type(<<"OracleExtendTx">>)         -> oracle_extend_tx;
+swagger_name_to_type(<<"OracleQueryTx">>)          -> oracle_query_tx;
+swagger_name_to_type(<<"OracleRespondTx">>)        -> oracle_response_tx;
+swagger_name_to_type(<<"NamePreclaimTx">>)         -> name_preclaim_tx;
+swagger_name_to_type(<<"NameClaimTx">>)            -> name_claim_tx;
+swagger_name_to_type(<<"NameTransferTx">>)         -> name_transfer_tx;
+swagger_name_to_type(<<"NameUpdateTx">>)           -> name_update_tx;
+swagger_name_to_type(<<"NameRevokeTx">>)           -> name_revoke_tx;
+swagger_name_to_type(<<"ContractCallTx">>)         -> contract_call_tx;
+swagger_name_to_type(<<"ContractCreateTx">>)       -> contract_create_tx;
+swagger_name_to_type(<<"GAAttachTx">>)             -> ga_attach_tx;
+swagger_name_to_type(<<"GAMetaTx">>)               -> ga_meta_tx;
+swagger_name_to_type(<<"PayingForTx">>)            -> paying_for_tx;
+swagger_name_to_type(<<"ChannelCreateTx">>)        -> channel_create_tx;
+swagger_name_to_type(<<"ChannelDepositTx">>)       -> channel_deposit_tx;
+swagger_name_to_type(<<"ChannelWithdrawTx">>)      -> channel_withdraw_tx;
+swagger_name_to_type(<<"ChannelForceProgressTx">>) -> channel_force_progress_tx;
+swagger_name_to_type(<<"ChannelCloseSoloTx">>)     -> channel_close_solo_tx;
+swagger_name_to_type(<<"ChannelCloseMutualTx">>)   -> channel_close_mutual_tx;
+swagger_name_to_type(<<"ChannelSlashTx">>)         -> channel_slash_tx;
+swagger_name_to_type(<<"ChannelSettleTx">>)        -> channel_settle_tx;
+swagger_name_to_type(<<"ChannelSnapshotSoloTx">>)  -> channel_snapshot_solo_tx;
+swagger_name_to_type(<<"ChannelSetDelegatesTx">>)  -> channel_set_delegates_tx;
 %% not exposed in HTTP API:
-swagger_name_to_type(<<"ChannelOffchainTx">>)         -> channel_offchain_tx.
+swagger_name_to_type(<<"ChannelOffchainTx">>)      -> channel_offchain_tx;
+swagger_name_to_type(<<"HCVoteTx">>)               -> hc_vote_tx.
 
 -spec specialize_type(Tx :: tx()) -> {tx_type(), tx_instance()}.
 specialize_type(#aetx{ type = Type, tx = Tx }) -> {Type, Tx}.

--- a/rebar.config
+++ b/rebar.config
@@ -73,7 +73,7 @@
                      {tag, "v3.4.0"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                          {tag, "v1.1.0"}}},
+                          {tag, "v1.2.0"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
                         {ref, "17b56c5"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"2488ff3978f63d4cd9bcf864c6fcd6916cd3f498"}},
+      {ref,"1fe1038c8a72a6a35209bf21011ce0805aca3218"}},
   0},
  {<<"aestratum_lib">>,
   {git,"https://github.com/aeternity/aestratum_lib.git",


### PR DESCRIPTION
Add separate transaction to transport HC end-of-epoch vote data. This TX is _never_ supposed to go on-chain, it is just a (cheap) way to piggy-back on the existing gossiping for data transport.

This PR is supported by Æternity Foundation.