### PR TITLE
Staking contracts overhaul

### DIFF
--- a/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
@@ -17,39 +17,11 @@
         ]).
 
 -export([ new_validator/1,
-          inspect_validator/1,
-          inspect_two_validators/1,
-          validator_withdrawal/1,
-          setting_online_delay/1,
-          setting_online_and_offline/1,
-          single_validator_gets_elected_every_time/1,
-          three_validators_election/1,
-          unstake_balances/1,
-          staking_and_unstaking_effects_election/1,
-          can_not_unstake_more_shares_than_owned/1,
-          change_name_description_avatar/1
-        ]).
-
--export([ can_not_have_two_validators_with_same_id/1,
-          delegate_can_support_multiple_validators/1,
-          if_unstake_all_delegate_is_deleted/1,
-          can_not_become_validator_below_treshold/1,
-          can_not_stake_below_treshold/1,
-          validator_can_not_unstake_below_30_percent_treshold/1,
-          total_stake_limit/1
-        ]).
-
--export([ stake_delay/1,
-          stake_delay_respects_upper_stake_limit/1,
-          stake_delay_set_to_zero/1,
-          unstake_delay/1,
-          unstake_delay_set_to_zero/1
-        ]).
-
--export([ staking_without_delay_return_shares/1,
-          staking_with_delay_return_shares/1,
-          unstaking_return_shares/1,
-          unstaking_below_minimum_stake/1
+          deposit/1,
+          stake/1,
+          adjust_stake/1,
+          withdraw/1,
+          rewards/1
         ]).
 
 -include_lib("aecontract/include/hard_forks.hrl").
@@ -100,26 +72,21 @@
       93,11,3,93,177,65,197,27,123,127,177,165,190,211,20,112,79,108,
       85,78,88,181,26,207,191,211,40,225,138,154>>}).
 
--define(STAKING_CONTRACT, "MainStaking").
--define(HC_ELECTION_CONTRACT, "HCElection").
+-define(MAIN_STAKING_CT, "MainStaking").
+-define(STAKING_VALIDATOR_CT, "StakingValidator").
+-define(HC_ELECTION_CT, "HCElection").
 
--define(HC, hc).
+-define(DEFAULT_GAS, 10000000).
+-define(DEFAULT_GAS_PRICE, aec_test_utils:min_gas_price()).
+-define(DEFAULT_FEE, 300000 * ?DEFAULT_GAS_PRICE).
 
--define(GAS, 10000000).
--define(GAS_PRICE, aec_test_utils:min_gas_price()).
--define(FEE, 1000000000000).
+-define(AE, 1000000000000000000). % 10^18
+-define(VALIDATOR_MIN, 10 * ?AE). % 10 AE
 
--define(AE, 1000000000000000000).   % math:pow(10,18)
--define(VALIDATOR_MIN, 1000 * ?AE). % 1000 AE
--define(STAKE_MIN, 10 * ?AE).       % 10 AE
+-define(HC_EPOCH_LENGTH, 10).
+-define(HC_PIN_REWARD, 4_711_000_000).
 
--define(VALIDATOR_MIN_PERCENT, 30).
--define(ONLINE_DELAY, 0).
--define(STAKE_DELAY, 0).
--define(UNSTAKE_DELAY, 0).
--define(ENTROPY, <<"asdf">>).
-
--record(staking_resp, {stake, shares, execution_height}).
+-define(UNIT, {tuple, {}}).
 
 all() -> [{group, staking}
          ].
@@ -127,33 +94,11 @@ all() -> [{group, staking}
 groups() ->
     [ {staking, [sequence],
        [ new_validator,
-         inspect_validator,
-         inspect_two_validators,
-         validator_withdrawal,
-         setting_online_delay,
-         setting_online_and_offline,
-         single_validator_gets_elected_every_time,
-         three_validators_election,
-         unstake_balances,
-         % staking_and_unstaking_effects_election,
-         can_not_unstake_more_shares_than_owned,
-         change_name_description_avatar,
-         can_not_have_two_validators_with_same_id,
-         delegate_can_support_multiple_validators,
-         if_unstake_all_delegate_is_deleted,
-         can_not_become_validator_below_treshold,
-         can_not_stake_below_treshold,
-         validator_can_not_unstake_below_30_percent_treshold,
-         total_stake_limit,
-         % stake_delay,
-         % stake_delay_set_to_zero,
-         % stake_delay_respects_upper_stake_limit,
-         % unstake_delay,
-         % unstake_delay_set_to_zero,
-         staking_without_delay_return_shares,
-         % staking_with_delay_return_shares,
-         unstaking_return_shares,
-         unstaking_below_minimum_stake
+         deposit,
+         stake,
+         adjust_stake,
+         withdraw,
+         rewards
        ]}
     ].
 
@@ -183,1601 +128,91 @@ end_per_testcase(_TC, _Config) ->
 new_validator(_Config) ->
     Trees0 = genesis_trees(),
     TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Alice = pubkey(?ALICE),
-    {ok, _, {contract, _}} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees0),
+    {ok, Trees1, #{res := {contract, _}}} =
+        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
+    {revert,<<"Owner must be unique">>} =
+        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees1),
+    {revert,<<"A new validator must stake the minimum amount">>} =
+        new_validator_(pubkey(?BOB), ?VALIDATOR_MIN - 1, TxEnv, Trees1),
     ok.
 
