### PR TITLE
Faster dev container builds

### DIFF
--- a/.devcontainer/focal/devcontainer.json
+++ b/.devcontainer/focal/devcontainer.json
@@ -18,6 +18,13 @@
     "ERLANG_ROCKSDB_OPTS": "-DWITH_SYSTEM_ROCKSDB=ON -DWITH_LZ4=ON -DWITH_SNAPPY=ON -DWITH_BZ2=ON -DWITH_ZSTD=ON"
   },
 
+  // Additional host directories
+  "mounts": [
+    // Uncomment to mount your local ~/.aeternity directory under the
+    // home directory of the container user
+    //"source=${localEnv:HOME}/.aeternity,target=/home/builder/.aeternity,type=bind,consistency=cached"
+  ],
+
   // Run container commands as a different user than the container default
   // (Note: containers running as root cannot be updated to the local UID)
   "remoteUser": "builder",

--- a/.devcontainer/focal/devcontainer.json
+++ b/.devcontainer/focal/devcontainer.json
@@ -12,6 +12,12 @@
    //   "args": { },
    // },
 
+  "containerEnv": {
+    // Build with dynamically linked RocksDB like we do in the
+    // main Aeternity Dockerfile, speeding up full builds a lot
+    "ERLANG_ROCKSDB_OPTS": "-DWITH_SYSTEM_ROCKSDB=ON -DWITH_LZ4=ON -DWITH_SNAPPY=ON -DWITH_BZ2=ON -DWITH_ZSTD=ON"
+  },
+
   // Run container commands as a different user than the container default
   // (Note: containers running as root cannot be updated to the local UID)
   "remoteUser": "builder",

--- a/.devcontainer/jammy/devcontainer.json
+++ b/.devcontainer/jammy/devcontainer.json
@@ -18,6 +18,13 @@
       "ERLANG_ROCKSDB_OPTS": "-DWITH_SYSTEM_ROCKSDB=ON -DWITH_LZ4=ON -DWITH_SNAPPY=ON -DWITH_BZ2=ON -DWITH_ZSTD=ON"
   },
 
+  // Additional host directories
+  "mounts": [
+    // Uncomment to mount your local ~/.aeternity directory under the
+    // home directory of the container user
+    //"source=${localEnv:HOME}/.aeternity,target=/home/builder/.aeternity,type=bind,consistency=cached"
+  ],
+
   // Run container commands as a different user than the container default
   // (Note: containers running as root cannot be updated to the local UID)
   "remoteUser": "builder",

--- a/.devcontainer/jammy/devcontainer.json
+++ b/.devcontainer/jammy/devcontainer.json
@@ -12,6 +12,12 @@
    //   "args": { },
    // },
 
+  "containerEnv": {
+      // Build with dynamically linked RocksDB like we do in the
+      // main Aeternity Dockerfile, speeding up full builds a lot
+      "ERLANG_ROCKSDB_OPTS": "-DWITH_SYSTEM_ROCKSDB=ON -DWITH_LZ4=ON -DWITH_SNAPPY=ON -DWITH_BZ2=ON -DWITH_ZSTD=ON"
+  },
+
   // Run container commands as a different user than the container default
   // (Note: containers running as root cannot be updated to the local UID)
   "remoteUser": "builder",

--- a/.devcontainer/noble/devcontainer.json
+++ b/.devcontainer/noble/devcontainer.json
@@ -18,6 +18,13 @@
     "ERLANG_ROCKSDB_OPTS": "-DWITH_SYSTEM_ROCKSDB=ON -DWITH_LZ4=ON -DWITH_SNAPPY=ON -DWITH_BZ2=ON -DWITH_ZSTD=ON"
   },
 
+  // Additional host directories
+  "mounts": [
+    // Uncomment to mount your local ~/.aeternity directory under the
+    // home directory of the container user
+    //"source=${localEnv:HOME}/.aeternity,target=/home/builder/.aeternity,type=bind,consistency=cached"
+  ],
+
   // Run container commands as a different user than the container default
   // (Note: containers running as root cannot be updated to the local UID)
   "remoteUser": "builder",

--- a/.devcontainer/noble/devcontainer.json
+++ b/.devcontainer/noble/devcontainer.json
@@ -12,6 +12,12 @@
    //   "args": { },
    // },
 
+  "containerEnv": {
+    // Build with dynamically linked RocksDB like we do in the
+    // main Aeternity Dockerfile, speeding up full builds a lot
+    "ERLANG_ROCKSDB_OPTS": "-DWITH_SYSTEM_ROCKSDB=ON -DWITH_LZ4=ON -DWITH_SNAPPY=ON -DWITH_BZ2=ON -DWITH_ZSTD=ON"
+  },
+
   // Run container commands as a different user than the container default
   // (Note: containers running as root cannot be updated to the local UID)
   "remoteUser": "builder",


### PR DESCRIPTION
To speed up building from scratch in a dev container, we need to set the environment variable ERLANG_ROCKSDB_OPTS like we do in the main Aeternity Dockerfile, so that we link with the pre-built RocksDb library in the container, instead of building the entire RocksDb C++ codebase which takes quite a long time.

Also includes an example of how to easily mount your ~/.aeternity directory into the container.