### PR TITLE
Add conditonal POS compilation target.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -244,7 +244,7 @@
                             {aesophia_cli, {git, "https://github.com/aeternity/aesophia_cli", {ref,"e0a1730"}}},
                             {aestratum_client, {git, "https://github.com/aeternity/aestratum_client", {ref, "cfd406a"}}},
                             {websocket_client, {git, "https://github.com/aeternity/websocket_client", {ref, "506d8e2"}}},
-                            {aesophia_aci_encoder, {git, "https://github.com/aeternity/aesophia_aci_encoder", {ref, "f4d60c2"}}}
+                            {aesophia_aci_encoder, {git, "https://github.com/aeternity/aesophia_aci_encoder", {ref, "1f55ee5"}}}
                            ]}
                    ]},
             {prod, [{relx, [{dev_mode, false},

--- a/rebar.config
+++ b/rebar.config
@@ -193,8 +193,13 @@
 
 {profiles, [{local, [{relx, [{dev_mode, true},
                              {include_erts, false},
-                             {include_src, true}]}]
-            },
+                             {include_src, true}]}
+                    ]},
+            {local_pos, [{relx, [{dev_mode, true},
+                                {include_erts, false},
+                                {include_src, true}]},
+                          {erl_opts, [{d, 'POS'}, {d, 'DEBUG_INFO'}]}
+                        ]},
             {dev1, [{relx, [{dev_mode, false},
                             {include_erts, false},
                             {sys_config, "./config/dev1/sys.config"},
@@ -226,6 +231,22 @@
                             {aesophia_aci_encoder, {git, "https://github.com/aeternity/aesophia_aci_encoder", {ref, "f4d60c2"}}}
                            ]}
                    ]},
+            {test_pos, [{relx, [{dev_mode, true},
+                            {include_erts, false},
+                            {include_src, true},
+                            {sys_config, "./config/dev1/sys.config"},
+                            {vm_args, "./config/dev1/vm.args"}]},
+                        {erl_opts, [{d, 'POS'}, {d, 'DEBUG_INFO'}]},
+                        {dist_node, [{setcookie, 'aeternity_cookie'},
+                                     {sname, 'aeternity_ct@localhost'}]},
+                        {deps, [{meck, "0.8.12"},
+                            {aesophia, {git, "https://github.com/aeternity/aesophia.git", {ref,"ffdd4ec"}}},
+                            {aesophia_cli, {git, "https://github.com/aeternity/aesophia_cli", {ref,"e0a1730"}}},
+                            {aestratum_client, {git, "https://github.com/aeternity/aestratum_client", {ref, "cfd406a"}}},
+                            {websocket_client, {git, "https://github.com/aeternity/websocket_client", {ref, "506d8e2"}}},
+                            {aesophia_aci_encoder, {git, "https://github.com/aeternity/aesophia_aci_encoder", {ref, "f4d60c2"}}}
+                           ]}
+                   ]},
             {prod, [{relx, [{dev_mode, false},
                             {include_erts, true},
                             {include_src, false},
@@ -236,6 +257,18 @@
                                         "_build/prod/lib/aeutils/priv/aeternity_config_schema.json",
                                         "data/aeternity_config_schema.json"}]}
                            ]}
+                   ]},
+             {prod_pos, [{relx, [{dev_mode, false},
+                                 {include_erts, true},
+                                 {include_src, false},
+                                 {overlay, [{copy,
+                                             "_build/prod/bin/check_config",
+                                             "bin/check_config"},
+                                            {copy,
+                                             "_build/prod/lib/aeutils/priv/aeternity_config_schema.json",
+                                             "data/aeternity_config_schema.json"}]}
+                         ]},
+                         {erl_opts, [{d, 'POS'}, {d, 'DEBUG_INFO'}]}
                    ]},
             {system_test, [
                 {extra_src_dirs, ["system_test/common", "system_test/common/helpers", "apps/aehttp/test", "apps/aecontract/test/include"]},


### PR DESCRIPTION
Fixes #4476 

Create some pos make targets, where POS is defined in the Erlang compilation for conditional compilation of HyperChains/POS versions of aeternity. 

When using this, consider how we should run tests and build docker images for HC in the future.

This PR is supported by Æternity Foundation.