### PR TITLE
4428 adjust child epoch length based on vote

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -319,7 +319,7 @@ state_pre_transform_node(Type, Height, PrevNode, Trees) ->
     {ok, PrevHash} = aec_headers:hash_header(PrevHeader),
     {TxEnv0, _} = aetx_env:tx_env_and_trees_from_hash(aetx_transaction, PrevHash),
     TxEnv = aetx_env:set_height(TxEnv0, Height),
-    {ok, #{epoch := Epoch, first := EpochFirst, last := EpochLast} = EpochInfo} =
+    {ok, #{epoch := Epoch, first := EpochFirst, last := EpochLast, length := EpochLength} = EpochInfo} =
         aec_chain_hc:epoch_info({TxEnv, Trees}),
     {ok, Leader} = leader_for_height(Height, {TxEnv, Trees}),
     case Type of
@@ -337,7 +337,13 @@ state_pre_transform_node(Type, Height, PrevNode, Trees) ->
                     case get_entropy_hash(Epoch + 2) of
                         {ok, Seed} ->
                             cache_validators_for_epoch({TxEnv, Trees1}, Seed, Epoch + 2),
-                            Trees2 = step_eoe(TxEnv, Trees1, Leader, Seed, 0, -1, CarryOverFlag),
+                            NewEpochLength = case aec_chain_hc:finalize_info({TxEnv, Trees1}) of
+                                                {ok, #{epoch_length := FinalizeEpochLength}} ->
+                                                    FinalizeEpochLength;
+                                                _ ->
+                                                    EpochLength
+                                              end,
+                            Trees2 = step_eoe(TxEnv, Trees1, Leader, Seed, NewEpochLength, -1, CarryOverFlag),
                             {ok, NextEpochInfo} = aec_chain_hc:epoch_info({TxEnv, Trees2}),
                             {Trees2, Events ++ [{new_epoch, NextEpochInfo}]};
                         {error, _} ->
@@ -654,8 +660,8 @@ step(TxEnv, Trees, Leader) ->
             aec_conductor:throw_error(step_failed)
     end.
 
-step_eoe(TxEnv, Trees, Leader, Seed, Adjust, BasePinReward, CarryOver) ->
-    {ok, CD} = aeb_fate_abi:create_calldata("step_eoe", [{address, Leader}, {bytes, Seed}, Adjust, BasePinReward, CarryOver]),
+step_eoe(TxEnv, Trees, Leader, Seed, Length, BasePinReward, CarryOver) ->
+    {ok, CD} = aeb_fate_abi:create_calldata("step_eoe", [{address, Leader}, {bytes, Seed}, Length, BasePinReward, CarryOver]),
     CallData = aeser_api_encoder:encode(contract_bytearray, CD),
     case call_consensus_contract_(?ELECTION_CONTRACT, TxEnv, Trees, CallData, "step_eoe", 0) of
         {ok, Trees1, _Call} ->

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -319,7 +319,7 @@ state_pre_transform_node(Type, Height, PrevNode, Trees) ->
     {ok, PrevHash} = aec_headers:hash_header(PrevHeader),
     {TxEnv0, _} = aetx_env:tx_env_and_trees_from_hash(aetx_transaction, PrevHash),
     TxEnv = aetx_env:set_height(TxEnv0, Height),
-    {ok, #{epoch := Epoch, first := EpochFirst, last := EpochLast, length := EpochLength} = EpochInfo} =
+    {ok, #{epoch := Epoch, first := EpochFirst, last := EpochLast} = EpochInfo} =
         aec_chain_hc:epoch_info({TxEnv, Trees}),
     {ok, Leader} = leader_for_height(Height, {TxEnv, Trees}),
     case Type of

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -337,10 +337,13 @@ state_pre_transform_node(Type, Height, PrevNode, Trees) ->
                     case get_entropy_hash(Epoch + 2) of
                         {ok, Seed} ->
                             cache_validators_for_epoch({TxEnv, Trees1}, Seed, Epoch + 2),
-                            NewEpochLength = case aec_chain_hc:finalize_info({TxEnv, Trees1}) of
-                                                {ok, #{epoch_length := FinalizeEpochLength}} ->
+                            FinalizeHeight = EpochFirst - 1,
+                            FinalizeEpoch = Epoch - 1,
+                            NewEpochLength = case aec_chain_hc:finalize_info(FinalizeHeight) of
+                                                #{epoch_length := FinalizeEpochLength, epoch := FinalizeEpoch} ->
                                                     FinalizeEpochLength;
                                                 _ ->
+                                                    lager:warning("Finalize info not found for epoch ~p height ~p", [FinalizeEpoch, FinalizeHeight]),
                                                     EpochLength
                                               end,
                             Trees2 = step_eoe(TxEnv, Trees1, Leader, Seed, NewEpochLength, -1, CarryOverFlag),

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -818,11 +818,11 @@ next_beneficiary(TxEnv, Trees) ->
     ChildHeight1 = ChildHeight + 1,
     case leader_for_height(ChildHeight1, {TxEnv, Trees}) of
         {ok, Leader} ->
-            {ok, #{epoch := Epoch, seed := Seed, validators := Validators} = EpochInfo} = aec_chain_hc:epoch_info({TxEnv, Trees}),
+            {ok, #{epoch := Epoch, seed := Seed, validators := Validators, length := EpochLength} = EpochInfo} = aec_chain_hc:epoch_info({TxEnv, Trees}),
             case ChildHeight1 == maps:get(last, EpochInfo) of
                 true ->
                     Hash = aetx_env:key_hash(TxEnv),
-                    aec_eoe_vote:negotiate(Epoch, ChildHeight1, Hash, Leader, Validators, Seed, child_epoch_length());
+                    aec_eoe_vote:negotiate(Epoch, ChildHeight1, Hash, Leader, Validators, Seed, EpochLength);
                 false ->
                     ok
             end,

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -816,7 +816,7 @@ next_beneficiary(TxEnv, Trees) ->
             case ChildHeight1 == maps:get(last, EpochInfo) of
                 true ->
                     Hash = aetx_env:key_hash(TxEnv),
-                    aec_eoe_vote:negotiate(Epoch, ChildHeight1, Hash, Leader, Validators, Seed, 0, child_epoch_length()); %% TODO epoch delta
+                    aec_eoe_vote:negotiate(Epoch, ChildHeight1, Hash, Leader, Validators, Seed, child_epoch_length());
                 false ->
                     ok
             end,
@@ -844,6 +844,7 @@ get_entropy_hash(ChildEpoch) ->
     lager:debug("Entropy for epoch ~p from PC block at height ~p", [ChildEpoch, EntropyHeight]),
     case aec_parent_chain_cache:get_block_by_height(EntropyHeight, 1000) of
         {ok, Block} ->
+            aec_eoe_vote:add_parent_block(ChildEpoch, Block),
             {ok, aec_parent_chain_block:hash(Block)};
         {error, _Err} ->
             lager:debug("Unable to pick the next leader for epoch ~p, parent height ~p; reason is ~p",

--- a/apps/aecore/src/aec_eoe_vote.erl
+++ b/apps/aecore/src/aec_eoe_vote.erl
@@ -306,8 +306,6 @@ check_voting_majority(#data{majority = CurrentMajority, validators=Validators, b
 
 check_other_votes({next_state, _, #data{other_votes = []}, _} = NextEvent) ->
     NextEvent;
-check_other_votes({next_state, _, #data{other_votes = []}} = NextEvent) ->
-    NextEvent;
 check_other_votes({next_state, NextState, #data{other_votes = [{_Type, SignedTx}|OtherVotes]} = Data, Actions}) ->
     Data1 = Data#data{other_votes = OtherVotes},
     case handle_vote(?COMMIT_TYPE, SignedTx, Data1, fun on_valid_commit/3, fun on_other_vote_type/3) of

--- a/apps/aecore/src/aec_eoe_vote.erl
+++ b/apps/aecore/src/aec_eoe_vote.erl
@@ -338,7 +338,6 @@ on_valid_commit(_Validator, _CommitFields, #data{result = Result, majority = Cur
 on_other_vote(?COMMIT_TYPE, SignedTx, #data{other_votes=OtherVotes} = Data) ->
     {keep_state, Data#data{other_votes = [{?COMMIT_TYPE, SignedTx}|OtherVotes]}};
 on_other_vote(_Type, _SignedTx, _Data) ->
-    lager:warning("Other vote type_ ~p", [_Type]),
     keep_state_and_data.
 
 on_other_vote_type(Type, _SignedTx, _Data) ->

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -534,14 +534,15 @@ entropy_impact_schedule(Config) ->
     Node = hd(Nodes),
     %% Sync nodes
     ChildHeight = rpc(Node, aec_chain, top_height, []),
-    {ok, #{epoch := Epoch0, length := Length0}} = rpc(Node, aec_chain_hc, epoch_info, []),
+    {ok, #{epoch := Epoch0, length := Length0, first := StartHeight}} = rpc(Node, aec_chain_hc, epoch_info, []),
     %% Make sure chain is long enough
     case Epoch0 =< 5 of
       true ->
         %% Chain to short to have meaningful test, e.g. when ran in isolation
         produce_cc_blocks(Config, 5 * Length0 - ChildHeight);
       false ->
-        ok
+        %% Make sure at start of epoch
+        produce_cc_blocks(Config, StartHeight - ChildHeight)
     end,
     {ok, #{seed := Seed,
            first := First,

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -909,7 +909,6 @@ epochs_with_slow_parent(Config) ->
     ?assertEqual([{ok, (N-1) * ?CHILD_EPOCH_LENGTH + 1} || N <- lists:seq(1, EndEpoch)],
                  [rpc(Node, aec_chain_hc, epoch_start_height, [N]) || N <- lists:seq(1, EndEpoch)]),
 
-    timer:sleep(?CHILD_BLOCK_TIME),
     %% Quickly produce parent blocks to be in sync again
     ParentBlocksNeeded =
         EndEpoch * ?PARENT_EPOCH_LENGTH + ?config(parent_start_height, Config) + ?PARENT_FINALITY - ParentTopHeight,

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -921,7 +921,8 @@ epochs_with_slow_parent(Config) ->
 
     ?assert(FinalizeEpochLength > EpochLength),
 
-    produce_cc_blocks(Config, EpochLength * 2),
+    lists:foreach(fun(_) -> {ok, #{length := CurrentEpochLen}} = rpc(Node, aec_chain_hc, epoch_info, []),
+                             produce_cc_blocks(Config, CurrentEpochLen) end, lists:seq(1, 2)),
     {ok, #{length := AdjEpochLength} = EpochInfo} = rpc(Node, aec_chain_hc, epoch_info, []),
     ct:log("Info ~p", [EpochInfo]),
     ?assertEqual(FinalizeEpochLength, AdjEpochLength),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -969,7 +969,7 @@ epochs_with_fast_parent(Config) ->
     ct:log("The agreed epoch length is ~p three epochs previous length was ~p", [FinalizeEpochLength, Len1]),
     ?assert(CurrentEpoch == FinalizeEpoch),
     lists:foreach(fun(_) -> {ok, #{length := CurrentEpochLen}} = rpc(Node, aec_chain_hc, epoch_info, []),
-                             produce_cc_blocks(Config, CurrentEpochLen) end, lists:seq(1, 3)),
+                             produce_cc_blocks(Config, CurrentEpochLen) end, lists:seq(1, 2)),
 
     {ok, #{length := AdjEpochLength} = EpochInfo3} = rpc(Node, aec_chain_hc, epoch_info, []),
     ?assertEqual(FinalizeEpochLength, AdjEpochLength),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -921,7 +921,7 @@ epochs_with_slow_parent(Config) ->
 
     ?assert(FinalizeEpochLength > EpochLength),
 
-    produce_cc_blocks(Config, EpochLength * 3),
+    produce_cc_blocks(Config, EpochLength * 2),
     {ok, #{length := AdjEpochLength} = EpochInfo} = rpc(Node, aec_chain_hc, epoch_info, []),
     ct:log("Info ~p", [EpochInfo]),
     ?assertEqual(FinalizeEpochLength, AdjEpochLength),

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -105,7 +105,7 @@ main contract HCElection =
       switch(state.finalize)
         None       => state.epochs[epoch + 3]
         Some(info) =>
-          if ( info.epoch == epoch - 1 )
+          if ( info.epoch == epoch )
             state.epochs[epoch + 3]{ length = info.epoch_length }
           else
             state.epochs[epoch + 3]

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -85,7 +85,7 @@ main contract HCElection =
     assert_protocol_call()
     put(state{ leader = leader })
 
-  stateful entrypoint step_eoe(leader : address, seed : bytes(), epoch_adjust : int,
+  stateful entrypoint step_eoe(leader : address, seed : bytes(), epoch_length : int,
                                next_base_pin_reward : int, carry_over_flag : bool) =
     assert_protocol_call()
     let epoch = state.epoch
@@ -101,8 +101,7 @@ main contract HCElection =
 
     // update epochs
     require(ei.start + ei.length - 1 == Chain.block_height, "This is not the end")
-    let ei2 = state.epochs[epoch + 2]
-    let ei_adjust = state.epochs[epoch + 3]{ length = ei2.length + epoch_adjust }
+    let ei_adjust = state.epochs[epoch + 3]{ length = epoch_length }
     let new_epochs = { [epoch] = state.epochs[epoch],
                        [epoch + 1] = state.epochs[epoch + 1],
                        [epoch + 2] = state.epochs[epoch + 2]{ seed = Some(seed) },

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -85,7 +85,7 @@ main contract HCElection =
     assert_protocol_call()
     put(state{ leader = leader })
 
-  stateful entrypoint step_eoe(leader : address, seed : bytes(), epoch_length : int,
+  stateful entrypoint step_eoe(leader : address, seed : bytes(),
                                next_base_pin_reward : int, carry_over_flag : bool) =
     assert_protocol_call()
     let epoch = state.epoch
@@ -101,7 +101,15 @@ main contract HCElection =
 
     // update epochs
     require(ei.start + ei.length - 1 == Chain.block_height, "This is not the end")
-    let ei_adjust = state.epochs[epoch + 3]{ length = epoch_length }
+    let ei_adjust =
+      switch(state.finalize)
+        None       => state.epochs[epoch + 3]
+        Some(info) =>
+          if ( info.epoch == epoch - 1 )
+            state.epochs[epoch + 3]{ length = info.epoch_length }
+          else
+            state.epochs[epoch + 3]
+
     let new_epochs = { [epoch] = state.epochs[epoch],
                        [epoch + 1] = state.epochs[epoch + 1],
                        [epoch + 2] = state.epochs[epoch + 2]{ seed = Some(seed) },


### PR DESCRIPTION
This is to adjust the child epoch length based on the speed of the parent chain and the result of validators voting on the change to the epoch length. Each validator has a vote based on their stake.

This PR is supported by the Æternity Foundation.