### PR TITLE
Add proper event handling for HC key-blocks

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -943,14 +943,14 @@ apply_node_transactions(Node, PrevNode, Trees, ForkInfo, State) ->
             Trees2 = if Consensus =:= PrevConsensus -> Trees1;
                         true -> Consensus:state_pre_transform_key_node_consensus_switch(Node, Trees1)
                      end,
-            Trees3 = Consensus:state_pre_transform_key_node(Node, PrevNode, Trees2),
+            {Trees3, Events} = Consensus:state_pre_transform_key_node(Node, PrevNode, Trees2),
             %% leader generation happens after pre_transformations
             case validate_generation_leader(Node, Trees3, Env) of
                 ok ->
                     Delay  = aec_governance:beneficiary_reward_delay(),
                     case Height > aec_block_genesis:height() + Delay of
-                        true  -> {grant_fees(Node, Trees3, Delay, FraudStatus, State), TotalFees, no_events()};
-                        false -> {Trees3, TotalFees, no_events()}
+                        true  -> {grant_fees(Node, Trees3, Delay, FraudStatus, State), TotalFees, Events};
+                        false -> {Trees3, TotalFees, Events}
                     end;
                 {error, Reason} ->
                     error({leader_validation_failed, Reason})

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -945,6 +945,7 @@ publish_tx_events(Events, Hash, Origin) ->
      || {Event, Info} <- lists:reverse(Events)].
 
 publish_events(Events) ->
+    lager:debug("publish key-block events: ~p", [Events]),
     [aec_events:publish(Type, Info) || {Type, Info} <- Events].
 
 

