### PR TITLE
Penalty contract and test fixes

### DIFF
--- a/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
+++ b/apps/aecontract/test/aecontract_staking_contract_SUITE.erl
@@ -283,7 +283,7 @@ rewards(_Config) ->
         ?assertEqual(AStake, ?VALIDATOR_MIN - 4 * ?AE),
         ?assertEqual(BStake, ?VALIDATOR_MIN),
 
-        % resditirbuting the penalty pool, i.e rewards which are taken from the penalty pool
+        % resdistributing the penalty pool, i.e rewards which are taken from the penalty pool
 
         Redist = [{{address, pubkey(?CAROL)}, -1 * ?AE}, {{address, pubkey(?BOB)}, -1 * ?AE}],
         {ok, Trees4, #{res := ?UNIT}} =

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -41,8 +41,7 @@
          check_finalize_info/1,
          sanity_check_vote_tx/1,
          hole_production/1,
-         hole_production_eoe/1,
-         basic_penalty/1
+         hole_production_eoe/1
         ]).
 
 -include_lib("stdlib/include/assert.hrl").

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -214,11 +214,6 @@ groups() ->
           [ start_two_child_nodes,
             initial_validators
           ]}
-    , {penalties, [sequence],
-          [ start_two_child_nodes
-          ,  produce_first_epoch
-          ,  basic_penalty
-          ]}
     ].
 
 suite() -> [].
@@ -1419,63 +1414,6 @@ check_finalize_info(Config) ->
     ct:pal("~p >= ~p", [TotalVotersStake, MajorityVotes]),
     ?assert(TotalVotersStake >= MajorityVotes).
 
-%%%=============================================================================
-%%% Penalties
-%%%=============================================================================
-
-basic_penalty(Config) ->
-    [{Node, _, _, _} | _] = ?config(nodes, Config),
-
-    AliceCt = fetch_validator_contract(?ALICE, Config),
-    LisaCt = fetch_validator_contract(?LISA, Config),
-
-    {ok, AliceTot0} = inspect_validator(AliceCt, ?ALICE, get_total_balance, Config),
-    {ok, LisaTot0} = inspect_validator(LisaCt, ?LISA, get_total_balance, Config),
-    ct:log("Alice, Lisa bal: ~p ~p", [AliceTot0, LisaTot0]),
-    R = reported_penalty_contract_call(Config, ?ALICE, ?LISA, math:pow(10,6) * 1111, 50, 1, pubkey(?LISA)),
-    ct:log("Contract Call ~p", [R]),
-    mine_to_next_epoch(Node, Config),
-    {ok, AliceTot1} = inspect_validator(AliceCt, ?ALICE, get_total_balance, Config),
-    {ok, LisaTot1} = inspect_validator(LisaCt, ?LISA, get_total_balance, Config),
-    ct:log("Alice, Lisa bal: ~p ~p", [AliceTot1, LisaTot1]),
-
-    mine_to_next_epoch(Node, Config),
-    {ok, AliceTot2} = inspect_validator(AliceCt, ?ALICE, get_total_balance, Config),
-    {ok, LisaTot2} = inspect_validator(LisaCt, ?LISA, get_total_balance, Config),
-    ct:log("Alice, Lisa bal: ~p ~p", [AliceTot2, LisaTot2]),
-
-    mine_to_next_epoch(Node, Config),
-    {ok, AliceTot3} = inspect_validator(AliceCt, ?ALICE, get_total_balance, Config),
-    {ok, LisaTot3} = inspect_validator(LisaCt, ?LISA, get_total_balance, Config),
-    ct:log("Alice, Lisa bal: ~p ~p", [AliceTot3, LisaTot3]),
-
-    ok.
-
-reported_penalty_contract_call(Config, Offender, Reporter, Amount, Percentage, Height, FromPubKey) ->
-    Penalty = integer_to_list(trunc(Amount)), %% Amount AE
-    HeightInt = integer_to_list(trunc(Height)), %% Height
-    PercArg = integer_to_list(trunc(Percentage)),
-    APubO = binary_to_list(aeser_api_encoder:encode(account_pubkey, pubkey(Offender))),
-    APubR = binary_to_list(aeser_api_encoder:encode(account_pubkey, pubkey(Reporter))),
-
-    Tx = contract_call(?config(election_contract, Config), src(?HC_CONTRACT, Config),
-                        "add_reported_penalty", [HeightInt, Penalty, APubO, APubR, PercArg], 0, FromPubKey),
-
-    NetworkId = ?config(network_id, Config),
-    SignedTx = sign_tx(Tx, privkey(who_by_pubkey(FromPubKey)), NetworkId),
-    rpc:call(?NODE1_NAME, aec_tx_pool, push, [SignedTx, tx_received]).
-
-penalty_contract_call(Config, Offender, Amount, Height, FromPubKey) ->
-    Penalty = integer_to_list(trunc(Amount)), %% Amount AE
-    HeightInt = integer_to_list(trunc(Height)), %% Height
-    APubO = binary_to_list(aeser_api_encoder:encode(account_pubkey, pubkey(Offender))),
-
-    Tx = contract_call(?config(election_contract, Config), src(?HC_CONTRACT, Config),
-                        "add_penalty", [HeightInt, Penalty, APubO], 0, FromPubKey),
-
-    NetworkId = ?config(network_id, Config),
-    SignedTx = sign_tx(Tx, privkey(who_by_pubkey(FromPubKey)), NetworkId),
-    rpc:call(?NODE1_NAME, aec_tx_pool, push, [SignedTx, tx_received]).
 
 %%% --------- pinning helpers
 

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -150,7 +150,7 @@ main contract HCElection =
       require(penalty > 0, "Penalty is expressed as a positive integer")
       require(reporter_percentage >= 0 && reporter_percentage =< 100, "reporter reward percentage must be between 0 and 100")
       put(state{rewards[height = []] @ rs = (to, (-penalty)) :: rs})
