### PR TITLE
HC: Add the missing logic for skipping expected errors in logs

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1526,7 +1526,7 @@ is_leader(NewTopBlock, PrevKeyHeader, ConsensusModule) ->
         {error, _}     -> false
     end.
 
-setup_loop(State = #state{ mode = pos }, Restart, _, Origin) ->
+setup_loop(State = #state{ mode = pos }, Restart, _IsLeader, Origin) ->
     if not Restart andalso Origin == block_created -> create_key_block_candidate(State);
        true                                        -> State
     end;

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -276,7 +276,7 @@ state_pre_transform_node(Type, Height, PrevNode, Trees) ->
                     {Trees1, CarryOverFlag} = handle_pinning(TxEnv, Trees, EpochInfo, Leader),
                     case get_entropy_hash(Epoch + 2) of
                         {ok, Seed} ->
-                            cache_validators_for_epoch({TxEnv, Trees}, Seed, Epoch + 2),
+                            cache_validators_for_epoch({TxEnv, Trees1}, Seed, Epoch + 2),
                             step_eoe(TxEnv, Trees1, Leader, Seed, 0, -1, CarryOverFlag);
                         {error, _} ->
                             lager:debug("Entropy hash for height ~p is not in cache, attempting to resync", [Height]),

--- a/apps/aecore/test/aecore_errorfree_SUITE.erl
+++ b/apps/aecore/test/aecore_errorfree_SUITE.erl
@@ -5,7 +5,7 @@
 %% common_test exports
 -export(
    [
-    all/0, 
+    all/0,
     init_per_suite/1, end_per_suite/1,
     init_per_testcase/2, end_per_testcase/2
    ]).

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -82,7 +82,9 @@
          check_for_logs/2,
          times_in_epoch_log/3,
          errors_in_logs/2,
-         assert_no_errors_in_logs/1]).
+         assert_no_errors_in_logs/1,
+         assert_no_errors_in_logs/2
+        ]).
 
 -export([proxy/0,
          start_proxy/0,
@@ -121,6 +123,7 @@
 
 -include_lib("kernel/include/file.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -define(OPS_BIN, "aeternity").
 -define(DEFAULT_CUSTOM_EXPECTED_MINE_RATE, 100).
@@ -1091,14 +1094,34 @@ file_missing(F) ->
     end.
 
 assert_no_errors_in_logs(Config) ->
+    assert_no_errors_in_logs(Config, []).
+
+%% Scans the logs for '[error]' patterns and fails if any are found.
+%% If AllowedSubstrings is provided, then any log lines containing these substrings are not reported.
+-spec assert_no_errors_in_logs(Config :: proplists:proplist(), AllowedPatterns :: [string()]) -> ok.
+assert_no_errors_in_logs(Config, AllowedSubstrings) ->
     Nodes = [Node || {Node, _, _} <- ?config(nodes, Config)],
-    Errors = errors_in_logs(Nodes, Config),
-    lists:foreach(
-        fun({Node, {File, Line}}) ->
-            ct:log("Error [~s] in ~s: ~s", [Node, File, Line])
+    Group = proplists:get_value(name, proplists:get_value(tc_group_properties, Config, []), "?"),
+    {IgnoredErrors, ErrorsToReport} = lists:partition(
+        fun({_Node, {_File, Line}}) ->
+            lists:any(
+                fun(Pattern) -> string:find(Line, Pattern) =/= nomatch end,
+                AllowedSubstrings
+            )
         end,
-        Errors),
-    [ ct:fail("Errors in logs, expected 0 got ~p", [length(Errors)]) || [] /= Errors ].
+        errors_in_logs(Nodes, Config)),
+
+    case IgnoredErrors of
+        [] -> ok;
+        _ -> ct:pal("Ignoring errors found in logs, while running group=~s~n~150p", [Group, IgnoredErrors])
+    end,
+    case ErrorsToReport of
+        [] -> ok;
+        _ ->
+            ct:pal("Errors found in logs, while running group=~s~n~150p", [Group, ErrorsToReport]),
+            ?assert(false, "Found errors in logs. To ignore, add substrings to 2nd arg of aecore_suite_utils:assert_no_errors_in_logs/2")
+    end,
+    ok.
 
 errors_in_logs(Nodes, Config) ->
     [{N, Errs} || N <- Nodes,

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -268,7 +268,7 @@ end_per_group(_Group, Config) ->
     [ aecore_suite_utils:stop_node(Node, Config1)
       || {Node, _, _} <- proplists:get_value(nodes, Config1, []) ],
 
-    aecore_suite_utils:assert_no_errors_in_logs(Config1),
+    aecore_suite_utils:assert_no_errors_in_logs(Config1, ["{handled_abort,parent_chain_not_synced}"]),
 
     Config1.
 


### PR DESCRIPTION
This PR relates to #4444 - some logic got lost and fixes the problem with the unexpected output `{test_case_failed,"Errors in logs, expected 0 got 4"}`. Remains to _actually_ fail the test in case of errors.

This PR is supported by Æternity foundation.