### PR TITLE
Add child block production time configuration key

### DIFF
--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -49,7 +49,7 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
--define(CHILD_BLOCK_TIME, 400).
+-define(CHILD_BLOCK_TIME, 200).
 -define(CHILD_BLOCK_PRODUCTION_TIME, 80).
 -define(PARENT_EPOCH_LENGTH, 3).
 -define(PARENT_FINALITY, 2).

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -49,7 +49,8 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
--define(CHILD_BLOCK_TIME, 200).
+-define(CHILD_BLOCK_TIME, 400).
+-define(CHILD_BLOCK_PRODUCTION_TIME, 80).
 -define(PARENT_EPOCH_LENGTH, 3).
 -define(PARENT_FINALITY, 2).
 -define(REWARD_DELAY, 2).
@@ -1654,7 +1655,8 @@ node_config(Node, CTConfig, PotentialStakers, ReceiveAddress, ProducingCommitmen
                         },
                     <<"genesis_start_time">> => GenesisStartTime,
                     <<"child_epoch_length">> => ?CHILD_EPOCH_LENGTH,
-                    <<"child_block_time">> => ?CHILD_BLOCK_TIME
+                    <<"child_block_time">> => ?CHILD_BLOCK_TIME,
+                    <<"child_block_production_time">> => ?CHILD_BLOCK_PRODUCTION_TIME
                  },
     Protocol = aect_test_utils:latest_protocol_version(),
     {ok, ContractFileName} = aecore_suite_utils:hard_fork_filename(Node, CTConfig, integer_to_list(Protocol), binary_to_list(NetworkId) ++ "_contracts.json"),

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1735,6 +1735,10 @@
                                             "defult": 500,
                                             "type": "integer"
                                         },
+                                        "child_block_production_time": {
+                                            "description": "The time in milliseconds to produce a child block",
+                                            "type": "integer"
+                                        },
                                         "child_epoch_length": {
                                             "description": "The number of blocks in an epoch on the child chain",
                                             "type": "integer"


### PR DESCRIPTION
Needed for synchronizing hyperchains.

This PR is supported by Æternity Foundation.