-      let reporter_reward = penalty * (100/reporter_percentage)
+      let reporter_reward = (penalty * reporter_percentage) / 100
       put(state{rewards[height = []] @ rs = (reporter, reporter_reward) :: rs})
       put(state{penalty_reward_diff @ prd= prd + (penalty - reporter_reward)})
 
@@ -262,3 +262,10 @@ main contract HCElection =
       else
         let Some((_, haystack_)) = Bytes.split_any(haystack, 1)
         contains_bytes(needle, haystack_)
+
+  // Testing endpoints
+
+  payable stateful entrypoint test_pay_rewards(e : int) =
+    assert_protocol_call()
+    pay_rewards(e)
+

--- a/test/contracts/HCElection.aes
+++ b/test/contracts/HCElection.aes
@@ -1,10 +1,12 @@
 include "List.aes"
 include "Pair.aes"
+include "String.aes"
 
 contract interface MainStaking =
   entrypoint sorted_validators : () => list((address * int))
   entrypoint lock_stake  : (int) => list((address * int))
-  entrypoint add_rewards : (int, list(address * int), int) => unit
+  entrypoint add_rewards : (int, list(address * int)) => unit
+  entrypoint add_penalties : (int, list(address * int)) => unit
 
 main contract HCElection =
   record epoch_info =
@@ -41,7 +43,7 @@ main contract HCElection =
     { main_staking_ct       : MainStaking,
       leader                : address,
       rewards               : map(int, list(address * int)),
-      penalty_reward_diff   : int,
+      penalties             : map(int, list(address * int)),
       epoch                 : int,
       epochs                : map(int, epoch_info),
       pin                   : option(bytes()),
@@ -57,7 +59,7 @@ main contract HCElection =
       epochs                = {},
       pin                   = None,
       finalize              = None,
-      penalty_reward_diff   = 0,
+      penalties             = {},
       pin_reward            = {base = 0, current = 0, carry_over = 0} }
 
   stateful entrypoint init_epochs(epoch_length : int, base_pin_reward : int) =
