### PR TITLE
Mark `nonce` as required in transaction schemas

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -2409,6 +2409,7 @@ components:
         - from_id
         - payload
         - fee
+        - nonce
         - poi
     ChannelCreateTx:
       type: object
@@ -2443,6 +2444,7 @@ components:
         - channel_reserve
         - lock_period
         - fee
+        - nonce
         - state_hash
     ChannelDepositTx:
       type: object
@@ -2502,6 +2504,7 @@ components:
         - update
         - state_hash
         - fee
+        - nonce
     ChannelSetDelegatesTx:
       type: object
       properties:
@@ -2538,6 +2541,7 @@ components:
         - round
         - payload
         - fee
+        - nonce
     ChannelSettleTx:
       type: object
       properties:
@@ -2584,6 +2588,7 @@ components:
         - from_id
         - payload
         - fee
+        - nonce
         - poi
     ChannelSnapshotSoloTx:
       type: object
@@ -2605,6 +2610,7 @@ components:
         - from_id
         - payload
         - fee
+        - nonce
     ChannelWithdrawTx:
       type: object
       properties:
@@ -2709,6 +2715,7 @@ components:
           $ref: "#/components/schemas/EncodedByteArray"
       required:
         - caller_id
+        - nonce
         - contract_id
         - abi_version
         - fee
@@ -2745,6 +2752,7 @@ components:
           $ref: "#/components/schemas/EncodedByteArray"
       required:
         - owner_id
+        - nonce
         - code
         - vm_version
         - abi_version
@@ -3019,6 +3027,7 @@ components:
           pattern: "^(0x|0X)?[a-fA-F0-9]+$"
       required:
         - owner_id
+        - nonce
         - code
         - vm_version
         - abi_version
@@ -3249,6 +3258,7 @@ components:
         - name_salt
         - fee
         - account_id
+        - nonce
     NameEntry:
       type: object
       properties:
@@ -3302,6 +3312,7 @@ components:
         - commitment_id
         - fee
         - account_id
+        - nonce
     NameRevokeTx:
       type: object
       properties:
@@ -3319,6 +3330,7 @@ components:
         - name_id
         - fee
         - account_id
+        - nonce
     NameTransferTx:
       type: object
       properties:
@@ -3339,6 +3351,7 @@ components:
         - recipient_id
         - fee
         - account_id
+        - nonce
     NameUpdateTx:
       type: object
       properties:
@@ -3367,6 +3380,7 @@ components:
         - pointers
         - fee
         - account_id
+        - nonce
     NetworkStatus:
       type: object
       additionalProperties:
@@ -3494,6 +3508,7 @@ components:
         - fee
         - oracle_ttl
         - oracle_id
+        - nonce
     OracleQueries:
       type: object
       properties:
@@ -3563,6 +3578,7 @@ components:
         - response_ttl
         - fee
         - sender_id
+        - nonce
     OracleRegisterTx:
       type: object
       properties:
@@ -3588,6 +3604,7 @@ components:
         - query_format
         - response_format
         - query_fee
+        - nonce
         - fee
         - oracle_ttl
         - account_id
@@ -3614,6 +3631,7 @@ components:
         - response_ttl
         - fee
         - oracle_id
+        - nonce
     PayingForTx:
       type: object
       properties:
@@ -3628,6 +3646,7 @@ components:
       required:
         - payer_id
         - fee
+        - nonce
         - tx
     Peer:
       type: string
@@ -3876,6 +3895,7 @@ components:
         - amount
         - fee
         - sender_id
+        - nonce
         - payload
     Status:
       type: object


### PR DESCRIPTION
This PR is supported by the Æternity Foundation