### PR TITLE
Improve block production logic

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1299,6 +1299,16 @@ handle_key_block_candidate_reply({{ok, KeyBlockCandidate}, TopHash},
                  end,
     State1 = State#state{key_block_candidates = Candidates},
     start_block_production_(State1);
+handle_key_block_candidate_reply({{ok, KeyBlockCandidate}, NewTopHash},
+                                 #state{top_block_hash = TopHash,
+                                        mode = pos} = State) ->
+    epoch_mining:info("Created PoS key block candidate: ~p with micro-block: ~p",
+                      [aec_blocks:height(KeyBlockCandidate), NewTopHash /= TopHash]),
+    {ForSealing, Candidate} = make_key_candidate(KeyBlockCandidate),
+
+    Candidates = [{ForSealing, Candidate}],
+    State1 = State#state{key_block_candidates = Candidates},
+    start_block_production_(State1);
 handle_key_block_candidate_reply({{ok, _KeyBlockCandidate}, _OldTopHash},
                                  #state{top_block_hash = _TopHash} = State) ->
     epoch_mining:debug("Created key block candidate is already stale, create a new one", []),

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -657,10 +657,11 @@ beneficiary() ->
     leader_for_height(Height).
 
 next_beneficiary() ->
-    {TxEnv, Trees} = aetx_env:tx_env_and_trees_from_top(aetx_transaction),
+    {ok, KeyBlock} = aec_chain:top_key_block(),
     ChildBlockTime = child_block_time(),
-    case aeu_time:now_in_msecs() - aetx_env:time_in_msecs(TxEnv) of
+    case aeu_time:now_in_msecs() - aec_blocks:time_in_msecs(KeyBlock) of
         T when T >= ChildBlockTime ->
+            {TxEnv, Trees} = aetx_env:tx_env_and_trees_from_top(aetx_transaction),
             next_beneficiary(TxEnv, Trees);
         T ->
             lager:debug("Not time for next block yet; sleeping ~p ms", [ChildBlockTime - T + 1]),


### PR DESCRIPTION
- base production on last key-block time
- don't (accidentally) discard key-blocks if they're built on micro-blocks.

This PR is supported by Æternity foundation.