### PR TITLE
Parent connector pinning refac

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -137,7 +137,7 @@ start(Config, _) ->
     start_dependency(aec_parent_chain_cache, [StartHeight, RetryInterval,
                                               fun target_parent_heights/1, %% prefetch the next parent block
                                               CacheSize, Confirmations]),
-    start_dependency(aec_pinning_agent, [get_contract_pubkey(?ELECTION_CONTRACT), default_pinning_behavior()]),
+    start_dependency(aec_pinning_agent, [get_contract_pubkey(?ELECTION_CONTRACT), default_pinning_behavior(), SignModule]),
     ok.
 
 start_btc(StakersEncoded, ParentConnMod) ->

--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -44,17 +44,17 @@
         get_parent_chain_type/0,
         %% Pinning
         pin_to_pc/3,
-        pin_tx_to_cc/4,
+        %pin_tx_to_cc/4,
         pin_contract_call/5,
         get_pinning_data/0,
         create_pin_tx/5,
         post_pin_tx/1,
         get_pin_by_tx_hash/1,
-        encode_parent_pin_payload/1,
-        decode_parent_pin_payload/1,
-        encode_child_pin_payload/1,
-        decode_child_pin_payload/1,
-        is_pin/1,
+        % encode_parent_pin_payload/1,
+        % decode_parent_pin_payload/1,
+        % encode_child_pin_payload/1,
+        % decode_child_pin_payload/1,
+        % is_pin/1,
         find_spends_to/1,
         has_parent_account/1
         ]).
@@ -160,8 +160,8 @@ get_pinning_data() ->
 pin_to_pc(Who, Amount, Fee) ->
     gen_server:call(?SERVER, {pin_to_pc, Who, Amount, Fee}).
 
-pin_tx_to_cc(PinTx, Who, Amount, Fee) ->
-    gen_server:call(?SERVER, {pin_tx_to_cc, PinTx, Who, Amount, Fee}).
+% pin_tx_to_cc(PinTx, Who, Amount, Fee) ->
+%     gen_server:call(?SERVER, {pin_tx_to_cc, PinTx, Who, Amount, Fee}).
 
 pin_contract_call(Contract, PinTx, Who, Amount, Fee) ->
     gen_server:call(?SERVER, {pin_contract_call, Contract, PinTx, Who, Amount, Fee}).
@@ -177,17 +177,17 @@ post_pin_tx(Tx) ->
 get_pin_by_tx_hash(TxHash) ->
     gen_server:call(?SERVER, {get_pin_by_tx_hash, TxHash}).
 
-encode_parent_pin_payload(Pin) ->
-    gen_server:call(?SERVER, {encode_parent_pin_payload, Pin}).
+% encode_parent_pin_payload(Pin) ->
+%     gen_server:call(?SERVER, {encode_parent_pin_payload, Pin}).
 
-decode_parent_pin_payload(PinPayload) ->
-    gen_server:call(?SERVER, {decode_parent_pin_payload, PinPayload}).
+% decode_parent_pin_payload(PinPayload) ->
+%     gen_server:call(?SERVER, {decode_parent_pin_payload, PinPayload}).
 
-encode_child_pin_payload(TxHash) ->
-    gen_server:call(?SERVER, {encode_child_pin_payload, TxHash}).
+% encode_child_pin_payload(TxHash) ->
+%     gen_server:call(?SERVER, {encode_child_pin_payload, TxHash}).
 
-decode_child_pin_payload(TxHash) ->
-    gen_server:call(?SERVER, {decode_child_pin_payload, TxHash}).
+% decode_child_pin_payload(TxHash) ->
+%     gen_server:call(?SERVER, {decode_child_pin_payload, TxHash}).
 
 has_parent_account(Account) ->
     gen_server:call(?SERVER, {has_parent_account, Account}).
