### PR TITLE
Improve staking contracts

### DIFF
--- a/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
@@ -170,7 +170,14 @@ stake(_Config) ->
         get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
 
     ?assertEqual(TotalBalance, ?VALIDATOR_MIN + 5 * ?AE),
-    ?assertEqual(AvailableBalance, 0),
+    %% staked isn't locked yet
+    ?assertEqual(AvailableBalance, 5 * ?AE),
+
+    {ok, Trees3, _} = lock_stake(2, TxEnv, Trees2),
+    {ok, _, #{res := AvailableBalance2}} =
+        get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees3),
+    ?assertEqual(AvailableBalance2, 0),
+
 
     ok.
 
@@ -178,21 +185,21 @@ adjust_stake(_Config) ->
     Trees0 = genesis_trees(),
     TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
     {ok, Trees1, #{res := {contract, AliceCt}}} =
-        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
+        new_validator_(pubkey(?ALICE), 2 * ?VALIDATOR_MIN, TxEnv, Trees0),
     {ok, Trees2, #{res := ?UNIT}} =
-        adjust_stake_(AliceCt, ?ALICE, -2 * ?AE, TxEnv, Trees1),
+        adjust_stake_(AliceCt, ?ALICE, -2 * ?AE, TxEnv, Trees1, 1), %% Lock at 1 to "overwrite"
 
     {ok, _, #{res := TotalBalance}}     = get_total_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
     {ok, _, #{res := AvailableBalance}} = get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees2),
-    ?assertEqual(TotalBalance,     ?VALIDATOR_MIN),
+    ?assertEqual(TotalBalance,     2 * ?VALIDATOR_MIN),
     ?assertEqual(AvailableBalance, 2 * ?AE),
 
     {ok, Trees3, #{res := ?UNIT}} =
-        adjust_stake_(AliceCt, ?ALICE, ?AE, TxEnv, Trees2),
+        adjust_stake_(AliceCt, ?ALICE, ?AE, TxEnv, Trees2, 1),
 
     {ok, _, #{res := TotalBalance2}}     = get_total_balance_(AliceCt, ?ALICE, TxEnv, Trees3),
     {ok, _, #{res := AvailableBalance2}} = get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees3),
-    ?assertEqual(TotalBalance2,     ?VALIDATOR_MIN),
+    ?assertEqual(TotalBalance2,     2 * ?VALIDATOR_MIN),
     ?assertEqual(AvailableBalance2, ?AE),
 
     ok.
@@ -201,10 +208,10 @@ withdraw(_Config) ->
     Trees0 = genesis_trees(),
     TxEnv = aetx_env:tx_env(?DEFAULT_HEIGHT),
     {ok, Trees1, #{res := {contract, AliceCt}}} =
-        new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
+        new_validator_(pubkey(?ALICE), 2 * ?VALIDATOR_MIN, TxEnv, Trees0),
 
     {ok, Trees2, #{res := ?UNIT}} =
-        adjust_stake_(AliceCt, ?ALICE, -2 * ?AE, TxEnv, Trees1),
+        adjust_stake_(AliceCt, ?ALICE, -2 * ?AE, TxEnv, Trees1, 1),
 
     {ok, Trees3, #{res := ?UNIT, cost := TxCost}} =
         withdraw_(AliceCt, ?ALICE, 2 * ?AE, TxEnv, Trees2),
@@ -220,11 +227,11 @@ rewards(_Config) ->
     {ok, Trees1, #{res := {contract, AliceCt}}} =
         new_validator_(pubkey(?ALICE), ?VALIDATOR_MIN, TxEnv, Trees0),
     {ok, Trees2, #{res := {contract, BobCt}}} =
-        new_validator_(pubkey(?BOB), ?VALIDATOR_MIN, false, TxEnv, Trees1),
+        new_validator_(pubkey(?BOB), ?VALIDATOR_MIN, false, TxEnv, Trees1, undefined),
 
     Rewards = [{{address, pubkey(?ALICE)}, 4 * ?AE}, {{address, pubkey(?BOB)}, 3 * ?AE}],
     {ok, Trees3, #{res := ?UNIT}} =
-        add_rewards_(1, Rewards, 7 * ?AE, TxEnv, Trees2),
+        add_rewards_(1, Rewards, 7 * ?AE, TxEnv, Trees2, 2),
 
     {ok, _, #{res := ABalance}}   = get_total_balance_(AliceCt, ?ALICE, TxEnv, Trees3),
     {ok, _, #{res := AAvailable}} = get_available_balance_(AliceCt, ?ALICE, TxEnv, Trees3),
@@ -367,10 +374,18 @@ create_contract(ContractName, CallData, TxEnv, Trees) ->
     {_, Trees2} = aec_block_fork:apply_contract_create_tx(Tx, Trees1, TxEnv),
     {Pubkey, Trees2}.
 
-call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees) ->
-  call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees, fun(X) -> X end).
+call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees, undefined) ->
+    call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees);
+call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees0, LockEpoch) when is_integer(LockEpoch) ->
+    case call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees0) of
+        {ok, Trees1, Res} ->
+            {ok, Trees2, _} = lock_stake(LockEpoch, TxEnv, Trees1),
+            {ok, Trees2, Res};
+        Res ->
+            Res
+    end.
 
-call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees, TransformFun) ->
+call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees) ->
     Nonce = next_nonce(Caller, Trees),
     ABI = aect_test_utils:latest_sophia_abi_version(),
     TxSpec = #{ caller_id    => aeser_id:create(account, Caller),
@@ -401,7 +416,7 @@ call_contract(ContractPubkey, Caller, CallData, Amount, TxEnv, Trees, TransformF
                     RespTrees = aect_call_state_tree:prune(Height, Trees2),
                     Resp = aeb_fate_encoding:deserialize(aect_call:return_value(Call)),
                     Cost = aetx:fee(Tx) + aect_call:gas_price(Call) * aect_call:gas_used(Call),
-                    {ok, RespTrees, #{res => TransformFun(Resp), cost => Cost}};
+                    {ok, RespTrees, #{res => Resp, cost => Cost}};
                 error -> {error, aect_call:return_value(Call)};
                 revert -> {revert,
                             aeb_fate_encoding:deserialize(aect_call:return_value(Call))}
@@ -428,63 +443,60 @@ election_contract_address() ->
     aect_contracts:compute_contract_pubkey(?OWNER_PUBKEY, 2).
 
 %% TODO match logic of election with HCElection contract logic
-test_elect_calls(StartHeight, GenerenationsCnt, TxEnv, StartTrees) ->
-    Alice = pubkey(?ALICE),
-    lists:foldl(
-        fun(Height, {TreesAccum1, Ls}) ->
-            TxEnvPrev = aetx_env:set_height(TxEnv, Height - 1),
-            {ok, TreesAccum2, {tuple, {}}} = elect_(Alice, ?OWNER_PUBKEY, TxEnvPrev, TreesAccum1),
-            TxEnv1 = aetx_env:set_height(TxEnv, Height),
-            {ok, _, {address, NextLeader}} = leader_(?OWNER_PUBKEY, TxEnv1, TreesAccum2),
-            ?assertEqual(Alice, NextLeader),
-            Ls1 = maps:update_with(NextLeader, fun(X) -> X + 1 end, 1, Ls),
-            {TreesAccum2, Ls1}
-        end,
-        {StartTrees, #{}},
-        lists:seq(StartHeight, StartHeight + GenerenationsCnt - 1)).
-
-%% % Total stake limit helpers
-%% calculate_total_stake_limit(Stake) ->
-%%     Stake * 100 div ?VALIDATOR_MIN_PERCENT.
-
-%% get_total_stake_limit(Validator, TxEnv, Trees) ->
-%%     {ok, _, State} = get_validator_state_(Validator, Validator, TxEnv, Trees),
-%%     {tuple, {_, _, _, _, _, StakeLimit, _, _}} = State,
-%%     StakeLimit.
-
-%% get_available_stake_limit(Validator, TxEnv, Trees) ->
-%%     {ok, _, State} = get_validator_state_(Validator, Validator, TxEnv, Trees),
-%%     {tuple, {_, _, _, Stake, PendingStake, StakeLimit, _, _}} = State,
-%%     StakeLimit-Stake-PendingStake.
-
-%% contract call wrappers
-new_validator_(Pubkey, Amount, TxEnv, Trees0) ->
-    new_validator_(Pubkey, Amount, true, TxEnv, Trees0).
-
-new_validator_(Pubkey, Amount, ReStake, TxEnv, Trees0) ->
-    ContractPubkey = staking_contract_address(),
-    Args = [aefa_fate_code:encode_arg({address, Pubkey}),
-            aefa_fate_code:encode_arg({address, Pubkey}),
-            aefa_fate_code:encode_arg(ReStake)],
-    {ok, CallData} = aeb_fate_abi:create_calldata("new_validator", Args),
-    call_contract(ContractPubkey, Pubkey, CallData, Amount, TxEnv, Trees0).
+%% test_elect_calls(StartHeight, GenerenationsCnt, TxEnv, StartTrees) ->
+%%     Alice = pubkey(?ALICE),
+%%     lists:foldl(
+%%         fun(Height, {TreesAccum1, Ls}) ->
+%%             TxEnvPrev = aetx_env:set_height(TxEnv, Height - 1),
+%%             {ok, TreesAccum2, {tuple, {}}} = elect_(Alice, ?OWNER_PUBKEY, TxEnvPrev, TreesAccum1),
+%%             TxEnv1 = aetx_env:set_height(TxEnv, Height),
+%%             {ok, _, {address, NextLeader}} = leader_(?OWNER_PUBKEY, TxEnv1, TreesAccum2),
+%%             ?assertEqual(Alice, NextLeader),
+%%             Ls1 = maps:update_with(NextLeader, fun(X) -> X + 1 end, 1, Ls),
+%%             {TreesAccum2, Ls1}
+%%         end,
+%%         {StartTrees, #{}},
+%%         lists:seq(StartHeight, StartHeight + GenerenationsCnt - 1)).
 
 create_calldata(Fun, Args0) ->
     Args = [ aefa_fate_code:encode_arg(Arg) || Arg <- Args0 ],
     {ok, CallData} = aeb_fate_abi:create_calldata(Fun, Args),
     CallData.
 
+%% contract call wrappers
+new_validator_(Pubkey, Amount, TxEnv, Trees0) ->
+    new_validator_(Pubkey, Amount, true, TxEnv, Trees0, 1).
+
+new_validator_(Pubkey, Amount, ReStake, TxEnv, Trees0, LockEpoch) ->
+    ContractPubkey = staking_contract_address(),
+    Args = [aefa_fate_code:encode_arg({address, Pubkey}),
+            aefa_fate_code:encode_arg({address, Pubkey}),
+            aefa_fate_code:encode_arg(ReStake)],
+    {ok, CallData} = aeb_fate_abi:create_calldata("new_validator", Args),
+    call_contract(ContractPubkey, Pubkey, CallData, Amount, TxEnv, Trees0, LockEpoch).
+
+lock_stake(Epoch, TxEnv, Trees0) ->
+    ContractPubkey = staking_contract_address(),
+    {ok, CallData} = aeb_fate_abi:create_calldata("lock_stake", [aefa_fate_code:encode_arg({integer, Epoch})]),
+    call_contract(ContractPubkey, ?OWNER_PUBKEY, CallData, 0, TxEnv, Trees0).
+
 deposit_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
     CallData = create_calldata("deposit", []),
     call_contract(ValidatorCt, pubkey(Validator), CallData, Amount, TxEnv, Trees0).
 
 stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
+    stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0, undefined).
+
+stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0, LockEpoch) ->
     CallData = create_calldata("stake", []),
-    call_contract(ValidatorCt, pubkey(Validator), CallData, Amount, TxEnv, Trees0).
+    call_contract(ValidatorCt, pubkey(Validator), CallData, Amount, TxEnv, Trees0, LockEpoch).
 
 adjust_stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
+    adjust_stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0, undefined).
+
+adjust_stake_(ValidatorCt, Validator, Amount, TxEnv, Trees0, LockEpoch) ->
     CallData = create_calldata("adjust_stake", [{integer, Amount}]),
-    call_contract(ValidatorCt, pubkey(Validator), CallData, 0, TxEnv, Trees0).
+    call_contract(ValidatorCt, pubkey(Validator), CallData, 0, TxEnv, Trees0, LockEpoch).
 
 withdraw_(ValidatorCt, Validator, Amount, TxEnv, Trees0) ->
     CallData = create_calldata("withdraw", [{integer, Amount}]),
@@ -500,10 +512,10 @@ get_available_balance_(ValidatorCt, Validator, TxEnv, Trees0) ->
 
 %% MainStaking
 
-add_rewards_(Epoch, Rewards, TotRewards, TxEnv, Trees0) ->
+add_rewards_(Epoch, Rewards, TotRewards, TxEnv, Trees0, LockEpoch) ->
     Contract = staking_contract_address(),
     CallData = create_calldata("add_rewards", [{integer, Epoch}, Rewards]),
-    call_contract(Contract, ?OWNER_PUBKEY, CallData, TotRewards, TxEnv, Trees0).
+    call_contract(Contract, ?OWNER_PUBKEY, CallData, TotRewards, TxEnv, Trees0, LockEpoch).
 
 sorted_validators_(TxEnv, Trees0) ->
     Contract = staking_contract_address(),

--- a/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
@@ -464,6 +464,7 @@ new_validator_(Pubkey, Amount, TxEnv, Trees0) ->
 new_validator_(Pubkey, Amount, ReStake, TxEnv, Trees0) ->
     ContractPubkey = staking_contract_address(),
     Args = [aefa_fate_code:encode_arg({address, Pubkey}),
+            aefa_fate_code:encode_arg({address, Pubkey}),
             aefa_fate_code:encode_arg(ReStake)],
     {ok, CallData} = aeb_fate_abi:create_calldata("new_validator", Args),
     call_contract(ContractPubkey, Pubkey, CallData, Amount, TxEnv, Trees0).

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -777,6 +777,10 @@ verify_rewards(Config) ->
     ?assertEqual(BobTot0 + maps:get(pubkey(?BOB_SIGN), Rewards, 0), BobTot1),
     ?assertEqual(LisaTot0 + maps:get(pubkey(?LISA), Rewards, 0), LisaTot1),
 
+    %% Check that MainStaking knows the right epoch.
+    {ok, #{epoch := Epoch}} = rpc(Node, aec_chain_hc, epoch_info, []),
+    {ok, Epoch} = inspect_staking_contract(?ALICE, get_current_epoch, Config),
+
     ok.
 
 calc_rewards(Blocks) ->
@@ -1468,6 +1472,8 @@ inspect_staking_contract(OriginWho, WhatToInspect, Config, TopHash) ->
                 {"get_validator_state", [binary_to_list(encoded_pubkey(Who))]};
             {get_validator_contract, Who} ->
                 {"get_validator_contract", [binary_to_list(encoded_pubkey(Who))]};
+            get_current_epoch ->
+                {"get_current_epoch", []};
             get_state ->
                 {"get_state", []};
             leaders ->

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1385,6 +1385,7 @@ privkey({_, Privkey, _}) -> Privkey.
 who_by_pubkey(Pubkey) ->
     Alice = pubkey(?ALICE),
     Bob = pubkey(?BOB),
+    BobSign = pubkey(?BOB_SIGN),
     Lisa = pubkey(?LISA),
     Dwight = pubkey(?DWIGHT),
     Edwin = pubkey(?EDWIN),
@@ -1392,6 +1393,7 @@ who_by_pubkey(Pubkey) ->
     case Pubkey of
         Alice -> ?ALICE;
         Bob -> ?BOB;
+        BobSign -> ?BOB_SIGN;
         Lisa -> ?LISA;
         Dwight -> ?DWIGHT;
         Edwin -> ?EDWIN;
@@ -1606,6 +1608,7 @@ build_json_files(ElectionContract, NodeConfig, CTConfig) ->
         #{  <<"ak_2evAxTKozswMyw9kXkvjJt3MbomCR1nLrf91BduXKdJLrvaaZt">> => 1000000000000000000000000000000000000000000000000,
             encoded_pubkey(?ALICE) => 2100000000000000000000000000,
             encoded_pubkey(?BOB) => 3100000000000000000000000000,
+            encoded_pubkey(?BOB_SIGN) => 3100000000000000000000000000,
             encoded_pubkey(?LISA) => 4100000000000000000000000000
          }),
     ok.

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -3,6 +3,7 @@ include "Pair.aes"
 
 contract interface MainStaking =
   entrypoint sorted_validators : () => list((address * int))
+  entrypoint lock_stake  : (int) => list((address * int))
   entrypoint add_rewards : (int, list(address * int)) => unit
 
 main contract HCElection =
@@ -42,10 +43,10 @@ main contract HCElection =
     assert_protocol_call()
     require(Chain.block_height == 0, "Only in genesis")
     put(state{ epochs = { [0] = mk_epoch_info(0, 1, None, None),
-                          [1] = mk_epoch_info(1, epoch_length, None, Some(state.main_staking_ct.sorted_validators())),
-                          [2] = mk_epoch_info(epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.sorted_validators())),
-                          [3] = mk_epoch_info(2 * epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.sorted_validators())),
-                          [4] = mk_epoch_info(3 * epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.sorted_validators()))
+                          [1] = mk_epoch_info(1, epoch_length, None, Some(state.main_staking_ct.lock_stake(1))),
+                          [2] = mk_epoch_info(epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.lock_stake(2))),
+                          [3] = mk_epoch_info(2 * epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.lock_stake(3))),
+                          [4] = mk_epoch_info(3 * epoch_length + 1, epoch_length, None, Some(state.main_staking_ct.lock_stake(4)))
                         },
                epoch  = 1,
                pin_reward.base = base_pin_reward
@@ -88,7 +89,7 @@ main contract HCElection =
                        [epoch + 2] = state.epochs[epoch + 2]{ seed = Some(seed) },
                        [epoch + 3] = ei_adjust,
                        [epoch + 4] = mk_epoch_info(ei_adjust.start + ei_adjust.length, ei_adjust.length, None,
-                                                   Some(state.main_staking_ct.sorted_validators()))
+                                                   Some(state.main_staking_ct.lock_stake(epoch + 4)))
                      }
 
     put(state{ leader = leader,

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -70,6 +70,13 @@ main contract MainStaking =
     withdraw_(Call.caller, amount)
     Chain.spend(Call.caller, amount)
 
+  stateful entrypoint set_restake(restake : bool) =
+    assert_validator(Call.caller)
+    put(state{validators[Call.caller] @ v = v{restake = restake}})
+
+  entrypoint get_restake() : bool =
+    state.validators[Call.caller].restake
+
   entrypoint get_staked_amount(epoch : int) =
     get_staked_amount_(Call.caller, epoch)
 
@@ -149,7 +156,8 @@ main contract MainStaking =
     validator_ct.rewards(epoch, amount, restake)
 
   stateful function lock_stake_(v_addr : address, validator : validator, epoch : int) : unit =
-    put(state{validators[v_addr] = validator{staked @ s = s{[epoch] = validator.current_stake}}})
+    if(validator.current_stake >= state.validator_min_stake)
+      put(state{validators[v_addr] = validator{staked @ s = s{[epoch] = validator.current_stake}}})
 
   stateful function unlock_stake_(v_addr : address, validator : validator, epoch : int) : unit =
     put(state{validators[v_addr] = validator{staked @ s = Map.delete(epoch, s)}})

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -78,9 +78,7 @@ main contract MainStaking =
 
   entrypoint get_available_balance_(validator : address) : int =
     let v = state.validators[validator]
-    // TODO: this is what it should be once locking is going
-    // v.total_balance - locked_stake(v)
-    v.total_balance - v.current_stake
+    v.total_balance - locked_stake(v)
 
   entrypoint get_total_balance() =
     get_total_balance_(Call.caller)
@@ -96,9 +94,15 @@ main contract MainStaking =
     let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards))
     require(total_rewards == Call.value, "Incorrect total reward given")
     List.foreach(rewards, (r) => add_reward(epoch, r))
+    [ unlock_stake_(v_addr, validator, epoch) | (v_addr, validator) <- Map.to_list(state.validators) ]
     // At the end of epoch X we distribute rewards for X - 1; thus current_epoch
     // is (soon) X + 1. I.e. X - 1 + 2.
     put(state{current_epoch = epoch + 2})
+
+  stateful entrypoint lock_stake(epoch : int) : list(address * int) =
+    assert_protocol_call()
+    [ lock_stake_(v_addr, validator, epoch) | (v_addr, validator) <- Map.to_list(state.validators) ]
+    sorted_validators()
 
   entrypoint sorted_validators() : list(address * int) =
     let vs = [ (sk, s) | (_, {sign_key = sk, current_stake = s}) <- Map.to_list(state.validators),
@@ -143,6 +147,12 @@ main contract MainStaking =
       deposit_(validator, amount)
     let validator_ct = Address.to_contract(validator) : StakingValidator
     validator_ct.rewards(epoch, amount, restake)
+
+  stateful function lock_stake_(v_addr : address, validator : validator, epoch : int) : unit =
+    put(state{validators[v_addr] = validator{staked @ s = s{[epoch] = validator.current_stake}}})
+
+  stateful function unlock_stake_(v_addr : address, validator : validator, epoch : int) : unit =
+    put(state{validators[v_addr] = validator{staked @ s = Map.delete(epoch, s)}})
 
   stateful function deposit_(validator : address, amount : int) =
     put(state{validators[validator] @ v = deposit_v(v, amount)})

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -8,6 +8,7 @@ contract interface StakingValidatorI =
 main contract MainStaking =
   record validator =
     { owner         : address,
+      sign_key      : address,
       total_balance : int,
       current_stake : int,
       staked        : map(int, int),
@@ -17,22 +18,27 @@ main contract MainStaking =
   record state =
     { validators          : map(address, validator),
       owners              : map(address, address),
+      sign_keys           : map(address, address),
       validator_min_stake : int
     }
 
   entrypoint init(validator_min_stake : int) =
     { validators = {},
       owners = {},
+      sign_keys = {},
       validator_min_stake = validator_min_stake }
 
-  // Should we user Call.caller instead?
-  payable stateful entrypoint new_validator(owner : address, restake : bool) : StakingValidator =
+  payable stateful entrypoint new_validator(owner : address, sign_key : address, restake : bool) : StakingValidator =
     require(Call.value >= state.validator_min_stake, "A new validator must stake the minimum amount")
     require(!Map.member(owner, state.owners), "Owner must be unique")
-    let validator_ct = Chain.create(Address.to_contract(Contract.address), owner) : StakingValidator
+    require(!Map.member(sign_key, state.sign_keys), "Sign key must be unique")
+    let validator_ct = Chain.create(Address.to_contract(Contract.address), owner, sign_key) : StakingValidator
     let v_addr = validator_ct.address
-    put(state{validators[v_addr] = {owner = owner, total_balance = 0, current_stake = 0, staked = {}, restake = restake},
-              owners[owner] = v_addr})
+    put(state{validators[v_addr] = {owner = owner, sign_key = sign_key,
+                                    total_balance = 0, current_stake = 0,
+                                    staked = {}, restake = restake},
+              owners[owner] = v_addr,
+              sign_keys[sign_key] = v_addr})
     stake_(v_addr, Call.value)
     validator_ct
 
@@ -88,8 +94,8 @@ main contract MainStaking =
     List.foreach(rewards, (r) => add_reward(epoch, r))
 
   entrypoint sorted_validators() : list(address * int) =
-    let vs = [ (o, s) | (_, {owner = o, current_stake = s}) <- Map.to_list(state.validators),
-                        if(s >= state.validator_min_stake) ]
+    let vs = [ (sk, s) | (_, {sign_key = sk, current_stake = s}) <- Map.to_list(state.validators),
+                         if(s >= state.validator_min_stake) ]
 
     List.sort(cmp_validator, vs)
 
@@ -117,9 +123,9 @@ main contract MainStaking =
     assert_owner(owner)
     state.validators[state.owners[owner]]
 
-  stateful function add_reward(epoch : int, (owner, amount) : address * int) =
-    assert_owner(owner)
-    let validator = state.owners[owner]
+  stateful function add_reward(epoch : int, (sign_key, amount) : address * int) =
+    assert_signer(sign_key)
+    let validator = state.sign_keys[sign_key]
     let restake = state.validators[validator].restake
     if(restake)
       stake_(validator, amount)
@@ -170,3 +176,6 @@ main contract MainStaking =
 
   function assert_owner(o : address) =
     require(Map.member(o, state.owners), "Not a registered validator owner")
+
+  function assert_signer(s : address) =
+    require(Map.member(s, state.sign_keys), "Not a registered sign key")

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -92,6 +92,7 @@ main contract MainStaking =
   // -- Called from HCElection and/or consensus logic
   // ------------------------------------------------------------------------
   payable stateful entrypoint add_rewards(epoch : int, rewards : list(address * int)) =
+    assert_protocol_call()
     let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards))
     require(total_rewards == Call.value, "Incorrect total reward given")
     List.foreach(rewards, (r) => add_reward(epoch, r))
@@ -188,3 +189,6 @@ main contract MainStaking =
 
   function assert_signer(s : address) =
     require(Map.member(s, state.sign_keys), "Not a registered sign key")
+
+  function assert_protocol_call() =
+    require(Call.origin == Contract.creator, "Must be called by the protocol")

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -19,14 +19,17 @@ main contract MainStaking =
     { validators          : map(address, validator),
       owners              : map(address, address),
       sign_keys           : map(address, address),
-      validator_min_stake : int
+      validator_min_stake : int,
+      current_epoch       : int
     }
 
   entrypoint init(validator_min_stake : int) =
     { validators = {},
       owners = {},
       sign_keys = {},
-      validator_min_stake = validator_min_stake }
+      validator_min_stake = validator_min_stake,
+      // The first block is part of epoch 1
+      current_epoch = 1 }
 
   payable stateful entrypoint new_validator(owner : address, sign_key : address, restake : bool) : StakingValidator =
     require(Call.value >= state.validator_min_stake, "A new validator must stake the minimum amount")
@@ -92,6 +95,9 @@ main contract MainStaking =
     let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards))
     require(total_rewards == Call.value, "Incorrect total reward given")
     List.foreach(rewards, (r) => add_reward(epoch, r))
