### PR TITLE
Add flag field to header records.

### DIFF
--- a/apps/aecore/include/blocks.hrl
+++ b/apps/aecore/include/blocks.hrl
@@ -5,9 +5,38 @@
 -define(BENEFICIARY_PUB_BYTES, 32).
 -define(BLOCK_SIGNATURE_BYTES, 64).
 -define(OPTIONAL_INFO_BYTES, 4).
+-define(FLAG_BYTES, 4).
+-define(FLAG_BITS, 32).
 
--define(KEY_HEADER_TAG, 1).
--define(MICRO_HEADER_TAG, 0).
+-define(SET(X,Y),((X) bor (Y))).
+-define(CLR(X,Y),((X) band (bnot (Y)))).
+
+-define(KEY_HEADER_TAG,              1).
+-define(KEY_HEADER_FLAG,    (1 bsl 31)).
+-define(CONTAINS_INFO_FLAG, (1 bsl 30)).
+-define(HOLE_FLAG,          (1 bsl 29)).
+
+
+-define(MICRO_HEADER_TAG,            0).
+-define(MICRO_HEADER_FLAG,           0).
+-define(POF_FLAG,           (1 bsl 30)).
+
+
+%% The flag field is a 32 bit (4 bytes) field, bits 31 to 0.
+%% %% With the following meaning:
+%%
+%% BIT        MEANING
+%% 31         Block Type: 1 - key, 0 - micro (KEY_HEADER_TAG/MICRO_HEADER_TAG)
+%%
+%% Key blocks (bit 31:1)
+%% 30         ContainsInfo 1 - true, 0 - false
+%% 29         RESERVED (HC Hole block: 1 - a hole block, 0 - ordinary block)
+%% 0 - 28     Unused, should be 0.
+%%
+%% Micro blocks (bit 31:0)
+%% 30         PoFFlag: 1 - pof_hash, 0 - no pof_hash
+%% 0 - 29     Unused, should be 0.
+
 
 -define(KEY_HEADER_MIN_BYTES, 364).
 -define(MIC_HEADER_MIN_BYTES, 216).
@@ -18,6 +47,7 @@
 -type(beneficiary_pubkey() :: <<_:(?BENEFICIARY_PUB_BYTES*8)>>).
 -type(block_header_hash() :: <<_:(?BLOCK_HEADER_HASH_BYTES*8)>>).
 -type(block_signature() :: <<_:(?BLOCK_SIGNATURE_BYTES*8)>>).
+-type(block_header_flags() ::  <<_:?FLAG_BYTES*8>>).
 
 -type(block_type() :: 'key' | 'micro').
 

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1121,7 +1121,7 @@ dirty_get_top_block_node() ->
 %% Some migration code: Ideally, top_block_node is there, and we're done.
 %% If not, we should find top_block_hash. Fetch the corresponding
 %% header, delete the obsolete top_block_hash and put in the new top_block_node.
-%% We do not update the top blok in the DB if it is there, the next top block
+%% We do not update the top block in the DB if it is there, the next top block
 %% will be of the latest version and the get_top_block_node function converts
 %% on the fly.
 convert_top_block_entry() ->

--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -1103,14 +1103,27 @@ get_top_block_hash() ->
     end.
 
 get_top_block_node() ->
-    get_chain_state_value(top_block_node).
+    case get_chain_state_value(top_block_node) of
+        #{ header := Header, hash := Hash} ->
+            NewHeader = aec_headers:from_db_header(Header),
+            #{ header => NewHeader, hash => Hash};
+        undefined -> undefined
+    end.
 
 dirty_get_top_block_node() ->
-    dirty_get_chain_state_value(top_block_node).
+    case dirty_get_chain_state_value(top_block_node) of
+        #{ header := Header, hash := Hash} ->
+            NewHeader = aec_headers:from_db_header(Header),
+            #{ header => NewHeader, hash => Hash};
+        undefined -> undefined
+    end.
 
 %% Some migration code: Ideally, top_block_node is there, and we're done.
 %% If not, we should find top_block_hash. Fetch the corresponding
 %% header, delete the obsolete top_block_hash and put in the new top_block_node.
+%% We do not update the top blok in the DB if it is there, the next top block
+%% will be of the latest version and the get_top_block_node function converts
+%% on the fly.
 convert_top_block_entry() ->
     ?t(convert_top_block_entry_()).
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -49,7 +49,7 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
--define(CHILD_BLOCK_TIME, 500).
+-define(CHILD_BLOCK_TIME, 300).
 -define(PARENT_EPOCH_LENGTH, 3).
 -define(PARENT_FINALITY, 2).
 -define(REWARD_DELAY, 2).

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -49,7 +49,7 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
--define(CHILD_BLOCK_TIME, 300).
+-define(CHILD_BLOCK_TIME, 200).
 -define(PARENT_EPOCH_LENGTH, 3).
 -define(PARENT_FINALITY, 2).
 -define(REWARD_DELAY, 2).

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -49,7 +49,7 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
--define(CHILD_BLOCK_TIME, 200).
+-define(CHILD_BLOCK_TIME, 500).
 -define(PARENT_EPOCH_LENGTH, 3).
 -define(PARENT_FINALITY, 2).
 -define(REWARD_DELAY, 2).

--- a/system_test/common/aest_sync_SUITE.erl
+++ b/system_test/common/aest_sync_SUITE.erl
@@ -259,7 +259,10 @@ new_node_joins_network(Cfg) ->
     ct:log("Node 3 at height ~p: ~p", [Length, Height3]),
 
     %% Checks node 3 is synchronized with nodes 1 and 2
-    ?assertEqual(Height1#{info => aeser_api_encoder:encode(contract_bytearray, <<>>)}, Height3),
+    %% ?assertEqual(Height1#{info => aeser_api_encoder:encode(contract_bytearray, <<>>)}, Height3),
+    %% Comparing the hash of the block should be sufficient allowing for
+    %% new fields such as flags to be added to the block map.
+    ?assertEqual(maps:get(hash, Height1), maps:get(hash, Height3)),
     ok.
 
 %% When we stop and restart a node we will be able to read the blocks


### PR DESCRIPTION
Fixes #4479 

Include the flags for both key- and micro-blocks in the header record.

Handle old versions of the record when read from the database.
Handles the old and new versions in binary and client serialization/deserialization.

Fixes the db function *get_top_block_node, which did not do a header upgrade.

This PR is supported by Æternity Foundation.