### PR TITLE
Verify voting information in HCElection

### DIFF
--- a/apps/aecore/src/aec_chain_hc.erl
+++ b/apps/aecore/src/aec_chain_hc.erl
@@ -168,7 +168,7 @@ decode_votes(Votes) ->
 
 decode_votes([], Accum) ->
     lists:reverse(Accum);
-decode_votes([{tuple, {{address, Producer}, {bytes, Hash}, EpochDelta, {bytes, Signature}}}|Rest], Accum) ->
+decode_votes([{tuple, {{address, Producer}, {bytes, Hash}, EpochDelta, {bytes, _SignData}, {bytes, Signature}}}|Rest], Accum) ->
     decode_votes(Rest, [#{ producer => Producer, hash => Hash, epoch_delta => EpochDelta, signature => Signature}|Accum]).
 
 call_consensus_contract_w_env(Contract, top, Endpoint, Args) ->

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -216,4 +216,19 @@ main contract HCElection =
     (acc{[addr = 0] @ r = r + amt}, tot + amt)
 
   function validate_vote(vote) =
-    Crypto.verify_sig(vote.sign_data, vote.producer, vote.signature)
+    if(Crypto.verify_sig(vote.sign_data, vote.producer, vote.signature))
+      contains_bytes(vote.hash, vote.sign_data)
+    else
+      false
+
+  function contains_bytes(needle : hash, haystack : bytes()) : bool =
+    if(Bytes.size(haystack) < 32)
+      false
+    else
+      let Some((bs_, _)) = Bytes.split_any(haystack, 32)
+      let Some(bs__) = Bytes.to_fixed_size(bs_)
+      if(bs__ == needle)
+        true
+      else
+        let Some((_, haystack_)) = Bytes.split_any(haystack, 1)
+        contains_bytes(needle, haystack_)

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -22,9 +22,10 @@ main contract HCElection =
 
   record vote =
     { producer    : address,
-      hash        : bytes(),
+      hash        : hash,
       epoch_delta : int,
-      signature   : bytes()
+      sign_data   : bytes(),
+      signature   : signature
     }
 
   record finalize_info =
@@ -133,6 +134,7 @@ main contract HCElection =
     require(Chain.block_height == last, "Only in last block")
     require(Call.caller == state.leader, "Must be called by the last leader of epoch")
     require(epoch_number == state.epoch, "Not correct epoch")
+    require(List.all(validate_vote, votes), "Invalid vote")
     put(state{finalize=Some({epoch = epoch_number, fork = fork, epoch_length = epoch_length, pc_hash = pc_hash, producer = producer, votes = votes})})
 
   entrypoint leader() =
@@ -212,3 +214,6 @@ main contract HCElection =
 
   function pay_reward_((acc, tot), (addr, amt)) =
     (acc{[addr = 0] @ r = r + amt}, tot + amt)
+
+  function validate_vote(vote) =
+    Crypto.verify_sig(vote.sign_data, vote.producer, vote.signature)


### PR DESCRIPTION
The idea is to not have nodes having to "manually" check the votes. This is a slightly hacky way to acheive this. In the long run the voting information should be more structured in order not having to recursively search for binaries etc.

This PR is supported by Æternity Foundation.