-inspect_validator(_Config) ->
-    Trees0 = genesis_trees(),
-    Amount = ?VALIDATOR_MIN,
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Alice = pubkey(?ALICE),
-    %% no stakers, empty contract
-    {ok, _, ContractState0} = get_staking_contract_state_(Alice, TxEnv, Trees0),
-    {tuple, {   StakingValidatorCT,
-                [],
-                0, %% total stake, only one offline staker
-                ValidatorMinStake,
-                ValidatorMinPercent,
-                StakeMin,
-                OnlineDelay,
-                StakeDelay,
-                UnstakeDelay
-                }} = ContractState0,
-    {contract, ValidatorContractPubkey} = StakingValidatorCT,
-    ValidatorContractPubkey = validator_contract_address(),
-    {ok, _, Leader} = leader_(Alice, TxEnv, Trees0),
-    {ok, _, StakingCT} = election_staking_contract_(Alice, TxEnv, Trees0),
-    {contract, StakingContractPubkey} = StakingCT,
-    StakingContractPubkey = staking_contract_address(),
-    ElectionContractPubkey = election_contract_address(),
-    {address, ElectionContractPubkey} = Leader, %% no election yet, the contract is the first leader
-    %% create a validator and check the contract state; the newly created
-    %% validator is offline
-    {ok, Trees1, {contract, AliceContract}} = new_validator_(Alice, Amount, TxEnv, Trees0),
-    {ok, _, SPower} = staking_power_(Alice, Alice, TxEnv, Trees1),
-    {SPower, SPower} = {Amount, SPower},
-    {ok, _, State} = get_validator_state_(Alice, Alice, TxEnv, Trees1),
-    ExpectedAliceOfflineState =
-        expected_validator_state(AliceContract, Alice, ?DEFAULT_HEIGHT, SPower, 0,
-                                 calculate_total_stake_limit(SPower),
-                                 false, <<>>, <<>>, <<>>,
-                                 #{Alice => SPower}),
-    assert_equal_states(State, ExpectedAliceOfflineState),
-    {ok, _, IsOnline} = is_validator_online_(Alice, Alice, TxEnv, Trees1),
-    false = IsOnline,
-    {ok, _, ContractState} = get_staking_contract_state_(Alice, TxEnv, Trees1),
-    {tuple, {   StakingValidatorCT,
-                Validators,
-                0, %% total stake, only one offline staker
-                ValidatorMinStake,
-                ValidatorMinPercent,
-                StakeMin,
-                OnlineDelay,
-                StakeDelay,
-                UnstakeDelay
-                }} = ContractState,
-    ?assertEqual([ExpectedAliceOfflineState], Validators),
-    ?VALIDATOR_MIN = ValidatorMinStake,
-    ?VALIDATOR_MIN_PERCENT = ValidatorMinPercent,
-    ?STAKE_MIN = StakeMin,
-    ?ONLINE_DELAY = OnlineDelay,
-    ?STAKE_DELAY = StakeDelay,
-    ?UNSTAKE_DELAY = UnstakeDelay,
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees1),
-    %% set the validator as online; the total stake shall be the total stake
-    %% of the validator
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    ExpectedAliceOnlineState =
-        expected_validator_state(AliceContract, Alice, ?DEFAULT_HEIGHT, SPower, 0,
-                                 calculate_total_stake_limit(SPower),
-                                 true, <<>>, <<>>, <<>>,
-                                 #{Alice => SPower}),
-    {ok, _, State2} = get_validator_state_(Alice, Alice, TxEnv, Trees2),
-    assert_equal_states(State2, ExpectedAliceOnlineState),
-    {ok, _, ContractState1} = get_staking_contract_state_(Alice, TxEnv, Trees2),
-    {tuple, {   StakingValidatorCT,
-                Validators1,
-                TotalStake, %% total stake, only one online staker
-                ValidatorMinStake,
-                ValidatorMinPercent,
-                StakeMin,
-                OnlineDelay,
-                StakeDelay,
-                UnstakeDelay
-                }} = ContractState1,
-    [ExpectedAliceOnlineState] = Validators1,
-    Amount = TotalStake,
-    SPower = TotalStake,
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees2),
-    %% set the validator back to offline, the state is exactly the same as
-    %% before setting it online; it is important that going online/offline is
-    %% idempotent
-    {ok, Trees3, {tuple, {}}} = set_validator_offline_(Alice, TxEnv, Trees2),
-    {ok, _, ContractState} = get_staking_contract_state_(Alice, TxEnv, Trees3),
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees3),
-    %% test idempotence to getting back online
-    {ok, Trees4, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees3),
-    {ok, _, ContractState1} = get_staking_contract_state_(Alice, TxEnv, Trees4),
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees4),
-    %% test that "election" sets Alice as a leader
-    {ok, Trees5, {tuple, {}}} = elect_(Alice, ?OWNER_PUBKEY, TxEnv, Trees4),
-    %% no change in staking contract:
-    {ok, _, ContractState1} = get_staking_contract_state_(Alice, TxEnv, Trees5),
-    {ok, _, ElectionContractState1} = get_election_contract_state_(Alice, TxEnv, Trees5),
-    {ok, _, Leader2} = leader_(Alice, TxEnv, Trees5),
-    {address, Alice} = Leader2, %% Alice is being elected as a leader
-    %% give away some rewards; this changes the total staking power but does
-    %% not change the shares distribution
-    Reward = 1000,
-    {ok, Trees6, {tuple, {}}} = reward_(Alice, Reward, ?OWNER_PUBKEY,
-                                        TxEnv, Trees5),
-    ExpectedAliceOnlineState1 =
-        expected_validator_state(AliceContract, Alice, ?DEFAULT_HEIGHT, SPower + Reward, 0,
-                                 calculate_total_stake_limit(SPower + Reward),
-                                 true, <<>>, <<>>, <<>>,
-                                 #{Alice => SPower}), %% share distribution is the same
-    {ok, _, State3} = get_validator_state_(Alice, Alice, TxEnv, Trees6),
-    assert_equal_states(State3, ExpectedAliceOnlineState1),
-    {ok, _, ContractState3} = get_staking_contract_state_(Alice, TxEnv, Trees6),
-    ExpectedTotalStake = TotalStake + Reward,
-    {tuple, {   StakingValidatorCT,
-                Validators2, %% same validator
-                ExpectedTotalStake,
-                ValidatorMinStake, %% same
-                ValidatorMinPercent, %% same
-                StakeMin, %% same
-                OnlineDelay, %% same
-                StakeDelay, %% same
-                UnstakeDelay %% same
-                }} = ContractState3,
-    [ExpectedAliceOnlineState1] = Validators2,
-    %% election contract state is unchanged
-    {ok, _, ElectionContractState1} = get_election_contract_state_(Alice, TxEnv, Trees6),
-    %% test online-offline idemptence after a reward distribution
-    {ok, Trees7, {tuple, {}}} = set_validator_offline_(Alice, TxEnv, Trees6),
-    %% election contract state is unchanged
-    {ok, _, ElectionContractState1} = get_election_contract_state_(Alice, TxEnv, Trees7),
-    {ok, _, ContractState4} = get_staking_contract_state_(Alice, TxEnv, Trees7),
-    {tuple, {   StakingValidatorCT, %% same
-                Validators3,
-                0,
-                ValidatorMinStake, %% same
-                ValidatorMinPercent, %% same
-                StakeMin, %% same
-                OnlineDelay, %% same
-                StakeDelay, %% same
-                UnstakeDelay %% same
-                }} = ContractState4,
-    ExpectedAliceOfflineState1 =
-        expected_validator_state(AliceContract, Alice, ?DEFAULT_HEIGHT, SPower + Reward, 0,
-                                 calculate_total_stake_limit(SPower + Reward),
-                                 false, <<>>, <<>>, <<>>,
-                                 #{Alice => SPower}), %% share distribution is the same
-    [ExpectedAliceOfflineState1] = Validators3,
-    {ok, Trees8, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees7),
-    {ok, _, ContractState3} = get_staking_contract_state_(Alice, TxEnv, Trees8),
-    %% election contract state is unchanged
-    {ok, _, ElectionContractState1} = get_election_contract_state_(Alice, TxEnv, Trees7),
-    ok.
-
-inspect_two_validators(_Config) ->
-    Trees0 = genesis_trees(),
-    Amount = ?VALIDATOR_MIN,
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    %% no stakers, empty contract
-    {ok, _, ContractState0} = get_staking_contract_state_(Alice, TxEnv, Trees0),
-    {tuple, {   StakingValidatorCT,
-                [],
-                0, %% total stake, only one offline staker
-                _ValidatorMinStake,
-                _ValidatorMinPercent,
-                _StakeMin,
-                _OnlineDelay,
-                _StakeDelay,
-                _UnstakeDelay
-                }} = ContractState0,
-    {contract, _} = StakingValidatorCT,
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees0),
-    {ok, _, Leader} = leader_(Alice, TxEnv, Trees0),
-    ElectionContractPubkey = election_contract_address(),
-    {address, ElectionContractPubkey} = Leader, %% no election yet, the contract is the first leader
-    %% create a validator and check the contract state; the newly created
-    %% validator is offline
-    {ok, Trees1, {contract, AliceContract}} = new_validator_(Alice, Amount, TxEnv, Trees0),
-    {ok, _, AliceSPower} = staking_power_(Alice, Alice, TxEnv, Trees1),
-    ExpectedAliceOfflineState0 =
-        expected_validator_state(AliceContract, Alice, ?DEFAULT_HEIGHT, AliceSPower, 0,
-                                 calculate_total_stake_limit(AliceSPower),
-                                 false, <<>>, <<>>, <<>>,
-                                 #{Alice => AliceSPower}), %% share distribution is the same
-    {ok, Trees2, {contract, BobContract}} = new_validator_(Bob, 2 * Amount,
-                                                           TxEnv, Trees1),
-    {ok, _, BobSPower} = staking_power_(Bob, Bob, TxEnv, Trees2),
-    ?assertEqual(BobSPower, 2 * Amount),
-    ExpectedBobOfflineState0 =
-        expected_validator_state(BobContract, Bob, ?DEFAULT_HEIGHT, BobSPower, 0,
-                                 calculate_total_stake_limit(BobSPower),
-                                 false, <<>>, <<>>, <<>>,
-                                 #{Bob => BobSPower}), %% share distribution is the same
-    {ok, _, ContractState1} = get_staking_contract_state_(Alice, TxEnv, Trees2),
-    {ok, _, ContractState1} = get_staking_contract_state_(Bob, TxEnv, Trees2),
-    {tuple, {StakingValidatorCT, [ExpectedBobOfflineState0, ExpectedAliceOfflineState0],
-             0, %% total stake, only offline stakers
-             _, _, _, _, _, _ }} = ContractState1,
-    %% election contract state is unchanged
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees2),
-    %% set Alice online; this changes the total staked amount to Alice's
-    %% balance
-    {ok, Trees3, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees2),
-    ExpectedAliceOnlineState0 =
-        expected_validator_state(AliceContract, Alice, ?DEFAULT_HEIGHT, AliceSPower, 0,
-                                 calculate_total_stake_limit(AliceSPower),
-                                 true, <<>>, <<>>, <<>>,
-                                 #{Alice => AliceSPower}), %% share distribution is the same
-    {ok, _, ContractState2} = get_staking_contract_state_(Alice, TxEnv, Trees3),
-    {ok, _, ContractState2} = get_staking_contract_state_(Bob, TxEnv, Trees3),
-    {tuple, {StakingValidatorCT,
-             [ ExpectedAliceOnlineState0, %% Alice is online
-               ExpectedBobOfflineState0 ],
-             AliceSPower, %% total stake, only Alice is online
-             _, _, _, _, _, _ }} = ContractState2,
-    %% election contract state is unchanged
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees2),
-    %% set Bob online as well
-    {ok, Trees4, {tuple, {}}} = set_validator_online_(Bob, TxEnv, Trees3),
-    ExpectedBobOnlineState0 =
-        expected_validator_state(BobContract, Bob, ?DEFAULT_HEIGHT, BobSPower, 0,
-                                 calculate_total_stake_limit(BobSPower),
-                                 true, <<>>, <<>>, <<>>,
-                                 #{Bob => BobSPower}), %% share distribution is the same
-    {ok, _, ContractState3} = get_staking_contract_state_(Alice, TxEnv, Trees4),
-    {ok, _, ContractState3} = get_staking_contract_state_(Bob, TxEnv, Trees4),
-    CombinedSPower = AliceSPower + BobSPower,
-    {tuple, {StakingValidatorCT, %% same
-             [ ExpectedBobOnlineState0, ExpectedAliceOnlineState0 ],
-             CombinedSPower, %% total stake, only Alice is online
-             _, _, _, _, _, _ }} = ContractState3,
-    %% election contract state is unchanged
-    {ok, _, ElectionContractState0} = get_election_contract_state_(Alice, TxEnv, Trees2),
-    ok.
-
-validator_withdrawal(_Config) ->
-    Trees0 = genesis_trees(),
-    OverheadAmt = 1000,
-    Amount = ?VALIDATOR_MIN + OverheadAmt,
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    {ok, Trees1, {contract, _AliceContract}} = new_validator_(Alice, Amount, TxEnv, Trees0),
-    {ok, Trees2, {contract, _BobContract}} = new_validator_(Bob, Amount, TxEnv, Trees1),
-    %% Alice will be online and Bob will be offline
-    {ok, Trees3, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees2),
-    %% can not withdraw more than OverheadAmt
-    {revert, <<"Validator can not withdraw below the treshold">>}
-        = unstake_(Alice, OverheadAmt + 1, Alice, TxEnv, Trees3),
-    {revert, <<"Validator can not withdraw below the treshold">>}
-        = unstake_(Bob, OverheadAmt + 1, Bob, TxEnv, Trees3),
-    {ok, _, AliceUnstakeResp3} = unstake_(Alice, OverheadAmt, Alice, TxEnv, Trees3),
-    {ok, _, BobUnstakeResp3} = unstake_(Bob, OverheadAmt, Bob, TxEnv, Trees3),
-    ?assertEqual(OverheadAmt, AliceUnstakeResp3#staking_resp.stake),
-    ?assertEqual(OverheadAmt, BobUnstakeResp3#staking_resp.stake),
-
-    %% reward both parties and now they can unstake down to ?VALIDATOR_MIN amount
-    Reward = 1,
-    {ok, Trees4, {tuple, {}}} = reward_(Alice, Reward, ?OWNER_PUBKEY, TxEnv, Trees3),
-    {ok, Trees5, {tuple, {}}} = reward_(Bob, Reward, ?OWNER_PUBKEY, TxEnv, Trees4),
-    {revert, <<"Validator can not withdraw below the treshold">>}
-        = unstake_(Alice, OverheadAmt + Reward + 1, Alice, TxEnv, Trees5),
-    {revert, <<"Validator can not withdraw below the treshold">>}
-        = unstake_(Bob, OverheadAmt + Reward + 1, Bob, TxEnv, Trees5),
-    %% TODO: revisit the tests once decision is being made for unstaking AE or
-    %% unstaking stake shares
-    {ok, Trees6, AliceUnstakeResp} = unstake_(Alice, 1, Alice, TxEnv, Trees5),
-    {ok, _, BobUnstakeResp} = unstake_(Bob, 1, Bob, TxEnv, Trees6),
-    ?assertEqual(1, AliceUnstakeResp#staking_resp.stake),
-    ?assertEqual(1, BobUnstakeResp#staking_resp.stake),
-    ok.
-
-setting_online_delay(_Config) ->
-    Delay = 100,
-    Alice = pubkey(?ALICE),
-    Trees0 = genesis_trees(#{online_delay => Delay}),
-    TxEnv = aetx_env:tx_env(?GENESIS_HEIGHT, aect_test_utils:latest_protocol_version()),
-
-    {ok, Trees1, {contract, _}} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees0),
-
-    % State contains setting online delay
-    ?assertMatch({ok, _, {tuple, {_, _, _, _, _, _, Delay, _, _}}},
-                 get_staking_contract_state_(Alice, TxEnv, Trees1)),
-
-    % Validator state contains creation height
-    ?assertMatch({ok, _, {tuple, {_, _, ?GENESIS_HEIGHT, _, _, _, _, _}}},
-                 get_validator_state_(Alice, Alice, TxEnv, Trees1)),
-
-    % always allow to set online on genesis height
-    ?assertEqual(?GENESIS_HEIGHT, aetx_env:height(TxEnv)),
-    ?assertMatch({ok, _, _}, set_validator_online_(Alice, TxEnv, Trees1)),
-
-    Reason = <<"Minimum height not reached">>,
-
-    %% The delay is counted from genesis height
-    TxEnv1  = aetx_env:set_height(TxEnv, ?GENESIS_HEIGHT + 1),
-    ?assertEqual({revert, Reason}, set_validator_online_(Alice, TxEnv1, Trees1)),
-
-    TxEnv2 = aetx_env:set_height(TxEnv1, ?GENESIS_HEIGHT + Delay - 1),
-    ?assertEqual({revert, Reason}, set_validator_online_(Alice, TxEnv2, Trees1)),
-
-    TxEnv3 = aetx_env:set_height(TxEnv, ?GENESIS_HEIGHT + Delay),
-    ?assertMatch({ok, _, _}, set_validator_online_(Alice, TxEnv3, Trees1)),
-
-    ok.
-
-setting_online_and_offline(_Config) ->
-    Alice = pubkey(?ALICE),
-    Trees0 = genesis_trees(),
-    Amount = ?VALIDATOR_MIN,
-    AliceStake = {tuple, {{address, Alice}, Amount}},
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    {ok, Trees1, _AliceRes} = new_validator_(pubkey(?ALICE), Amount, TxEnv, Trees0),
-    %% a new validator is offline
-    {ok, _, false} = is_validator_online_(Alice, Alice, TxEnv, Trees1),
-    {revert, <<"Validator not online">>} =
-        set_validator_offline_(Alice, TxEnv, Trees1),
-    {ok, _, []} = online_validators_(Alice, TxEnv, Trees1),
-    {ok, _, [AliceStake]} = offline_validators_(Alice, TxEnv, Trees1),
-    %% set it online
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    {ok, _, true} = is_validator_online_(Alice, Alice, TxEnv, Trees2),
-    {revert, <<"Validator not offline">>} =
-        set_validator_online_(Alice, TxEnv, Trees2),
-    {ok, _, [AliceStake]} = online_validators_(Alice, TxEnv, Trees2),
-    {ok, _, []} = offline_validators_(Alice, TxEnv, Trees2),
-    %% set it back offline
-    {ok, Trees3, {tuple, {}}} = set_validator_offline_(Alice, TxEnv, Trees2),
-    {ok, _, false} = is_validator_online_(Alice, Alice, TxEnv, Trees3),
-    {revert, <<"Validator not online">>} =
-        set_validator_offline_(Alice, TxEnv, Trees3),
-    {ok, _, []} = online_validators_(Alice, TxEnv, Trees3),
-    {ok, _, [AliceStake]} = offline_validators_(Alice, TxEnv, Trees3),
-    ok.
-
-single_validator_gets_elected_every_time(_Config) ->
-    Alice = pubkey(?ALICE),
+deposit(_Config) ->
     Trees0 = genesis_trees(),
     TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    {ok, Trees1, _} = new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    %% no rewards
-    lists:foldl(
-        fun(Height, TreesAccum) ->
-            %% Alice is expected to be next
-            TxEnvPrev = aetx_env:set_height(TxEnv, Height - 1),
-            {ok, TreesAccum1, {tuple, {}}} = elect_(Alice, ?OWNER_PUBKEY, TxEnvPrev, TreesAccum),
-            TxEnv1 = aetx_env:set_height(TxEnv, Height),
-            {ok, _, {address, Alice}} = leader_(Alice, TxEnv1, TreesAccum1),
-            TreesAccum1
-        end,
-        Trees2,
-        lists:seq(?DEFAULT_HEIGHT, 10)),
-    %% with rewards
-    lists:foldl(
-        fun(Height, TreesAccum) ->
-            %% Alice is expected to be next
-            TxEnvPrev = aetx_env:set_height(TxEnv, Height - 1),
-            {ok, TreesAccum1, {tuple, {}}} = reward_(Alice, 1000, ?OWNER_PUBKEY, TxEnvPrev, TreesAccum),
-            {ok, TreesAccum2, {tuple, {}}} = elect_(Alice, ?OWNER_PUBKEY, TxEnvPrev, TreesAccum1),
-            TxEnv1 = aetx_env:set_height(TxEnv, Height),
-            {ok, _, {address, Alice}} = leader_(Alice, TxEnv1, TreesAccum2),
-            TreesAccum2
-        end,
-        Trees2,
-        lists:seq(?DEFAULT_HEIGHT, 10)),
+    {ok, Trees1, #{res := {contract, AliceCt}}} =
+        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
+    {ok, Trees2, #{res := ?UNIT}} =
+        deposit_(AliceCt, ?ALICE, 5 * ?AE, TxEnv, Trees1),
+
+    {ok, _, #{res := TotalBalance}} =
+        get_total_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
+    {ok, _, #{res := AvailableBalance}} =
+        get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
+
+    ?assertEqual(TotalBalance, ?VALIDATOR_MIN + 5 * ?AE),
+    ?assertEqual(AvailableBalance, 5 * ?AE),
+
     ok.
 
-three_validators_election(_Config) ->
-    %% Alice will have twice the staking power compared to Bob, she shall get
-    %% elected twice as often
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Carol = pubkey(?CAROL), %% will be offline
+stake(_Config) ->
     Trees0 = genesis_trees(),
     TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees1 =
-        lists:foldl(
-            fun({Pubkey,  Amount}, TreesAccum) ->
-                {ok, TreesAccum1, _} = new_validator_(Pubkey, Amount, TxEnv, TreesAccum),
-                TreesAccum1
-            end,
-            Trees0,
-            [{Alice, 2 * ?VALIDATOR_MIN},
-            {Bob, ?VALIDATOR_MIN},
-            {Carol, ?VALIDATOR_MIN}]),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    {ok, _, {tuple, {}}} = set_validator_online_(Bob, TxEnv, Trees2),
-    %% no rewards to check probabilities
+    {ok, Trees1, #{res := {contract, AliceCt}}} =
+        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
+    {ok, Trees2, #{res := ?UNIT}} =
+        stake_(AliceCt, ?ALICE, 5 * ?AE, TxEnv, Trees1),
+
+    {ok, _, #{res := TotalBalance}} =
+        get_total_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
+    {ok, _, #{res := AvailableBalance}} =
+        get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
+
+    ?assertEqual(TotalBalance, ?VALIDATOR_MIN + 5 * ?AE),
+    ?assertEqual(AvailableBalance, 0),
+
     ok.
 
-unstake_balances(_Config) ->
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
+adjust_stake(_Config) ->
     Trees0 = genesis_trees(),
     TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
+    {ok, Trees1, #{res := {contract, AliceCt}}} =
+        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
+    {ok, Trees2, #{res := ?UNIT}} =
+        adjust_stake_(AliceCt, ?ALICE, -2 * ?AE, TxEnv, Trees1),
 
-    {ok, Trees0_1, _} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees0),
-    {ok, Trees0_2, _} = new_validator_(Bob, ?VALIDATOR_MIN, TxEnv, Trees0_1),
-    Trees1 = Trees0_2,
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    {ok, Trees3, {tuple, {}}} = set_validator_online_(Bob, TxEnv, Trees2),
+    {ok, _, #{res := TotalBalance}}     = get_total_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
+    {ok, _, #{res := AvailableBalance}} = get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
+    ?assertEqual(TotalBalance,     ?VALIDATOR_MIN),
+    ?assertEqual(AvailableBalance, 2 * ?AE),
 
-    %% a new staker
-    {Sam, Trees4} = set_up_account(Trees3),
+    {ok, Trees3, #{res := ?UNIT}} =
+        adjust_stake_(AliceCt, ?ALICE, ?AE, TxEnv, Trees2),
 
-    %% let Sam put his stake in Alice's staking pool. He will have as much
-    %% staking power as her so he will get 50% of the rewards
-    SamSPower0 = account_balance(Sam, Trees4),
-    {ok, Trees5, StakeResp5} = stake_(Alice, ?VALIDATOR_MIN, Sam, TxEnv, Trees4),
-    ?assertEqual(?VALIDATOR_MIN, StakeResp5#staking_resp.stake),
-    SharesStaked = StakeResp5#staking_resp.shares,
-    SamSPower1 = account_balance(Sam, Trees5),
-    ?assert(SamSPower0 - SamSPower1 - ?VALIDATOR_MIN > 0), % some gas fees
-
-    {ok, _, {tuple, {_, _, _, _, _, _, _, AliceState5}}}
-        = get_validator_state_(Alice, Alice, TxEnv, Trees5),
-    {tuple, {_, _, _, _, _, _, _, Stakers5, _}} = AliceState5,
-    ?assertEqual(2, maps:size(Stakers5)),
-    ?assertEqual(?VALIDATOR_MIN, maps:get({address, Alice}, Stakers5)),
-    ?assertEqual(?VALIDATOR_MIN, maps:get({address, Sam}, Stakers5)),
-
-    ExpectedSamReward = ?VALIDATOR_MIN,
-    TotalReward = 2 * ExpectedSamReward,
-    {ok, Trees6, {tuple, {}}} = reward_(Alice, TotalReward, ?OWNER_PUBKEY, TxEnv, Trees5),
-    {ok, _, StakingResp} = unstake_(Alice, SharesStaked, Sam, TxEnv, Trees6),
-    ActualReward = StakingResp#staking_resp.stake - ?VALIDATOR_MIN,
-    ?assertEqual(ActualReward, ExpectedSamReward),
+    {ok, _, #{res := TotalBalance2}}     = get_total_balance_(AliceCt, ?ALICE, TxEnv, Trees3),
+    {ok, _, #{res := AvailableBalance2}} = get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees3),
+    ?assertEqual(TotalBalance2,     ?VALIDATOR_MIN),
+    ?assertEqual(AvailableBalance2, ?AE),
 
     ok.
 
-%% TODO this is different for hyperchains. Create better test
-staking_and_unstaking_effects_election(_Config) ->
+withdraw(_Config) ->
     Trees0 = genesis_trees(),
     TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    %% Alice will have twice the staking power compared to Bob, she shall get
-    %% elected twice as often
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Carol = pubkey(?CAROL), %% will be offline
+    {ok, Trees1, #{res := {contract, AliceCt}}} =
+        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
 
-    {ok, Trees0_1, _} = new_validator_(Alice, 2*?VALIDATOR_MIN, TxEnv, Trees0),
-    {ok, Trees0_2, _} = new_validator_(Bob, ?VALIDATOR_MIN, TxEnv, Trees0_1),
-    {ok, Trees0_3, _} = new_validator_(Carol, ?VALIDATOR_MIN, TxEnv, Trees0_2),
+    {ok, Trees2, #{res := ?UNIT}} =
+        adjust_stake_(AliceCt, ?ALICE, -2 * ?AE, TxEnv, Trees1),
 
-    Trees1 = Trees0_3,
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    {ok, Trees3, {tuple, {}}} = set_validator_online_(Bob, TxEnv, Trees2),
+    {ok, Trees3, #{res := ?UNIT, cost := TxCost}} =
+        withdraw_(AliceCt, ?ALICE, 2 * ?AE, TxEnv, Trees2),
 
-    %% create a lot of stakers with some significant stake
-    %% the following would state 100 stakers, half of which would stake to
-    %% Alice, the other half - to Bob
-    %% if Alice's initial staking power was 2 * X, then Bob's was X, we would
-    %% stake X more to each other so Alice would have 3 * X and Bob - 2 * X
-    StakersCnt = 100,
-    StakerStake = ?VALIDATOR_MIN div 50,
-    %% create staker accounts
-    {Stakers, Trees4} = lists:foldl(fun(_, {AccStakers, AccTrees}) ->
-                {Staker, NewAccTrees} = set_up_account(AccTrees),
-                {[Staker | AccStakers], NewAccTrees}
-            end, {[], Trees3}, lists:seq(1, StakersCnt)),
-
-    AliceStakers = lists:nthtail(StakersCnt div 2, lists:reverse(Stakers)),
-    BobStakers = lists:nthtail(StakersCnt div 2, Stakers),
-
-    StakeFun =
-        fun(Who, StakersList, StakeTrees0) ->
-            {ok, _, SPower0} = staking_power_(Who, Who, TxEnv, StakeTrees0),
-
-            StakeTrees = lists:foldl( fun(Pubkey, TreesAccum) ->
-                        {ok, TreesAccum1, _} = stake_(Who, StakerStake, Pubkey, TxEnv, TreesAccum),
-                        TreesAccum1
-                    end, StakeTrees0, StakersList),
-
-            {ok, _, SPower1} = staking_power_(Who, Who, TxEnv, StakeTrees),
-            ?assertEqual(length(StakersList) * StakerStake + SPower0, SPower1),
-            StakeTrees
-        end,
-
-    Trees5 = StakeFun(Alice, AliceStakers, Trees4),
-    Trees6 = StakeFun(Bob, BobStakers, Trees5),
-
-    {ok, _, AliceSPower} = staking_power_(Alice, Alice, TxEnv, Trees6),
-    {ok, _, BobSPower}   = staking_power_(Bob, Bob, TxEnv, Trees6),
-    ?assertEqual(2*AliceSPower, 3*BobSPower),
-
-    {_, Leaders} = test_elect_calls(?DEFAULT_HEIGHT, 1000, TxEnv, Trees6),
-    #{Alice := AliceTurns, Bob := BobTurns} = Leaders,
-    ?assertEqual(600-6, AliceTurns),
-    ?assertEqual(400+6, BobTurns),
-
-    %% reward both pools by doubling their total amount. This would yeld 100%
-    %% RoI for all stakers: at this point withdrawing X stakes would provide
-    %% them with 2 * X aettos
-    %% NB: we start from Trees6 (just after staking)
-
-    {ok, Trees7, {tuple, {}}} = reward_(Alice, ?VALIDATOR_MIN, ?OWNER_PUBKEY, TxEnv, Trees6),
-    {ok, _, AliceSPower7} = staking_power_(Alice, Alice, TxEnv, Trees7),
-    ?assertMatch(4 * ?VALIDATOR_MIN, AliceSPower7),
-
-    {ok, Trees8, {tuple, {}}} = reward_(Bob, ?VALIDATOR_MIN, ?OWNER_PUBKEY, TxEnv, Trees7),
-    {ok, _, BobSPower8} = staking_power_(Bob, Bob, TxEnv, Trees8),
-    ?assertEqual(3 * ?VALIDATOR_MIN, BobSPower8),
-
-    UnStakeFun =
-        fun(Who, StakersList, StakeTrees0) ->
-            {ok, _, SPower0} = staking_power_(Who, Who, TxEnv, StakeTrees0),
-
-            {StakeTrees, TotalWithdrawnAmt} = lists:foldl(
-                    fun(Pubkey, {TreesAccum, WithdrawnSum}) ->
-                        {ok, TreesAccum1, Resp} = unstake_(Who, StakerStake, Pubkey, TxEnv, TreesAccum),
-                        {TreesAccum1, WithdrawnSum + Resp#staking_resp.stake}
-                    end, {StakeTrees0, 0}, StakersList),
-
-            {ok, _, SPower1} = staking_power_(Who, Who, TxEnv, StakeTrees),
-            ?assertEqual(SPower0 - TotalWithdrawnAmt, SPower1),
-            StakeTrees
-        end,
-
-    %% unstake all Bob's stakers
-    Trees9 = UnStakeFun(Bob, BobStakers, Trees8),
-    {_, _Leaders2} = test_elect_calls(?DEFAULT_HEIGHT, 1000, TxEnv, Trees9),
-    ok.
-
-can_not_unstake_more_shares_than_owned(_Config) ->
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Trees0 = genesis_trees(),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees1 =
-        lists:foldl(
-            fun({Pubkey,  Amount}, TreesAccum) ->
-                {ok, TreesAccum1, _} = new_validator_(Pubkey, Amount, TxEnv,
-                                                      TreesAccum),
-                TreesAccum1
-            end,
-            Trees0,
-            [{Alice, ?VALIDATOR_MIN},
-            {Bob, ?VALIDATOR_MIN}]),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    #{public := Sam} = enacl:sign_keypair(),
-    Trees3 = set_up_account({Sam, trunc(math:pow(10, 30))}, Trees2),
-    {ok, Trees4, StakeResp4} = stake_(Alice, ?STAKE_MIN, Sam, TxEnv, Trees3),
-    ?assertEqual(?STAKE_MIN, StakeResp4#staking_resp.stake),
-    Test =
-        fun(Trees) ->
-            %% Bob is offline and can not unstake more than he has
-            {revert, <<"Not enough shares">>} =
-                unstake_(Bob, ?VALIDATOR_MIN + 1, Bob, TxEnv, Trees),
-            %% Alice is online but she still can not unstake more shares than
-            %% she has
-            {revert, <<"Not enough shares">>} =
-                unstake_(Alice, ?VALIDATOR_MIN + 1, Alice, TxEnv, Trees),
-            %% Sam has a ?STAKE_MIN stakes in Alice's pool. He can not unstake
-            %% more than he has
-            {revert, <<"Not enough shares">>} =
-                unstake_(Alice, ?STAKE_MIN + 1, Sam, TxEnv, Trees),
-            %% Sam has no stake in Bob's pool
-            {revert, <<"Not enough shares">>} =
-                unstake_(Bob, 1, Sam, TxEnv, Trees)
-        end,
-    Test(Trees4),
-    %% rewards do not change the amount of stakes
-    {ok, Trees5, {tuple, {}}} = reward_(Alice, 100000000000000, ?OWNER_PUBKEY, TxEnv, Trees4),
-    Test(Trees5),
-    {ok, Trees6, {tuple, {}}} = reward_(Bob, 100000000000000, ?OWNER_PUBKEY, TxEnv, Trees5),
-    Test(Trees6),
-    ok.
-
-change_name_description_avatar(_Config) ->
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Trees0 = genesis_trees(),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees1 =
-        lists:foldl(
-            fun({Pubkey,  Amount}, TreesAccum) ->
-                {ok, TreesAccum1, _} = new_validator_(Pubkey, Amount, TxEnv,
-                                                      TreesAccum),
-                TreesAccum1
-            end,
-            Trees0,
-            [{Alice, ?VALIDATOR_MIN},
-            {Bob, ?VALIDATOR_MIN}]),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    #{public := Sam} = enacl:sign_keypair(),
-    {ok, _, AliceState0} = get_validator_state_(Alice, Alice, TxEnv, Trees2),
-    {tuple, {{contract, _}, %% the pool contract
-             {address, Alice},
-             _, %% creation height
-             _, %% staker pool balance
-             _, %% pending stake
-             _, %% total stake limit
-             true, %% is online
-             {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                      0,     %% unstake delay
-                      0,     %% pending unstake amount
-                      #{},   %% pending unstake
-                     <<"">>, %% name
-                     <<"">>, %% description
-                     <<"">>, %% avatarURL,
-                     _MapA, ?VALIDATOR_MIN }}}} = AliceState0,
-    {ok, _, BobState0} = get_validator_state_(Bob, Bob, TxEnv, Trees2),
-    {tuple, {{contract, _}, %% the pool contract
-             {address, Bob},
-             _, %% creation height
-             _, %% staker pool balance
-             _, %% pending stake
-             _, %% total stake limit
-             false, %% is online
-             {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                      0,     %% unstake delay
-                      0,     %% pending unstake amount
-                      #{},   %% pending unstake
-                     <<"">>, %% name
-                     <<"">>, %% description
-                     <<"">>, %% avatarURL,
-                     _MapB, ?VALIDATOR_MIN }}}} = BobState0,
-    AliceName = <<"AL1CE">>,
-    {ok, Trees3, {tuple, {}}} = set_name_(AliceName, Alice, TxEnv, Trees2),
-    {ok, _, AliceState1} = get_validator_state_(Alice, Alice, TxEnv, Trees3),
-    {tuple, {{contract, _}, %% the pool contract
-             {address, Alice},
-             _, %% creation height
-             _, %% staker pool balance
-             _, %% pending stake
-             _, %% total stake limit
-             true, %% is online
-             {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                      0,     %% unstake delay
-                      0,     %% pending unstake amount
-                      #{},   %% pending unstake
-                     AliceName, %% name
-                     <<"">>, %% description
-                     <<"">>, %% avatarURL,
-                     MapA, ?VALIDATOR_MIN }}}} = AliceState1,
-    %% Bob is unchanged
-    {ok, _, BobState0} = get_validator_state_(Bob, Bob, TxEnv, Trees3),
-    AliceDescription = <<"Who in the world am I?' Ah, that's the great puzzle!">>,
-    {ok, Trees4, {tuple, {}}} = set_description_(AliceDescription, Alice, TxEnv, Trees3),
-    {ok, _, AliceState2} = get_validator_state_(Alice, Alice, TxEnv, Trees4),
-    {tuple, {{contract, _}, %% the pool contract
-             {address, Alice},
-             _, %% creation height
-             _, %% staker pool balance
-             _, %% pending stake
-             _, %% total stake limit
-             true, %% is online
-             {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                      0,     %% unstake delay
-                      0,     %% pending unstake amount
-                      #{},   %% pending unstake
-                     AliceName, %% name
-                     AliceDescription, %% description
-                     <<"">>, %% avatarURL,
-                     MapA, ?VALIDATOR_MIN}}}} = AliceState2,
-    %% Bob is unchanged
-    {ok, _, BobState0} = get_validator_state_(Bob, Bob, TxEnv, Trees4),
-    AliceAvatar = <<"test.test/img.jpg">>,
-    {ok, Trees5, {tuple, {}}} = set_avatar_(AliceAvatar, Alice, TxEnv, Trees4),
-    {ok, _, AliceState3} = get_validator_state_(Alice, Alice, TxEnv, Trees5),
-    {tuple, {{contract, _}, %% the pool contract
-             {address, Alice},
-             _, %% creation height
-             _, %% staker pool balance
-             _, %% pending stake
-             _, %% total stake limit
-             true, %% is online
-             {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                      0,     %% unstake delay
-                      0,     %% pending unstake amount
-                      #{},   %% pending unstake
-                     AliceName, %% name
-                     AliceDescription, %% description
-                     AliceAvatar, %% avatarURL,
-                     MapA, ?VALIDATOR_MIN}}}} = AliceState3,
-    %% Bob is unchanged
-    {ok, _, BobState0} = get_validator_state_(Bob, Bob, TxEnv, Trees5),
-    %% Sam has no account
-    {error, account_not_found} = set_name_(AliceName, Sam, TxEnv, Trees5),
-    {error, account_not_found} = set_description_(AliceDescription, Sam, TxEnv, Trees5),
-    {error, account_not_found} = set_avatar_(AliceAvatar, Sam, TxEnv, Trees5),
-    %% Sam is not a validator and can not change anything
-    Trees6 = set_up_account({Sam, 10000000000000000000000000}, Trees5),
-    {revert, <<"Validator must exists">>} = set_name_(AliceName, Sam, TxEnv, Trees6),
-    {revert, <<"Validator must exists">>} = set_description_(AliceDescription, Sam, TxEnv, Trees6),
-    {revert, <<"Validator must exists">>} = set_avatar_(AliceAvatar, Sam, TxEnv, Trees6),
-    ok.
-
-can_not_have_two_validators_with_same_id(_Config) ->
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Trees0 = genesis_trees(),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees1 =
-        lists:foldl(
-            fun({Pubkey,  Amount}, TreesAccum) ->
-                {ok, TreesAccum1, _} = new_validator_(Pubkey, Amount, TxEnv,
-                                                      TreesAccum),
-                TreesAccum1
-            end,
-            Trees0,
-            [{Alice, ?VALIDATOR_MIN},
-            {Bob, ?VALIDATOR_MIN}]),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    %% registering a validator for the second time fails
-    {revert, <<"Validator exists">>} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees2),
-    {revert, <<"Validator exists">>} = new_validator_(Bob, ?VALIDATOR_MIN, TxEnv, Trees2),
-    ok.
-
-delegate_can_support_multiple_validators(_Config) ->
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Carol = pubkey(?CAROL),
-    Trees0 = genesis_trees(),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees1 =
-        lists:foldl(
-            fun({Pubkey,  Amount}, TreesAccum) ->
-                {ok, TreesAccum1, _} = new_validator_(Pubkey, Amount, TxEnv,
-                                                      TreesAccum),
-                TreesAccum1
-            end,
-            Trees0,
-            [{Alice, ?VALIDATOR_MIN},
-             {Bob, ?VALIDATOR_MIN},
-             {Carol, ?VALIDATOR_MIN}]),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    %% assert initial balances
-    {ok, _, SPowerA0} = staking_power_(Alice, Alice, TxEnv, Trees2),
-    {SPowerA0, SPowerA0} = {SPowerA0, ?VALIDATOR_MIN},
-    {ok, _, SPowerB0} = staking_power_(Bob, Bob, TxEnv, Trees2),
-    {SPowerB0, SPowerB0} = {SPowerB0, ?VALIDATOR_MIN},
-    {ok, _, SPowerC0} = staking_power_(Carol, Carol, TxEnv, Trees2),
-    {SPowerC0, SPowerC0} = {SPowerC0, ?VALIDATOR_MIN},
-    %% create a delegate
-    #{public := Sam} = enacl:sign_keypair(),
-    SamSPower0 = trunc(math:pow(10, 30)),
-    Trees3 = set_up_account({Sam, SamSPower0}, Trees2),
-    %% the delegate supports Alice, only her balance changes
-    {ok, Trees4, _} = stake_(Alice, ?STAKE_MIN, Sam, TxEnv, Trees3),
-    {ok, _, SPowerA1} = staking_power_(Alice, Alice, TxEnv, Trees4),
-    {SPowerA1, SPowerA1} = {SPowerA1, ?VALIDATOR_MIN + ?STAKE_MIN},
-    {ok, _, SPowerB0} = staking_power_(Bob, Bob, TxEnv, Trees4),
-    {ok, _, SPowerC0} = staking_power_(Carol, Carol, TxEnv, Trees4),
-    %% the delegate supports Bob, only his balance changes
-    {ok, Trees5, _} = stake_(Bob, 5 * ?STAKE_MIN, Sam, TxEnv, Trees4),
-    {ok, _, SPowerA1} = staking_power_(Alice, Alice, TxEnv, Trees5),
-    {ok, _, SPowerB1} = staking_power_(Bob, Bob, TxEnv, Trees5),
-    {SPowerB1, SPowerB1} = {SPowerB1, ?VALIDATOR_MIN + 5 * ?STAKE_MIN},
-    {ok, _, SPowerC0} = staking_power_(Carol, Carol, TxEnv, Trees5),
-    {ok, Trees6, _} = stake_(Carol, 10 * ?STAKE_MIN, Sam, TxEnv, Trees5),
-    {ok, _, SPowerA1} = staking_power_(Alice, Alice, TxEnv, Trees6),
-    {ok, _, SPowerB1} = staking_power_(Bob, Bob, TxEnv, Trees6),
-    {ok, _, SPowerC1} = staking_power_(Carol, Carol, TxEnv, Trees6),
-    {SPowerC1, SPowerC1} = {SPowerC1, ?VALIDATOR_MIN + 10 * ?STAKE_MIN},
-    ok.
-
-if_unstake_all_delegate_is_deleted(_Config) ->
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Trees0 = genesis_trees(),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees1 =
-        lists:foldl(
-            fun({Pubkey,  Amount}, TreesAccum) ->
-                {ok, TreesAccum1, _} = new_validator_(Pubkey, Amount, TxEnv,
-                                                      TreesAccum),
-                TreesAccum1
-            end,
-            Trees0,
-            [{Alice, ?VALIDATOR_MIN},
-             {Bob, ?VALIDATOR_MIN}]),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    %% assert initial balances
-    {ok, _, SPowerA0} = staking_power_(Alice, Alice, TxEnv, Trees2),
-    {SPowerA0, SPowerA0} = {SPowerA0, ?VALIDATOR_MIN},
-    {ok, _, SPowerB0} = staking_power_(Bob, Bob, TxEnv, Trees2),
-    {SPowerB0, SPowerB0} = {SPowerB0, ?VALIDATOR_MIN},
-    %% create a delegate
-    #{public := Sam} = enacl:sign_keypair(),
-    SamSPower0 = trunc(math:pow(10, 30)),
-    Trees3 = set_up_account({Sam, SamSPower0}, Trees2),
-    Test =
-        fun(ToWhom) ->
-            {ok, _, State0} = get_validator_state_(ToWhom, ToWhom, TxEnv, Trees3),
-            {tuple, {{contract, _}, %% the pool contract
-                    {address, ToWhom},
-                    _, %% creation height
-                    ?VALIDATOR_MIN, %% staker pool balance
-                    _, %% pending stake
-                    _, %% total stake limit
-                    _, %% is online
-                    {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                            _, _, _, _, _, _, Map0, SPower0}}}} = State0,
-            %% assert balances
-            AddressKey = {address, ToWhom},
-            ?assertEqual(?VALIDATOR_MIN, maps:get(AddressKey, Map0)),
-            ?assertEqual(1, maps:size(Map0)), %% no other keys
-            TotalStakedAmt = ?STAKE_MIN + 10,
-            TotalAmt = ?VALIDATOR_MIN + TotalStakedAmt,
-            {ok, Trees4, StakeResp4} = stake_(ToWhom, TotalStakedAmt, Sam, TxEnv, Trees3),
-            ?assertEqual(TotalStakedAmt, StakeResp4#staking_resp.stake),
-            {ok, _, State1} = get_validator_state_(ToWhom, ToWhom, TxEnv,
-                                                   Trees4),
-            {tuple, {{contract, _}, %% the pool contract
-                    {address, ToWhom},
-                    _, %% creation height
-                    TotalAmt, %% staker pool balance
-                    _, %% pending stake
-                    _, %% total stake limit
-                    _, %% is online
-                    {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                            _, _, _, _Name, _Description,
-                            _AvatarURL, Map1, SPower1}}}} = State1,
-            ?assertEqual({SPower1, SPower1}, {SPower1, SPower0 + TotalStakedAmt}),
-            ?assertEqual(?VALIDATOR_MIN, maps:get({address, ToWhom}, Map1)),
-            ?assertEqual(TotalStakedAmt, maps:get({address, Sam}, Map1)),
-            ?assertEqual(2, maps:size(Map1)), %% no other keys
-            %% withdraw some shares and assert balances
-            WithdrawnAmt = 10,
-            StakeLeft = TotalStakedAmt - WithdrawnAmt,
-            PoolStakeLeft = TotalAmt - WithdrawnAmt,
-            {ok, Trees5, Resp5} = unstake_(ToWhom, WithdrawnAmt, Sam, TxEnv, Trees4),
-            ?assertEqual(WithdrawnAmt, Resp5#staking_resp.stake),
-            {ok, _, State2} = get_validator_state_(ToWhom, ToWhom, TxEnv, Trees5),
-            {tuple, {{contract, _}, %% the pool contract
-                    {address, ToWhom},
-                    _, %% creation height
-                    PoolStakeLeft, %% staker pool balance
-                    _, %% pending stake
-                    _, %% total stake limit
-                    _, %% is online
-                    {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                            _, _, _, _, _, _, Map2, SPower2}}}} = State2,
-            ?assertEqual({SPower2, SPower2}, {SPower2, SPower1 - WithdrawnAmt}),
-            ?assertEqual(?VALIDATOR_MIN, maps:get({address, ToWhom}, Map2)),
-            ?assertEqual(StakeLeft, maps:get({address, Sam}, Map2)),
-            ?assertEqual(2, maps:size(Map2)), %% no other keys
-            %% withdraw what is left, the delegate is being deleted
-            {ok, Trees6, Resp6} = unstake_(ToWhom, StakeLeft, Sam, TxEnv, Trees5),
-            ?assertEqual(StakeLeft, Resp6#staking_resp.stake),
-            {ok, _, State3} = get_validator_state_(ToWhom, ToWhom, TxEnv, Trees6),
-            {tuple, {{contract, _}, %% the pool contract
-                    {address, ToWhom},
-                    _, %% creation height
-                    ?VALIDATOR_MIN, %% staker pool balance
-                    _, %% pending stake
-                    _, %% total stake limit
-                    _, %% is online
-                    {tuple, {{address, ConsensusContractPubkey}, %% main staking contract
-                            _, _, _, _, _, _, Map3, SPower3}}}} = State3,
-            ?assertEqual({SPower3, SPower3}, {SPower3, SPower0}),
-            ?assertEqual(?VALIDATOR_MIN, maps:get({address, ToWhom}, Map3)),
-            ?assertEqual(1, maps:size(Map3)) %% no other keys
-        end,
-    Test(Alice), %% online
-    Test(Bob), %% offline
-    ok.
-
-can_not_become_validator_below_treshold(_Config) ->
-    Alice = pubkey(?ALICE),
-    Trees0 = genesis_trees(),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    {revert, <<"A new validator stake the minimum amount">>}
-        = new_validator_(Alice, ?VALIDATOR_MIN - 1, TxEnv, Trees0),
-    ok.
-
-can_not_stake_below_treshold(_Config) ->
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    Trees0 = genesis_trees(),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees1 =
-        lists:foldl(
-            fun({Pubkey,  Amount}, TreesAccum) ->
-                {ok, TreesAccum1, _} = new_validator_(Pubkey, Amount, TxEnv,
-                                                      TreesAccum),
-                TreesAccum1
-            end,
-            Trees0,
-            [{Alice, ?VALIDATOR_MIN},
-             {Bob, ?VALIDATOR_MIN}]),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees1),
-    %% create a delegate
-    #{public := Sam} = enacl:sign_keypair(),
-    SamSPower0 = trunc(math:pow(10, 30)),
-    Trees3 = set_up_account({Sam, SamSPower0}, Trees2),
-    {revert, <<"Must stake the minimum amount">>} =
-        stake_(Alice, ?STAKE_MIN - 1, Sam, TxEnv, Trees3),
-    ok.
-
-validator_can_not_unstake_below_30_percent_treshold(_Config) ->
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(),
-    {Sam, Trees1} = set_up_account(Trees0),
-
-    InitialStake = 2 * ?VALIDATOR_MIN,
-    {ok, Trees2, {contract, _}} = new_validator_(Alice, InitialStake, TxEnv, Trees1),
-    {ok, Trees3, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees2),
-    {ok, Trees4, _} = stake_(Alice, InitialStake, Sam, TxEnv, Trees3),
-
-    Bob = pubkey(?BOB),
-    {ok, Trees5, {contract, _}} = new_validator_(Bob, InitialStake, TxEnv, Trees4),
-    {ok, Trees6, {tuple, {}}} = set_validator_online_(Bob, TxEnv, Trees5),
-
-    %% Total stake: 6000
-    %% Alice total stake: 4000
-    %% Alice stake 2000
-    %% Sam stake: 2000
-    %% 30% treshold for Alice: 1200
-    UnstakeAmt = 800*?AE,
-
-    ?assertEqual({revert, <<"Validator can not withdraw below the treshold">>},
-                 unstake_(Alice, UnstakeAmt + 1, Alice, TxEnv, Trees6)),
-    {ok, _, _} = unstake_(Alice, UnstakeAmt, Alice, TxEnv, Trees6),
+    ?assertEqual(account_balance(pubkey(?ALICE), Trees3) - account_balance(pubkey(?ALICE), Trees2),
+                 2 * ?AE - TxCost),
 
     ok.
 
-total_stake_limit(_Config) ->
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees = genesis_trees(),
-    {Sam, Trees0} = set_up_account(Trees),
-
-    InitialStake = ?VALIDATOR_MIN,
-
-    %% Online Validator
-    BaseStakeLimit = calculate_total_stake_limit(InitialStake),
-    {ok, TreesOnline1, {contract, _}} = new_validator_(Alice, InitialStake, TxEnv, Trees0),
-    ?assertEqual(BaseStakeLimit, get_total_stake_limit(Alice, TxEnv, TreesOnline1)),
-
-    {ok, TreesOnline2, {tuple, {}}} = set_validator_online_(Alice, TxEnv, TreesOnline1),
-    ?assertEqual(BaseStakeLimit, get_total_stake_limit(Alice, TxEnv, TreesOnline2)),
-    TreesOnline3 = check_total_stake_limit_cases(Alice, Sam, InitialStake, TxEnv, TreesOnline2),
-
-    %% Validator going offline does not change staking limit
-    PreOfflineStakeLimit = get_total_stake_limit(Alice, TxEnv, TreesOnline3),
-    {ok, TreesOnline4, {tuple, {}}} = set_validator_offline_(Alice, TxEnv, TreesOnline3),
-    ?assertEqual(PreOfflineStakeLimit, get_total_stake_limit(Alice, TxEnv, TreesOnline4)),
-
-    %% Offline validator
-    {ok, TreesOffline1, {contract, _}} = new_validator_(Alice, InitialStake, TxEnv, Trees0),
-    ?assertEqual(BaseStakeLimit, get_total_stake_limit(Alice, TxEnv, TreesOffline1)),
-    check_total_stake_limit_cases(Alice, Sam, InitialStake, TxEnv, TreesOffline1),
-
-    ok.
-
-stake_delay(_Config) ->
-    StakeDelay = 11,
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(#{stake_delay => StakeDelay}),
-
-    ?assertMatch({ok, _, {tuple, {_, _, _, _, _, _, _, StakeDelay, _}}},
-                 get_staking_contract_state_(Alice, TxEnv, Trees0)),
-
-    InitialStake = ?VALIDATOR_MIN,
-
-    % Bob is always online
-    {ok, Trees1, {contract, _}} = new_validator_(Bob, InitialStake, TxEnv, Trees0),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Bob, TxEnv, Trees1),
-
-    %% Offline validator
-    {ok, Trees3, {contract, AliceCt}} = new_validator_(Alice, InitialStake, TxEnv, Trees2),
-    check_stake_delay(Alice, AliceCt, InitialStake, StakeDelay, TxEnv, Trees3),
-
-    %% Online validator
-    {ok, Trees4, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees3),
-    check_stake_delay(Alice, AliceCt, InitialStake, StakeDelay, TxEnv, Trees4),
-
-    ok.
-
-check_stake_delay(Alice, AliceCt, InitialStake, StakeDelay, TxEnv, Trees) ->
-    Ct = staking_contract_address(),
-    {Sam, Trees1} = set_up_account(Trees),
-    {Paul, Trees2} = set_up_account(Trees1),
-
-    SamStake = 100*?AE,
-    Sam2Stake = 101*?AE,
-    Paul2Stake = 102*?AE,
-
-    %% no stakers
-    {ok, _, {tuple, {_, _, _, AliceStake2, AlicePendingStake2, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, Trees2),
-    ?assertEqual(InitialStake, AliceStake2),
-    ?assertEqual(0, AlicePendingStake2),
-    ?assertEqual(0, account_balance(Ct, Trees2)),
-    ?assertEqual(InitialStake, account_balance(AliceCt, Trees2)),
-
-    %% single staker with delay
-    {ok, Trees3, _} = stake_(Alice, SamStake, Sam, TxEnv, Trees2),
-    {ok, _, {tuple, {_, _, _, AliceStake3, AlicePendingStake3, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, Trees3),
-    ?assertEqual(InitialStake, AliceStake3),
-    ?assertEqual(SamStake, AlicePendingStake3),
-    ?assertEqual(SamStake, account_balance(Ct, Trees3)),
-    ?assertEqual(InitialStake, account_balance(AliceCt, Trees3)),
-
-    %% two stakers with delay
-    TxEnv0_1  = aetx_env:set_height(TxEnv, ?DEFAULT_HEIGHT + 1),
-    {ok, Trees4, _} = stake_(Alice, Sam2Stake, Sam, TxEnv0_1, Trees3),
-    {ok, _, {tuple, {_, _, _, AliceStake4, AlicePendingStake4, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv0_1, Trees4),
-    ?assertEqual(InitialStake, AliceStake4),
-    ?assertEqual(SamStake+Sam2Stake, AlicePendingStake4),
-    ?assertEqual(InitialStake, account_balance(AliceCt, Trees4)),
-
-    {ok, Trees5, _} = stake_(Alice, Paul2Stake, Paul, TxEnv0_1, Trees4),
-    {ok, _, {tuple, {_, _, _, AliceStake5, AlicePendingStake5, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv0_1, Trees5),
-    ?assertEqual(InitialStake, AliceStake5),
-    ?assertEqual(SamStake+Sam2Stake+Paul2Stake, AlicePendingStake5),
-    ?assertEqual(SamStake+Sam2Stake+Paul2Stake, account_balance(Ct, Trees5)),
-    ?assertEqual(InitialStake, account_balance(AliceCt, Trees5)),
-
-    AssertTotalStake5 = case is_validator_online_(Alice, Alice, TxEnv, Trees5) of
-                          {ok, _, true} -> 2*InitialStake; % alice + bob
-                          {ok, _, false} -> InitialStake % bob
-                        end,
-    {ok, _, {tuple, {_, _, TotalStake5, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, Trees5),
-    ?assertMatch(AssertTotalStake5, TotalStake5),
-
-    %% stake distribution for single staker
-    TxEnv1  = aetx_env:set_height(TxEnv, ?DEFAULT_HEIGHT + StakeDelay),
-    {ok, Trees6, _} = elect_(Alice, ?OWNER_PUBKEY, TxEnv1, Trees5),
-    {ok, _, {tuple, {_, _, _, AliceStake6, AlicePendingStake6, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv1, Trees6),
-    ?assertEqual(InitialStake+SamStake, AliceStake6),
-    ?assertEqual(Sam2Stake+Paul2Stake, AlicePendingStake6),
-    ?assertEqual(Sam2Stake+Paul2Stake, account_balance(Ct, Trees6)),
-    ?assertEqual(InitialStake+SamStake, account_balance(AliceCt, Trees6)),
-    AssertTotalStake6 = case is_validator_online_(Alice, Alice, TxEnv1, Trees6) of
-                          {ok, _, true} -> 2*InitialStake+SamStake; % alice + bob
-                          {ok, _, false} -> InitialStake % bob
-                        end,
-    {ok, _, {tuple, {_, _, TotalStake6, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv1, Trees6),
-    ?assertMatch(AssertTotalStake6, TotalStake6),
-
-    % do not double spend
-    {ok, Trees6_1, _} = elect_(Alice, ?OWNER_PUBKEY, TxEnv1, Trees6),
-    ?assertEqual(InitialStake+SamStake, account_balance(AliceCt, Trees6_1)),
-
-    %% stake distribution for multiple stakers
-    TxEnv2  = aetx_env:set_height(TxEnv, ?DEFAULT_HEIGHT + StakeDelay + 1),
-    {ok, Trees7, _} = elect_(Alice, ?OWNER_PUBKEY, TxEnv2, Trees6),
-    %{ok, _, AliceState7} = get_validator_state_(Alice, Alice, TxEnv2, Trees7),
-    %?assertMatch({tuple, {_, _, _, ?VALIDATOR_MIN+303, 0, _, _, _}}, AliceState7),
-    {ok, _, {tuple, {_, _, _, AliceStake7, AlicePendingStake7, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv2, Trees7),
-    ?assertEqual(InitialStake+SamStake+Sam2Stake+Paul2Stake, AliceStake7),
-    ?assertEqual(0, AlicePendingStake7),
-    ?assertEqual(0, account_balance(Ct, Trees7)),
-    ?assertEqual(InitialStake+SamStake+Sam2Stake+Paul2Stake, account_balance(AliceCt, Trees7)),
-    AssertTotalStake7 = case is_validator_online_(Alice, Alice, TxEnv2, Trees7) of
-                          {ok, _, true} -> 2*InitialStake+SamStake+Sam2Stake+Paul2Stake; %% alice + bob
-                          {ok, _, false} -> InitialStake % bob
-                        end,
-    {ok, _, {tuple, {_, _, TotalStake7, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv2, Trees7),
-    ?assertMatch(AssertTotalStake7, TotalStake7),
-    ok.
-
-stake_delay_respects_upper_stake_limit(_Config) ->
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(#{stake_delay => 100}),
-    Ct = staking_contract_address(),
-    {Sam, Trees1} = set_up_account(Trees0),
-
-    InitialStake = ?VALIDATOR_MIN,
-    SamStake = 100*?AE,
-
-    % Online validator
-    {ok, OnlineTrees2, {contract, AliceCt}} = new_validator_(Alice, InitialStake, TxEnv, Trees1),
-    {ok, OnlineTrees3, {tuple, {}}} = set_validator_online_(Alice, TxEnv, OnlineTrees2),
-    {ok, OnlineTrees4, _} = stake_(Alice, SamStake, Sam, TxEnv, OnlineTrees3),
-    ?assertEqual(SamStake, account_balance(Ct, OnlineTrees4)),
-    ?assertEqual(InitialStake, account_balance(AliceCt, OnlineTrees4)),
-
-    StakeLimit = get_total_stake_limit(Alice, TxEnv, OnlineTrees4),
-    ?assertMatch({revert, <<"Total stake limit exceeded">>},
-                 stake_(Alice, StakeLimit, Sam, TxEnv, OnlineTrees4)),
-
-    % Offline validator
-    {ok, OfflineTrees2, {contract, _}} = new_validator_(Alice, InitialStake, TxEnv, Trees1),
-    {ok, OfflineTrees3, _} = stake_(Alice, SamStake, Sam, TxEnv, OfflineTrees2),
-    ?assertEqual(SamStake, account_balance(Ct, OfflineTrees3)),
-    ?assertEqual(InitialStake, account_balance(AliceCt, OfflineTrees3)),
-
-    StakeLimit = get_total_stake_limit(Alice, TxEnv, OfflineTrees3),
-    ?assertMatch({revert, <<"Total stake limit exceeded">>},
-                 stake_(Alice, StakeLimit, Sam, TxEnv, OfflineTrees3)),
-    ok.
-
-stake_delay_set_to_zero(_Config) ->
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(#{stake_delay => 0}),
-    Ct = staking_contract_address(),
-    {Sam, Trees1} = set_up_account(Trees0),
-
-    InitialStake = ?VALIDATOR_MIN,
-    SamStake = 100*?AE,
-
-    % Online validator
-    {ok, OnlineTrees2, {contract, AliceCt}} = new_validator_(Alice, InitialStake, TxEnv, Trees1),
-    {ok, OnlineTrees3, {tuple, {}}} = set_validator_online_(Alice, TxEnv, OnlineTrees2),
-    {ok, OnlineTrees4, _} = stake_(Alice, SamStake, Sam, TxEnv, OnlineTrees3),
-    ?assertEqual(0, account_balance(Ct, OnlineTrees4)),
-    ?assertEqual(InitialStake+SamStake, account_balance(AliceCt, OnlineTrees4)),
-    {ok, _, {tuple, {_, _, OnlineTotalStake, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OnlineTrees4),
-    ?assertEqual(InitialStake+SamStake, OnlineTotalStake),
-
-    % Offline validator
-    {ok, OfflineTrees2, {contract, AliceCt}} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees1),
-    {ok, OfflineTrees3, _} = stake_(Alice, SamStake, Sam, TxEnv, OfflineTrees2),
-    ?assertEqual(0, account_balance(Ct, OfflineTrees3)),
-    ?assertEqual(InitialStake+SamStake, account_balance(AliceCt, OfflineTrees3)),
-    {ok, _, {tuple, {_, _, OfflineTotalStake, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OfflineTrees3),
-    ?assertEqual(0, OfflineTotalStake),
-
-    ok.
-
-check_total_stake_limit_cases(Validator, Staker, InitialStake, TxEnv, Trees) ->
-    BaseStakeLimit = calculate_total_stake_limit(InitialStake),
-
-    %% Staker's stake does not change the staking limit
-    Stake = 100*?AE,
-    {ok, Trees3, _} = stake_(Validator, Stake, Staker, TxEnv, Trees),
-    ?assertEqual(BaseStakeLimit, get_total_stake_limit(Validator, TxEnv, Trees3)),
-    StakeToLimit = get_available_stake_limit(Validator, TxEnv, Trees3),
-
-    %% Staker can not stake about the staking limit
-    ?assertEqual({revert, <<"Total stake limit exceeded">>},
-                 stake_(Validator, StakeToLimit+?AE, Staker, TxEnv, Trees3)),
-
-    %% Staker can stake up to the staking limit
-    {ok, Trees4, _} = stake_(Validator, StakeToLimit, Staker, TxEnv, Trees3),
-    ?assertEqual(BaseStakeLimit, get_total_stake_limit(Validator, TxEnv, Trees4)),
-
-    %% Validator stake does change the staking limit
-    {ok, Trees5, _} = stake_(Validator, InitialStake, Validator, TxEnv, Trees4),
-    NewStakeLimit = calculate_total_stake_limit(InitialStake+InitialStake),
-    ?assert(BaseStakeLimit < NewStakeLimit),
-    ?assertEqual(NewStakeLimit, get_total_stake_limit(Validator, TxEnv, Trees5)),
-
-    %% Validator can stake about the staking limit
-    NewStakeToLimit = get_available_stake_limit(Validator, TxEnv, Trees5),
-    ?assertEqual({revert, <<"Total stake limit exceeded">>},
-                 stake_(Validator, NewStakeToLimit+?AE, Staker, TxEnv, Trees5)),
-    {ok, Trees6, _} = stake_(Validator, NewStakeToLimit+?AE, Validator, TxEnv, Trees5),
-    IncreasedStakeLimit = get_total_stake_limit(Validator, TxEnv, Trees6),
-
-    %% Staker unstake does not change the staking limit
-    {ok, Trees7, _} = unstake_(Validator, 10*?AE, Staker, TxEnv, Trees6),
-    ?assertEqual(IncreasedStakeLimit, get_total_stake_limit(Validator, TxEnv, Trees7)),
-
-    %% Validator unstake does change the staking limit
-    {ok, Trees8, _} = unstake_(Validator, InitialStake, Validator, TxEnv, Trees7),
-    DecreasedStakeLimit = get_total_stake_limit(Validator, TxEnv, Trees8),
-    ?assert(IncreasedStakeLimit > DecreasedStakeLimit),
-
-    %% Reward distribution does change the staking limit
-    {ok, Trees9, {tuple, {}}} = reward_(Validator, InitialStake, ?OWNER_PUBKEY, TxEnv, Trees8),
-    ?assert(DecreasedStakeLimit < get_total_stake_limit(Validator, TxEnv, Trees9)),
-
-    Trees9.
-
-unstake_delay(_Config) ->
-    UnstakeDelay = 101,
-    Alice = pubkey(?ALICE),
-    Bob = pubkey(?BOB),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(#{unstake_delay => UnstakeDelay}),
-
-    ?assertMatch({ok, _, {tuple, {_, _, _, _, _, _, _, _, UnstakeDelay}}},
-                 get_staking_contract_state_(Alice, TxEnv, Trees0)),
-
-    InitialStake = ?VALIDATOR_MIN,
-
-    % Bob is always online
-    {ok, Trees1, {contract, BobCt}} = new_validator_(Bob, InitialStake, TxEnv, Trees0),
-    {ok, Trees2, {tuple, {}}} = set_validator_online_(Bob, TxEnv, Trees1),
-
-    %% Offline validator
-    {ok, OfflineTrees, {contract, AliceCt}} = new_validator_(Alice, InitialStake, TxEnv, Trees2),
-    check_unstake_delay(Alice, AliceCt, InitialStake, UnstakeDelay, TxEnv, OfflineTrees),
-
-    %% Online validator
-    {ok, OnlineTrees, {tuple, {}}} = set_validator_online_(Alice, TxEnv, OfflineTrees),
-    check_unstake_delay(Alice, AliceCt, InitialStake, UnstakeDelay, TxEnv, OnlineTrees),
-
-    %% unstake from two validators
-    AliceStake = 1001*?AE,
-    BobStake = 1002*?AE,
-    AliceUnstake = 99*?AE,
-    BobUnstake = 101*?AE,
-
-    {Sam, Trees3} = set_up_account(OfflineTrees),
-    {ok, Trees4, _} = stake_(Alice, AliceStake, Sam, TxEnv, Trees3),
-    {ok, Trees5, _} = stake_(Bob, BobStake, Sam, TxEnv, Trees4),
-
-    % main contract
-    {ok, _, {tuple, {_, _, CtStake5, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, Trees5),
-    ?assertEqual(InitialStake+BobStake, CtStake5), %% bob
-
-    % alice contract
-    {ok, _, {tuple, {_, _, _, AliceStake5, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, Trees5),
-    ?assertEqual(InitialStake+AliceStake, AliceStake5),
-    ?assertEqual(InitialStake+AliceStake, account_balance(AliceCt, Trees5)),
-
-    % bob contract
-    {ok, _, {tuple, {_, _, _, BobStake5, _, _, _, _}}}
-        = get_validator_state_(Bob, Bob, TxEnv, Trees5),
-    ?assertEqual(InitialStake+BobStake, BobStake5),
-    ?assertEqual(InitialStake+BobStake, account_balance(BobCt, Trees5)),
-
-    SamBalancePreUnstake = account_balance(Sam, Trees5),
-    {ok, Trees6, _} = unstake_(Alice, AliceUnstake, Sam, TxEnv, Trees5),
-    {ok, Trees7, _} = unstake_(Bob, BobUnstake, Sam, TxEnv, Trees6),
-    SamBalancePostUnstake = account_balance(Sam, Trees7),
-    ?assert(SamBalancePreUnstake > SamBalancePostUnstake),
-
-    % main contract
-    {ok, _, {tuple, {_, _, CtStake7, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, Trees7),
-
-    ?assertEqual(InitialStake+BobStake-BobUnstake, CtStake7), %% bob
-
-    % alice contract
-    {ok, _, AliceState7} = get_validator_state_(Alice, Alice, TxEnv, Trees7),
-    {tuple, {_, _, _, AliceStake7, _, _, _, AliceCtState7}} = AliceState7,
-    {tuple, {_, _, AlicePendingUnstakeAmount7, AlicePendingUnstake7, _, _, _, _, _}} = AliceCtState7,
-    ?assertEqual(InitialStake+AliceStake-AliceUnstake, AliceStake7),
-    ?assertEqual(AliceUnstake, AlicePendingUnstakeAmount7),
-    ?assertEqual(1, maps:size(AlicePendingUnstake7)),
-    ?assertEqual([{tuple, {{address, Sam}, AliceUnstake}}],
-                 maps:get(?DEFAULT_HEIGHT + UnstakeDelay, AlicePendingUnstake7)),
-    ?assertEqual(InitialStake+AliceStake, account_balance(AliceCt, Trees7)),
-
-    % bob contract
-    {ok, _, BobState7} = get_validator_state_(Bob, Bob, TxEnv, Trees7),
-    {tuple, {_, _, _, BobStake7, _, _, _, BobCtState7}} = BobState7,
-    {tuple, {_, _, BobPendingUnstakeAmount7, BobPendingUnstake7, _, _, _, _, _}} = BobCtState7,
-    ?assertEqual(InitialStake+BobStake-BobUnstake, BobStake7),
-    ?assertEqual(BobUnstake, BobPendingUnstakeAmount7),
-    ?assertEqual(1, maps:size(BobPendingUnstake7)),
-    ?assertEqual([{tuple, {{address, Sam}, BobUnstake}}],
-                 maps:get(?DEFAULT_HEIGHT + UnstakeDelay, BobPendingUnstake7)),
-    ?assertEqual(InitialStake+BobStake, account_balance(BobCt, Trees7)),
-
-    %% unstake distribution
-    TxEnv1  = aetx_env:set_height(TxEnv, ?DEFAULT_HEIGHT + UnstakeDelay),
-    {ok, Trees8, _} = elect_(Alice, ?OWNER_PUBKEY, TxEnv1, Trees7),
-
-    % main contract
-    {ok, _, {tuple, {_, _, CtStake8, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv1, Trees8),
-    ?assertEqual(InitialStake+BobStake-BobUnstake, CtStake8), %% bob
-
-    % alice contract
-    {ok, _, AliceState8} = get_validator_state_(Alice, Alice, TxEnv1, Trees8),
-    {tuple, {_, _, _, AliceStake8, _, _, _, AliceCtState8}} = AliceState8,
-    {tuple, {_, _, AlicePendingUnstakeAmount8, AlicePendingUnstake8, _, _, _, _, _}} = AliceCtState8,
-    ?assertEqual(InitialStake+AliceStake-AliceUnstake, AliceStake8),
-    ?assertEqual(0, AlicePendingUnstakeAmount8),
-    ?assertEqual(#{}, AlicePendingUnstake8),
-    ?assertEqual(InitialStake+AliceStake-AliceUnstake, account_balance(AliceCt, Trees8)),
-
-    % bob contract
-    {ok, _, BobState8} = get_validator_state_(Bob, Bob, TxEnv1, Trees8),
-    {tuple, {_, _, _, BobStake8, _, _, _, BobCtState8}} = BobState8,
-    {tuple, {_, _, BobPendingUnstakeAmount8, BobPendingUnstake8, _, _, _, _, _}} = BobCtState8,
-    ?assertEqual(InitialStake+BobStake-BobUnstake, BobStake8),
-    ?assertEqual(0, BobPendingUnstakeAmount8),
-    ?assertEqual(#{}, BobPendingUnstake8),
-    ?assertEqual(InitialStake+BobStake-BobUnstake, account_balance(BobCt, Trees8)),
-
-    ?assertEqual(AliceUnstake+BobUnstake, account_balance(Sam, Trees8) - SamBalancePostUnstake),
-    ok.
-
-check_unstake_delay(Alice, AliceCt, InitialStake, UnstakeDelay, TxEnv0, Trees0) ->
-    {Sam, Trees1} = set_up_account(Trees0),
-    {Paul, Trees2} = set_up_account(Trees1),
-
-    SamStake = ?STAKE_MIN+(1000*?AE),
-    PaulStake = ?STAKE_MIN+(1000*?AE),
-    SamUnstake = 100*?AE,
-    Sam2Unstake = 99*?AE,
-    Paul2Unstake = 101*?AE,
-
-    {ok, Trees3, _} = stake_(Alice, SamStake, Sam, TxEnv0, Trees2),
-    {ok, Trees4, _} = stake_(Alice, PaulStake, Paul, TxEnv0, Trees3),
-
-    {ok, _, CtState4} = get_staking_contract_state_(Alice, TxEnv0, Trees4),
-    AssertTotalStake4 = case is_validator_online_(Alice, Alice, TxEnv0, Trees4) of
-                          {ok, _, true} -> 2*InitialStake + SamStake + PaulStake; % alice + bob
-                          {ok, _, false} -> InitialStake % bob
-                        end,
-    ?assertMatch({tuple, {_, _, AssertTotalStake4, _, _, _, _, _, _}}, CtState4),
-    {ok, _, {tuple, {_, _, _, AliceStake4, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv0, Trees4),
-    ?assertEqual(InitialStake+SamStake+PaulStake, AliceStake4),
-    ?assertEqual(AliceStake4, account_balance(AliceCt, Trees4)),
-
-    %% single unstake
-    {ok, Trees5, _} = unstake_(Alice, SamUnstake, Sam, TxEnv0, Trees4),
-
-    {ok, _, CtState5} = get_staking_contract_state_(Alice, TxEnv0, Trees5),
-    AssertTotalStake5 = case is_validator_online_(Alice, Alice, TxEnv0, Trees5) of
-                          {ok, _, true} -> 2*InitialStake + SamStake + PaulStake - SamUnstake; % alice + bob
-                          {ok, _, false} -> ?VALIDATOR_MIN % bob
-                        end,
-    ?assertMatch({tuple, {_, _, AssertTotalStake5, _, _, _, _, _, _}}, CtState5),
-    {ok, _, AliceState5} = get_validator_state_(Alice, Alice, TxEnv0, Trees5),
-    {tuple, {_, _, _, AliceStake5, _, _, _, AliceCtState5}} = AliceState5,
-    {tuple, {_, _, PendingUnstakeAmount5, PendingUnstake5, _, _, _, _, _}} = AliceCtState5,
-    ?assertEqual(InitialStake + SamStake + PaulStake - SamUnstake, AliceStake5),
-    ?assertEqual(SamUnstake, PendingUnstakeAmount5),
-    ?assertEqual(1, maps:size(PendingUnstake5)),
-    ?assertEqual([{tuple, {{address, Sam}, SamUnstake}}],
-                 maps:get(?DEFAULT_HEIGHT + UnstakeDelay, PendingUnstake5)),
-    ?assertEqual(InitialStake + SamStake + PaulStake, account_balance(AliceCt, Trees5)),
-
-    %% two unstakes
-    TxEnv1  = aetx_env:set_height(TxEnv0, ?DEFAULT_HEIGHT + 1),
-    {ok, Trees6, _} = unstake_(Alice, Sam2Unstake, Sam, TxEnv1, Trees5),
-    {ok, Trees7, _} = unstake_(Alice, Paul2Unstake, Paul, TxEnv1, Trees6),
-    {ok, _, CtState7} = get_staking_contract_state_(Alice, TxEnv1, Trees7),
-    AssertTotalStake7 = case is_validator_online_(Alice, Alice, TxEnv1, Trees7) of
-                          {ok, _, true} -> 2*InitialStake
-                                           + SamStake + PaulStake
-                                           - SamUnstake - Sam2Unstake - Paul2Unstake; % alice + bob
-                          {ok, _, false} -> InitialStake % bob
-                        end,
-    ?assertMatch({tuple, {_, _, AssertTotalStake7, _, _, _, _, _, _}}, CtState7),
-    {ok, _, AliceState7} = get_validator_state_(Alice, Alice, TxEnv1, Trees7),
-    {tuple, {_, _, _, AliceStake7, _, _, _, AliceCtState7}} = AliceState7,
-    {tuple, {_, _, PendingUnstakeAmount7, PendingUnstake7, _, _, _, _, _}} = AliceCtState7,
-    ?assertEqual(InitialStake + SamStake+PaulStake-SamUnstake-Sam2Unstake-Paul2Unstake, AliceStake7),
-    ?assertEqual(SamUnstake+Sam2Unstake+Paul2Unstake, PendingUnstakeAmount7),
-    ?assertEqual(2, maps:size(PendingUnstake7)),
-    ?assertEqual([{tuple, {{address, Sam}, SamUnstake}}],
-                 maps:get(?DEFAULT_HEIGHT + UnstakeDelay, PendingUnstake7)),
-    ?assertEqual(lists:sort([{tuple, {{address, Sam}, Sam2Unstake}},
-                             {tuple, {{address, Paul}, Paul2Unstake}}]),
-                 lists:sort(maps:get(?DEFAULT_HEIGHT + UnstakeDelay + 1, PendingUnstake7))),
-    ?assertEqual(InitialStake+SamStake+PaulStake, account_balance(AliceCt, Trees7)),
-
-    %% unstake distribution for single staker
-    TxEnv2  = aetx_env:set_height(TxEnv1, ?DEFAULT_HEIGHT + UnstakeDelay),
-    {ok, Trees8, _} = elect_(Alice, ?OWNER_PUBKEY, TxEnv2, Trees7),
-    {ok, _, CtState8} = get_staking_contract_state_(Alice, TxEnv2, Trees8),
-    AssertTotalStake8 = case is_validator_online_(Alice, Alice, TxEnv2, Trees8) of
-                          {ok, _, true} -> 2*InitialStake
-                                           + SamStake + PaulStake
-                                           - SamUnstake - Sam2Unstake - Paul2Unstake; % alice + bob
-                          {ok, _, false} -> InitialStake % bob
-                        end,
-    ?assertMatch({tuple, {_, _, AssertTotalStake8, _, _, _, _, _, _}}, CtState8),
-    {ok, _, AliceState8} = get_validator_state_(Alice, Alice, TxEnv2, Trees8),
-    {tuple, {_, _, _, AliceStake8, _, _, _, AliceCtState8}} = AliceState8,
-    {tuple, {_, _, PendingUnstakeAmount8, PendingUnstake8, _, _, _, _, _}} = AliceCtState8,
-    ?assertEqual(InitialStake + SamStake+PaulStake-SamUnstake-Sam2Unstake-Paul2Unstake, AliceStake8),
-    ?assertEqual(Sam2Unstake+Paul2Unstake, PendingUnstakeAmount8),
-    ?assertEqual(1, maps:size(PendingUnstake8)),
-    ?assertEqual(lists:sort([{tuple, {{address, Sam}, Sam2Unstake}},
-                             {tuple, {{address, Paul}, Paul2Unstake}}]),
-                 lists:sort(maps:get(?DEFAULT_HEIGHT + UnstakeDelay + 1, PendingUnstake8))),
-    ?assertEqual(InitialStake+SamStake+PaulStake-SamUnstake, account_balance(AliceCt, Trees8)),
-
-    %% do not double spend
-    {ok, Trees8_1, _} = elect_(Alice, ?OWNER_PUBKEY, TxEnv2, Trees8),
-    ?assertEqual(InitialStake+SamStake+PaulStake-SamUnstake, account_balance(AliceCt, Trees8_1)),
-
-    %% unstake distribution for multiple stakers
-    TxEnv3  = aetx_env:set_height(TxEnv2, ?DEFAULT_HEIGHT + UnstakeDelay + 1),
-    {ok, Trees9, _} = elect_(Alice, ?OWNER_PUBKEY, TxEnv3, Trees8),
-    {ok, _, CtState9} = get_staking_contract_state_(Alice, TxEnv3, Trees9),
-    AssertTotalStake9 = case is_validator_online_(Alice, Alice, TxEnv3, Trees9) of
-                          {ok, _, true} -> 2*InitialStake
-                                           + SamStake + PaulStake
-                                           - SamUnstake - Sam2Unstake - Paul2Unstake; % alice + bob
-                          {ok, _, false} -> InitialStake % bob
-                        end,
-    ?assertMatch({tuple, {_, _, AssertTotalStake9, _, _, _, _, _, _}}, CtState9),
-    {ok, _, AliceState9} = get_validator_state_(Alice, Alice, TxEnv3, Trees9),
-    {tuple, {_, _, _, AliceStake9, _, _, _, AliceCtState9}} = AliceState9,
-    {tuple, {_, _, PendingUnstakeAmount9, PendingUnstake9, _, _, _, _, _}} = AliceCtState9,
-    ?assertEqual(InitialStake + SamStake+PaulStake-SamUnstake-Sam2Unstake-Paul2Unstake, AliceStake9),
-    ?assertEqual(0, PendingUnstakeAmount9),
-    ?assertEqual(#{}, PendingUnstake9),
-    ?assertEqual(
-        InitialStake + SamStake + PaulStake - SamUnstake - Sam2Unstake - Paul2Unstake,
-        account_balance(AliceCt, Trees9)
-    ),
-
-    ok.
-
-unstake_delay_set_to_zero(_Config) ->
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(#{unstake_delay => 0}),
-    {Sam, Trees1} = set_up_account(Trees0),
-
-    InitialStake = ?VALIDATOR_MIN+(1000*?AE),
-    SamStake = ?STAKE_MIN+(100*?AE),
-    SamUnstake = 100*?AE,
-    AliceUnstake = 100*?AE,
-
-    {ok, Trees2, {contract, AliceCt}} = new_validator_(Alice, InitialStake, TxEnv, Trees1),
-
-    % Online validator
-    {ok, OnlineTrees3, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees2),
-
-    {ok, OnlineTrees4, _} = stake_(Alice, SamStake, Sam, TxEnv, OnlineTrees3),
-    {ok, _, {tuple, {_, _, OnlineCtStake4, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OnlineTrees4),
-    {ok, _, {tuple, {_, _, _, OnlineAliceStake4, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, OnlineTrees4),
-    ?assertEqual(InitialStake+SamStake, OnlineCtStake4),
-    ?assertEqual(InitialStake+SamStake, OnlineAliceStake4),
-    ?assertEqual(InitialStake+SamStake, account_balance(AliceCt, OnlineTrees4)),
-
-    {ok, OnlineTrees5, _} = unstake_(Alice, SamUnstake, Sam, TxEnv, OnlineTrees4),
-    {ok, _, {tuple, {_, _, OnlineCtStake5, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OnlineTrees5),
-    {ok, _, {tuple, {_, _, _, OnlineAliceStake5, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, OnlineTrees5),
-    ?assertEqual(InitialStake+SamStake-SamUnstake, OnlineCtStake5),
-    ?assertEqual(InitialStake+SamStake-SamUnstake, OnlineAliceStake5),
-    ?assertEqual(InitialStake+SamStake-SamUnstake, account_balance(AliceCt, OnlineTrees5)),
-
-    {ok, OnlineTrees6, _} = unstake_(Alice, AliceUnstake, Alice, TxEnv, OnlineTrees5),
-    {ok, _, {tuple, {_, _, OnlineCtStake6, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OnlineTrees6),
-    {ok, _, {tuple, {_, _, _, OnlineAliceStake6, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, OnlineTrees6),
-    ?assertEqual(InitialStake+SamStake-SamUnstake-AliceUnstake, OnlineCtStake6),
-    ?assertEqual(InitialStake+SamStake-SamUnstake-AliceUnstake, OnlineAliceStake6),
-    ?assertEqual(InitialStake+SamStake-SamUnstake-AliceUnstake, account_balance(AliceCt, OnlineTrees6)),
-
-    % Offline validator
-    {ok, OfflineTrees3, _} = stake_(Alice, SamStake, Sam, TxEnv, Trees2),
-    {ok, _, {tuple, {_, _, OfflineCtStake3, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OfflineTrees3),
-    {ok, _, {tuple, {_, _, _, OfflineAliceStake3, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, OfflineTrees3),
-    ?assertEqual(0, OfflineCtStake3),
-    ?assertEqual(InitialStake+SamStake, OfflineAliceStake3),
-    ?assertEqual(InitialStake+SamStake, account_balance(AliceCt, OfflineTrees3)),
-
-    {ok, OfflineTrees4, _} = unstake_(Alice, SamUnstake, Sam, TxEnv, OfflineTrees3),
-    {ok, _, {tuple, {_, _, OfflineCtStake4, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OfflineTrees4),
-    {ok, _, {tuple, {_, _, _, OfflineAliceStake4, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, OfflineTrees4),
-    ?assertEqual(0, OfflineCtStake4),
-    ?assertEqual(InitialStake+SamStake-SamUnstake, OfflineAliceStake4),
-    ?assertEqual(InitialStake+SamStake-SamUnstake, account_balance(AliceCt, OfflineTrees4)),
-
-    {ok, OfflineTrees5, _} = unstake_(Alice, AliceUnstake, Alice, TxEnv, OfflineTrees4),
-    {ok, _, {tuple, {_, _, OfflineCtStake5, _, _, _, _, _, _}}}
-        = get_staking_contract_state_(Alice, TxEnv, OfflineTrees5),
-    {ok, _, {tuple, {_, _, _, OfflineAliceStake5, _, _, _, _}}}
-        = get_validator_state_(Alice, Alice, TxEnv, OfflineTrees5),
-    ?assertEqual(0, OfflineCtStake5),
-    ?assertEqual(InitialStake+SamStake-SamUnstake-AliceUnstake, OfflineAliceStake5),
-    ?assertEqual(InitialStake+SamStake-SamUnstake-AliceUnstake, account_balance(AliceCt, OfflineTrees5)),
-    ok.
-
-staking_without_delay_return_shares(_Config) ->
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(),
-    {Sam, Trees1} = set_up_account(Trees0),
-    {ok, Trees2, _} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees1),
-
-    AliceStake = ?STAKE_MIN + 1*?AE,
-    SamStake = ?STAKE_MIN + 2*?AE,
-
-    {ok, _, {tuple, AliceState2}} = get_validator_state_(Alice, Alice, TxEnv, Trees2),
-    {_, _, _, _, _, _, _, {tuple, AliceCtState2}} = AliceState2,
-    {_, _, _, _, _, _, _, _, TotalShares2} = AliceCtState2,
-
-    {ok, Trees3, AliceResp} = stake_(Alice, AliceStake, Alice, TxEnv, Trees2),
-    {ok, _, {tuple, AliceState3}} = get_validator_state_(Alice, Alice, TxEnv, Trees3),
-    {_, _, _, _, _, _, _, {tuple, AliceCtState3}} = AliceState3,
-    {_, _, _, _, _, _, _, _, TotalShares3} = AliceCtState3,
-
-    {ok, Trees4, SamResp} = stake_(Alice, SamStake, Sam, TxEnv, Trees3),
-    {ok, _, {tuple, AliceState4}} = get_validator_state_(Alice, Alice, TxEnv, Trees4),
-    {_, _, _, _, _, _, _, {tuple, AliceCtState4}} = AliceState4,
-    {_, _, _, _, _, _, _, Delegates, TotalShares4} = AliceCtState4,
-
-    ?assertEqual(AliceStake, AliceResp#staking_resp.shares),
-    ?assertEqual(SamStake, SamResp#staking_resp.shares),
-
-    ?assertEqual(?DEFAULT_HEIGHT, AliceResp#staking_resp.execution_height),
-    ?assertEqual(?DEFAULT_HEIGHT, SamResp#staking_resp.execution_height),
-
-    ?assertEqual(TotalShares3, TotalShares2 + AliceResp#staking_resp.shares),
-    ?assertEqual(TotalShares4, TotalShares3 + SamResp#staking_resp.shares),
-    ?assertEqual(TotalShares2 + AliceResp#staking_resp.shares, maps:get({address, Alice}, Delegates)),
-    ?assertEqual(SamResp#staking_resp.shares, maps:get({address, Sam}, Delegates)),
-    ok.
-
-%%TODO test the actual staking rewards for hyperchains
-staking_with_delay_return_shares(_Config) ->
-    StakeDelay = 10,
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(#{stake_delay => StakeDelay}),
-    {Sam, Trees1} = set_up_account(Trees0),
-    {ok, Trees2, _} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees1),
-
-    AliceStake = ?STAKE_MIN + 1*?AE,
-    SamStake = ?STAKE_MIN + 2*?AE,
-
-    {ok, _, {tuple, AliceState2}} = get_validator_state_(Alice, Alice, TxEnv, Trees2),
-    {_, _, _, _, _, _, _, {tuple, AliceCtState2}} = AliceState2,
-    {_, _, _, _, _, _, _, _, TotalShares2} = AliceCtState2,
-
-    {ok, Trees3, AliceResp} = stake_(Alice, AliceStake, Alice, TxEnv, Trees2),
-    {ok, _, {tuple, AliceState3}} = get_validator_state_(Alice, Alice, TxEnv, Trees3),
-    {_, _, _, _, _, _, _, {tuple, AliceCtState3}} = AliceState3,
-    {_, _, _, _, _, _, _, _, TotalShares3} = AliceCtState3,
-
-    {ok, Trees4, SamResp} = stake_(Alice, SamStake, Sam, TxEnv, Trees3),
-    {ok, _, {tuple, AliceState4}} = get_validator_state_(Alice, Alice, TxEnv, Trees4),
-    {_, _, _, _, _, _, _, {tuple, AliceCtState4}} = AliceState4,
-    {_, _, _, _, _, _, _, Delegates, TotalShares4} = AliceCtState4,
-
-    ?assertEqual(AliceStake, AliceResp#staking_resp.shares),
-    ?assertEqual(SamStake, SamResp#staking_resp.shares),
-
-    ?assertEqual(?DEFAULT_HEIGHT + StakeDelay, AliceResp#staking_resp.execution_height),
-    ?assertEqual(?DEFAULT_HEIGHT + StakeDelay, SamResp#staking_resp.execution_height),
-
-    ?assertEqual(TotalShares3, TotalShares2),
-    ?assertEqual(TotalShares4, TotalShares2),
-    ?assertEqual(#{{address, Alice} => TotalShares2}, Delegates),
-    ok.
-
-unstaking_return_shares(_Config) ->
-    UnstakeDelay = 10,
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(#{unstake_delay => UnstakeDelay}),
-
-    {ok, Trees1, _} = new_validator_(Alice, 2*?VALIDATOR_MIN, TxEnv, Trees0),
-    {ok, Trees2, {tuple, {}}} = reward_(Alice, 2*?VALIDATOR_MIN, ?OWNER_PUBKEY, TxEnv, Trees1),
-    {ok, _, UnstakeResp} = unstake_(Alice, ?VALIDATOR_MIN, Alice, TxEnv, Trees2),
-
-    ?assertEqual(2*?VALIDATOR_MIN, UnstakeResp#staking_resp.stake),
-    ?assertEqual(?VALIDATOR_MIN, UnstakeResp#staking_resp.shares),
-    ?assertEqual(?DEFAULT_HEIGHT + UnstakeDelay, UnstakeResp#staking_resp.execution_height),
-    ok.
-
-unstaking_below_minimum_stake(_Config) ->
-    Alice = pubkey(?ALICE),
-    TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
-    Trees0 = genesis_trees(),
-    {Sam, Trees1} = set_up_account(Trees0),
-    {ok, Trees, _} = new_validator_(Alice, ?VALIDATOR_MIN, TxEnv, Trees1),
-
-    Reason = <<"Staker can not withdraw below the treshold">>,
-    %% Offline validator
-    {ok, OfflineTrees1, _} = stake_(Alice, ?STAKE_MIN + 1, Sam, TxEnv, Trees),
-    ?assertMatch({ok, _, _}, unstake_(Alice, 1, Sam, TxEnv, OfflineTrees1)),
-    ?assertEqual({revert, Reason}, unstake_(Alice, ?STAKE_MIN, Sam, TxEnv, OfflineTrees1)),
-    ?assertMatch({ok, _, _}, unstake_(Alice, ?STAKE_MIN + 1, Sam, TxEnv, OfflineTrees1)),
-
-    %% Online validator
-    {ok, OnlineTrees1, {tuple, {}}} = set_validator_online_(Alice, TxEnv, Trees),
-    {ok, OnlineTrees2, _} = stake_(Alice, ?STAKE_MIN + 1, Sam, TxEnv, OnlineTrees1),
-    ?assertMatch({ok, _, _}, unstake_(Alice, 1, Sam, TxEnv, OnlineTrees2)),
-    ?assertEqual({revert, Reason}, unstake_(Alice, ?STAKE_MIN, Sam, TxEnv, OnlineTrees2)),
-    ?assertMatch({ok, _, _}, unstake_(Alice, ?STAKE_MIN + 1, Sam, TxEnv, OnlineTrees2)),
-
+rewards(_Config) ->
     ok.
 
 genesis_trees_opts(Type, Key, Opts, Default) ->
@@ -1788,50 +223,42 @@ genesis_trees() ->
     genesis_trees(#{}).
 
 genesis_trees(Opts) ->
-    ElectionContract = ?HC_ELECTION_CONTRACT,
+    ElectionContract = ?HC_ELECTION_CT,
     Trees0 = aec_trees:new_without_backend(),
     Trees1 = set_up_accounts(Trees0),
     TxEnv = aetx_env:tx_env(?GENESIS_HEIGHT, aect_test_utils:latest_protocol_version()),
-    {ok, SVCD} =
-        aeb_fate_abi:create_calldata("init",
-                                     [aefa_fate_code:encode_arg({address, ?OWNER_PUBKEY}),
-                                      genesis_trees_opts(integer, unstake_delay, Opts, ?UNSTAKE_DELAY)
-                                     ]),
-    {SVPubkey, Trees2} = create_contract("StakingValidator", SVCD, TxEnv, Trees1),
+
+    %% Main staking contract
     {ok, MainCD} = aeb_fate_abi:create_calldata("init",
-                       [genesis_trees_opts(contract,  validator_ct, Opts, SVPubkey),
-                        genesis_trees_opts(integer,   min_stake,    Opts, ?VALIDATOR_MIN),
-                        genesis_trees_opts(integer,   min_percent,  Opts, ?VALIDATOR_MIN_PERCENT),
-                        genesis_trees_opts(integer,   stake_min,    Opts, ?STAKE_MIN),
-                        genesis_trees_opts(integer,   online_delay, Opts, ?ONLINE_DELAY),
-                        genesis_trees_opts(integer,   stake_delay,  Opts, ?STAKE_DELAY),
-                        genesis_trees_opts(integer,   unstake_delay, Opts, ?UNSTAKE_DELAY)
-                       ]),
-    {StakingPubkey, Trees3} = create_contract(?STAKING_CONTRACT, MainCD, TxEnv, Trees2),
-    %% assert expectation:
-    StakingPubkey = staking_contract_address(),
+                       [genesis_trees_opts(integer, min_stake, Opts, ?VALIDATOR_MIN)]),
+    {StakingPubkey, Trees2} = create_contract(?MAIN_STAKING_CT, MainCD, TxEnv, Trees1),
+    ?assertEqual(StakingPubkey, staking_contract_address()),
+
+    %% HC Election contract
     {ok, ElectionCD} = aeb_fate_abi:create_calldata("init",
-                                              [aefa_fate_code:encode_arg({contract, StakingPubkey})]),
-    {ElectionPubkey, Trees4} = create_contract(ElectionContract, ElectionCD, TxEnv, Trees3),
+                          [aefa_fate_code:encode_arg({contract, StakingPubkey})]),
+    {ElectionPubkey, Trees3} = create_contract(ElectionContract, ElectionCD, TxEnv, Trees2),
     ?assertEqual(ElectionPubkey, election_contract_address()),
+
     {ok, EpochInit} = aeb_fate_abi:create_calldata("init_epochs",
-                                              [aefa_fate_code:encode_arg({integer, 10}), aefa_fate_code:encode_arg({integer, 4711})]),
-    {ok, Trees5, _} = call_contract(ElectionPubkey,  ?OWNER_PUBKEY, EpochInit, 0, TxEnv, Trees4),
-    %% assert expectation:
-    Trees5.
+                          [genesis_trees_opts(integer, hc_epoch_length, Opts, ?HC_EPOCH_LENGTH),
+                           genesis_trees_opts(integer, hc_pin_reward, Opts, ?HC_PIN_REWARD)]),
+    {ok, Trees4, _} = call_contract(ElectionPubkey,  ?OWNER_PUBKEY, EpochInit, 0, TxEnv, Trees3),
+
+    Trees4.
 
 set_up_accounts(Trees) ->
     lists:foldl(fun set_up_account/2,
                 Trees,
-                [ {?OWNER_PUBKEY, trunc(math:pow(10, 30))},
-                  {pubkey(?ALICE), trunc(math:pow(10, 30))},
-                  {pubkey(?BOB), trunc(math:pow(10, 30))},
-                  {pubkey(?CAROL), trunc(math:pow(10, 30))}]).
+                [ {?OWNER_PUBKEY,  1_000_000_000_000 * ?AE},
+                  {pubkey(?ALICE), 1_000_000_000_000 * ?AE},
+                  {pubkey(?BOB),   1_000_000_000_000 * ?AE},
+                  {pubkey(?CAROL), 1_000_000_000_000 * ?AE}]).
 
-set_up_account(Trees) ->
-    #{public := Account} = enacl:sign_keypair(),
-    Trees1 = set_up_account({Account, trunc(math:pow(10, 30))}, Trees),
-    {Account, Trees1}.
+%% set_up_account(Trees) ->
+%%     #{public := Account} = enacl:sign_keypair(),
+%%     Trees1 = set_up_account({Account, trunc(math:pow(10, 30))}, Trees),
+%%     {Account, Trees1}.
 
 set_up_account({Pubkey, Amount}, Trees) ->
     Account = aec_accounts:new(Pubkey, Amount),
@@ -1859,10 +286,10 @@ create_contract(ContractName, CallData, TxEnv, Trees) ->
                abi_version => ABI,
                deposit     => 0,
                amount      => 0,
-               gas         => ?GAS,
-               gas_price   => ?GAS_PRICE,
+               gas         => ?DEFAULT_GAS,
+               gas_price   => ?DEFAULT_GAS_PRICE,
                call_data   => CallData,
-               fee         => ?FEE},
+               fee         => ?DEFAULT_FEE},
     {ok, DummyTx} = aect_create_tx:new(TxSpec),
     Height   = aetx_env:height(TxEnv),
     Protocol = aetx_env:consensus_version(TxEnv),
@@ -1871,9 +298,9 @@ create_contract(ContractName, CallData, TxEnv, Trees) ->
     {ok, Tx} = aect_create_tx:new(TxSpec#{fee => MinFee}),
     %% Make sure the transaction will give the expected pubkey.
     case aect_contracts:compute_contract_pubkey(Owner, Nonce) of
-                    Pubkey -> Tx;
-                    Other          -> error({unexpected_pubkey, Other, Pubkey})
-                end,
+        Pubkey -> Tx;
+        Other  -> error({unexpected_pubkey, Other, Pubkey})
+    end,
     Trees1 = aec_block_fork:prepare_contract_owner([Tx], TxEnv, Trees),
     {_, Trees2} = aec_block_fork:apply_contract_create_tx(Tx, Trees1, TxEnv),
     {Pubkey, Trees2}.
@@ -1889,10 +316,10 @@ call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees, TransformF
                 nonce        => Nonce,
                 abi_version  => ABI,
                 amount       => Amount,
-                gas          => ?GAS,
-                gas_price    => ?GAS_PRICE,
+                gas          => ?DEFAULT_GAS,
+                gas_price    => ?DEFAULT_GAS_PRICE,
                 call_data    => CallData,
-                fee          => ?FEE},
+                fee          => ?DEFAULT_FEE},
     {ok, DummyTx} = aect_call_tx:new(TxSpec),
     Height   = aetx_env:height(TxEnv),
     Protocol = aetx_env:consensus_version(TxEnv),
@@ -1911,7 +338,8 @@ call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees, TransformF
                     %% would be redistributed to the corresponding leaders
                     RespTrees = aect_call_state_tree:prune(Height, Trees2),
                     Resp = aeb_fate_encoding:deserialize(aect_call:return_value(Call)),
-                    {ok, RespTrees, TransformFun(Resp)};
+                    Cost = aetx:fee(Tx) + aect_call:gas_price(Call) * aect_call:gas_used(Call),
+                    {ok, RespTrees, #{res => TransformFun(Resp), cost => Cost}};
                 error -> {error,
                             aeb_fate_encoding:deserialize(aect_call:return_value(Call))};
                 revert -> {revert,
@@ -1932,18 +360,11 @@ next_nonce(Pubkey, Trees) ->
 
 pubkey({P, _}) -> P.
 
-%% black magic: this relies that there are 2 contracts and that the validator
-%% one is first, then the staking one is the second (having a nonce 2) and the
-%% election one is the next one; this allows us not passing around the address
-%% of the consensus contract between tests
-validator_contract_address() ->
+staking_contract_address() ->
     aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 1).
 
-staking_contract_address() ->
-    aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 2).
-
 election_contract_address() ->
-    aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 3).
+    aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 2).
 
 %% TODO match logic of election with HCElection contract logic
 test_elect_calls(StartHeight, GenerenationsCnt, TxEnv, StartTrees) ->
@@ -1961,25 +382,59 @@ test_elect_calls(StartHeight, GenerenationsCnt, TxEnv, StartTrees) ->
         {StartTrees, #{}},
         lists:seq(StartHeight, StartHeight + GenerenationsCnt - 1)).
 
-% Total stake limit helpers
-calculate_total_stake_limit(Stake) ->
-    Stake * 100 div ?VALIDATOR_MIN_PERCENT.
+%% % Total stake limit helpers
+%% calculate_total_stake_limit(Stake) ->
+%%     Stake * 100 div ?VALIDATOR_MIN_PERCENT.
 
-get_total_stake_limit(Validator, TxEnv, Trees) ->
-    {ok, _, State} = get_validator_state_(Validator, Validator, TxEnv, Trees),
-    {tuple, {_, _, _, _, _, StakeLimit, _, _}} = State,
-    StakeLimit.
+%% get_total_stake_limit(Validator, TxEnv, Trees) ->
+%%     {ok, _, State} = get_validator_state_(Validator, Validator, TxEnv, Trees),
+%%     {tuple, {_, _, _, _, _, StakeLimit, _, _}} = State,
+%%     StakeLimit.
 
-get_available_stake_limit(Validator, TxEnv, Trees) ->
-    {ok, _, State} = get_validator_state_(Validator, Validator, TxEnv, Trees),
-    {tuple, {_, _, _, Stake, PendingStake, StakeLimit, _, _}} = State,
-    StakeLimit-Stake-PendingStake.
+%% get_available_stake_limit(Validator, TxEnv, Trees) ->
+%%     {ok, _, State} = get_validator_state_(Validator, Validator, TxEnv, Trees),
+%%     {tuple, {_, _, _, Stake, PendingStake, StakeLimit, _, _}} = State,
+%%     StakeLimit-Stake-PendingStake.
 
 %% contract call wrappers
 new_validator_(Pubkey, Amount, TxEnv, Trees0) ->
+    new_validator_(Pubkey, Amount, true, TxEnv, Trees0).
+
+new_validator_(Pubkey, Amount, ReStake, TxEnv, Trees0) ->
     ContractPubkey = staking_contract_address(),
-    {ok, CallData} = aeb_fate_abi:create_calldata("new_validator", []),
+    Args = [aefa_fate_code:encode_arg({address, Pubkey}),
+            aefa_fate_code:encode_arg(ReStake)],
+    {ok, CallData} = aeb_fate_abi:create_calldata("new_validator", Args),
     call_contract(ContractPubkey, Pubkey, CallData, Amount, TxEnv, Trees0).
+
+create_calldata(Fun, Args0) ->
+    Args = [ aefa_fate_code:encode_arg(Arg) || Arg <- Args0 ],
+    {ok, CallData} = aeb_fate_abi:create_calldata(Fun, Args),
+    CallData.
+
+deposit_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
+    CallData = create_calldata("deposit", []),
+    call_contract(ValidatorCt, pubkey(Validator), CallData, Amount, TxEnv, Trees0).
+
+stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
+    CallData = create_calldata("stake", []),
+    call_contract(ValidatorCt, pubkey(Validator), CallData, Amount, TxEnv, Trees0).
+
+adjust_stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
+    CallData = create_calldata("adjust_stake", [{integer, Amount}]),
+    call_contract(ValidatorCt, pubkey(Validator), CallData, 0, TxEnv, Trees0).
+
+withdraw_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
+    CallData = create_calldata("withdraw", [{integer, Amount}]),
+    call_contract(ValidatorCt, pubkey(Validator), CallData, 0, TxEnv, Trees0).
+
+get_total_balance_(ValidatorCt, Validator, TxEnv, Trees0) ->
+    CallData = create_calldata("get_total_balance", []),
+    call_contract(ValidatorCt, pubkey(Validator), CallData, 0, TxEnv, Trees0).
+
+get_available_balance_(ValidatorCt, Validator, TxEnv, Trees0) ->
+    CallData = create_calldata("get_available_balance", []),
+    call_contract(ValidatorCt, pubkey(Validator), CallData, 0, TxEnv, Trees0).
 
 staking_power_(Who, Caller, TxEnv, Trees0) ->
     ContractPubkey = staking_contract_address(),
@@ -2065,127 +520,3 @@ reward_(Who, Amount, Caller, TxEnv, Trees0) ->
                                                   [aefa_fate_code:encode_arg({address,
                                                                               Who})]),
     call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees0).
-
-stake_(Who, Amount, Caller, TxEnv, Trees0) ->
-    ContractPubkey = staking_contract_address(),
-    {ok, CallData} = aeb_fate_abi:create_calldata("stake",
-                                                  [aefa_fate_code:encode_arg({address,
-                                                                              Who})]),
-    call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees0, fun to_staking_resp/1).
-
-unstake_(Who, Stakes, Caller, TxEnv, Trees0) ->
-    ContractPubkey = staking_contract_address(),
-    {ok, CallData} = aeb_fate_abi:create_calldata("unstake",
-                                                  [aefa_fate_code:encode_arg({address,
-                                                                              Who}),
-                                                   aefa_fate_code:encode_arg({integer,
-                                                                              Stakes})]),
-    call_contract(ContractPubkey, Caller, CallData, 0, TxEnv, Trees0, fun to_staking_resp/1).
-
-set_name_(Name, Caller, TxEnv, Trees0) when is_list(Name) ->
-    set_name_(list_to_binary(Name), Caller, TxEnv, Trees0);
-set_name_(Name, Caller, TxEnv, Trees0) when is_binary(Name) ->
-    ContractPubkey = staking_contract_address(),
-    {ok, CallData} = aeb_fate_abi:create_calldata("set_validator_name",
-                                                  [aefa_fate_code:encode_arg({string, Name})]),
-    call_contract(ContractPubkey, Caller, CallData, 0, TxEnv, Trees0).
-
-set_description_(Description, Caller, TxEnv, Trees0) when is_list(Description) ->
-    set_description_(list_to_binary(Description), Caller, TxEnv, Trees0);
-set_description_(Description, Caller, TxEnv, Trees0) when is_binary(Description) ->
-    ContractPubkey = staking_contract_address(),
-    {ok, CallData} = aeb_fate_abi:create_calldata("set_validator_description",
-                                                  [aefa_fate_code:encode_arg({string, Description})]),
-    call_contract(ContractPubkey, Caller, CallData, 0, TxEnv, Trees0).
-
-set_avatar_(Avatar, Caller, TxEnv, Trees0) when is_list(Avatar) ->
-    set_avatar_(list_to_binary(Avatar), Caller, TxEnv, Trees0);
-set_avatar_(Avatar, Caller, TxEnv, Trees0) when is_binary(Avatar) ->
-    ContractPubkey = staking_contract_address(),
-    {ok, CallData} = aeb_fate_abi:create_calldata("set_validator_avatar_url",
-                                                  [aefa_fate_code:encode_arg({string, Avatar})]),
-    call_contract(ContractPubkey, Caller, CallData, 0, TxEnv, Trees0).
-
-to_staking_resp({tuple, {Stake, Shares, Height}}) ->
-  #staking_resp{
-    stake = Stake,
-    shares = Shares,
-    execution_height = Height}.
-
-expected_validator_state(PoolContract, ValidatorAddr, OnlineDelay,
-                         TotalSPower, PendingStake, TotalSLimit, IsOnline, Name,
-                         Description, Avatar, PoolMap) ->
-    ContractPubkey = staking_contract_address(),
-    Pool = maps:to_list(PoolMap),
-    Shares =
-        lists:foldl(
-            fun({_, SPower}, AccumAmt) -> SPower + AccumAmt end,
-            0,
-            Pool),
-    Map =
-        maps:from_list(lists:map(
-            fun({Address, SPower}) ->
-                {{address, Address}, SPower}
-            end,
-            Pool)),
-    {tuple,
-          {{contract, PoolContract},
-           {address, ValidatorAddr},
-           OnlineDelay,
-           TotalSPower,
-           PendingStake,
-           TotalSLimit,
-           IsOnline,
-           {tuple,
-               {{address, ContractPubkey},
-                0, 0, #{},
-                Name, Description, Avatar,
-                Map,
-                Shares}}}}.
-
-assert_equal_states(State1, State2) ->
-    {tuple,
-          {{contract, PoolContract1},
-           {address, ValidatorAddr1},
-           OnlineDelay1,
-           TotalSPower1,
-           PendingStake1,
-           TotalSLimit1,
-           IsOnline1,
-           {tuple,
-               {{address, ContractPubkey1},
-                UnstakeDelay1, PendingUnstakeAmount1, PendingUnstake1,
-                Name1, Description1, Avatar1,
-                Map1,
-                Shares1}}}} = State1,
-    {tuple,
-          {{contract, PoolContract2},
-           {address, ValidatorAddr2},
-           OnlineDelay2,
-           TotalSPower2,
-           PendingStake2,
-           TotalSLimit2,
-           IsOnline2,
-           {tuple,
-               {{address, ContractPubkey2},
-                UnstakeDelay2, PendingUnstakeAmount2, PendingUnstake2,
-                Name2, Description2, Avatar2,
-                Map2,
-                Shares2}}}} = State2,
-    ?assertEqual(PoolContract1, PoolContract2),
-    ?assertEqual(ValidatorAddr1, ValidatorAddr2),
-    ?assertEqual(OnlineDelay1, OnlineDelay2),
-    ?assertEqual(TotalSPower1, TotalSPower2),
-    ?assertEqual(PendingStake1, PendingStake2),
-    ?assertEqual(TotalSLimit1, TotalSLimit2),
-    ?assertEqual(IsOnline1, IsOnline2),
-    ?assertEqual(ContractPubkey1, ContractPubkey2),
-    ?assertEqual(UnstakeDelay1, UnstakeDelay2),
-    ?assertEqual(PendingUnstakeAmount1, PendingUnstakeAmount2),
-    ?assertEqual(PendingUnstake1, PendingUnstake2),
-    ?assertEqual(Name1, Name2),
-    ?assertEqual(Description1, Description2),
-    ?assertEqual(Avatar1, Avatar2),
-    ?assertEqual(Map1, Map2),
-    ?assertEqual(Shares1, Shares2),
-    ok.

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -1024,7 +1024,7 @@ grant_fees(Node, Trees, Delay, FraudStatus, _State) ->
                              OldestBeneficiaryVersion),
     Trees1 = lists:foldl(
                fun({K, Amt}, TreesAccum) when Amt > 0 ->
-                       Consensus:state_grant_reward(K, Node, TreesAccum, Amt);
+                       Consensus:state_grant_reward(K, Node, Delay, TreesAccum, Amt);
                   (_, TreesAccum) -> TreesAccum
                end,
                Trees,

--- a/apps/aecore/src/aec_consensus.erl
+++ b/apps/aecore/src/aec_consensus.erl
@@ -178,7 +178,7 @@
 -callback state_pre_transform_micro_node(non_neg_integer(), #node{}, aec_trees:trees()) -> aec_trees:trees() | no_return().
 
 %% Block rewards :)
--callback state_grant_reward(aec_keys:pubkey(), #node{}, aec_trees:trees(), non_neg_integer()) -> aec_trees:trees() | no_return().
+-callback state_grant_reward(aec_keys:pubkey(), #node{}, non_neg_integer(), aec_trees:trees(), non_neg_integer()) -> aec_trees:trees() | no_return().
 
 %% PoGF - called just before exiting the DB transaction and fully validating the node in question
 -callback pogf_detected(aec_headers:key_header(), aec_headers:key_header()) -> ok.

--- a/apps/aecore/src/aec_consensus_bitcoin_ng.erl
+++ b/apps/aecore/src/aec_consensus_bitcoin_ng.erl
@@ -37,7 +37,7 @@
         , state_pre_transform_key_node/3
         , state_pre_transform_micro_node/3
         %% Block rewards
-        , state_grant_reward/4
+        , state_grant_reward/5
         %% PoGF
         , pogf_detected/2
         %% Genesis block
@@ -436,7 +436,7 @@ state_pre_transform_micro_node(_Height, _PrevNode, Trees) -> Trees.
 
 %% -------------------------------------------------------------------
 %% Block rewards
-state_grant_reward(Beneficiary, _Node, Trees, Amount) -> aec_trees:grant_fee(Beneficiary, Trees, Amount).
+state_grant_reward(Beneficiary, _Node, _Delay, Trees, Amount) -> aec_trees:grant_fee(Beneficiary, Trees, Amount).
 
 %% -------------------------------------------------------------------
 %% PoGF

--- a/apps/aecore/src/aec_consensus_common_tests.erl
+++ b/apps/aecore/src/aec_consensus_common_tests.erl
@@ -43,7 +43,7 @@
         , state_pre_transform_key_node/3
         , state_pre_transform_micro_node/3
         %% Block rewards
-        , state_grant_reward/4
+        , state_grant_reward/5
         %% PoGF
         , pogf_detected/2
         %% Genesis block
@@ -191,8 +191,8 @@ state_pre_transform_micro_node(_Height, _PrevNode, Trees) -> Trees.
 
 %% -------------------------------------------------------------------
 %% Block rewards
-state_grant_reward(Beneficiary, Node, Trees, Amount) ->
-    aec_consensus_bitcoin_ng:state_grant_reward(Beneficiary, Node, Trees, Amount).
+state_grant_reward(Beneficiary, Node, Delay, Trees, Amount) ->
+    aec_consensus_bitcoin_ng:state_grant_reward(Beneficiary, Node, Delay, Trees, Amount).
 
 %% -------------------------------------------------------------------
 %% PoGF

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -363,12 +363,12 @@ get_child_epoch_info(Epoch) ->
 %% -------------------------------------------------------------------
 %% Block rewards
 state_grant_reward(Beneficiary, Node, Trees, Amount) ->
-    {ok, CD} = aeb_fate_abi:create_calldata(
-                 "reward", [aefa_fate_code:encode_arg({address, Beneficiary})]),
+    {ok, CD} = aeb_fate_abi:create_calldata("add_rewards",
+                 [aefa_fate_code:encode_arg({integer, 1}),
+                  aefa_fate_code:encode_arg([{{address, Beneficiary}, {integer, Amount}}])]),
     CallData = aeser_api_encoder:encode(contract_bytearray, CD),
-    case call_consensus_contract(?REWARDS_CONTRACT,
-           Node, Trees, CallData,
-           ["reward(", aeser_api_encoder:encode(account_pubkey, Beneficiary), ")"], Amount) of
+    case call_consensus_contract(?REWARDS_CONTRACT, Node, Trees, CallData,
+           ["add_rewards(1, [{", aeser_api_encoder:encode(account_pubkey, Beneficiary), ", ", integer_to_list(Amount), "}])"], Amount) of
         {ok, Trees1, _} -> Trees1;
         {error, What} ->
             error({failed_to_reward_leader, What}) %% maybe a softer approach than crash and burn?

--- a/apps/aecore/src/aec_consensus_on_demand.erl
+++ b/apps/aecore/src/aec_consensus_on_demand.erl
@@ -42,7 +42,7 @@
         , state_pre_transform_key_node/3
         , state_pre_transform_micro_node/3
         %% Block rewards
-        , state_grant_reward/4
+        , state_grant_reward/5
         %% PoGF
         , pogf_detected/2
         %% Genesis block
@@ -208,8 +208,8 @@ state_pre_transform_micro_node(_Height, _PrevNode, Trees) -> Trees.
 
 %% -------------------------------------------------------------------
 %% Block rewards
-state_grant_reward(Beneficiary, Node, Trees, Amount) ->
-    aec_consensus_bitcoin_ng:state_grant_reward(Beneficiary, Node, Trees, Amount).
+state_grant_reward(Beneficiary, Node, Delay, Trees, Amount) ->
+    aec_consensus_bitcoin_ng:state_grant_reward(Beneficiary, Node, Delay, Trees, Amount).
 
 %% -------------------------------------------------------------------
 %% PoGF

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -47,6 +47,7 @@
 -include_lib("aecontract/include/hard_forks.hrl").
 -include("../../aecontract/test/include/aect_sophia_vsn.hrl").
 
+-define(STAKING_VALIDATOR_CONTRACT, "StakingValidator").
 -define(MAIN_STAKING_CONTRACT, "MainStaking").
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
@@ -225,14 +226,9 @@ init_per_suite(Config0) ->
                 }),
             StakingContract = staking_contract_address(),
             ElectionContract = election_contract_address(),
-            {ok, SVBinSrc} = aect_test_utils:read_contract("StakingValidator"),
-            {ok, MSBinSrc} = aect_test_utils:read_contract(?MAIN_STAKING_CONTRACT),
-            {ok, EBinSrc} = aect_test_utils:read_contract(?HC_CONTRACT),
-            [{staking_contract, StakingContract}, {election_contract, ElectionContract},
-             {contract_src, #{"StakingValidator" => create_stub(binary_to_list(SVBinSrc)),
-                              ?MAIN_STAKING_CONTRACT => create_stub(binary_to_list(MSBinSrc)),
-                              ?HC_CONTRACT => create_stub(binary_to_list(EBinSrc))
-                              }} | Config1]
+            CtSrcMap = maps:from_list([{C, create_stub(C)}
+                                       || C <- [?MAIN_STAKING_CONTRACT, ?STAKING_VALIDATOR_CONTRACT, ?HC_CONTRACT]]),
+            [{staking_contract, StakingContract}, {election_contract, ElectionContract}, {contract_src, CtSrcMap} | Config1]
     end.
 
 end_per_suite(Config) ->
@@ -551,55 +547,62 @@ entropy_impact_schedule(Config) ->
 
 simple_withdraw(Config) ->
     [{_Node, NodeName, _, _} | _] = ?config(nodes, Config),
+    NetworkId = ?config(network_id, Config),
+
     produce_cc_blocks(Config, 3), %% Make sure there are no lingering TxFees in the reward
-    AliceBin = encoded_pubkey(?ALICE),
-    Alice = binary_to_list(encoded_pubkey(?ALICE)),
+    _AliceBin = encoded_pubkey(?ALICE),
     {ok, []} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
 
-    InitBalance  = account_balance(pubkey(?ALICE)),
-    {ok, AliceContractSPower} = inspect_staking_contract(?ALICE, {staking_power, ?ALICE}, Config),
-    {ok, BobContractSPower} = inspect_staking_contract(?ALICE, {staking_power, ?BOB}, Config),
-    {ok,
-        #{<<"ct">> := _, %% pool contract
-          <<"is_online">> := true,
-          <<"stake">> := _,
-          <<"state">> :=
-                #{<<"delegates">> := [[AliceBin, ?INITIAL_STAKE]],
-                  <<"main_staking_ct">> := CPubkey,
-                  <<"shares">> := ?INITIAL_STAKE}
-         }} =
-        inspect_staking_contract(?ALICE, {get_validator_state, ?ALICE}, Config),
+    %% grab Alice's and Bob's staking validator contract
+    {ok, AliceCtEnc} = inspect_staking_contract(?ALICE, {get_validator_contract, ?ALICE}, Config),
+    {ok, AliceCt} = aeser_api_encoder:safe_decode(contract_pubkey, AliceCtEnc),
+    {ok, BobCtEnc} = inspect_staking_contract(?ALICE, {get_validator_contract, ?BOB}, Config),
+    {ok, BobCt} = aeser_api_encoder:safe_decode(contract_pubkey, BobCtEnc),
+    ValidatorStub = src(?STAKING_VALIDATOR_CONTRACT, Config),
 
-    %% The results translation somehow makes a contract key into an account key!
-    ?assertEqual(aeser_api_encoder:encode(account_pubkey, ?config(staking_contract, Config)), CPubkey),
+    %% Get the initial state
+    InitBalance  = account_balance(pubkey(?ALICE)),
+
+    %% Auto-stake is on, so available balance should be 0
+    {ok, 0} = inspect_validator(AliceCt, ?ALICE, get_available_balance, Config),
+
+    %% Adjust stake to prepare for a withdrawal...
     WithdrawAmount = 1000,
-    NetworkId = ?config(network_id, Config),
-    CallTx =
-        sign_and_push(
-            NodeName,
-            contract_call(?config(staking_contract, Config), src(?MAIN_STAKING_CONTRACT, Config), "unstake",
-                [Alice, integer_to_list(WithdrawAmount)], 0, pubkey(?ALICE)),
-            ?ALICE,
-            NetworkId),
+    Call1 = contract_call(AliceCt, ValidatorStub, "adjust_stake", [integer_to_list(-WithdrawAmount)], 0, pubkey(?ALICE)),
+    CallTx1 = sign_and_push(NodeName, Call1, ?ALICE, NetworkId),
+    {ok, [_]} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
+    produce_cc_blocks(Config, 1),
+    {ok, CallRes1} = call_info(CallTx1),
+    {ok, _Res1} = decode_consensus_result(CallRes1, "adjust_stake", ValidatorStub),
+
+    {ok, WithdrawAmount} = inspect_validator(AliceCt, ?ALICE, get_available_balance, Config),
+
+    %% Now test the withdrawal
+
+    {ok, AliceStake} = inspect_validator(AliceCt, ?ALICE, get_total_balance, Config),
+    {ok, BobStake} = inspect_validator(BobCt, ?BOB, get_total_balance, Config),
+
+    Call2 = contract_call(AliceCt, ValidatorStub, "withdraw", [integer_to_list(WithdrawAmount)], 0, pubkey(?ALICE)),
+    CallTx2 = sign_and_push( NodeName, Call2, ?ALICE, NetworkId),
     {ok, [_]} = rpc:call(NodeName, aec_tx_pool, peek, [infinity]),
     StakeWithdrawDelay = 1,
     produce_cc_blocks(Config, StakeWithdrawDelay),
     EndBalance = account_balance(pubkey(?ALICE)),
-    {ok, Call} = call_info(CallTx),
-    {ok, _Res} = decode_consensus_result(Call, "unstake", src(?MAIN_STAKING_CONTRACT, Config)),
-    GasUsed = aect_call:gas_used(Call),
-    GasPrice = aect_call:gas_price(Call),
-    Fee = aetx:fee(aetx_sign:tx(CallTx)),
+    {ok, CallRes2} = call_info(CallTx2),
+    {ok, _Res2} = decode_consensus_result(CallRes2, "withdraw", ValidatorStub),
+    GasUsed = aect_call:gas_used(CallRes2),
+    GasPrice = aect_call:gas_price(CallRes2),
+    Fee = aetx:fee(aetx_sign:tx(CallTx2)),
     {Producer, KeyReward} = key_reward_provided(),
     ct:log("Initial balance: ~p, withdrawn: ~p, gas used: ~p, gas price: ~p, fee: ~p, end balance: ~p",
            [InitBalance, WithdrawAmount, GasUsed, GasPrice, Fee, EndBalance]),
-    {ok, AliceContractSPower1} = inspect_staking_contract(?ALICE, {staking_power, ?ALICE}, Config),
-    {ok, BobContractSPower1} = inspect_staking_contract(?ALICE, {staking_power, ?BOB}, Config),
-    ?assert(BobContractSPower == BobContractSPower1 orelse
-            (Producer == pubkey(?BOB) andalso BobContractSPower + KeyReward == BobContractSPower1)),
-    ct:log("Staking power before: ~p and after ~p", [AliceContractSPower, AliceContractSPower1]),
-    ?assert(AliceContractSPower - 1000 == AliceContractSPower1 orelse
-            (Producer == pubkey(?ALICE) andalso AliceContractSPower + KeyReward - 1000 == AliceContractSPower1)),
+    {ok, AliceStake1} = inspect_validator(AliceCt, ?ALICE, get_total_balance, Config),
+    {ok, BobStake1} = inspect_validator(BobCt, ?BOB, get_total_balance, Config),
+    ?assert(BobStake == BobStake1 orelse
+            (Producer == pubkey(?BOB) andalso BobStake + KeyReward == BobStake1)),
+    ct:log("Staking power before: ~p and after ~p", [AliceStake, AliceStake1]),
+    ?assert(AliceStake - 1000 == AliceStake1 orelse
+            (Producer == pubkey(?ALICE) andalso AliceStake + KeyReward - 1000 == AliceStake1)),
     ok.
 
 correct_leader_in_micro_block(Config) ->
@@ -1439,6 +1442,15 @@ account_balance(Pubkey) ->
         none -> no_such_account
     end.
 
+inspect_validator(Ct, Origin, What, Config) ->
+    TopHash = rpc(?NODE1, aec_chain, top_block_hash, []),
+    {Fun, Args} =
+        case What of
+            get_available_balance -> {"get_available_balance", []};
+            get_total_balance     -> {"get_total_balance", []}
+        end,
+    do_contract_call(Ct, src(?STAKING_VALIDATOR_CONTRACT, Config), Fun, Args, Origin, TopHash).
+
 inspect_staking_contract(OriginWho, WhatToInspect, Config) ->
     TopHash = rpc(?NODE1, aec_chain, top_block_hash, []),
     inspect_staking_contract(OriginWho, WhatToInspect, Config, TopHash).
@@ -1450,6 +1462,8 @@ inspect_staking_contract(OriginWho, WhatToInspect, Config, TopHash) ->
                 {"staking_power", [binary_to_list(encoded_pubkey(Who))]};
             {get_validator_state, Who} ->
                 {"get_validator_state", [binary_to_list(encoded_pubkey(Who))]};
+            {get_validator_contract, Who} ->
+                {"get_validator_contract", [binary_to_list(encoded_pubkey(Who))]};
             get_state ->
                 {"get_state", []};
             leaders ->
@@ -1576,108 +1590,45 @@ build_json_files(ElectionContract, NodeConfig, CTConfig) ->
         fun(P) ->
             binary_to_list(aeser_api_encoder:encode(account_pubkey, P))
         end,
+
     %% create staking contract
-    MinValidatorAmt = integer_to_list(trunc(math:pow(10,18) * math:pow(10, 6))), %% 1 mln AE
     MinStakeAmt = integer_to_list(trunc(math:pow(10,18) * 1)), %% 1 AE
-    MinStakePercent = "30",
-    OnlineDelay = "0",
-    StakeDelay = "0",
-    UnstakeDelay = "0",
-    #{ <<"pubkey">> := StakingValidatorContract} = C0
-        = contract_create_spec("StakingValidator", src("StakingValidator", CTConfig),
-                                [EncodePub(Pubkey), UnstakeDelay], 0, 1, Pubkey),
-    {ok, ValidatorPoolAddress} = aeser_api_encoder:safe_decode(contract_pubkey,
-                                                              StakingValidatorContract),
-    %% assert assumption
-    ValidatorPoolAddress = validator_pool_contract_address(),
     MSSrc = src(?MAIN_STAKING_CONTRACT, CTConfig),
     #{ <<"pubkey">> := StakingContractPubkey
-        , <<"owner_pubkey">> := ContractOwner } = SC
-        = contract_create_spec(?MAIN_STAKING_CONTRACT, MSSrc,
-                               [binary_to_list(StakingValidatorContract),
-                               MinValidatorAmt, MinStakePercent, MinStakeAmt,
-                               OnlineDelay, StakeDelay, UnstakeDelay],
-                               0, 2, Pubkey),
+     , <<"owner_pubkey">> := ContractOwner } = SC
+        = contract_create_spec(?MAIN_STAKING_CONTRACT, MSSrc, [MinStakeAmt], 0, 1, Pubkey),
     {ok, StakingAddress} = aeser_api_encoder:safe_decode(contract_pubkey,
                                                          StakingContractPubkey),
     %% assert assumption
     StakingAddress = staking_contract_address(),
+
     %% create election contract
     #{ <<"pubkey">> := ElectionContractPubkey
-        , <<"owner_pubkey">> := ContractOwner } = EC
+     , <<"owner_pubkey">> := ContractOwner } = EC
         = contract_create_spec(ElectionContract, src(ElectionContract, CTConfig),
-                               [binary_to_list(StakingContractPubkey)], 0, 3, Pubkey),
+                               [binary_to_list(StakingContractPubkey)], 0, 2, Pubkey),
     {ok, ElectionAddress} = aeser_api_encoder:safe_decode(contract_pubkey,
                                                           ElectionContractPubkey),
     %% assert assumption
     ElectionAddress = election_contract_address(),
-    {ok, SCId} = aeser_api_encoder:safe_decode(contract_pubkey,
-                                                StakingContractPubkey),
+    {ok, SCId} = aeser_api_encoder:safe_decode(contract_pubkey, StakingContractPubkey),
+
     Call1 =
-        contract_call_spec(SCId, MSSrc,
-                           "new_validator", [],
+        contract_call_spec(SCId, MSSrc, "new_validator", [EncodePub(pubkey(?ALICE)), "true"],
                            ?INITIAL_STAKE, pubkey(?ALICE), 1),
     Call2 =
-        contract_call_spec(SCId, MSSrc,
-                            "new_validator", [],
-                            ?INITIAL_STAKE, pubkey(?BOB), 1),
+        contract_call_spec(SCId, MSSrc, "new_validator", [EncodePub(pubkey(?BOB)), "true"],
+                           ?INITIAL_STAKE, pubkey(?BOB), 1),
     Call3 =
-        contract_call_spec(SCId, MSSrc,
-                            "new_validator", [],
-                            ?INITIAL_STAKE, pubkey(?LISA), 1),
-    Call4  =
-        contract_call_spec(SCId, MSSrc,
-                            "set_online", [], 0, pubkey(?ALICE), 2),
-    Call5  =
-        contract_call_spec(SCId, MSSrc,
-                            "set_online", [], 0, pubkey(?BOB), 2),
-    Call6 =
-        contract_call_spec(SCId, MSSrc,
-                            "set_online", [], 0, pubkey(?LISA), 2),
-    Call7 =
-        contract_call_spec(SCId, MSSrc,
-                            "set_validator_name", ["\"Alice\""], 0, pubkey(?ALICE), 3),
-    Call8 =
-        contract_call_spec(SCId, MSSrc,
-                            "set_validator_name", ["\"Bob\""], 0, pubkey(?BOB), 3),
-    Call9 =
-        contract_call_spec(SCId, MSSrc,
-                            "set_validator_name", ["\"Lisa\""], 0, pubkey(?LISA), 3),
-    Call10 =
-        contract_call_spec(SCId, MSSrc,
-                            "set_validator_description",
-                            ["\"Alice is a really awesome validator and she had set a description of her great service to the work.\""], 0,
-                            pubkey(?ALICE), 4),
-    Call11 =
-        contract_call_spec(SCId, MSSrc,
-                            "set_validator_avatar_url",
-                            ["\"https://aeternity.com/images/aeternity-logo.svg\""], 0,
-                            pubkey(?ALICE), 5),
+        contract_call_spec(SCId, MSSrc, "new_validator", [EncodePub(pubkey(?LISA)), "true"],
+                           ?INITIAL_STAKE, pubkey(?LISA), 1),
 
-    %% create a BRI validator in the contract so they can receive
-    %% rewards as well
-    %% TODO: discuss how we want to tackle this:
-    %%  A) require the BRI account to be validator
-    %%  B) allow pending stake in the contract that is not allocated
-    %%  yet
-    %%  C) something else
-    %% Call12 =
-    %%     contract_call_spec(SCId, MSSrc,
-    %%                         "new_validator", [],
-    %%                         ?INITIAL_STAKE, BRIPub, 1),
-    %% Call13 =
-    %%     contract_call_spec(SCId, MSSrc,
-    %%                         "set_validator_description",
-    %%                         ["\"This validator is offline. She can never become a leader. She has no name set. She is receiving the BRI rewards\""],
-    %%                         0, BRIPub, 2),
-    %% keep the BRI offline
-    AllCalls =  [Call1, Call2, Call3, Call4, Call5, Call6,
-		 Call7, Call8, Call9, Call10, Call11],
+    AllCalls =  [Call1, Call2, Call3],
     ProtocolBin = integer_to_binary(aect_test_utils:latest_protocol_version()),
     #{<<"chain">> := #{<<"hard_forks">> := #{ProtocolBin := #{<<"contracts_file">> := ContractsFileName,
                                                               <<"accounts_file">> := AccountsFileName}}}} = NodeConfig,
     aecore_suite_utils:create_seed_file(ContractsFileName,
-        #{<<"contracts">> => [C0, SC, EC], <<"calls">> => AllCalls}),
+        #{<<"contracts">> => [SC, EC], <<"calls">> => AllCalls}),
     aecore_suite_utils:create_seed_file(AccountsFileName,
         #{  <<"ak_2evAxTKozswMyw9kXkvjJt3MbomCR1nLrf91BduXKdJLrvaaZt">> => 1000000000000000000000000000000000000000000000000,
             encoded_pubkey(?ALICE) => 2100000000000000000000000000,
@@ -1764,14 +1715,11 @@ node_config(Node, CTConfig, PotentialStakers, PotentialPinners, ReceiveAddress) 
             <<"beneficiary_reward_delay">> => ?REWARD_DELAY
         }}.  %% this relies on certain nonce numbers
 
-validator_pool_contract_address() ->
+staking_contract_address() ->
     aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 1).
 
-staking_contract_address() ->
-    aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 2).
-
 election_contract_address() ->
-    aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 3).
+    aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 2).
 
 %% Increase the child chain with a number of key blocks
 %% Automatically add key blocks on parent chain and
@@ -1902,11 +1850,14 @@ key_reward_provided(RewardHeight) ->
   {get_block_producer(?NODE1, RewardHeight),
    rpc(?NODE1, aec_governance, block_mine_reward, [RewardHeight])}.
 
-create_stub(ContractFile) ->
-    create_stub(ContractFile, []).
+create_stub(Contract) ->
+    create_stub(Contract, []).
 
-create_stub(ContractFile, Opts) ->
-    {ok, Enc}  = aeso_aci:contract_interface(json, ContractFile, Opts ++ [{no_code, true}]),
+create_stub(Contract, Opts0) ->
+    File = aect_test_utils:contract_filename(Contract),
+    Opts = Opts0 ++ [{no_code, true}] ++ aect_test_utils:copts({file, File}),
+    {ok, SrcBin} = aect_test_utils:read_contract(Contract),
+    {ok, Enc}  = aeso_aci:contract_interface(json, binary_to_list(SrcBin), Opts),
     {ok, Stub} = aeso_aci:render_aci_json(Enc),
     binary_to_list(Stub).
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -150,7 +150,7 @@ groups() ->
       {hc, [sequence],
           [ start_two_child_nodes
           , produce_first_epoch
-          , verify_fees
+          %% , verify_fees
           , spend_txs
           , simple_withdraw
           , correct_leader_in_micro_block

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1649,7 +1649,7 @@ node_config(Node, CTConfig, PotentialStakers, PotentialPinners, ReceiveAddress) 
                                         <<"stakers">> => Stakers,
                                         <<"pinners">> => Pinners,
                                         <<"pinning_reward_value">> => 4711,
-                                        <<"hyperchain_static_coinbase">> => 100000000000000000000,
+                                        <<"fixed_coinbase">> => ?BLOCK_REWARD,
                                         <<"default_pinning_behavior">> => ?config(default_pinning_behavior, CTConfig)},
                                     SpecificConfig)
                                     }}},

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -105,6 +105,7 @@ main contract HCElection =
     put(state{pin = Some(proof)})
 
   payable stateful entrypoint add_reward(height : int, to : address) =
+    assert_protocol_call()
     put(state{rewards[height = []] @ rs = (to, Call.value) :: rs})
 
   entrypoint leader() =

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -3,6 +3,7 @@ include "Pair.aes"
 
 contract interface MainStaking =
   entrypoint sorted_validators : () => list((address * int))
+  entrypoint add_rewards : (int, list(address * int)) => unit
 
 main contract HCElection =
   record epoch_info =
@@ -21,7 +22,7 @@ main contract HCElection =
   record state =
     { main_staking_ct       : MainStaking,
       leader                : address,
-      added_stake           : int,
+      rewards               : map(int, address * int),
       epoch                 : int,
       epochs                : map(int, epoch_info),
       pin                   : option(bytes()),
@@ -31,7 +32,7 @@ main contract HCElection =
   entrypoint init(main_staking_ct : MainStaking) =
     { main_staking_ct       = main_staking_ct,
       leader                = Contract.address,
-      added_stake           = 0,
+      rewards               = {},
       epoch                 = 0,
       epochs                = {},
       pin                   = None,
@@ -74,6 +75,10 @@ main contract HCElection =
     let next_base = calc_next_base_reward(next_base_pin_reward)
     let next_reward = next_base + next_carry_over
     let pr = {current = next_reward, carry_over = next_carry_over, base = next_base}
+
+    // pay rewards to sunset epoch
+    pay_rewards(state.epoch - 1)
+
     // update epochs
     require(ei.start + ei.length - 1 == Chain.block_height, "This is not the end")
     let ei2 = state.epochs[epoch + 2]
@@ -99,11 +104,11 @@ main contract HCElection =
     require(Call.caller == state.leader, "Must be called by the last leader of epoch")
     put(state{pin = Some(proof)})
 
+  payable stateful entrypoint add_reward(height : int, to : address) =
+    put(state{rewards[height] = (to, Call.value)})
+
   entrypoint leader() =
     state.leader
-
-  // entrypoint added_stake() =
-  //   state.added_stake
 
   entrypoint epoch() =
     state.epoch
@@ -159,5 +164,16 @@ main contract HCElection =
     else
       state.pin_reward.base
 
-  // function accum_stake((accum, total_s, current_hash, network_id), (addr, stake)) =
-  //   ((addr, stake) :: accum, stake + total_s, current_hash, network_id)
+  stateful function pay_rewards(e : int) =
+    let ei = state.epochs[e]
+    let (rewards, tot) = pay_rewards_(ei.start, ei.length, {}, 0)
+    state.main_staking_ct.add_rewards(value = tot, e, rewards)
+
+  stateful function
+    pay_rewards_(_, 0, acc, tot) = (Map.to_list(acc), tot)
+    pay_rewards_(h, n, acc, tot) =
+      switch(Map.lookup(h, state.rewards))
+        None              => pay_rewards_(h + 1, n - 1, acc, tot)
+        Some((addr, amt)) =>
+          put(state{rewards @ r = Map.delete(h, r)})
+          pay_rewards_(h + 1, n - 1, acc{[addr = 0] @ r = r + amt}, tot + amt)

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -22,7 +22,7 @@ main contract HCElection =
   record state =
     { main_staking_ct       : MainStaking,
       leader                : address,
-      rewards               : map(int, address * int),
+      rewards               : map(int, list(address * int)),
       epoch                 : int,
       epochs                : map(int, epoch_info),
       pin                   : option(bytes()),
@@ -105,7 +105,7 @@ main contract HCElection =
     put(state{pin = Some(proof)})
 
   payable stateful entrypoint add_reward(height : int, to : address) =
-    put(state{rewards[height] = (to, Call.value)})
+    put(state{rewards[height = []] @ rs = (to, Call.value) :: rs})
 
   entrypoint leader() =
     state.leader
@@ -173,7 +173,11 @@ main contract HCElection =
     pay_rewards_(_, 0, acc, tot) = (Map.to_list(acc), tot)
     pay_rewards_(h, n, acc, tot) =
       switch(Map.lookup(h, state.rewards))
-        None              => pay_rewards_(h + 1, n - 1, acc, tot)
-        Some((addr, amt)) =>
+        None      => pay_rewards_(h + 1, n - 1, acc, tot)
+        Some(aas) =>
+          let (acc1, tot1) = List.foldl(pay_reward_, (acc, tot), aas)
           put(state{rewards @ r = Map.delete(h, r)})
-          pay_rewards_(h + 1, n - 1, acc{[addr = 0] @ r = r + amt}, tot + amt)
+          pay_rewards_(h + 1, n - 1, acc1, tot1)
+
+  function pay_reward_((acc, tot), (addr, amt)) =
+    (acc{[addr = 0] @ r = r + amt}, tot + amt)

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -3,9 +3,6 @@ include "Pair.aes"
 
 contract interface MainStaking =
   entrypoint sorted_validators : () => list((address * int))
-  entrypoint is_validator : (address) => bool
-  entrypoint total_stake : () => int
-  stateful entrypoint post_elect : () => unit
 
 main contract HCElection =
   record epoch_info =

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -27,7 +27,7 @@ main contract MainStaking =
 
   // Should we user Call.caller instead?
   payable stateful entrypoint new_validator(owner : address, restake : bool) : StakingValidator =
-    require(Call.value >= state.validator_min_stake, "A new validator stake the minimum amount")
+    require(Call.value >= state.validator_min_stake, "A new validator must stake the minimum amount")
     require(!Map.member(owner, state.owners), "Owner must be unique")
     let validator_ct = Chain.create(Address.to_contract(Contract.address), owner) : StakingValidator
     let v_addr = validator_ct.address

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -1,398 +1,172 @@
 include "List.aes"
-contract interface StakingValidator =
-  record validator_pending_transfer = { staker : address, stake : int }
-  record validator_state = { main_staking_ct : address,
-                             unstake_delay : int,
-                             pending_unstake_amount : int,
-                             pending_unstake : map(int, list(validator_pending_transfer)),
-                             name : string,
-                             description : string,
-                             image_url : string,
-                             delegates : map(address, int),
-                             shares : int }
-  entrypoint init : (address, int) => unit
-  payable stateful entrypoint stake : address => int
-  payable entrypoint profit : () => unit
-  stateful entrypoint distribute_unstake : () => unit
-  stateful entrypoint unstake : (address, int) => int
-  entrypoint get_state : () => validator_state
-  entrypoint balance : (address) => int
-  entrypoint shares : (address) => int
-  entrypoint all_shares : () => int
-  entrypoint estimate_stake_shares : (int) => int
-  stateful entrypoint set_name : (string) => unit
-  stateful entrypoint set_description : (string) => unit
-  stateful entrypoint set_avatar_url : (string) => unit
+include "Pair.aes"
+include "StakingValidator.aes"
+
+contract interface StakingValidatorI =
+  entrypoint rewards : (int, int, bool) => unit
 
 main contract MainStaking =
-  datatype bucket = ONLINE | OFFLINE
-
-  record pending_transfer =
-    { validator : address,
-      staker    : address,
-      stake     : int}
-
   record validator =
-    { ct              : StakingValidator,
-      creation_height : int,
-      stake           : int,
-      pending_stake   : int,
-      stake_limit     : int}
-
-  record staking_response =
-    { stake            : int,
-      shares           : int,
-      execution_height : int}
-
-  record get_validator_response =
-    { ct              : StakingValidator,
-      address         : address,
-      creation_height : int,
-      stake           : int,
-      pending_stake   : int,
-      stake_limit     : int,
-      is_online       : bool,
-      state           : StakingValidator.validator_state}
-
-  record get_state_response =
-    { staking_validator_ct  : StakingValidator,
-      validators            : list(get_validator_response),
-      total_stake           : int,
-      validator_min_stake   : int,
-      validator_min_percent : int,
-      stake_minimum         : int,
-      online_delay          : int,
-      stake_delay           : int,
-      unstake_delay         : int
-      }
+    { owner         : address,
+      total_balance : int,
+      current_stake : int,
+      staked        : map(int, int),
+      restake       : bool
+    }
 
   record state =
-    { staking_validator_ct  : StakingValidator,
-      genesis_height        : int,
-      online_validators     : map(address, validator),
-      offline_validators    : map(address, validator),
-      total_stake           : int,
-      validator_min_stake   : int,
-      validator_min_percent : int,
-      stake_minimum         : int,
-      online_delay          : int,
-      stake_delay           : int,
-      unstake_delay         : int,
-      pending_stake         : map(int, list(pending_transfer)),
-      pending_unstake       : map(int, list(address))
-      }
+    { validators          : map(address, validator),
+      owners              : map(address, address),
+      validator_min_stake : int
+    }
 
-  entrypoint init(staking_validator_ct : StakingValidator,
-                  validator_min_stake : int,
-                  validator_min_percent : int,
-                  stake_minimum : int,
-                  online_delay : int,
-                  stake_delay : int,
-                  unstake_delay : int
-                  ) =
-    { staking_validator_ct  = staking_validator_ct,
-      genesis_height        = Chain.block_height,
-      online_validators     = {},
-      offline_validators    = {},
-      total_stake           = 0,
-      validator_min_stake   = validator_min_stake,
-      validator_min_percent = validator_min_percent,
-      stake_minimum         = stake_minimum,
-      online_delay          = online_delay,
-      stake_delay           = stake_delay,
-      unstake_delay         = unstake_delay,
-      pending_stake         = {},
-      pending_unstake       = {}
-      }
+  entrypoint init(validator_min_stake : int) =
+    { validators = {},
+      owners = {},
+      validator_min_stake = validator_min_stake }
 
-  entrypoint online_validators() =
-    let vs = Map.to_list(state.online_validators)
-    [ (v, s) | (v, {stake = s}) <- vs ]
-
-  entrypoint offline_validators() =
-    let vs = Map.to_list(state.offline_validators)
-    [ (v, s) | (v, {stake = s}) <- vs ]
-
-  entrypoint total_stake() =
-    state.total_stake
-
-  payable stateful entrypoint new_validator() : StakingValidator =
+  // Should we user Call.caller instead?
+  payable stateful entrypoint new_validator(owner : address, restake : bool) : StakingValidator =
     require(Call.value >= state.validator_min_stake, "A new validator stake the minimum amount")
-    assert_uknown_validator(Call.caller)
-    let validator_ct : StakingValidator = Chain.clone(ref = state.staking_validator_ct, Contract.address, state.unstake_delay)
-    validator_ct.stake(value = Call.value, Call.caller)
-    let stake_limit = calculate_stake_limit(Call.value)
-    put(state{offline_validators[Call.caller] = {
-        ct = validator_ct,
-        creation_height = Chain.block_height,
-        stake = Call.value,
-        pending_stake = 0,
-        stake_limit = stake_limit}})
+    require(!Map.member(owner, state.owners), "Owner must be unique")
+    let validator_ct = Chain.create(Address.to_contract(Contract.address), owner) : StakingValidator
+    let v_addr = validator_ct.address
+    put(state{validators[v_addr] = {owner = owner, total_balance = 0, current_stake = 0, staked = {}, restake = restake},
+              owners[owner] = v_addr})
+    stake_(v_addr, Call.value)
     validator_ct
 
-  stateful entrypoint set_online() =
-    require(validator_bucket(Call.caller) == OFFLINE, "Validator not offline")
-    let validator = state.offline_validators[Call.caller]
-    assert_allowed_to_set_online(validator)
-    put(state{online_validators[Call.caller] = validator,
-              offline_validators @ offv = Map.delete(Call.caller, offv),
-              total_stake @ ts = ts + validator.stake})
+  // ------------------------------------------------------------------------
+  // -- StakingValidator API
+  // ------------------------------------------------------------------------
+  payable stateful entrypoint deposit() =
+    require(Call.value > 0, "Deposit needs a positive value")
+    assert_validator(Call.caller)
+    deposit_(Call.caller, Call.value)
 
-  stateful entrypoint set_offline() =
-    require(validator_bucket(Call.caller) == ONLINE, "Validator not online")
-    let validator = state.online_validators[Call.caller]
-    put(state{offline_validators[Call.caller] = validator,
-              online_validators @ onv = Map.delete(Call.caller, onv),
-              total_stake @ ts = ts - validator.stake})
+  payable stateful entrypoint stake() =
+    require(Call.value > 0, "Stake needs a positive value")
+    assert_validator(Call.caller)
+    stake_(Call.caller, Call.value)
 
-  payable stateful entrypoint stake(to : address) : staking_response =
-    require(Call.value >= state.stake_minimum, "Must stake the minimum amount")
-    switch(state.stake_delay)
-      0 =>
-        let validator : validator = get_validator(to)
-        let shares = validator.ct.stake(value = Call.value, Call.caller)
-        let new_validator = maybe_set_stake_limit(to, Call.caller, validator{ stake @ s = s + Call.value })
-        switch(validator_bucket(to))
-          ONLINE => put(state{online_validators[to] = new_validator, total_stake @ ts = ts + Call.value })
-          OFFLINE => put(state{offline_validators[to] = new_validator})
-        {stake = Call.value, shares = shares, execution_height = Chain.block_height }
-      _ =>
-        let validator : validator = get_validator(to)
-        let shares = validator.ct.estimate_stake_shares(Call.value)
-        let new_validator = maybe_set_stake_limit(to, Call.caller, validator{ pending_stake @ ps = ps + Call.value })
-        let height  = Chain.block_height + state.stake_delay
-        let pending_transfer = { validator = to, staker = Call.caller, stake = Call.value}
-        let ps = switch(Map.member(height, state.pending_stake))
-            false => []
-            true => state.pending_stake[height]
-        put(state{pending_stake[height] = pending_transfer::ps})
-        switch(validator_bucket(to))
-          ONLINE => put(state{online_validators[to] = new_validator})
-          OFFLINE => put(state{offline_validators[to] = new_validator})
-        {stake = Call.value, shares = shares, execution_height = height }
+  stateful entrypoint adjust_stake(amount : int) =
+    assert_validator(Call.caller)
+    adjust_stake_(Call.caller, amount)
 
-  stateful entrypoint unstake(from : address, stakes : int) : staking_response =
-    let validator : validator = get_validator(from)
-    let payout = validator.ct.unstake(Call.caller, stakes)
-    assert_allowed_to_unstake(from, Call.caller, validator)
-    switch(state.unstake_delay)
-      0 => ()
-      _ =>
-        let height = Chain.block_height + state.unstake_delay
-        let pus = switch(Map.member(height, state.pending_unstake))
-            false => []
-            true => state.pending_unstake[height]
-        put(state{pending_unstake[height] = from::pus})
-    let new_validator = set_stake_limit(from, validator)
-    switch(validator_bucket(from))
-      ONLINE => put(state{online_validators[from] = new_validator{ stake @ s = s - payout}, total_stake @ ts = ts - payout})
-      OFFLINE => put(state{offline_validators[from] = new_validator{ stake @ s = s - payout }})
-    { stake = payout, shares = stakes, execution_height = Chain.block_height + state.unstake_delay}
+  stateful entrypoint withdraw(amount) =
+    assert_validator(Call.caller)
+    let available = get_available_balance_(Call.caller)
+    require(available >= amount, "Too large withdrawal")
 
-  payable stateful entrypoint reward(to : address) =
-    assert_protocol_call()
-    switch(validator_bucket(to))
-      ONLINE =>
-        let validator = state.online_validators[to]
-        validator.ct.profit(value = Call.value)
-        let new_validator = set_stake_limit(to, validator)
-        put(state{online_validators[to] = new_validator{ stake @ s = s + Call.value },
-                  total_stake @ ts = ts + Call.value})
-      OFFLINE =>
-        let validator = state.offline_validators[to]
-        validator.ct.profit(value = Call.value)
-        let new_validator = set_stake_limit(to, validator)
-        put(state{offline_validators[to] = new_validator{ stake @ s = s + Call.value }})
+    withdraw_(Call.caller, amount)
+    Chain.spend(Call.caller, amount)
 
-  entrypoint get_validator_state(address : address) : get_validator_response =
-    let validator = get_validator(address)
-    let online =
-        switch(validator_bucket(address))
-            ONLINE => true
-            OFFLINE => false
-    get_validator_state_(address, validator, online)
+  entrypoint get_staked_amount(epoch : int) =
+    get_staked_amount_(Call.caller, epoch)
 
-  entrypoint get_state() : get_state_response =
-    let validators = map_validators_state(state.online_validators, true) ++
-                     map_validators_state(state.offline_validators, false)
-    { staking_validator_ct  = state.staking_validator_ct,
-      validators            = validators,
-      total_stake           = state.total_stake,
-      validator_min_stake   = state.validator_min_stake,
-      validator_min_percent = state.validator_min_percent,
-      stake_minimum         = state.stake_minimum,
-      online_delay          = state.online_delay,
-      stake_delay           = state.stake_delay,
-      unstake_delay         = state.unstake_delay
-      }
+  entrypoint get_available_balance() =
+    get_available_balance_(Call.caller)
 
-  entrypoint set_validator_name(name : string) =
-    let validator = get_validator(Call.caller)
-    validator.ct.set_name(name)
+  entrypoint get_available_balance_(validator : address) : int =
+    let v = state.validators[validator]
+    // TODO: this is what it should be once locking is going
+    // v.total_balance - locked_stake(v)
+    v.total_balance - v.current_stake
 
-  entrypoint set_validator_description(description : string) =
-    let validator = get_validator(Call.caller)
-    validator.ct.set_description(description)
+  entrypoint get_total_balance() =
+    get_total_balance_(Call.caller)
 
-  entrypoint set_validator_avatar_url(avatar_url : string) =
-    let validator = get_validator(Call.caller)
-    validator.ct.set_avatar_url(avatar_url)
+  entrypoint get_total_balance_(v : address) =
+    state.validators[v].total_balance
 
-  stateful entrypoint post_elect() =
-    assert_protocol_call()
-    let height = Chain.block_height
-    switch(Map.member(height, state.pending_stake))
-      false => ()
-      true =>
-        let payouts = state.pending_stake[height]
-        List.foreach(payouts, distribute_stake_payout)
-        let new_ps = Map.delete(height, state.pending_stake)
-        put(state{pending_stake = new_ps})
-    switch(Map.member(height, state.pending_unstake))
-      false => ()
-      true =>
-        let payouts = state.pending_unstake[height]
-        List.foreach(payouts, distribute_unstake_payout)
-        let new_pus = Map.delete(height, state.pending_unstake)
-        put(state{pending_unstake = new_pus})
+  // ------------------------------------------------------------------------
+  // -- Called from HCElection and/or consensus logic
+  // ------------------------------------------------------------------------
+  payable stateful entrypoint add_rewards(epoch : int, rewards : list(address * int)) =
+    let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards))
+    require(total_rewards == Call.value, "Incorrect total reward given")
+    List.foreach(rewards, (r) => add_reward(epoch, r))
 
-  stateful function distribute_stake_payout(payout) =
-    let validator : validator = get_validator(payout.validator)
-    validator.ct.stake(value = payout.stake, payout.staker)
-    let new_validator = validator{ stake @ s = s + payout.stake, pending_stake @ ps = ps - payout.stake}
-    switch(validator_bucket(payout.validator))
-      ONLINE => put(state{online_validators[payout.validator] = new_validator, total_stake @ ts = ts + payout.stake})
-      OFFLINE =>
-        put(state{offline_validators[payout.validator] = new_validator})
+  entrypoint sorted_validators() : list(address * int) =
+    let vs = [ (o, s) | (_, {owner = o, current_stake = s}) <- Map.to_list(state.validators),
+                        if(s >= state.validator_min_stake) ]
 
-  stateful function distribute_unstake_payout(address : address) =
-    let validator = get_validator(address)
-    validator.ct.distribute_unstake()
+    List.sort(cmp_validator, vs)
 
-  entrypoint sorted_validators() =
-    let validators = Map.to_list(state.online_validators)
-    List.sort(validator_cmp, [ (v, s) | (v, {stake = s}) <- validators ])
+  // ------------------------------------------------------------------------
+  // -- Lookup API
+  // ------------------------------------------------------------------------
+  entrypoint staking_power(owner : address) =
+    let v = lookup_validator(owner)
+    v.current_stake
 
-  entrypoint staking_power(who : address) =
-    let validator = get_validator(who)
-    validator.stake
+  entrypoint get_validator_state(owner : address) =
+    lookup_validator(owner)
 
-  entrypoint is_validator_online(who : address) =
-    switch(validator_bucket(who))
-      ONLINE => true
-      OFFLINE => false
+  entrypoint get_validator_contract(owner : address) : StakingValidator =
+    assert_owner(owner)
+    Address.to_contract(state.owners[owner])
 
-  entrypoint get_validator_contract(who : address) =
-    let validator = get_validator(who)
-    validator.ct
-
-  function get_validator(who : address) : validator =
-    switch(validator_bucket(who))
-      ONLINE => state.online_validators[who]
-      OFFLINE => state.offline_validators[who]
-
-  stateful function set_validator(who : address, v : validator) : unit =
-    switch(validator_bucket(who))
-      ONLINE => put(state{online_validators[who] = v})
-      OFFLINE => put(state{offline_validators[who] = v})
-
-  function assert_uknown_validator(who) : bool =
-    switch(Map.member(who, state.online_validators))
-      true =>
-        abort("Validator exists")
-      false =>
-        switch(Map.member(who, state.offline_validators))
-          true =>
-            abort("Validator exists")
-          false =>
-            true
-
-  function validator_cmp((x_addr : address, x_stake : int), (y_addr : address, y_stake : int)) =
+  // ------------------------------------------------------------------------
+  // --   Internal functions
+  // ------------------------------------------------------------------------
+  function cmp_validator((x_addr : address, x_stake : int), (y_addr : address, y_stake : int)) =
     if (x_stake == y_stake) x_addr < y_addr else x_stake < y_stake
 
-  function validator_bucket(who) : bucket =
-    switch(Map.member(who, state.online_validators))
-      true =>
-        ONLINE
-      false =>
-        switch(Map.member(who, state.offline_validators))
-          true =>
-            OFFLINE
-          false =>
-            abort("Validator must exists")
+  function lookup_validator(owner : address) =
+    assert_owner(owner)
+    state.validators[state.owners[owner]]
 
-  function assert_protocol_call() =
-      require(Call.origin == Contract.creator, "Must be called by the protocol")
-
-  function get_validator_state_(address : address, validator : validator, is_online : bool) : get_validator_response =
-    {ct = validator.ct,
-     address = address,
-     creation_height = validator.creation_height,
-     stake = validator.stake,
-     pending_stake = validator.pending_stake,
-     stake_limit = validator.stake_limit,
-     is_online = is_online,
-     state = validator.ct.get_state()}
-
-  function map_validators_state(map, is_online) =
-    [get_validator_state_(addr, validator, is_online) | (addr, validator) <- Map.to_list(map)]
-
-  function assert_allowed_to_unstake(from : address, who : address, v : validator) =
-    if(from == who)
-      let balance_left = v.ct.balance(from)
-      assert_validator_min_stake(balance_left)
-      assert_min_percent_stake(who, balance_left)
+  stateful function add_reward(epoch : int, (owner, amount) : address * int) =
+    assert_owner(owner)
+    let validator = state.owners[owner]
+    let restake = state.validators[validator].restake
+    if(restake)
+      stake_(validator, amount)
     else
-      let balance_left = v.ct.balance(who)
-      assert_staker_min_stake(balance_left)
+      deposit_(validator, amount)
+    let validator_ct = Address.to_contract(validator) : StakingValidator
+    validator_ct.rewards(epoch, amount, restake)
 
-  function assert_validator_min_stake(balance : int) =
-      if(balance < state.validator_min_stake)
-        abort("Validator can not withdraw below the treshold")
-      else false
+  stateful function deposit_(validator : address, amount : int) =
+    put(state{validators[validator] @ v = deposit_v(v, amount)})
 
-  function assert_staker_min_stake(balance : int) =
-      if(balance == 0) false
-      else
-        if(balance < state.stake_minimum)
-          abort("Staker can not withdraw below the treshold")
-        else false
+  stateful function stake_(validator : address, amount : int) =
+    put(state{validators[validator] @ v = stake_v(v, amount)})
 
-  function assert_min_percent_stake(v: address, balance : int) =
-      let validator = get_validator_state(v)
-      let min_percent = state.validator_min_percent
-      if((100 * balance) < (min_percent * validator.stake))
-        abort("Validator can not withdraw below the treshold")
-      else false
+  stateful function withdraw_(validator : address, amount : int) =
+    put(state{validators[validator] @ v = withdraw_v(v, amount)})
 
-  stateful function maybe_set_stake_limit(to : address, who : address, v : validator) : validator =
-    if(to == who) set_stake_limit(to, v)
-    else assert_stake_limit(v)
+  function get_staked_amount_(validator : address, epoch : int) =
+    Map.lookup_default(epoch, state.validators[validator].staked, 0)
 
-  function set_stake_limit(v_address : address, v : validator) : validator =
-    let balance = v.ct.balance(v_address)
-    v{ stake_limit = calculate_stake_limit(balance) }
+  stateful function adjust_stake_(validator : address, amount : int) =
+    put(state{validators[validator] @ v = adjust_stake_v(v, amount)})
 
-  function calculate_stake_limit(stake : int) : int =
-    stake * 100 / state.validator_min_percent
+  function deposit_v(v : validator, amount) =
+    v{total_balance @ tb = tb + amount}
 
-  function assert_stake_limit(v : validator) : validator =
-    if(v.stake_limit < v.stake + v.pending_stake) abort("Total stake limit exceeded")
-    else v
+  function stake_v(v : validator, amount) =
+    v{total_balance @ tb = tb + amount,
+      current_stake @ cs = cs + amount}
 
-  function assert_allowed_to_set_online(v : validator) =
-    if(Chain.block_height == state.genesis_height) true
-    else
-      if(v.creation_height + state.online_delay =< Chain.block_height) true
-      else abort("Minimum height not reached")
+  function withdraw_v(v : validator, amount) =
+    v{total_balance @ tb = tb - amount}
 
-  entrypoint is_validator(who : address) : bool =
-    switch(Map.member(who, state.online_validators))
-      true =>
-        true
-      false =>
-        switch(Map.member(who, state.offline_validators))
-          true =>
-            true
-          false =>
-            false
+  function adjust_stake_v(v : validator, amount) =
+    require(v.total_balance >= v.current_stake + amount, "Too large stake")
+    require(0 =< v.current_stake + amount, "Too small stake")
+    v{current_stake @ cs = cs + amount}
+
+  function locked_stake(v : validator) =
+    let stakes = List.map(Pair.snd, Map.to_list(v.staked))
+    max(stakes)
+
+  function max(ls : list(int)) : int =
+    List.foldl((a, b) => if(a > b) a else b, 0, ls)
+
+  function assert_validator(v : address) =
+    require(Map.member(v, state.validators), "Not a registered validator")
+
+  function assert_owner(o : address) =
+    require(Map.member(o, state.owners), "Not a registered validator owner")

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -111,7 +111,7 @@ main contract MainStaking =
   // --   Internal functions
   // ------------------------------------------------------------------------
   function cmp_validator((x_addr : address, x_stake : int), (y_addr : address, y_stake : int)) =
-    if (x_stake == y_stake) x_addr < y_addr else x_stake < y_stake
+    if (x_stake == y_stake) x_addr < y_addr else x_stake > y_stake
 
   function lookup_validator(owner : address) =
     assert_owner(owner)

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -1,130 +1,70 @@
-include "List.aes"
-main contract StakingValidator =
-  record pending_transfer =
-    { staker : address, stake : int }
+contract interface RewardCallbackI =
+  entrypoint reward_cb : (int, int, bool) => unit
 
+contract interface MainStakingI =
+  payable entrypoint deposit          : () => unit
+  payable entrypoint stake            : () => unit
+  entrypoint adjust_stake             : (int) => unit
+  entrypoint withdraw                 : (int) => unit
+  entrypoint get_staked_amount        : (int) => int
+  entrypoint get_available_balance    : () => int
+  entrypoint get_total_balance        : () => int
+  entrypoint register_reward_callback : (RewardCallbackI) => unit
+
+payable contract StakingValidator =
   record state =
-    { main_staking_ct : address,
-      unstake_delay : int,
-      pending_unstake_amount : int,
-      pending_unstake : map(int, list(pending_transfer)),
-      name : string,
-      description : string,
-      avatar_url : string,
-      delegates : map(address, int),
-      shares : int }
+    { main_staking_ct : MainStakingI,
+      owner           : address,
+      signing_key     : address,
+      reward_callback : option(RewardCallbackI)
+    }
 
-  entrypoint init(main_staking_ct : address, unstake_delay : int) =
+  entrypoint init(main_staking_ct : MainStakingI, owner : address) =
     { main_staking_ct = main_staking_ct,
-      unstake_delay = unstake_delay,
-      pending_unstake_amount = 0,
-      pending_unstake = {},
-      name = "",
-      description = "",
-      avatar_url = "",
-      delegates = {},
-      shares = 0 }
+      owner           = owner,
+      signing_key     = owner,
+      reward_callback = None }
 
-  payable stateful entrypoint stake(staker : address) =
-    assert_caller()
-    require(Call.value > 0, "Stake must be > 0")
-    let new_shares = calculate_shares(Call.value)
-    add_shares(staker, new_shares)
-    put(state{shares @ s = s + new_shares})
-    new_shares
+  payable stateful entrypoint deposit() =
+    require(Call.value > 0, "Deposit must be positive")
+    assert_owner_caller()
+    state.main_staking_ct.deposit(value = Call.value)
 
-  entrypoint estimate_stake_shares(value : int) =
-    estimate_shares(value)
+  payable stateful entrypoint stake() =
+    require(Call.value > 0, "Stake must be positive")
+    assert_owner_caller()
+    state.main_staking_ct.stake(value = Call.value)
 
-  payable entrypoint profit() =
-    assert_caller()
-    ()
+  stateful entrypoint adjust_stake(adjust_amount : int) =
+    assert_owner_caller()
+    state.main_staking_ct.adjust_stake(adjust_amount)
 
-  stateful entrypoint distribute_unstake() =
-    assert_caller()
-    let height = Chain.block_height
-    switch(Map.member(height, state.pending_unstake))
-      false => ()
-      true =>
-        let payouts = state.pending_unstake[height]
-        List.foreach(payouts, distribute_payout)
-        let new_pus = Map.delete(height, state.pending_unstake)
-        put(state{pending_unstake = new_pus})
+  stateful entrypoint withdraw(amount : int) =
+    assert_owner_caller()
+    state.main_staking_ct.withdraw(amount)
+    Chain.spend(Call.caller, amount)
 
-  stateful function distribute_payout(payout) =
-    Chain.spend(payout.staker, payout.stake)
-    put(state{pending_unstake_amount @ pua = pua - payout.stake})
+  entrypoint get_staked_amount(epoch : int) =
+    state.main_staking_ct.get_staked_amount(epoch)
 
-  stateful entrypoint unstake(staker : address, withdraw_shares : int) : int =
-    assert_caller()
-    let staker_shares = state.delegates[staker = 0]
-    require(staker_shares >= withdraw_shares, "Not enough shares")
-    let payout_amt = shares_to_ae(withdraw_shares)
-    switch(state.unstake_delay)
-      0 => Chain.spend(staker, payout_amt)
-      _ =>
-        let height  = Chain.block_height + state.unstake_delay
-        let pending_transfer = { staker = staker, stake = payout_amt}
-        let pu = switch(Map.member(height, state.pending_unstake))
-            false => []
-            true => state.pending_unstake[height]
-        put(state{pending_unstake[height] = pending_transfer::pu,
-                  pending_unstake_amount @ pua = pua + payout_amt })
-    let remaining_shares = staker_shares - withdraw_shares
-    switch(remaining_shares == 0)
-      true =>
-        put(state{ shares @ s = s - withdraw_shares,
-                  delegates @ ds = Map.delete(staker, ds) })
-      false =>
-        put(state{ shares @ s = s - withdraw_shares,
-                  delegates[staker] @ balance = remaining_shares })
-    payout_amt
+  entrypoint get_available_balance() =
+    state.main_staking_ct.get_available_balance()
 
-  entrypoint get_state() =
-    assert_caller()
-    state
+  entrypoint get_total_balance() =
+    state.main_staking_ct.get_total_balance()
 
-  entrypoint shares(who : address) =
-    assert_caller()
-    state.delegates[who = 0]
+  stateful entrypoint register_reward_callback(cb_ct : RewardCallbackI) =
+    assert_owner_caller()
+    put(state{reward_callback = Some(cb_ct)})
 
-  entrypoint all_shares() =
-    assert_caller()
-    state.shares
+  entrypoint rewards(epoch : int, amount : int, restaked : bool) =
+    assert_main_staking_caller()
+    switch(state.reward_callback)
+      None => ()
+      Some(cb_ct) => cb_ct.reward_cb(epoch, amount, restaked)
 
-  entrypoint balance(who : address) =
-    assert_caller()
-    shares_to_ae(state.delegates[who = 0])
+  function assert_owner_caller() =
+    require(Call.caller == state.owner, "Only contract owner allowed")
 
-  stateful entrypoint set_name(name : string) =
-    assert_caller()
-    put(state{name = name})
-
-  stateful entrypoint set_description(description : string) =
-    assert_caller()
-    put(state{description = description})
-
-  stateful entrypoint set_avatar_url(avatar_url : string) =
-    assert_caller()
-    put(state{avatar_url = avatar_url})
-
-  stateful function add_shares(staker : address, shares : int) =
-    put(state{ delegates[staker = 0] @ dshares = dshares + shares })
-
-  function calculate_shares(stake_size : int) =
-    if (state.shares == 0)
-      stake_size
-    else
-      (stake_size * state.shares) / (contract_balance() - stake_size)
-
-  function estimate_shares(stake_size : int) =
-      (stake_size * state.shares) / contract_balance()
-
-  function assert_caller() =
-    require(Call.caller == state.main_staking_ct, "Only allowed through MainStaking")
-
-  function shares_to_ae(shares : int) =
-    (shares * contract_balance()) / state.shares
-
-  function contract_balance() : int =
-    Contract.balance - state.pending_unstake_amount
+  function assert_main_staking_caller() =
+    require(Call.caller == state.main_staking_ct.address, "Only main staking contract allowed")


### PR DESCRIPTION
New staking contracts... 

Hyperchains suite passes, and a new rather sparse staking contract suite also works.

Rewards are accumulated in the election contract and then distributed to stakers at the end of epoch (with one epoch delay). Each staker has a `StakingValidator` contract, created through a factory in `MainStaking`.


This PR is supported by the Æternity Foundation