### PR TITLE
Fix problem with unit tests not starting system apps in proper order

### DIFF
--- a/apps/aecore/test/aec_block_key_candidate_tests.erl
+++ b/apps/aecore/test/aec_block_key_candidate_tests.erl
@@ -136,6 +136,7 @@ compute_chain(Now, Height, Target, MiningOffset) ->
                 end, [], lists:seq(Height - (N + 1), Height - 1)).
 
 setup() ->
+    aec_test_utils:ensure_system_init(),
     InitialApps = {running_apps(), loaded_apps()},
     {ok, _} = application:ensure_all_started(setup), %% For data_dir.
     InitialApps.

--- a/apps/aecore/test/aec_metrics_rpt_dest_tests.erl
+++ b/apps/aecore/test/aec_metrics_rpt_dest_tests.erl
@@ -132,6 +132,7 @@ set_config(Rules) ->
                 end).
 
 setup() ->
+    aec_test_utils:ensure_system_init(),
     InitialApps = {running_apps(), loaded_apps()},
     {ok, _} = application:ensure_all_started(exometer_core),
     create_metrics(),

--- a/apps/aecore/test/aec_mining_tests.erl
+++ b/apps/aecore/test/aec_mining_tests.erl
@@ -97,8 +97,8 @@ mine_block_test_() ->
       ]}.
 
 setup() ->
+    aec_test_utils:ensure_system_init(),
     InitialApps = {running_apps(), loaded_apps()},
-    {ok, _} = application:ensure_all_started(setup),
     {ok, _} = application:ensure_all_started(aeutils),
     aec_test_utils:mock_fast_and_deterministic_cuckoo_pow(),
     aec_test_utils:start_chain_db(),

--- a/apps/aecore/test/aec_target_tests.erl
+++ b/apps/aecore/test/aec_target_tests.erl
@@ -45,8 +45,8 @@ target_adj_test_() ->
      }.
 
 setup() ->
+    aec_test_utils:ensure_system_init(),
     InitialApps = {running_apps(), loaded_apps()},
-    {ok, _} = application:ensure_all_started(setup),
     {ok, _} = application:ensure_all_started(aeutils),
     meck:new(aec_txs_trees, [passthrough]),
     meck:new(aec_conductor, [passthrough]),


### PR DESCRIPTION
Fixes some more problems found when trying to redirect logs to stdout. When running unit tests, the normal boot script is not used, and unit tests that rely on system apps must ensure they get started in the right order.