### PR TITLE
Mark `started_at` as required in AuctionEntry

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2310,6 +2310,7 @@ components:
           $ref: "#/components/schemas/UInt"
       required:
         - id
+        - started_at
         - ends_at
         - highest_bidder
         - highest_bid

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -2059,6 +2059,7 @@ definitions:
         $ref: '#/definitions/UInt'
     required:
       - id
+      - started_at
       - ends_at
       - highest_bidder
       - highest_bid


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

I don't know for sure, but the missing `started_at` looks like a typo. How can an auction have an end but no beginning?

initially was implemented in https://github.com/aeternity/aeternity/commit/01dd226e9042e31117b43b1d9f59a43e040663c6