--- a/apps/aecore/src/aec_consensus.erl
+++ b/apps/aecore/src/aec_consensus.erl
@@ -173,7 +173,7 @@
 %% Performs initial state transformation when the previous block used a different consensus algorithm
 -callback state_pre_transform_key_node_consensus_switch(#node{}, aec_trees:trees()) -> aec_trees:trees() | no_return().
 %% State pre transformations on every keyblock
--callback state_pre_transform_key_node(#node{}, #node{}, aec_trees:trees()) -> aec_trees:trees() | no_return().
+-callback state_pre_transform_key_node(#node{}, #node{}, aec_trees:trees()) -> {aec_trees:trees(), aetx_env:events()} | no_return().
 %% State pre transformations on every microblock
 -callback state_pre_transform_micro_node(non_neg_integer(), #node{}, aec_trees:trees()) -> aec_trees:trees() | no_return().
 

--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -431,7 +431,7 @@ micro_block_height_relative_previous_block(_Type, Height) ->
 %% -------------------------------------------------------------------
 %% Custom state transitions
 state_pre_transform_key_node_consensus_switch(_Node, Trees) -> Trees.
-state_pre_transform_key_node(_Node, _PrevNode, Trees) -> Trees.
+state_pre_transform_key_node(_Node, _PrevNode, Trees) ->  {Trees, []}.
 state_pre_transform_micro_node(_Height, _PrevNode, Trees) -> Trees.
 
 %% -------------------------------------------------------------------

--- a/apps/aecore/src/aec_consensus_common_tests.erl
+++ b/apps/aecore/src/aec_consensus_common_tests.erl
@@ -186,7 +186,7 @@ micro_block_height_relative_previous_block(_Type, Height) ->
 %% -------------------------------------------------------------------
 %% Custom state transitions
 state_pre_transform_key_node_consensus_switch(_Node, Trees) -> Trees.
-state_pre_transform_key_node(_Node, _PrevNode, Trees) -> Trees.
+state_pre_transform_key_node(_Node, _PrevNode, Trees) -> {Trees, []}.
 state_pre_transform_micro_node(_Height, _PrevNode, Trees) -> Trees.
 
 %% -------------------------------------------------------------------

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -303,20 +303,21 @@ state_pre_transform_node(Type, Height, PrevNode, Trees) ->
             end,
             %% note that EpochFirst and EpochLast could be the same, not exclusive
             if Height =:= EpochLast ->
-                    {Trees1, CarryOverFlag} = handle_pinning(TxEnv, Trees, EpochInfo, Leader),
+                    {Trees1, CarryOverFlag, Events} = handle_pinning(TxEnv, Trees, EpochInfo, Leader),
                     case get_entropy_hash(Epoch + 2) of
                         {ok, Seed} ->
                             cache_validators_for_epoch({TxEnv, Trees1}, Seed, Epoch + 2),
                             Trees2 = step_eoe(TxEnv, Trees1, Leader, Seed, 0, -1, CarryOverFlag),
                             start_default_pinning_process(TxEnv, Trees2, Height),
-                            Trees2;
+                            {Trees2, Events};
                         {error, _} ->
                             lager:debug("Entropy hash for height ~p is not in cache, attempting to resync", [Height]),
                             %% Fail the keyblock production flow, attempt to resync
                             aec_conductor:throw_error(parent_chain_not_synced)
                     end;
                true ->
-                    step(TxEnv, Trees, Leader)
+                    Trees1 = step(TxEnv, Trees, Leader),
+                    {Trees1, []}
             end;
         micro ->
             step_micro(TxEnv, Trees, Leader)
@@ -935,19 +936,19 @@ is_leader_valid(Node, _Trees, TxEnv, _PrevNode) ->
             aec_conductor:throw_error(parent_chain_block_not_synced)
     end.
 
-handle_pinning(TxEnv, Trees, EpochInfo, Leader ) ->
+handle_pinning(TxEnv, Trees, EpochInfo, Leader) ->
     case validate_pin(TxEnv, Trees, EpochInfo) of
         pin_missing ->
             lager:debug("PINNING: no proof posted"),
-            aec_events:publish(pin, {no_proof_posted}),
-            {Trees, true};
+            %% aec_events:publish(pin, {no_proof_posted}),
+            {Trees, true, [{pin, {no_proof_posted}}]};
         pin_correct ->
-            Trees1 = add_pin_reward(Trees, TxEnv, Leader, EpochInfo),
-            {Trees1, false};
+            {Trees1, Events} = add_pin_reward(Trees, TxEnv, Leader, EpochInfo),
+            {Trees1, false, Events};
         pin_validation_fail ->
             lager:debug("PINNING: Incorrect proof posted"),
-            aec_events:publish(pin, {incorrect_proof_posted}),
-            {Trees, true}
+            %% aec_events:publish(pin, {incorrect_proof_posted}),
+            {Trees, true, [{pin, {incorrect_proof_posted}}]}
     end.
 
 validate_pin(TxEnv, Trees, CurEpochInfo) ->
@@ -974,12 +975,13 @@ validate_pin(TxEnv, Trees, CurEpochInfo) ->
 
 add_pin_reward(Trees, TxEnv, Leader, #{epoch := CurEpoch, last := Last} = _EpochInfo) ->
     #{cur_pin_reward := Reward} = aec_chain_hc:pin_reward_info({TxEnv, Trees}),
-    aec_events:publish(pin, {pin_accepted, #{reward => Reward, recipient => Leader, epoch => CurEpoch, height => Last}}),
+    Event = {pin, {pin_accepted, #{reward => Reward, recipient => Leader, epoch => CurEpoch, height => Last}}},
+    %% aec_events:publish(pin, {pin_accepted, #{reward => Reward, recipient => Leader, epoch => CurEpoch, height => Last}}),
     ATrees = aec_trees:accounts(Trees),
     LeaderAcc = aec_accounts_trees:get(Leader, ATrees),
     {ok, LeaderAcc1} = aec_accounts:earn(LeaderAcc, Reward),
     ATrees1 = aec_accounts_trees:enter(LeaderAcc1, ATrees),
-    aec_trees:set_accounts(Trees, ATrees1).
+    {aec_trees:set_accounts(Trees, ATrees1), [Event]}.
 
 create_contracts([], _TxEnv, Trees) -> Trees;
 create_contracts([Contract | Tail], TxEnv, TreesAccum) ->

--- a/apps/aecore/src/aec_consensus_on_demand.erl
+++ b/apps/aecore/src/aec_consensus_on_demand.erl
@@ -203,7 +203,7 @@ micro_block_height_relative_previous_block(_Type, Height) ->
 %% -------------------------------------------------------------------
 %% Custom state transitions
 state_pre_transform_key_node_consensus_switch(_Node, Trees) -> Trees.
-state_pre_transform_key_node(_Node, _PrevNode, Trees) -> Trees.
+state_pre_transform_key_node(_Node, _PrevNode, Trees) -> {Trees, []}.
 state_pre_transform_micro_node(_Height, _PrevNode, Trees) -> Trees.
 
 %% -------------------------------------------------------------------

--- a/apps/aecore/src/aec_pinning_agent.erl
+++ b/apps/aecore/src/aec_pinning_agent.erl
@@ -43,11 +43,10 @@ spawn_for_epoch(EpochInfo, Contract, LastLeader) ->
     end.
 
 start(EpochInfo, Contract, LastLeader) ->
-    {ok,
     #{ first      := First
      , epoch      := _Epoch
      , length     := Length
-     , validators := _Validators}} = EpochInfo,
+     , validators := _Validators} = EpochInfo,
     subscribe(),
     lager:debug("AGENT: started ~p", [self()]),
     wait_for_top_changed(First + Length - 2, none, false, Contract, LastLeader).


### PR DESCRIPTION
- Let the key-block pre transformation return events and emit these _after_ the block is successfully inserted. 
- Use this mechanism for `pin` events
- Add `new_epoch` event
- Use the `new_epoch` event to implement GC in the HC vote pool

Closes #4494 (though an event for staking pool is not explicitly added)

This PR is supported by Æternity Foundation