### PR TITLE
Pinning Agent refactor to `new_epoch` event

### DIFF
--- a/apps/aecore/src/aec_events.erl
+++ b/apps/aecore/src/aec_events.erl
@@ -37,6 +37,7 @@
                | oracle_query_tx_created
                | oracle_response_tx_created
                | pin
+               | new_epoch
                | {tx_event, any()}.
 
 -spec publish(event(), any()) -> ok.

--- a/apps/aecore/src/aec_pinning_agent.erl
+++ b/apps/aecore/src/aec_pinning_agent.erl
@@ -8,6 +8,7 @@
 
 -module(aec_pinning_agent).
 -author("mans.af.klercker@happihacking.se").
+-behaviour(gen_server).
 
 %%%=============================================================================
 %%% Export and Defs
@@ -15,31 +16,114 @@
 
 %% External API
 -export([
+    start_link/2,
+    stop/0
+]).
+
+%% Callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-export([
     spawn_for_epoch/3,
     start/3
-    ]).
+]).
 
 -define(SERVER, ?MODULE).
+-define(WORKER, worker_name()).
+
+%% Loop state
+-record(state, {
+    contract
+}).
+-type state() :: state.
 
 %%%=============================================================================
 %%% API
 %%%=============================================================================
 
+-spec start_link(term(), atom()) -> {ok, pid()} | {error, {already_started, pid()}} | ignore | {error, Reason::any()}.
+start_link(Contract, PinningBehavior) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [Contract, PinningBehavior], []).
+
+%%%=============================================================================
+%%% Gen Server Callbacks
+%%%=============================================================================
+
+init([Contract, PinningBehavior]) ->
+    case PinningBehavior of
+        true ->
+            State = #state{contract = Contract},
+            lager:debug("started pinning agent"),
+            aec_events:subscribe(new_epoch),
+            {ok, State};
+        false ->
+            lager:debug("default pinning off - no agent started", []),
+            ignore
+    end.
+
+
+handle_call(_Request, _From, LoopState) ->
+    Reply = ok,
+    {reply, Reply, LoopState}.
+
+handle_cast(_Msg, LoopState) ->
+    {noreply, LoopState}.
+
+handle_info({gproc_ps_event, new_epoch, #{info := EpochInfo}}, #state{contract = Contract} = State) ->
+    Reply = spawn_for_epoch(EpochInfo, Contract),
+    {Reply, State};
+handle_info(_Info, LoopState) ->
+    {noreply, LoopState}.
+
+terminate(_Reason, _LoopState) ->
+    ok.
+
+code_change(_OldVsn, LoopState, _Extra) ->
+    {ok, LoopState}.
+
+    % case aec_parent_connector:has_parent_account(LastLeader) of
+    %     true -> aec_pinning_agent:spawn_for_epoch(NextEpochInfo, get_contract_pubkey(?ELECTION_CONTRACT), LastLeader);
+    %     false -> lager:debug("AGENT: No parent chain account found for ~p", [LastLeader])
+    % end
+stop() ->
+    lager:debug("STOPPED"),
+    gen_server:stop(?SERVER).
+%%%=============================================================================
+%%% API
+%%%=============================================================================
+
+
+%%%=============================================================================
+%%% Pinning Worker Process
+%%%=============================================================================
+
+spawn_for_epoch(#{last := Last} = EpochInfo, Contract) ->
+    {ok, LastLeader} = aec_consensus_hc:leader_for_height(Last),
+    case aec_parent_connector:has_parent_account(LastLeader) of
+        true -> spawn_for_epoch(EpochInfo, Contract, LastLeader);
+        false -> lager:debug("no pin in epoch, no parent account for ~p", [LastLeader]), noreply
+    end.
 
 spawn_for_epoch(EpochInfo, Contract, LastLeader) ->
-    lager:debug("AGENT: Trying to spawn pinning agent...", []),
     try
     case whereis(my_unique_process) of
         undefined ->
             Pid = spawn(aec_pinning_agent, start, [EpochInfo, Contract, LastLeader]),
-            register(?MODULE, Pid),
-            Pid;
+            register(?WORKER, Pid),
+            noreply;
         Pid when is_pid(Pid) ->
-            lager:debug("AGENT: already started", []),
-            ok
+            lager:debug("pinning worker already started", []),
+            noreply
     end
     catch
-        T:E -> lager:debug("AGENT: Broke!! ~p:~p", [T,E]), ok
+        T:E -> lager:debug("Pinning agent worker failed: ~p:~p", [T,E]),  noreply
     end.
 
 start(EpochInfo, Contract, LastLeader) ->
@@ -48,37 +132,32 @@ start(EpochInfo, Contract, LastLeader) ->
      , length     := Length
      , validators := _Validators} = EpochInfo,
     subscribe(),
-    lager:debug("AGENT: started ~p", [self()]),
+    lager:debug("pinning worker started ~p", [self()]),
     wait_for_top_changed(First + Length - 2, none, false, Contract, LastLeader).
 
-%%%=============================================================================
-%%% Internal functions
-%%%=============================================================================
 
 %%%=============================================================================
 %%% FSM
 %%%=============================================================================
 
-
 subscribe() ->
     aec_events:subscribe(top_changed).
 
 post_pin_to_pc(LastLeader, Height) ->
-    lager:debug("AGENT: (~p) Time to send to PC ~p", [self(), Height]),
     PCPinTx = aec_parent_connector:pin_to_pc(LastLeader, 1, 1000000 * min_gas_price()),
-    lager:debug("AGENT: (~p) pc-pinned ~p", [self(), PCPinTx]),
+    lager:debug("(~p) Pinned to PC ~p at height ~p", [self(), PCPinTx, Height]),
     PCPinTx.
 
 post_pin_pctx_to_cc(PinTx, LastLeader, Height) ->
-    lager:debug("AGENT: (~p) noting on CC @~p", [self(), Height]),
     try
-        aec_parent_connector:pin_tx_to_cc(PinTx, LastLeader, 1, 1000000 * min_gas_price())
+        aec_parent_connector:pin_tx_to_cc(PinTx, LastLeader, 1, 1000000 * min_gas_price()),
+        lager:debug("(~p) noting on CC @~p", [self(), Height])
     catch
-        T:E -> lager:debug("CRASHHHH: ~p:~p", [T,E]), ok
+        T:E -> lager:debug("Pin to CC failed: ~p:~p", [T,E]), ok
     end.
 
 post_pin_proof(ContractPubkey, PinTx, LastLeader, Height) ->
-    lager:debug("AGENT: (~p) pin proof @~p ~p", [self(), Height, PinTx]),
+    lager:debug("(~p) pin proof @~p ~p", [self(), Height, PinTx]),
     aec_parent_connector:pin_contract_call(ContractPubkey, PinTx, LastLeader, 0, 1000000 * min_gas_price()).
 
 wait_for_top_changed(Last, none, _, Contract, LastLeader) -> % no pin on PC yet, then we post one once the next CC block is done
@@ -121,6 +200,9 @@ wait_for_top_changed(Last, PCPinTx, true, Contract, LastLeader) ->
 %%%=============================================================================
 %%% Helpers, communication
 %%%=============================================================================
+
+worker_name() ->
+    list_to_atom(?MODULE_STRING "_worker").
 
 min_gas_price() ->
     Protocol = aec_hard_forks:protocol_effective_at_height(1),

--- a/apps/aehttp/src/aehttpc_aeternity.erl
+++ b/apps/aehttp/src/aehttpc_aeternity.erl
@@ -204,17 +204,17 @@ post_pin_tx(SignedSpendTx, NodeSpec) ->
 pin_contract_call(ContractPubkey, PinTx, Who, Amount, _Fee, SignModule) ->
     Nonce = get_local_nonce(Who),
     {ok, CallData} = aeb_fate_abi:create_calldata("pin", [{bytes, PinTx}]),
-    ABI = ?ABI_FATE_SOPHIA_1, % not really nice, what is the supported version of getting the latest ABI version
+    ABI = ?ABI_FATE_SOPHIA_1,
     TxSpec =
-        #{  caller_id   => aeser_id:create(account, Who)
-          , nonce       => Nonce
-          , contract_id => aeser_id:create(contract, ContractPubkey)
-          , abi_version => ABI
-          , fee         => 1000000 * min_gas_price()
-          , amount      => Amount
-          , gas         => 1000000
-          , gas_price   => min_gas_price()
-          , call_data   => CallData},
+        #{caller_id   => aeser_id:create(account, Who)
+        , nonce       => Nonce
+        , contract_id => aeser_id:create(contract, ContractPubkey)
+        , abi_version => ABI
+        , fee         => 1000000 * min_gas_price()
+        , amount      => Amount
+        , gas         => 1000000
+        , gas_price   => min_gas_price()
+        , call_data   => CallData},
     {ok, Tx} = aect_call_tx:new(TxSpec),
     NetworkId = aec_governance:get_network_id(),
     SignedCallTx = sign_tx(Tx, NetworkId, Who, SignModule),
@@ -231,8 +231,7 @@ get_pin_by_tx_hash(TxHashEnc, NodeSpec) ->
          {ok, TxHash} ->
             TxPath = <<"/v3/transactions/", TxHash/binary>>,
             case get_request(TxPath, NodeSpec, 5000) of
-                {ok, #{<<"tx">> := #{<<"payload">> := EncPin}, <<"block_height">> := Height}} = _Tx ->
-                    %lager:debug("TXXXX: ~p", [Tx]),
+                {ok, #{<<"tx">> := #{<<"payload">> := EncPin}, <<"block_height">> := Height}} ->
                     {ok, Pin} = aeser_api_encoder:safe_decode(bytearray, EncPin),
                     {ok, DecPin} = decode_parent_pin_payload(Pin),
                     {ok, maps:put(pc_height, Height, DecPin)}; % add the pc block height to pin map, -1 = not on chain yet.


### PR DESCRIPTION
Move pinning agent invocation code from inner consensus callbacks to separate gen_server+worker process.

This PR is supported by Æternity Foundation