@@ -98,11 +100,12 @@ main contract HCElection =
     let next_reward = next_base + next_carry_over
     let pr = {current = next_reward, carry_over = next_carry_over, base = next_base}
 
+    collect_penalties(state.epoch - 1)
     // pay rewards to sunset epoch
     pay_rewards(state.epoch - 1)
 
     // update epochs
-    require(ei.start + ei.length - 1 == Chain.block_height, "This is not the end")
+    require(ei.start + ei.length - 1 == Chain.block_height, String.concats(["This is not the end: ", Int.to_str(ei.start + ei.length - 1), " : ", Int.to_str(Chain.block_height)]))
     let ei_adjust =
       switch(state.finalize)
         None       => state.epochs[epoch + 3]
@@ -137,23 +140,18 @@ main contract HCElection =
     assert_protocol_call()
     put(state{rewards[height = []] @ rs = (to, Call.value) :: rs})
 
-
-
   stateful entrypoint add_penalty(height : int, penalty : int, to : address) =
       assert_protocol_call()
       require(penalty > 0, "Penalty is expressed as a positive integer")
-      put(state{rewards[height = []] @ rs = (to, (-penalty)) :: rs})
-      put(state{penalty_reward_diff @ prd = prd + penalty})
+      put(state{penalties[height = []] @ rs = (to, penalty) :: rs})
 
   stateful entrypoint add_reported_penalty(height : int, penalty : int, to : address, reporter : address, reporter_percentage : int) =
       assert_protocol_call()
       require(penalty > 0, "Penalty is expressed as a positive integer")
       require(reporter_percentage >= 0 && reporter_percentage =< 100, "reporter reward percentage must be between 0 and 100")
-      put(state{rewards[height = []] @ rs = (to, (-penalty)) :: rs})
+      put(state{penalties[height = []] @ rs = (to, (penalty)) :: rs})
       let reporter_reward = (penalty * reporter_percentage) / 100
-      put(state{rewards[height = []] @ rs = (reporter, reporter_reward) :: rs})
-      put(state{penalty_reward_diff @ prd= prd + (penalty - reporter_reward)})
-
+      put(state{penalties[height = []] @ rs = (reporter, -reporter_reward) :: rs})
 
   stateful entrypoint finalize_epoch(epoch_number : int, fork : bytes(), epoch_length : int, pc_hash : bytes(), producer : address, votes : list(vote)) =
     let epoch = state.epoch
@@ -227,10 +225,7 @@ main contract HCElection =
   stateful function pay_rewards(e : int) =
     let ei = state.epochs[e]
     let (rewards, tot) = pay_rewards_(ei.start, ei.length, {}, 0)
-    let pen_diff = state.penalty_reward_diff
-    let pool_adjusted_total = tot + pen_diff
-    state.main_staking_ct.add_rewards(value = pool_adjusted_total, e, rewards, pen_diff)
-    put(state{penalty_reward_diff = 0})
+    state.main_staking_ct.add_rewards(value = tot, e, rewards)
 
   stateful function
     pay_rewards_(_, 0, acc, tot) = (Map.to_list(acc), tot)
@@ -244,6 +239,28 @@ main contract HCElection =
 
   function pay_reward_((acc, tot), (addr, amt)) =
     (acc{[addr = 0] @ r = r + amt}, tot + amt)
+
+  stateful function collect_penalties(epoch : int) =
+    let ei = state.epochs[epoch]
+    let pens = collect_penalties_(ei.start, ei.length, {})
+    state.main_staking_ct.add_penalties(epoch, List.sort(compare_pens_, pens)) // penalties first to fill pool, rewards second
+
+  stateful function
+    collect_penalties_(_, 0, acc) = Map.to_list(acc)
+    collect_penalties_(h, n, acc) =
+      switch(Map.lookup(h, state.penalties))
+        None      => collect_penalties_(h + 1, n - 1, acc)
+        Some(aas) =>
+          let acc1 = List.foldl(collect_penalty_, acc, aas)
+          put(state{penalties @ r = Map.delete(h, r)})
+          collect_penalties_(h + 1, n - 1, acc1)
+
+  function collect_penalty_(acc, (addr, amt)) =
+    acc{[addr = 0] @ r = r + amt}
+
+  // sort largest penalties first
+  function compare_pens_((_, x), (_, y)) =
+    x > y
 
   function validate_vote(vote) =
     if(Crypto.verify_sig(vote.sign_data, vote.producer, vote.signature))