+    // At the end of epoch X we distribute rewards for X - 1; thus current_epoch
+    // is (soon) X + 1. I.e. X - 1 + 2.
+    put(state{current_epoch = epoch + 2})
 
   entrypoint sorted_validators() : list(address * int) =
     let vs = [ (sk, s) | (_, {sign_key = sk, current_stake = s}) <- Map.to_list(state.validators),
@@ -112,6 +118,9 @@ main contract MainStaking =
   entrypoint get_validator_contract(owner : address) : StakingValidator =
     assert_owner(owner)
     Address.to_contract(state.owners[owner])
+
+  entrypoint get_current_epoch() =
+    state.current_epoch
 
   // ------------------------------------------------------------------------
   // --   Internal functions

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -19,10 +19,10 @@ payable contract StakingValidator =
       reward_callback : option(RewardCallbackI)
     }
 
-  entrypoint init(main_staking_ct : MainStakingI, owner : address) =
+  entrypoint init(main_staking_ct : MainStakingI, owner : address, signing_key : address) =
     { main_staking_ct = main_staking_ct,
       owner           = owner,
-      signing_key     = owner,
+      signing_key     = signing_key,
       reward_callback = None }
 
   payable stateful entrypoint deposit() =

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -60,8 +60,9 @@ payable contract StakingValidator =
   entrypoint rewards(epoch : int, amount : int, restaked : bool) =
     assert_main_staking_caller()
     switch(state.reward_callback)
