### PR TITLE
add reward callback checks

### DIFF
--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -25,7 +25,7 @@ main contract MainStaking =
     { validators = {},
       owners = {},
       validator_min_stake = validator_min_stake,
-      current_epoch = 0 }
+      current_epoch = 1 }
 
   // Should we user Call.caller instead?
   payable stateful entrypoint new_validator(owner : address, restake : bool) : StakingValidator =
@@ -85,7 +85,7 @@ main contract MainStaking =
   // -- Called from HCElection and/or consensus logic
   // ------------------------------------------------------------------------
   payable stateful entrypoint add_rewards(epoch : int, rewards : list(address * int)) =
-    put(state{current_epoch = epoch + 1})
+    put(state{current_epoch = epoch + 2})
     let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards))
     require(total_rewards == Call.value, "Incorrect total reward given")
     List.foreach(rewards, (r) => add_reward(epoch, r))

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -17,13 +17,15 @@ main contract MainStaking =
   record state =
     { validators          : map(address, validator),
       owners              : map(address, address),
-      validator_min_stake : int
+      validator_min_stake : int,
+      current_epoch       : int
     }
 
   entrypoint init(validator_min_stake : int) =
     { validators = {},
       owners = {},
-      validator_min_stake = validator_min_stake }
+      validator_min_stake = validator_min_stake,
+      current_epoch = 0 }
 
   // Should we user Call.caller instead?
   payable stateful entrypoint new_validator(owner : address, restake : bool) : StakingValidator =
@@ -83,6 +85,7 @@ main contract MainStaking =
   // -- Called from HCElection and/or consensus logic
   // ------------------------------------------------------------------------
   payable stateful entrypoint add_rewards(epoch : int, rewards : list(address * int)) =
+    put(state{current_epoch = epoch + 1})
     let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards))
     require(total_rewards == Call.value, "Incorrect total reward given")
     List.foreach(rewards, (r) => add_reward(epoch, r))
@@ -106,6 +109,9 @@ main contract MainStaking =
   entrypoint get_validator_contract(owner : address) : StakingValidator =
     assert_owner(owner)
     Address.to_contract(state.owners[owner])
+
+  entrypoint get_current_epoch() =
+    state.current_epoch
 
   // ------------------------------------------------------------------------
   // --   Internal functions

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -10,6 +10,7 @@ contract interface MainStakingI =
   entrypoint get_available_balance    : () => int
   entrypoint get_total_balance        : () => int
   entrypoint register_reward_callback : (RewardCallbackI) => unit
+  entrypoint get_current_epoch        : () => int
 
 payable contract StakingValidator =
   record state =
@@ -67,6 +68,9 @@ payable contract StakingValidator =
     switch(state.reward_callback)
         None => false
         Some(cb_ct) => true
+
+  entrypoint get_current_epoch() =
+    state.main_staking_ct.get_current_epoch()
 
   function assert_owner_caller() =
     require(Call.caller == state.owner, "Only contract owner allowed")

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -55,7 +55,6 @@ payable contract StakingValidator =
 
   stateful entrypoint register_reward_callback(cb_ct : RewardCallbackI) =
     assert_owner_caller()
-    assert_reward_cb_exists(cb_ct)
     put(state{reward_callback = Some(cb_ct)})
 
   entrypoint rewards(epoch : int, amount : int, restaked : bool) =
@@ -64,7 +63,7 @@ payable contract StakingValidator =
       None => ()
       Some(cb_ct) => cb_ct.reward_cb(epoch, amount, restaked)
 
-  entrypoint has_reward_callback_registered() =
+  entrypoint has_reward_callback() =
     switch(state.reward_callback)
         None => false
         Some(cb_ct) => true
@@ -74,6 +73,3 @@ payable contract StakingValidator =
 
   function assert_main_staking_caller() =
     require(Call.caller == state.main_staking_ct.address, "Only main staking contract allowed")
-
-  stateful function assert_reward_cb_exists(cb_ct : RewardCallbackI) =
-    cb_ct.reward_cb(0, 0, true)

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -55,6 +55,7 @@ payable contract StakingValidator =
 
   stateful entrypoint register_reward_callback(cb_ct : RewardCallbackI) =
     assert_owner_caller()
+    assert_reward_cb_exists(cb_ct)
     put(state{reward_callback = Some(cb_ct)})
 
   entrypoint rewards(epoch : int, amount : int, restaked : bool) =
@@ -63,8 +64,16 @@ payable contract StakingValidator =
       None => ()
       Some(cb_ct) => cb_ct.reward_cb(epoch, amount, restaked)
 
+  entrypoint has_reward_callback_registered() =
+    switch(state.reward_callback)
+        None => false
+        Some(cb_ct) => true
+
   function assert_owner_caller() =
     require(Call.caller == state.owner, "Only contract owner allowed")
 
   function assert_main_staking_caller() =
     require(Call.caller == state.main_staking_ct.address, "Only main staking contract allowed")
+
+  stateful function assert_reward_cb_exists(cb_ct : RewardCallbackI) =
+    cb_ct.reward_cb(0, 0, true)


### PR DESCRIPTION
- For better user experience, additional checks, easier discovery, debugging and wherever this information might be useful: Add `has_reward_callback_registered()`

- Make assumption about the current `epoch` as being the `epoch` passed to 
https://github.com/aeternity/aeternity/blob/0daffd17abfca2853cb116e60c4ad62b69529f8f/test/contracts/MainStaking.aes#L85

+1 , and store it as the current_epoch in MainStaking so the accounting inside delegation logic does not need to be made aware of one more contract (`HCElection`)

- add getters to MainStaking and stakingValidator (the latter requesting it from MainStaking)