@@ -236,14 +236,14 @@ handle_call({pin_to_pc, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, 
         false -> {error, {no_pc_account_for_staker, Who}}
     end,
     {reply, Reply, State};
-handle_call({pin_tx_to_cc, PinTx, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, sign_module = SignModule} = State) ->
-    lager:debug("In here?",[]),
-    Reply = case SignModule:is_key_present(Who) of
-        true ->
-            Mod:pin_tx_to_cc(PinTx, Who, Amount, Fee, SignModule);
-        false -> {error, {no_cc_account_for_staker, Who}} % Could this actually happen????
-    end,
-    {reply, Reply, State};
+% handle_call({pin_tx_to_cc, PinTx, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, sign_module = SignModule} = State) ->
+%     lager:debug("In here?",[]),
+%     Reply = case SignModule:is_key_present(Who) of
+%         true ->
+%             Mod:pin_tx_to_cc(PinTx, Who, Amount, Fee, SignModule);
+%         false -> {error, {no_cc_account_for_staker, Who}} % Could this actually happen????
+%     end,
+%     {reply, Reply, State};
 handle_call({pin_contract_call, Contract, PinTx, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, sign_module = SignModule} = State) ->
     Reply =  Mod:pin_contract_call(Contract, PinTx, Who, Amount, Fee, SignModule),
     {reply, Reply, State};
@@ -258,21 +258,21 @@ handle_call({post_pin_tx, Tx}, _From, #state{parent_conn_mod = Mod, parent_hosts
 handle_call({get_pin_by_tx_hash, Tx}, _From, #state{parent_conn_mod = Mod, parent_hosts = ParentHosts} = State) ->
     Reply = handle_parent_pin_calls(Mod, get_pin_by_tx_hash, Tx, ParentHosts),
     {reply, Reply, State};
-handle_call({encode_parent_pin_payload, Pin}, _From, #state{parent_conn_mod = Mod} = State) ->
-    Reply = handle_conn_mod_calls(Mod, encode_parent_pin_payload, Pin),
-    {reply, Reply, State};
-handle_call({decode_parent_pin_payload, PinPayload}, _From, #state{parent_conn_mod = Mod} = State) ->
-    Reply = handle_conn_mod_calls(Mod, decode_parent_pin_payload, PinPayload),
-    {reply, Reply, State};
-handle_call({encode_child_pin_payload, TxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
-    Reply = handle_conn_mod_calls(Mod, encode_child_pin_payload, TxHash),
-    {reply, Reply, State};
-handle_call({decode_child_pin_payload, EncTxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
-    Reply = handle_conn_mod_calls(Mod, decode_child_pin_payload, EncTxHash),
-    {reply, Reply, State};
-handle_call({is_pin, EncTxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
-    Reply = handle_conn_mod_calls(Mod, is_pin, EncTxHash),
-    {reply, Reply, State};
+% handle_call({encode_parent_pin_payload, Pin}, _From, #state{parent_conn_mod = Mod} = State) ->
+%     Reply = handle_conn_mod_calls(Mod, encode_parent_pin_payload, Pin),
+%     {reply, Reply, State};
+% handle_call({decode_parent_pin_payload, PinPayload}, _From, #state{parent_conn_mod = Mod} = State) ->
+%     Reply = handle_conn_mod_calls(Mod, decode_parent_pin_payload, PinPayload),
+%     {reply, Reply, State};
+% handle_call({encode_child_pin_payload, TxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
+%     Reply = handle_conn_mod_calls(Mod, encode_child_pin_payload, TxHash),
+%     {reply, Reply, State};
+% handle_call({decode_child_pin_payload, EncTxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
+%     Reply = handle_conn_mod_calls(Mod, decode_child_pin_payload, EncTxHash),
+%     {reply, Reply, State};
+% handle_call({is_pin, EncTxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
+%     Reply = handle_conn_mod_calls(Mod, is_pin, EncTxHash),
+%     {reply, Reply, State};
 handle_call({has_parent_account, Account}, _From, #state{hcpc = HCPCMap} = State) ->
     Reply = maps:is_key(Account, HCPCMap),
     {reply, Reply, State};
@@ -435,8 +435,8 @@ handle_fetch_block(Fun, Arg,
 
 
 
-is_pin(Pin) ->
-    gen_server:call(?SERVER, {is_pin, Pin}).
+% is_pin(Pin) ->
+%     gen_server:call(?SERVER, {is_pin, Pin}).
 
 % PINREFAC is this (aec_p_c) the correct place for this and the following CC pin related ones?
 get_pinning_data_(Mod, NetworkID) ->
@@ -453,7 +453,7 @@ get_pinning_data_(Mod, NetworkID) ->
         {ok, #{epoch             => PrevEpoch,
                height            => Height,
                block_hash        => BlockHash,
-               parent_payload    => Mod:encode_parent_pin_payload(#{epoch => PrevEpoch, height => Height, block_hash => BlockHash}),
+               parent_payload    => aeser_api_encoder:encode_parent_pin_payload(#{epoch => PrevEpoch, height => Height, block_hash => BlockHash}),
                last_leader       => Leader,
                parent_type       => ChainType,
                parent_network_id => NetworkID}};
@@ -473,6 +473,12 @@ pick_pin_spends_to(Account, Txs) ->
     InnerTxs = [ aetx:specialize_type(Tx) || Tx <- BareTxs,  spend_tx == aetx:tx_type(Tx)],
     [ aec_spend_tx:payload(T) || {_, T} <- InnerTxs, aeser_id:specialize(aec_spend_tx:recipient_id(T)) == {account,Account}, is_pin(aec_spend_tx:payload(T))].
 
+
+is_pin(Pin) ->
+    case aeser_api_encoder:decode_child_pin_payload(Pin) of
+        {error,_} -> false;
+        _ -> true
+    end.
 %% handle (pin) calls to the parent connector module and ensure we don't throw anything
 %% FUTURE Should be reasonably easy to loop over NodeSpecs until one call suceeds.
 %%        For now, we just pick the first one.

--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -148,7 +148,7 @@ get_pinning_data() ->
     gen_server:call(?SERVER, get_pinning_data).
 
 %%=============================================================================
-%% Pinn the last block of the previous epoch to the parent chain, using the
+%% Pin the last block of the previous epoch to the parent chain, using the
 %% parent chain account associated with the provided staker pubkey. Returns the
 %% parent chain TX hash (if TX is finalized on the parent chain, it will be
 %% featchable using pet_pin_by_tx_hash/1).

--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -45,10 +45,10 @@
         %% Pinning
         pin_to_pc/3,
         %pin_tx_to_cc/4,
-        pin_contract_call/5,
+        %pin_contract_call/5,
         get_pinning_data/0,
-        create_pin_tx/5,
-        post_pin_tx/1,
+        %create_pin_tx/5,
+        %post_pin_tx/1,
         get_pin_by_tx_hash/1,
         % encode_parent_pin_payload/1,
         % decode_parent_pin_payload/1,
@@ -163,16 +163,16 @@ pin_to_pc(Who, Amount, Fee) ->
 % pin_tx_to_cc(PinTx, Who, Amount, Fee) ->
 %     gen_server:call(?SERVER, {pin_tx_to_cc, PinTx, Who, Amount, Fee}).
 
-pin_contract_call(Contract, PinTx, Who, Amount, Fee) ->
-    gen_server:call(?SERVER, {pin_contract_call, Contract, PinTx, Who, Amount, Fee}).
+% pin_contract_call(Contract, PinTx, Who, Amount, Fee) ->
+%     gen_server:call(?SERVER, {pin_contract_call, Contract, PinTx, Who, Amount, Fee}).
 
 
--spec create_pin_tx(binary(), binary(), integer(), integer(), binary()) -> aetx:tx().
-create_pin_tx(SenderEnc, ReceiverPubkey, Amount, Fee, PinningData) ->
-    gen_server:call(?SERVER, {create_pin_tx, SenderEnc, ReceiverPubkey, Amount, Fee, PinningData}).
+% -spec create_pin_tx(binary(), binary(), integer(), integer(), binary()) -> aetx:tx().
+% create_pin_tx(SenderEnc, ReceiverPubkey, Amount, Fee, PinningData) ->
+%     gen_server:call(?SERVER, {create_pin_tx, SenderEnc, ReceiverPubkey, Amount, Fee, PinningData}).
 
-post_pin_tx(Tx) ->
-    gen_server:call(?SERVER, {post_pin_tx, Tx}).
+% post_pin_tx(Tx) ->
+%     gen_server:call(?SERVER, {post_pin_tx, Tx}).
 
 get_pin_by_tx_hash(TxHash) ->
     gen_server:call(?SERVER, {get_pin_by_tx_hash, TxHash}).
@@ -247,11 +247,11 @@ handle_call({pin_to_pc, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, 
 handle_call({pin_contract_call, Contract, PinTx, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, sign_module = SignModule} = State) ->
     Reply =  Mod:pin_contract_call(Contract, PinTx, Who, Amount, Fee, SignModule),
     {reply, Reply, State};
-handle_call({create_pin_tx, SenderEnc, ReceiverPubkey, Amount, Fee, PinningData},
-             _From,
-             #state{parent_conn_mod = Mod, parent_hosts = ParentHosts} = State) ->
-    Reply = handle_parent_pin_calls(Mod, create_pin_tx, {SenderEnc, ReceiverPubkey, Amount, Fee, PinningData}, ParentHosts),
-    {reply, Reply, State};
+% handle_call({create_pin_tx, SenderEnc, ReceiverPubkey, Amount, Fee, PinningData},
+%              _From,
+%              #state{parent_conn_mod = Mod, parent_hosts = ParentHosts} = State) ->
+%     Reply = handle_parent_pin_calls(Mod, create_pin_tx, {SenderEnc, ReceiverPubkey, Amount, Fee, PinningData}, ParentHosts),
+%     {reply, Reply, State};
 handle_call({post_pin_tx, Tx}, _From, #state{parent_conn_mod = Mod, parent_hosts = ParentHosts} = State) ->
     Reply = handle_parent_pin_calls(Mod, post_pin_tx, Tx, ParentHosts),
     {reply, Reply, State};

--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -44,18 +44,8 @@
         get_parent_chain_type/0,
         %% Pinning
         pin_to_pc/3,
-        %pin_tx_to_cc/4,
-        %pin_contract_call/5,
         get_pinning_data/0,
-        %create_pin_tx/5,
-        %post_pin_tx/1,
         get_pin_by_tx_hash/1,
-        % encode_parent_pin_payload/1,
-        % decode_parent_pin_payload/1,
-        % encode_child_pin_payload/1,
-        % decode_child_pin_payload/1,
-        % is_pin/1,
-        find_spends_to/1,
         has_parent_account/1
         ]).
 
@@ -157,37 +147,17 @@ get_parent_chain_type() ->
 get_pinning_data() ->
     gen_server:call(?SERVER, get_pinning_data).
 
+%%=============================================================================
+%% Pinn the last block of the previous epoch to the parent chain, using the
+%% parent chain account associated with the provided staker pubkey. Returns the
+%% parent chain TX hash (if TX is finalized on the parent chain, it will be
+%% featchable using pet_pin_by_tx_hash/1).
+%%=============================================================================
 pin_to_pc(Who, Amount, Fee) ->
     gen_server:call(?SERVER, {pin_to_pc, Who, Amount, Fee}).
 
-% pin_tx_to_cc(PinTx, Who, Amount, Fee) ->
-%     gen_server:call(?SERVER, {pin_tx_to_cc, PinTx, Who, Amount, Fee}).
-
-% pin_contract_call(Contract, PinTx, Who, Amount, Fee) ->
-%     gen_server:call(?SERVER, {pin_contract_call, Contract, PinTx, Who, Amount, Fee}).
-
-
-% -spec create_pin_tx(binary(), binary(), integer(), integer(), binary()) -> aetx:tx().
-% create_pin_tx(SenderEnc, ReceiverPubkey, Amount, Fee, PinningData) ->
-%     gen_server:call(?SERVER, {create_pin_tx, SenderEnc, ReceiverPubkey, Amount, Fee, PinningData}).
-
-% post_pin_tx(Tx) ->
-%     gen_server:call(?SERVER, {post_pin_tx, Tx}).
-
 get_pin_by_tx_hash(TxHash) ->
     gen_server:call(?SERVER, {get_pin_by_tx_hash, TxHash}).
-
-% encode_parent_pin_payload(Pin) ->
-%     gen_server:call(?SERVER, {encode_parent_pin_payload, Pin}).
-
-% decode_parent_pin_payload(PinPayload) ->
-%     gen_server:call(?SERVER, {decode_parent_pin_payload, PinPayload}).
-
-% encode_child_pin_payload(TxHash) ->
-%     gen_server:call(?SERVER, {encode_child_pin_payload, TxHash}).
-
-% decode_child_pin_payload(TxHash) ->
-%     gen_server:call(?SERVER, {decode_child_pin_payload, TxHash}).
 
 has_parent_account(Account) ->
     gen_server:call(?SERVER, {has_parent_account, Account}).
@@ -236,43 +206,9 @@ handle_call({pin_to_pc, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, 
         false -> {error, {no_pc_account_for_staker, Who}}
     end,
     {reply, Reply, State};
-% handle_call({pin_tx_to_cc, PinTx, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, sign_module = SignModule} = State) ->
-%     lager:debug("In here?",[]),
-%     Reply = case SignModule:is_key_present(Who) of
-%         true ->
-%             Mod:pin_tx_to_cc(PinTx, Who, Amount, Fee, SignModule);
-%         false -> {error, {no_cc_account_for_staker, Who}} % Could this actually happen????
-%     end,
-%     {reply, Reply, State};
-handle_call({pin_contract_call, Contract, PinTx, Who, Amount, Fee}, _From, #state{parent_conn_mod = Mod, sign_module = SignModule} = State) ->
-    Reply =  Mod:pin_contract_call(Contract, PinTx, Who, Amount, Fee, SignModule),
-    {reply, Reply, State};
-% handle_call({create_pin_tx, SenderEnc, ReceiverPubkey, Amount, Fee, PinningData},
-%              _From,
-%              #state{parent_conn_mod = Mod, parent_hosts = ParentHosts} = State) ->
-%     Reply = handle_parent_pin_calls(Mod, create_pin_tx, {SenderEnc, ReceiverPubkey, Amount, Fee, PinningData}, ParentHosts),
-%     {reply, Reply, State};
-handle_call({post_pin_tx, Tx}, _From, #state{parent_conn_mod = Mod, parent_hosts = ParentHosts} = State) ->
-    Reply = handle_parent_pin_calls(Mod, post_pin_tx, Tx, ParentHosts),
-    {reply, Reply, State};
 handle_call({get_pin_by_tx_hash, Tx}, _From, #state{parent_conn_mod = Mod, parent_hosts = ParentHosts} = State) ->
     Reply = handle_parent_pin_calls(Mod, get_pin_by_tx_hash, Tx, ParentHosts),
     {reply, Reply, State};
-% handle_call({encode_parent_pin_payload, Pin}, _From, #state{parent_conn_mod = Mod} = State) ->
-%     Reply = handle_conn_mod_calls(Mod, encode_parent_pin_payload, Pin),
-%     {reply, Reply, State};
-% handle_call({decode_parent_pin_payload, PinPayload}, _From, #state{parent_conn_mod = Mod} = State) ->
-%     Reply = handle_conn_mod_calls(Mod, decode_parent_pin_payload, PinPayload),
-%     {reply, Reply, State};
-% handle_call({encode_child_pin_payload, TxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
-%     Reply = handle_conn_mod_calls(Mod, encode_child_pin_payload, TxHash),
-%     {reply, Reply, State};
-% handle_call({decode_child_pin_payload, EncTxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
-%     Reply = handle_conn_mod_calls(Mod, decode_child_pin_payload, EncTxHash),
-%     {reply, Reply, State};
-% handle_call({is_pin, EncTxHash}, _From, #state{parent_conn_mod = Mod} = State) ->
-%     Reply = handle_conn_mod_calls(Mod, is_pin, EncTxHash),
-%     {reply, Reply, State};
 handle_call({has_parent_account, Account}, _From, #state{hcpc = HCPCMap} = State) ->
     Reply = maps:is_key(Account, HCPCMap),
     {reply, Reply, State};
@@ -433,11 +369,6 @@ handle_fetch_block(Fun, Arg,
     end.
 
 
-
-
-% is_pin(Pin) ->
-%     gen_server:call(?SERVER, {is_pin, Pin}).
-
 % PINREFAC is this (aec_p_c) the correct place for this and the following CC pin related ones?
 get_pinning_data_(Mod, NetworkID) ->
     {ok, #{epoch := Epoch,
@@ -453,7 +384,7 @@ get_pinning_data_(Mod, NetworkID) ->
         {ok, #{epoch             => PrevEpoch,
                height            => Height,
                block_hash        => BlockHash,
-               parent_payload    => aeser_api_encoder:encode_parent_pin_payload(#{epoch => PrevEpoch, height => Height, block_hash => BlockHash}),
+               parent_payload    => aeser_hc:encode_parent_pin_payload(#{epoch => PrevEpoch, height => Height, block_hash => BlockHash}),
                last_leader       => Leader,
                parent_type       => ChainType,
                parent_network_id => NetworkID}};
@@ -462,23 +393,6 @@ get_pinning_data_(Mod, NetworkID) ->
           {error, last_leader_unknown}
     end.
 
-find_spends_to(Account) ->
-    {ok, #{last := Last, first := First}} = aec_chain_hc:epoch_info(),
-    Blocks = aec_chain_hc:get_micro_blocks_between(First, Last-1),
-    lists:flatten([ pick_pin_spends_to(Account, aec_blocks:txs(B)) || B <- Blocks ]).
-
-
-pick_pin_spends_to(Account, Txs) ->
-    BareTxs = [ aetx_sign:tx(T) || T <- Txs],
-    InnerTxs = [ aetx:specialize_type(Tx) || Tx <- BareTxs,  spend_tx == aetx:tx_type(Tx)],
-    [ aec_spend_tx:payload(T) || {_, T} <- InnerTxs, aeser_id:specialize(aec_spend_tx:recipient_id(T)) == {account,Account}, is_pin(aec_spend_tx:payload(T))].
-
-
-is_pin(Pin) ->
-    case aeser_api_encoder:decode_child_pin_payload(Pin) of
-        {error,_} -> false;
-        _ -> true
-    end.
 %% handle (pin) calls to the parent connector module and ensure we don't throw anything
 %% FUTURE Should be reasonably easy to loop over NodeSpecs until one call suceeds.
 %%        For now, we just pick the first one.

--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -151,7 +151,7 @@ get_pinning_data() ->
 %% Pin the last block of the previous epoch to the parent chain, using the
 %% parent chain account associated with the provided staker pubkey. Returns the
 %% parent chain TX hash (if TX is finalized on the parent chain, it will be
-%% featchable using pet_pin_by_tx_hash/1).
+%% fetchable using get_pin_by_tx_hash/1).
 %%=============================================================================
 pin_to_pc(Who, Amount, Fee) ->
     gen_server:call(?SERVER, {pin_to_pc, Who, Amount, Fee}).

--- a/apps/aecore/src/aec_parent_connector.erl
+++ b/apps/aecore/src/aec_parent_connector.erl
@@ -407,12 +407,3 @@ handle_parent_pin_calls(Mod, Fun, Args, NodeSpecs) ->
             {error, Err}
     end.
 
-handle_conn_mod_calls(Mod, Fun, Args) ->
-    try
-        Mod:Fun(Args)
-    catch
-        Type:Err ->
-            lager:debug("PINNING: caught bad connector call: ~p :  ~p", [Type, Err]),
-            {error, Err}
-    end.
-

--- a/apps/aecore/src/aec_pinning_agent.erl
+++ b/apps/aecore/src/aec_pinning_agent.erl
@@ -178,7 +178,7 @@ create_pin_tx_({SenderPubkey, ReceiverPubkey, Nonce, Amount, Fee, PinPayload}) -
                 amount       => Amount,
                 fee          => Fee,
                 nonce        => Nonce,
-                payload      => PinPayload},
+                payload      => aeser_hc:encode_child_pin_payload(PinPayload)},
     {ok, SpendTx} = aec_spend_tx:new(TxArgs),
     SpendTx.
 
@@ -220,7 +220,7 @@ pick_pin_spends_to(Account, Txs) ->
 
 
 is_pin(Pin) ->
-    case aeser_api_encoder:decode_child_pin_payload(Pin) of
+    case aeser_hc:decode_child_pin_payload(Pin) of
         {error,_} -> false;
         _ -> true
     end.

--- a/apps/aecore/src/aec_pinning_agent.erl
+++ b/apps/aecore/src/aec_pinning_agent.erl
@@ -207,23 +207,24 @@ pin_contract_call(ContractPubkey, PinTx, Who, Amount, _Fee, SignModule) ->
     SignedCallTx = sign_tx(Tx, NetworkId, Who, SignModule),
     aec_tx_pool:push(SignedCallTx, tx_received).
 
-find_spends_to(Account) ->
-    {ok, #{last := Last, first := First}} = aec_chain_hc:epoch_info(),
-    Blocks = aec_chain_hc:get_micro_blocks_between(First, Last-1),
-    lists:flatten([ pick_pin_spends_to(Account, aec_blocks:txs(B)) || B <- Blocks ]).
+%% below code will be enabled in later PR
+% find_spends_to(Account) ->
+%     {ok, #{last := Last, first := First}} = aec_chain_hc:epoch_info(),
+%     Blocks = aec_chain_hc:get_micro_blocks_between(First, Last-1),
+%     lists:flatten([ pick_pin_spends_to(Account, aec_blocks:txs(B)) || B <- Blocks ]).
 
 
-pick_pin_spends_to(Account, Txs) ->
-    BareTxs = [ aetx_sign:tx(T) || T <- Txs],
-    InnerTxs = [ aetx:specialize_type(Tx) || Tx <- BareTxs,  spend_tx == aetx:tx_type(Tx)],
-    [ aec_spend_tx:payload(T) || {_, T} <- InnerTxs, aeser_id:specialize(aec_spend_tx:recipient_id(T)) == {account,Account}, is_pin(aec_spend_tx:payload(T))].
+% pick_pin_spends_to(Account, Txs) ->
+%     BareTxs = [ aetx_sign:tx(T) || T <- Txs],
+%     InnerTxs = [ aetx:specialize_type(Tx) || Tx <- BareTxs,  spend_tx == aetx:tx_type(Tx)],
+%     [ aec_spend_tx:payload(T) || {_, T} <- InnerTxs, aeser_id:specialize(aec_spend_tx:recipient_id(T)) == {account,Account}, is_pin(aec_spend_tx:payload(T))].
 
 
-is_pin(Pin) ->
-    case aeser_hc:decode_child_pin_payload(Pin) of
-        {error,_} -> false;
-        _ -> true
-    end.
+% is_pin(Pin) ->
+%     case aeser_hc:decode_child_pin_payload(Pin) of
+%         {error,_} -> false;
+%         _ -> true
+%     end.
 
 
 min_gas_price() ->

--- a/apps/aehttp/src/aehttpc.erl
+++ b/apps/aehttp/src/aehttpc.erl
@@ -36,6 +36,12 @@
 -callback get_chain_type() ->
     {ok, chain()}.
 
+-callback pin_to_pc({term(), hash(), non_neg_integer(), non_neg_integer(), term(), term()}, node_spec()) ->
+    binary() | {error, term()}.
+
+-callback get_pin_by_tx_hash(term(), node_spec()) ->
+    {ok, map()} | {error, term()}.
+
 -spec parse_node_url(string()) -> node_spec().
 parse_node_url(NodeURL) ->
     URIMap = uri_string:parse(NodeURL),

--- a/apps/aehttp/src/aehttpc_aeternity.erl
+++ b/apps/aehttp/src/aehttpc_aeternity.erl
@@ -11,7 +11,6 @@
          get_header_by_height/3,
          hash_to_integer/1,
          pin_to_pc/2,
-         pin_tx_to_cc/5,
          pin_contract_call/6,
          create_pin_tx/2,
          post_pin_tx/2,
@@ -180,12 +179,12 @@ pin_to_pc({PinningData, Who, Amount, Fee, NetworkId, SignModule}, NodeSpec) ->
     SignedSpendTx = sign_tx(SpendTx, NetworkId, Who, SignModule),
     post_pin_tx(SignedSpendTx, NodeSpec).
 
-pin_tx_to_cc(PinTxHash, Who, Amount, Fee, SignModule) ->
-    Nonce = get_local_nonce(Who),
-    SpendTx = create_pin_tx_({Who, Who, Nonce, Amount, Fee, PinTxHash}),
-    NetworkId = aec_governance:get_network_id(),
-    SignedSpendTx = sign_tx(SpendTx, NetworkId, Who, SignModule),
-    aec_tx_pool:push(SignedSpendTx, tx_received).
+% pin_tx_to_cc(PinTxHash, Who, Amount, Fee, SignModule) ->
+%     Nonce = get_local_nonce(Who),
+%     SpendTx = create_pin_tx_({Who, Who, Nonce, Amount, Fee, PinTxHash}),
+%     NetworkId = aec_governance:get_network_id(),
+%     SignedSpendTx = sign_tx(SpendTx, NetworkId, Who, SignModule),
+%     aec_tx_pool:push(SignedSpendTx, tx_received).
 
 sign_tx(Tx, NetworkId, Signer, SignModule) when is_binary(Signer) ->
     Bin0 = aetx:serialize_to_binary(Tx),

--- a/apps/aehttp/src/aehttpc_aeternity.erl
+++ b/apps/aehttp/src/aehttpc_aeternity.erl
@@ -11,15 +11,7 @@
          get_header_by_height/3,
          hash_to_integer/1,
          pin_to_pc/2,
-         %pin_contract_call/6,
-         %create_pin_tx/2,
-         %post_pin_tx/2,
          get_pin_by_tx_hash/2
-        %  encode_parent_pin_payload/1,
-        %  decode_parent_pin_payload/1,
-        %  encode_child_pin_payload/1,
-        %  decode_child_pin_payload/1,
-        %  is_pin/1
         ]).
 
 %% Util exports
@@ -111,46 +103,15 @@ get_generation_by_height(NodeSpec, Height) ->
 %%% Pinning
 %%%=============================================================================
 
-% -spec encode_parent_pin_payload(#{epoch => integer(), height => integer(), block_hash => binary()}) -> binary().
-% encode_parent_pin_payload(#{epoch := Epoch, height := Height, block_hash := BlockHash}) ->
-%     EpochHex = list_to_binary(erlang:integer_to_list(Epoch, 16)),
-%     HeightHex = list_to_binary(erlang:integer_to_list(Height, 16)),
-%     EncBlockHash = aeser_api_encoder:encode(key_block_hash, BlockHash),
-%     <<EpochHex/binary, ":", HeightHex/binary, " ", EncBlockHash/binary>>.
+pin_to_pc({PinningData, Who, Amount, Fee, NetworkId, SignModule}, NodeSpec) ->
+    PinPayload = aeser_hc:encode_parent_pin_payload(PinningData),
+    Nonce = get_pc_nonce(Who, NodeSpec),
+    SpendTx = create_pin_tx_(Who, Who, Nonce, Amount, Fee, PinPayload),
+    SignedSpendTx = sign_tx(SpendTx, NetworkId, Who, SignModule),
+    post_pin_tx(SignedSpendTx, NodeSpec).
 
-% %-spec decode_parent_pin_payload(binary()) -> #{epoch => integer(), height => integer(), block_hash => binary()}.
-% decode_parent_pin_payload(Binary) ->
-%     try
-%         [HexEpoch, HexHeight, EncBlockHash] = binary:split(Binary, [<<":">>, <<" ">>], [global]),
-%         Epoch = erlang:list_to_integer(binary_to_list(HexEpoch), 16),
-%         Height = erlang:list_to_integer(binary_to_list(HexHeight), 16),
-%         {ok, BlockHash} = aeser_api_encoder:safe_decode(key_block_hash, EncBlockHash),
-%         {ok, #{epoch => Epoch, height => Height, block_hash => BlockHash}}
-%     catch
-%         _ -> {error, {bad_parent_pin_payload, Binary}}
-%     end.
 
-% encode_child_pin_payload(TxHash) ->
-%     <<"pin", TxHash/binary>>.
-
-% decode_child_pin_payload(<<"pin", TxHash/binary>>) ->
-%     {ok, TxHash};
-% decode_child_pin_payload(BadTxHash) ->
-%     {error, {bad_child_pin_payload, BadTxHash}}.
-
-% is_pin(Pin) ->
-%     case decode_child_pin_payload(Pin) of
-%         {error,_} -> false;
-%         _ -> true
-%     end.
-
-% -spec create_pin_tx(binary(), binary(), binary(), integer(), integer(), binary()) -> aetx:tx().
-create_pin_tx({SenderPubkey, ReceiverPubkey, Amount, Fee, PinningData}, NodeSpec) ->
-    Nonce = get_pc_nonce(SenderPubkey, NodeSpec),
-    PinPayload = aeser_api_encoder:encode_parent_pin_payload(PinningData),
-    create_pin_tx_({SenderPubkey, ReceiverPubkey, Nonce, Amount, Fee, PinPayload}).
-
-create_pin_tx_({SenderPubkey, ReceiverPubkey, Nonce, Amount, Fee, PinPayload}) ->
+create_pin_tx_(SenderPubkey, ReceiverPubkey, Nonce, Amount, Fee, PinPayload) ->
     TxArgs = #{ sender_id    => aeser_id:create(account, SenderPubkey),
                 recipient_id => aeser_id:create(account, ReceiverPubkey),
                 amount       => Amount,
@@ -166,26 +127,6 @@ get_pc_nonce(Who, NodeSpec) ->
     {ok, #{<<"next_nonce">> := Nonce}} = get_request(NoncePath, NodeSpec, 5000),
     Nonce.
 
-% get_local_nonce(Who) ->
-%     case aec_next_nonce:pick_for_account(Who, max) of
-%         {ok, NextNonce} -> NextNonce;
-%         {error, account_not_found} -> 1
-%     end.
-
-pin_to_pc({PinningData, Who, Amount, Fee, NetworkId, SignModule}, NodeSpec) ->
-    PinPayload = aeser_api_encoder:encode_parent_pin_payload(PinningData),
-    Nonce = get_pc_nonce(Who, NodeSpec),
-    SpendTx = create_pin_tx_({Who, Who, Nonce, Amount, Fee, PinPayload}),
-    SignedSpendTx = sign_tx(SpendTx, NetworkId, Who, SignModule),
-    post_pin_tx(SignedSpendTx, NodeSpec).
-
-% pin_tx_to_cc(PinTxHash, Who, Amount, Fee, SignModule) ->
-%     Nonce = get_local_nonce(Who),
-%     SpendTx = create_pin_tx_({Who, Who, Nonce, Amount, Fee, PinTxHash}),
-%     NetworkId = aec_governance:get_network_id(),
-%     SignedSpendTx = sign_tx(SpendTx, NetworkId, Who, SignModule),
-%     aec_tx_pool:push(SignedSpendTx, tx_received).
-
 sign_tx(Tx, NetworkId, Signer, SignModule) when is_binary(Signer) ->
     Bin0 = aetx:serialize_to_binary(Tx),
     BinForNetwork = aec_governance:add_custom_network_id(NetworkId, Bin0),
@@ -197,47 +138,17 @@ post_pin_tx(SignedSpendTx, NodeSpec) ->
     Body = #{<<"tx">> => Transaction},
     Path = <<"/v3/transactions">>,
     {ok, #{<<"tx_hash">> := TxHash}} = post_request(Path, Body, NodeSpec, 5000),
-    %lager:debug("PINNING: wrote to PC tx hash: ~p", [TxHash]),
-    aeser_api_encoder:encode_child_pin_payload(TxHash).
+    TxHash.
 
-% pin_contract_call(ContractPubkey, PinTx, Who, Amount, _Fee, SignModule) ->
-%     Nonce = get_local_nonce(Who),
-%     {ok, CallData} = aeb_fate_abi:create_calldata("pin", [{bytes, PinTx}]),
-%     ABI = ?ABI_FATE_SOPHIA_1,
-%     TxSpec =
-%         #{ caller_id   => aeser_id:create(account, Who),
-%            nonce       => Nonce,
-%            contract_id => aeser_id:create(contract, ContractPubkey),
-%            abi_version => ABI,
-%            fee         => 1000000 * min_gas_price(),
-%            amount      => Amount,
-%            gas         => 1000000,
-%            gas_price   => min_gas_price(),
-%            call_data   => CallData },
-%     {ok, Tx} = aect_call_tx:new(TxSpec),
-%     NetworkId = aec_governance:get_network_id(),
-%     SignedCallTx = sign_tx(Tx, NetworkId, Who, SignModule),
-%     aec_tx_pool:push(SignedCallTx, tx_received).
-
-% min_gas_price() ->
-%     Protocol = aec_hard_forks:protocol_effective_at_height(1),
-%     max(aec_governance:minimum_gas_price(Protocol),
-%         aec_tx_pool:minimum_miner_gas_price()).
-
-get_pin_by_tx_hash(TxHashEnc, NodeSpec) ->
-    case aeser_api_encoder:decode_child_pin_payload(TxHashEnc) of
-         {error, _} -> {error, {bad_child_pin_tx_hash, TxHashEnc}};
-         {ok, TxHash} ->
-            TxPath = <<"/v3/transactions/", TxHash/binary>>,
-            case get_request(TxPath, NodeSpec, 5000) of
-                {ok, #{<<"tx">> := #{<<"payload">> := EncPin}, <<"block_height">> := Height}} ->
-                    {ok, Pin} = aeser_api_encoder:safe_decode(bytearray, EncPin),
-                    {ok, DecPin} = aeser_api_encoder:decode_parent_pin_payload(Pin),
-                    {ok, maps:put(pc_height, Height, DecPin)}; % add the pc block height to pin map, -1 = not on chain yet.
-                OtherErr -> {error, OtherErr}
-            end
+get_pin_by_tx_hash(TxHash, NodeSpec) ->
+    TxPath = <<"/v3/transactions/", TxHash/binary>>,
+    case get_request(TxPath, NodeSpec, 5000) of
+        {ok, #{<<"tx">> := #{<<"payload">> := EncPin}, <<"block_height">> := Height}} ->
+            {ok, Pin} = aeser_api_encoder:safe_decode(bytearray, EncPin),
+            {ok, DecPin} = aeser_hc:decode_parent_pin_payload(Pin),
+            {ok, maps:put(pc_height, Height, DecPin)}; % add the pc block height to pin map, -1 = not on chain yet.
+        OtherErr -> {error, OtherErr}
     end.
-
 
 get_request(Path, NodeSpec, Timeout) ->
     try
@@ -246,10 +157,8 @@ get_request(Path, NodeSpec, Timeout) ->
     Req = {UrlPath, []},
     HTTPOpt = [{timeout, Timeout}],
     Opt = [],
-    %% lager:debug("Req: ~p, with URL: ~ts", [Req, Url]),
     case httpc:request(get, Req, HTTPOpt, Opt) of
         {ok, {{_, 200 = _Code, _}, _, Res}} ->
-            %% lager:debug("Req: ~p, Res: ~p with URL: ~ts", [Req, Res, Url]),
             {ok, jsx:decode(list_to_binary(Res), [return_maps])};
         {ok, {{_, 404 = _Code, _}, _, "{\"reason\":\"Block not found\"}"}} ->
             {error, not_found};

--- a/apps/aehttp/src/aehttpc_aeternity.erl
+++ b/apps/aehttp/src/aehttpc_aeternity.erl
@@ -12,8 +12,8 @@
          hash_to_integer/1,
          pin_to_pc/2,
          %pin_contract_call/6,
-         create_pin_tx/2,
-         post_pin_tx/2,
+         %create_pin_tx/2,
+         %post_pin_tx/2,
          get_pin_by_tx_hash/2
         %  encode_parent_pin_payload/1,
         %  decode_parent_pin_payload/1,

--- a/apps/aehttp/src/aehttpc_btc.erl
+++ b/apps/aehttp/src/aehttpc_btc.erl
@@ -7,11 +7,10 @@
 -export([get_latest_block/2,
          get_header_by_hash/3,
          get_header_by_height/3,
-        %  get_commitment_tx_in_block/5,
-        %  get_commitment_tx_at_height/4,
-        %  post_commitment/8,
          hash_to_integer/1,
-         get_chain_type/0]).
+         get_chain_type/0,
+         pin_to_pc/2,
+         get_pin_by_tx_hash/2]).
 
 %% Temporary exports for keeping useful chain utils around
 -export([select_utxo/2,
@@ -67,6 +66,18 @@ hash_to_integer(Hash) ->
 
 get_chain_type() ->
     {ok, btc}.
+
+
+%%%=============================================================================
+%%% Pinning
+%%%=============================================================================
+
+pin_to_pc({_PinningData, _Who, _Amount, _Fee, _NetworkId, _SignModule}, _NodeSpec) ->
+    erlang:error(not_implemented).
+
+get_pin_by_tx_hash(_TxHash, _NodeSpec) ->
+    erlang:error(not_implemented).
+
 
 select_utxo([#{<<"spendable">> := true, <<"amount">> := Amount} = Unspent | _Us], Needed) when Amount >= Needed ->
     %% For now just pick first spendable UTXO with enough funds. There is no end to how fancy this can get

--- a/apps/aehttp/src/aehttpc_doge.erl
+++ b/apps/aehttp/src/aehttpc_doge.erl
@@ -7,11 +7,10 @@
 -export([get_latest_block/2,
          get_header_by_hash/3,
          get_header_by_height/3,
-        %  get_commitment_tx_in_block/5,
-        %  get_commitment_tx_at_height/4,
-        %  post_commitment/8,
          hash_to_integer/1,
-         get_chain_type/0]).
+         get_chain_type/0,
+         pin_to_pc/2,
+         get_pin_by_tx_hash/2]).
 
 %% Temporary exports for keeping useful chain utils around
 -export([select_utxo/2,
@@ -57,6 +56,17 @@ hash_to_integer(Hash) ->
 
 get_chain_type() ->
     {ok, doge}.
+
+%%%=============================================================================
+%%% Pinning
+%%%=============================================================================
+
+pin_to_pc({_PinningData, _Who, _Amount, _Fee, _NetworkId, _SignModule}, _NodeSpec) ->
+    erlang:error(not_implemented).
+
+get_pin_by_tx_hash(_TxHash, _NodeSpec) ->
+    erlang:error(not_implemented).
+
 
 % get_commitment_tx_in_block(NodeSpec, Seed, BlockHash, _PrevHash, ParentHCAccountPubKey) ->
 %     {ok, {_Height, _Hash, __PrevHash, Txs}}

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1008,7 +1008,7 @@ get_pin(Config) ->
     ?assertEqual(BH1Dec, IBH1),
 
     %% Verify that decoding function works on encoded payload:
-    {ok, DecodedPin} = rpc(Node, aec_parent_connector, decode_parent_pin_payload, [Payload]),
+    {ok, DecodedPin} = rpc(Node, aeser_api_encoder, decode_parent_pin_payload, [Payload]),
     ?assertEqual(#{epoch => PrevEpoch, height => Height1, block_hash => BH1Dec},
                  DecodedPin),
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -33,8 +33,6 @@
          check_blocktime/1,
          get_pin/1,
          wallet_post_pin_to_pc/1,
-         post_pin_to_pc/1,
-         last_leader_validates_pin_and_post_to_contract/1,
          get_contract_pubkeys/1,
          correct_leader_in_micro_block/1,
          first_leader_next_epoch/1,
@@ -189,8 +187,6 @@ groups() ->
             produce_first_epoch,
             get_pin,
             wallet_post_pin_to_pc
-            %post_pin_to_pc,
-            %last_leader_validates_pin_and_post_to_contract
         ]}
     , {default_pin, [sequence],
           [ start_two_child_nodes,
@@ -1011,7 +1007,7 @@ get_pin(Config) ->
     ?assertEqual(BH1Dec, IBH1),
 
     %% Verify that decoding function works on encoded payload:
-    {ok, DecodedPin} = rpc(Node, aeser_api_encoder, decode_parent_pin_payload, [Payload]),
+    {ok, DecodedPin} = rpc(Node, aeser_hc, decode_parent_pin_payload, [Payload]),
     ?assertEqual(#{epoch => PrevEpoch, height => Height1, block_hash => BH1Dec},
                  DecodedPin),
 
@@ -1036,54 +1032,6 @@ get_pin(Config) ->
     ?assertEqual(maps:get(last, EpochInfo1), Height2),
     {ok, IBH2} = rpc(?NODE1, aec_chain_state, get_key_block_hash_at_height, [Height2]),
     ?assertEqual(BH2Dec, IBH2),
-    ok.
-
-post_pin_to_pc(Config) ->
-    [{Node, _, _, _} | _] = ?config(nodes, Config),
-
-    %% Get to first block in new epoch
-    Height1 = rpc(Node, aec_chain, top_height, []),
-    {ok, #{last := Last1}} = rpc(Node, aec_chain_hc, epoch_info, []),
-    {ok, _} = produce_cc_blocks(Config, Last1 - Height1 + 1),
-    {ok, Pin} = rpc(Node, aec_parent_connector, get_pinning_data, []),
-    {ok, _} = produce_cc_blocks(Config, 5),
-
-    DwightPub = pubkey(?DWIGHT), % PC chain account
-    %DwightEnc = aeser_api_encoder:encode(account_pubkey, DwightPub),
-    {ok, []} = rpc(?PARENT_CHAIN_NODE, aec_tx_pool, peek, [infinity]), % no pending transactions
-    ct:log("DWIGHT: ~p ",[DwightPub]),
-    PinTx = rpc(Node, aec_parent_connector, create_pin_tx, [DwightPub, DwightPub, 1, 30000 * ?DEFAULT_GAS_PRICE, Pin]),
-    ct:log("PinTX: ~p", [PinTx]),
-    SignedPinTx = sign_tx(PinTx, privkey(?DWIGHT),?PARENT_CHAIN_NETWORK_ID),
-    EncTxHash = rpc(Node, aec_parent_connector, post_pin_tx, [SignedPinTx]),
-    {ok, [_]} = rpc(?PARENT_CHAIN_NODE, aec_tx_pool, peek, [infinity]), % one transaction pending now.
-    {ok, _} = produce_cc_blocks(Config, 5),
-    {ok, []} = rpc(?PARENT_CHAIN_NODE, aec_tx_pool, peek, [infinity]), % all transactions comitted
-
-    {ok, #{last := Last}} = rpc(Node, aec_chain_hc, epoch_info, []),
-
-    {ok, LastLeader} = rpc(Node, aec_consensus_hc, leader_for_height, [Last]),
-
-    NetworkId = ?config(network_id, Config), % TODO not 100% sure about this one...
-    Nonce = next_nonce(Node, pubkey(?ALICE)),
-    Params = #{ sender_id    => aeser_id:create(account, pubkey(?ALICE)),
-                recipient_id => aeser_id:create(account, LastLeader),
-                amount       => 1,
-                fee          => 30000 * ?DEFAULT_GAS_PRICE,
-                nonce        => Nonce,
-                payload      => EncTxHash},
-    ct:log("Preparing a spend tx: ~p", [Params]),
-    {ok, Tx} = aec_spend_tx:new(Params),
-    SignedTx = sign_tx(Tx, privkey(?ALICE), NetworkId),
-    ok = rpc(Node, aec_tx_pool, push, [SignedTx, tx_received]),
-    {ok, [_]} = rpc(Node, aec_tx_pool, peek, [infinity]), % transactions in pool
-    {ok, _} = produce_cc_blocks(Config, 1),
-    CH = rpc(Node, aec_chain, top_height, []),
-    {ok, []} = rpc(?PARENT_CHAIN_NODE, aec_tx_pool, peek, [infinity]), % all transactions comitted
-    DistToBeforeLast = Last - CH - 1,
-    {ok, _} = produce_cc_blocks(Config, DistToBeforeLast), % produce blocks until last
-    BL = Last - 1,
-    BL = rpc(Node, aec_chain, top_height, []), % we're producing in last black
     ok.
 
 %% A wallet posting a pin transaction by only using HTTP API towards Child and Parent
@@ -1157,141 +1105,6 @@ wallet_post_pin_to_pc(Config) ->
     {ok, _} = produce_cc_blocks(Config, CollectHeight - Height2),
     ok.
 
-last_leader_validates_pin_and_post_to_contract(Config) ->
-    [{Node, NodeName, _, _} | _] = ?config(nodes, Config),
-    %% 1. Correct pin is posted in the contract
-
-    #{cur_pin_reward := _Reward} = rpc(Node, aec_chain_hc , pin_reward_info, []),
-
-    %% move into next epoch
-    mine_to_next_epoch(Node, Config),
-    %% post pin to PC
-    {ok, PinningData} = rpc(Node, aec_parent_connector, get_pinning_data, []),
-    ct:log("Pinning data ~p", [PinningData]),
-    TxHash = pin_to_parent(Node, pubkey(?ALICE)),
-    %% post parent spend tx hash to CC
-    {ok, #{epoch  := _Epoch,
-           last   := Last,
-           length := _Length}} = rpc(Node, aec_chain_hc, epoch_info, []),
-    {ok, LastLeader} = rpc(Node, aec_consensus_hc, leader_for_height, [Last]),
-    tx_hash_to_child(Node, TxHash, ?ALICE, LastLeader, Config),
-    %% move forward to last block
-
-    mine_to_last_block_in_epoch(Node, Config),
-    % produce blocks until last
-
-    aecore_suite_utils:subscribe(NodeName, pin),
-    %% TODO test to see that LastLeader actually is leader now?
-
-    %% Find the first spend
-    % [FirstSpend|_] = rpc(Node, aec_parent_connector, find_spends_to, [LastLeader]),
-    % ct:log("First Spend: ~p", [FirstSpend]),
-
-    %% call contract with PC pin tx hash
-    %ok = pin_contract_call_tx(Config, FirstSpend, LastLeader),
-
-    {value, Account} = rpc(?NODE1, aec_chain, get_account, [LastLeader]),
-    ct:log("Leader Account: ~p", [Account]),
-
-    LeaderBalance1A = account_balance(LastLeader),
-    %% use get_pin_by_tx_hash to get the posted hash back and compare with actual keyblock (to test encoding decoding etc)
-    % {ok, #{epoch := _PinEpoch, height := PinHeight, block_hash := PinHash}} =
-    %     rpc(Node, aec_parent_connector, get_pin_by_tx_hash, [FirstSpend]),
-    % ?assertEqual({ok, PinHash}, rpc(Node, aec_chain_state, get_key_block_hash_at_height, [PinHeight])),
-
-    %% move into next epoch - trigger leader validation?
-    {ok, _} = produce_cc_blocks(Config, 2),
-    {ok, #{info := {pin_accepted, _}}} = wait_for_ps(pin),
-    LeaderBalance1B = account_balance(LastLeader),
-
-    ct:log("Account balance for leader was: ~p, is now: ~p", [LeaderBalance1A, LeaderBalance1B]),
-    % Any Reasonable way to do this test? Likely a bunch of rewards/fees etc have been awarded, although
-    % the above log clearly shows that 4711 (and a bunch more coin) was added.
-    % LeaderBalance0 = LeaderBalance1 - 4711,
-
-    aecore_suite_utils:unsubscribe(NodeName, pin),
-
-    %% 2. No pin is posted
-
-    % to end of (next) epoch
-    mine_to_last_block_in_epoch(Node, Config),
-
-    aecore_suite_utils:subscribe(NodeName, pin),
-
-    % In last generation, but we don't post pin
-
-    {ok, _} = produce_cc_blocks(Config, 2),
-    {ok, #{info := {no_proof_posted}}} = wait_for_ps(pin),
-
-    aecore_suite_utils:unsubscribe(NodeName, pin),
-
-    %% 3. Incorrect pin posted to contract a) bad tx hash
-
-    mine_to_last_block_in_epoch(Node, Config),
-
-    aecore_suite_utils:subscribe(NodeName, pin),
-
-    % post bad hash to contract
-
-    {ok, #{last := Last3}} = rpc(Node, aec_chain_hc, epoch_info, []),
-    {ok, LastLeader3} = rpc(Node, aec_consensus_hc, leader_for_height, [Last3]),
-    ok = pin_contract_call_tx(Config, <<"THIS IS A BAD TX HASH">>, LastLeader3),
-
-    {ok, _} = produce_cc_blocks(Config, 2),
-    {ok, #{info := {incorrect_proof_posted}}} = wait_for_ps(pin),
-
-    aecore_suite_utils:unsubscribe(NodeName, pin),
-
-    % post bad hash to contract
-    % {ok, #{last := Last4}} = rpc(Node, aec_chain_hc, epoch_info, []),
-    % {ok, LastLeader4} = rpc(Node, aec_consensus_hc, leader_for_height, [Last4]),
-
-    % LeaderBalance4A = account_balance(LastLeader4),
-    % ok = pin_contract_call_tx(Config, EncTxHash4, LastLeader4),
-
-    % {ok, _} = produce_cc_blocks(Config, 2),
-    % {ok, #{info := {incorrect_proof_posted}}} = wait_for_ps(pin),
-
-    % LeaderBalance4B = account_balance(LastLeader4),
-
-    % ct:log("Account balance for leader was: ~p, is now: ~p", [LeaderBalance4A, LeaderBalance4B]),
-    % See above for when a reward for pinning actually was given... Same problem here.
-    % LeaderBalance4A = LeaderBalance4B, % nothing was rewarded
-
-    aecore_suite_utils:unsubscribe(NodeName, pin),
-
-    %% 4. Bad height and then bad leader
-
-    EncTxHash5 = pin_to_parent(Node, pubkey(?ALICE)),
-
-    {ok, #{last := Last5}} = rpc(Node, aec_chain_hc, epoch_info, []),
-    {ok, LastLeader5} = rpc(Node, aec_consensus_hc, leader_for_height, [Last5]),
-
-    {ok, _} = produce_cc_blocks(Config, 1),
-
-    %% at the wrong height
-    ok = pin_contract_call_tx(Config, EncTxHash5, LastLeader5),
-
-    {ok, _} = produce_cc_blocks(Config, 1),
-    {ok, []} = rpc(Node, aec_tx_pool, peek, [infinity]), % transaction not in pool
-    %% check that no pin info was stored.
-    undefined = rpc(Node, aec_chain_hc, pin_info, []),
-
-    mine_to_last_block_in_epoch(Node, Config),
-
-    aecore_suite_utils:subscribe(NodeName, pin),
-
-    % post by wrong leader
-    NotLeader = hd([pubkey(?ALICE), pubkey(?BOB)] -- [LastLeader5]),
-    ok = pin_contract_call_tx(Config, EncTxHash5, NotLeader),
-
-    {ok, _} = produce_cc_blocks(Config, 2),
-    {ok, #{info := {no_proof_posted}}} = wait_for_ps(pin),
-
-    aecore_suite_utils:unsubscribe(NodeName, pin),
-
-    ok.
-
 check_default_pin(Config) ->
     [{Node, NodeName, _, _} | _] = ?config(nodes, Config),
 
@@ -1355,47 +1168,6 @@ mine_to_last_block_in_epoch(Node, Config) ->
     CH = rpc(Node, aec_chain, top_height, []),
     DistToBeforeLast = Last - CH - 1,
     {ok, _} = produce_cc_blocks(Config, DistToBeforeLast).
-
-bytes_literal(Bin) ->
-    [_, _ | PinLit] = binary_to_list(aeu_hex:hexstring_encode(Bin)),
-    "#" ++ PinLit.
-
-% PINREFAC
-pin_contract_call_tx(Config, PinProof, FromPubKey) ->
-    Tx = contract_call(?config(election_contract, Config), src(?HC_CONTRACT, Config),
-                       "pin", [bytes_literal(PinProof)], 0, FromPubKey),
-
-    NetworkId = ?config(network_id, Config),
-    SignedTx = sign_tx(Tx, privkey(who_by_pubkey(FromPubKey)), NetworkId),
-    rpc:call(?NODE1_NAME, aec_tx_pool, push, [SignedTx, tx_received]),
-    ok.
-
-% PINREFAC aec_parent_connector??
-pin_to_parent(Node, AccountPK) ->
-    rpc(Node, aec_parent_connector, pin_to_pc, [AccountPK, 1, 30000 * ?DEFAULT_GAS_PRICE]).
-    %AccPKEncEnc = aeser_api_encoder:encode(account_pubkey, AccountPK),
-    % {ok, []} = rpc(?PARENT_CHAIN_NODE, aec_tx_pool, peek, [infinity]), % no pending transactions
-    % PinTx = rpc(Node, aec_parent_connector, create_pin_tx, [AccountPK, AccountPK, 1, 30000 * ?DEFAULT_GAS_PRICE, PinningData]),
-    % SignedPinTx = sign_tx(PinTx, privkey(?DWIGHT),?PARENT_CHAIN_NETWORK_ID),
-    % rpc(Node, aec_parent_connector, post_pin_tx, [SignedPinTx]).
-
-% PINREFAC
-tx_hash_to_child(Node, EncTxHash, SendAccount, Leader, Config) ->
-    NodeName = aecore_suite_utils:node_name(Node),
-    NetworkId = ?config(network_id, Config),
-    Nonce = next_nonce(Node, pubkey(SendAccount)),
-    Params = #{ sender_id    => aeser_id:create(account, pubkey(SendAccount)),
-                recipient_id => aeser_id:create(account, Leader),
-                amount       => 1,
-                fee          => 30000 * ?DEFAULT_GAS_PRICE,
-                nonce        => Nonce,
-                payload      => EncTxHash},
-    ct:log("Preparing a spend tx: ~p", [Params]),
-    {ok, Tx} = aec_spend_tx:new(Params),
-    SignedTx = sign_tx(Tx, privkey(SendAccount), NetworkId),
-    ok = rpc:call(NodeName, aec_tx_pool, push, [SignedTx, tx_received]),
-    Hash = rpc:call(NodeName, aetx_sign, hash, [SignedTx]),
-    Hash.
 
 mine_to_next_epoch(Node, Config) ->
     Height1 = rpc(Node, aec_chain, top_height, []),

--- a/rebar.config
+++ b/rebar.config
@@ -73,7 +73,7 @@
                      {tag, "v3.4.0"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                          {ref, "9445e56"}}},
+                          {ref, "a1204df"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
                         {ref, "17b56c5"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -73,7 +73,7 @@
                      {tag, "v3.4.0"}}},
 
         {aeserialization, {git, "https://github.com/aeternity/aeserialization.git",
-                          {tag, "v1.2.0"}}},
+                          {ref, "9445e56"}}},
 
         {aestratum_lib, {git, "https://github.com/aeternity/aestratum_lib.git",
                         {ref, "17b56c5"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"9445e56eeaf4dcbbc07030cff69997a4a87a9234"}},
+      {ref,"a1204dfe7d6f39c20dd210f73745d4747f66f335"}},
   0},
  {<<"aestratum_lib">>,
   {git,"https://github.com/aeternity/aestratum_lib.git",

--- a/rebar.lock
+++ b/rebar.lock
@@ -18,7 +18,7 @@
   0},
  {<<"aeserialization">>,
   {git,"https://github.com/aeternity/aeserialization.git",
-      {ref,"1fe1038c8a72a6a35209bf21011ce0805aca3218"}},
+      {ref,"9445e56eeaf4dcbbc07030cff69997a4a87a9234"}},
   0},
  {<<"aestratum_lib">>,
   {git,"https://github.com/aeternity/aestratum_lib.git",


### PR DESCRIPTION
Refactoring pinning-related methods, mostly out of `parent_connector` into the `pinning_agent` and some other places. Generally, the `parent_connector` now only handles the two calls to the parent chain (posting and fetching the pin data). This is in prep for pinning to Doge and BTC.

This PR is supported by the Æternity Foundation.