### PR TITLE
Make logdir configuration work as intended

### DIFF
--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -22,6 +22,7 @@
     exometer_core,
     redbug,
     yamerl,
+    setup,
     lager,
     aeutils,
     base58,

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -98,6 +98,7 @@ mine_block_test_() ->
 
 setup() ->
     InitialApps = {running_apps(), loaded_apps()},
+    {ok, _} = application:ensure_all_started(setup),
     {ok, _} = application:ensure_all_started(aeutils),
     aec_test_utils:mock_fast_and_deterministic_cuckoo_pow(),
     aec_test_utils:start_chain_db(),

--- a/apps/aecore/test/aec_target_tests.erl
+++ b/apps/aecore/test/aec_target_tests.erl
@@ -46,6 +46,7 @@ target_adj_test_() ->
 
 setup() ->
     InitialApps = {running_apps(), loaded_apps()},
+    {ok, _} = application:ensure_all_started(setup),
     {ok, _} = application:ensure_all_started(aeutils),
     meck:new(aec_txs_trees, [passthrough]),
     meck:new(aec_conductor, [passthrough]),

--- a/apps/aeutils/src/aeutils.app.src
+++ b/apps/aeutils/src/aeutils.app.src
@@ -5,6 +5,7 @@
   {applications,
    [kernel,
     stdlib,
+    setup,
     lager,
     gproc,
     jobs,

--- a/config/sys.config
+++ b/config/sys.config
@@ -161,6 +161,7 @@
                     {mnesia_compatible_aborts, true}]},
 
   {setup, [
+           {verify_directories, false},  % stop setup from creating dirs
            {abort_on_error, true},
            {data_dir, "$HOME/data"},
            {log_dir, "$HOME/log"}

--- a/config/sys.config
+++ b/config/sys.config
@@ -163,6 +163,8 @@
   {setup, [
            {verify_directories, false},  % stop setup from creating dirs
            {abort_on_error, true},
+           %% Note: $HOME here means the aeternity directory, not the user home!
+           %% (These variables are a feature of the setup application.)
            {data_dir, "$HOME/data"},
            {log_dir, "$HOME/log"}
           ]}

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -155,9 +155,12 @@ the temporary directory that was created, do:
       variable expansion on the configuration values. E.g., if an application
       `x` has a configuration entry `{log_dir, "$HOME/log"}`, then calling
       `setup:get_env(x, log_dir)` will return something like
-      "/home/username/log". (This only works on variables defined via `setup`
-      itself, not general shell environment variables - `$HOME` is a
-      predefined special case.)
+      "/home/username/log". *This only works on variables defined by `setup`
+      itself, not operating system environment variables. Note in particular
+      that `$HOME` does not mean the current user's home directory - it
+      refers to the `setup` configuration key `{home, Dir}` meaning the
+      root directory of the Aeternity system; if not set, the current
+      directory is used.*
     - Setup has a configuration option `data_dir` which the Aeternity system
       uses to know where its database is located. The directory needs to
       already exist and be populated at system start, else the startup fails.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
-%% The requirements on the OTP version come mainly from the patches%% for OTP modules - see `otp_patches/` - requiring the version of
+%% The requirements on the OTP version come mainly from the patches
+%% for OTP modules - see `otp_patches/` - requiring the version of
 %% certain OTP applications, e.g. `mnesia`, to be well known in order
 %% for such patches to be applied deterministically.
 %%
@@ -114,8 +115,9 @@
 
 {relx, [{release, { aeternity, "version value comes from VERSION" },
          % sasl is required for the command `aeternity versions` to work,
-         % it is disabled in `sys.config` though.
-         [runtime_tools, sasl, lager, setup, sext, gproc, jobs, lz4, argparse, trace_runner, app_ctrl,
+         % it is disabled in `sys.config` though. Note that setup must be
+         % started before lager
+         [runtime_tools, sasl, setup, lager, sext, gproc, jobs, lz4, argparse, trace_runner, app_ctrl,
           {rocksdb, load}, {mnesia_rocksdb, load}, {mnesia, load}, kache,
           parse_trans, exometer_core, ranch, aeminer, aecore, aeapi, aehttp, enacl, enoise,
           aebytecode, aeserialization, aevm, aechannel, aefate, aemon, aestratum, ecrecover,


### PR DESCRIPTION
The logdir configuration is defined in `setup` part of the sys.config, just like the data dir, but it did not work as intended because lager wants to create the log directory on disk as soon as it starts, and at that point it will have its own default config settings. This fixes the problem and switches the start order of setup and lager.
Depends on #4496.

This PR is supported by Æternity Foundation.