### PR TITLE
added missing "default_pinning_behavior" config schema entry

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1748,6 +1748,11 @@
                                             "default": 0,
                                             "type": "integer"
                                         },
+                                        "default_pinning_behavior": {
+                                            "description": "Use the default pinning behavior, where in each epoch, if the last leader has defined pinning/parent chain credentials, they will pin",
+                                            "default": false,
+                                            "type": "boolean"
+                                        },
                                         "fixed_coinbase": {
                                             "type": "integer",
                                             "default": 0,


### PR DESCRIPTION
Quick fix to add missing config schema for `default_pinning_behavior`

This PR is supported by the Aeternity Foundation