### PR TITLE
Add missed `flags` to KeyBlock definition

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -3169,6 +3169,8 @@ components:
           $ref: "#/components/schemas/EncodedPubkey"
         beneficiary:
           $ref: "#/components/schemas/EncodedPubkey"
+        flags:
+          $ref: "#/components/schemas/EncodedByteArray"
         target:
           $ref: "#/components/schemas/UInt32"
         pow:
@@ -3189,6 +3191,7 @@ components:
         - state_hash
         - miner
         - beneficiary
+        - flags
         - target
         - time
         - version


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

I'm running `aeternity/aeternity:v7.3.0-rc2-bundle` locally, and http://localhost:3013/v3/key-blocks/current returns
```json
{
  "beneficiary": "ak_DwhTzW31KKbTh9LnNJooHfcjieeopfKz2UU82Msd774ufBfGj",
  "flags": "ba_wAAAAKv2ZV4=",
  "hash": "kh_qW4wYGba5C6PS16rETWRtQ8t7B2yDscfC5DWGGJoMZDjQsU6",
  "height": 1,
  "info": "cb_AAAC2rLD9E0=",
  "miner": "ak_2hg4jw4SZneELLmVVsXMCNa9uP2fdWjyCfh4JgmapwcyxxUmMC",
  "prev_hash": "kh_2gvqwZaAfWx4SbYcMHELS2BTnbHNs2wDbdiJ8xwZV1AoiYzLyW",
  "prev_key_hash": "kh_2gvqwZaAfWx4SbYcMHELS2BTnbHNs2wDbdiJ8xwZV1AoiYzLyW",
  "state_hash": "bs_2vnKkmcnuTibAG3nwwhcH2qs4HmotQre9kMnkgSmvoshdQAys2",
  "target": 1338,
  "time": 1738496082011,
  "version": 6
}
```