-      None => ()
-      Some(cb_ct) => cb_ct.reward_cb(epoch, amount, restaked)
+      None => None
+      Some(cb_ct) => cb_ct.reward_cb(protected = true, gas = 20000, epoch, amount, restaked)
+    ()
 
   function assert_owner_caller() =
     require(Call.caller == state.owner, "Only contract owner allowed")

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -1,3 +1,5 @@
+include "Option.aes"
+
 contract interface RewardCallbackI =
   entrypoint reward_cb : (int, int, bool) => unit
 
@@ -6,9 +8,12 @@ contract interface MainStakingI =
   payable entrypoint stake            : () => unit
   entrypoint adjust_stake             : (int) => unit
   entrypoint withdraw                 : (int) => unit
+  entrypoint set_restake              : (bool) => unit
+  entrypoint get_restake              : () => bool
   entrypoint get_staked_amount        : (int) => int
   entrypoint get_available_balance    : () => int
   entrypoint get_total_balance        : () => int
+  entrypoint get_current_epoch        : () => int
   entrypoint register_reward_callback : (RewardCallbackI) => unit
 
 payable contract StakingValidator =
@@ -44,6 +49,13 @@ payable contract StakingValidator =
     state.main_staking_ct.withdraw(amount)
     Chain.spend(Call.caller, amount)
 
