### PR TITLE
Add getters for validator_min_stake

### DIFF
--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -93,6 +93,9 @@ main contract MainStaking =
   entrypoint get_total_balance_(v : address) =
     state.validators[v].total_balance
 
+  entrypoint get_validator_min_stake() =
+    state.validator_min_stake
+
   // ------------------------------------------------------------------------
   // -- Called from HCElection and/or consensus logic
   // ------------------------------------------------------------------------

--- a/test/contracts/StakingValidator.aes
+++ b/test/contracts/StakingValidator.aes
@@ -15,6 +15,7 @@ contract interface MainStakingI =
   entrypoint get_total_balance        : () => int
   entrypoint get_current_epoch        : () => int
   entrypoint register_reward_callback : (RewardCallbackI) => unit
+  entrypoint get_validator_min_stake  : () => int
 
 payable contract StakingValidator =
   record state =
@@ -87,3 +88,6 @@ payable contract StakingValidator =
 
   function assert_main_staking_caller() =
     require(Call.caller == state.main_staking_ct.address, "Only main staking contract allowed")
+
+  entrypoint get_validator_min_stake() =
+    state.main_staking_ct.get_validator_min_stake()


### PR DESCRIPTION
for delegated staking, staking apps etc., this getter is needed. 

This PR is supported by the aeternity Foundation.