@@ -262,10 +279,3 @@ main contract HCElection =
       else
         let Some((_, haystack_)) = Bytes.split_any(haystack, 1)
         contains_bytes(needle, haystack_)
-
-  // Testing endpoints
-
-  payable stateful entrypoint test_pay_rewards(e : int) =
-    assert_protocol_call()
-    pay_rewards(e)
-

--- a/test/contracts/MainStaking.aes
+++ b/test/contracts/MainStaking.aes
@@ -108,16 +108,19 @@ main contract MainStaking =
   // ------------------------------------------------------------------------
   // -- Called from HCElection and/or consensus logic
   // ------------------------------------------------------------------------
-  payable stateful entrypoint add_rewards(epoch : int, rewards : list(address * int), pool_adj : int) =
+  payable stateful entrypoint add_rewards(epoch : int, rewards : list(address * int)) =
     assert_protocol_call()
-    let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards)) + pool_adj
+    let total_rewards = List.foldl((+), 0, List.map(Pair.snd, rewards))
     require(total_rewards == Call.value, "Incorrect total reward given")
-    put(state{penalty_pool @ pp = pp + pool_adj})
     List.foreach(rewards, (r) => add_reward(epoch, r))
     [ unlock_stake_(v_addr, validator, epoch) | (v_addr, validator) <- Map.to_list(state.validators) ]
     // At the end of epoch X we distribute rewards for X - 1; thus current_epoch
     // is (soon) X + 1. I.e. X - 1 + 2.
     put(state{current_epoch = epoch + 2})
+
+  stateful entrypoint add_penalties(epoch : int, penalties : list(address * int)) =
+    assert_protocol_call()
+    List.foreach(penalties, (p) => add_penalty(epoch, p))
 
   stateful entrypoint lock_stake(epoch : int) : list(address * int) =
     assert_protocol_call()
@@ -170,6 +173,22 @@ main contract MainStaking =
       deposit_(validator, amount)
     let validator_ct = Address.to_contract(validator) : StakingValidator
     validator_ct.rewards(epoch, amount, restake)
+
+  // an penalty will be a positive amount, a redistribution of penalty (reporting reward or other)
+  // will be a negative amount
+  stateful function add_penalty(epoch : int, (sign_key, amount) : address * int) =
+    assert_signer(sign_key)
+    if (amount < 0)
+      require(state.penalty_pool >= -amount, "Not enough penalty pool")
+    let validator_key = state.sign_keys[sign_key]
+    let validator = state.validators[validator_key]
+    let total_balance = validator.total_balance
+    let current_stake = validator.current_stake
+    let new_total = max([0, total_balance - amount])
+    let new_cur_stake = min(current_stake, new_total)
+    put(state{validators[validator_key] @ v = v{total_balance = new_total,
+                                            current_stake = new_cur_stake},
+              penalty_pool = state.penalty_pool + amount})
 
   stateful function lock_stake_(v_addr : address, validator : validator, epoch : int) : unit =
     if(validator.current_stake >= state.validator_min_stake)


### PR DESCRIPTION
Fixes brainfart error in `add_reported_penalty()`
Moved tests from HC suite to staking ct suite
Added test access method to HCElection to enable more granualr "unit" testing of the functionality.

NOTE: This PR (and it's predecessor) only implements and tests the support for penalties - mostly in the core HC contracts. How to register them, how distribution of the fees are done etc. No actual staker/validator penalty offences are implemented here.

This PR is supported by the Aeternity Foundation