+  entrypoint set_restake(restake : bool) =
+    assert_owner_caller()
+    state.main_staking_ct.set_restake(restake)
+
+  entrypoint get_restake() : bool =
+    state.main_staking_ct.get_restake()
+
   entrypoint get_staked_amount(epoch : int) =
     state.main_staking_ct.get_staked_amount(epoch)
 
@@ -63,6 +75,12 @@ payable contract StakingValidator =
       None => None
       Some(cb_ct) => cb_ct.reward_cb(protected = true, gas = 20000, epoch, amount, restaked)
     ()
+
+  entrypoint has_reward_callback() =
+    Option.is_some(state.reward_callback)
+
+  entrypoint get_current_epoch() =
+    state.main_staking_ct.get_current_epoch()
 
   function assert_owner_caller() =
     require(Call.caller == state.owner, "Only contract owner allowed")


### PR DESCRIPTION
- Pinning reward should be part of the staking reward flow
- Stake should be recorded (and enforced/locked) on a per-epoch basis
- To facilitate for the StakingValidator owner being a contract, we need a separate field for the block signing key
- The callback function should be restricted, both with protected = true and a gas limit (the exact limit could be discussed…)
- Add the ability to change the auto re-stake setting
- Cache epoch info in MainStaking + getter
- Function to check if callback is defined in `StakingValidator`
- Rudimentary tests

Implements #4506

This PR is supported by the Æternity Foundation