### PR TITLE
Validate parent pin height

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -688,7 +688,7 @@ pc_start_height() ->
     aeu_ets_cache:get(?ETS_CACHE_TABLE, pc_start_height, Fun).
 
 parent_finality() ->
-    Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"finality">>], 0) end,
+    Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"finality">>], 5) end,
     aeu_ets_cache:get(?ETS_CACHE_TABLE, finality, Fun).
 
 genesis_start_time() ->
@@ -1242,12 +1242,11 @@ validate_pin(TxEnv, Trees, CurEpochInfo) ->
                 #{epoch := CurEpoch} = CurEpochInfo,
                 {ok, #{epoch := PinEpoch, height := PinHeight, block_hash := PinHash, pc_height := PcHeight}} =
                     aec_parent_connector:get_pin_by_tx_hash(EncTxHash),
-                lager:debug("PINNING pin epoch: ~p, pin epoch last: ~p, cur epoch: ~p",[PinEpoch, PinHeight, CurEpoch]),
-                {Min, Max} = get_pcpinheights_from_pinepoch(PinEpoch),
-                lager:debug("pc pin height: ~p, pc_epoch_from_height: ~p: pc_epoch_to_height: ~p; pc_epoch_length: ~p", [PcHeight, Min, Max, parent_epoch_length()]), % validate it was actually last epoch
+                lager:debug("PINNING pin epoch: ~p, pin epoch last: ~p, cur epoch: ~p",[PinEpoch, cPinHeight, CurEpoch]),
+                {PcMin, PcMax} = get_pcpinheights_from_pinepoch(PinEpoch),
+                lager:debug("pc pin height: ~p, pc_epoch_from_height: ~p: pc_epoch_to_height: ~p; pc_epoch_length: ~p", [PcHeight, PcMin, PcMax, parent_epoch_length()]), % validate it was actually last epoch
                 case {ok, PinHash} =:= aec_chain_state:get_key_block_hash_at_height(PinHeight) of
                     true ->
-                        {PcMin, PcMax} = get_pcpinheights_from_pinepoch(PinEpoch),
                         if
                             PcHeight >= PcMin andalso PcHeight =< PcMax ->
                                 pin_correct;

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -687,9 +687,9 @@ pc_start_height() ->
     Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"start_height">>], 0) end,
     aeu_ets_cache:get(?ETS_CACHE_TABLE, pc_start_height, Fun).
 
-%pc_finality() ->
-%    Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"finality">>], 0) end,
-%    aeu_ets_cache:get(?ETS_CACHE_TABLE, finality, Fun).
+parent_finality() ->
+    Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"finality">>], 0) end,
+    aeu_ets_cache:get(?ETS_CACHE_TABLE, finality, Fun).
 
 genesis_start_time() ->
     Fun = fun() -> get_consensus_config_key([<<"genesis_start_time">>], 0) end,
@@ -698,6 +698,10 @@ genesis_start_time() ->
 parent_epoch_length() ->
     Fun = fun() -> get_consensus_config_key([<<"parent_chain">>, <<"parent_epoch_length">>]) end,
     aeu_ets_cache:get(?ETS_CACHE_TABLE, parent_epoch_length, Fun).
+
+parent_pin_sync_margin() ->
+    Fun = fun() -> get_consensus_config_key([<<"parent_pin_sync_margin">>], 0) end,
+    aeu_ets_cache:get(?ETS_CACHE_TABLE, parent_pin_sync_margin, Fun).
 
 child_epoch_length() ->
     Fun = fun() -> get_consensus_config_key([<<"child_epoch_length">>]) end,
@@ -1224,8 +1228,8 @@ handle_pinning(TxEnv, Trees, EpochInfo, Leader) ->
             {Trees1, Events} = add_pin_reward(Trees, TxEnv, Leader, EpochInfo),
             lager:debug("PINNING: pin validated"),
             {Trees1, false, Events};
-        pin_validation_fail ->
-            lager:warning("PINNING: Incorrect proof posted"),
+        {pin_validation_fail, Msg} ->
+            lager:warning("PINNING: Incorrect proof posted: ~p", [Msg]),
             {Trees, true, [{pin, {incorrect_proof_posted}}]}
     end.
 
@@ -1233,31 +1237,41 @@ validate_pin(TxEnv, Trees, CurEpochInfo) ->
     case aec_chain_hc:pin_info({TxEnv, Trees}) of
         undefined -> pin_missing;
         {bytes, EncTxHash} ->
-            % TODO make this code much more robust - incorrect EncTxHash, bad value from PC, incorrect hash etc.etc
             lager:debug("PINNING: EncHash: ~p", [EncTxHash]),
             try
                 #{epoch := CurEpoch} = CurEpochInfo,
                 {ok, #{epoch := PinEpoch, height := PinHeight, block_hash := PinHash, pc_height := PcHeight}} =
                     aec_parent_connector:get_pin_by_tx_hash(EncTxHash),
                 lager:debug("PINNING pin epoch: ~p, pin epoch last: ~p, cur epoch: ~p",[PinEpoch, PinHeight, CurEpoch]),
-                lager:debug("pc pin height: ~p, pc_epoch_from_height: ~p: pc_start_height: ~p; pc_epoch_length: ~p", [PcHeight, pc_epoch_from_height(PcHeight), pc_start_height(), parent_epoch_length()]), % validate it was actually last epoch
-                HashCorrect =
-                    case {ok, PinHash} =:= aec_chain_state:get_key_block_hash_at_height(PinHeight) of
-                        true -> pin_correct;
-                        false -> pin_validation_fail
-                    end
-                %PcEpochCorrect = (PinEpoch == pc_epoch_from_height(PcHeight) - 1) % validate that pinning was in epoch directly following
+                {Min, Max} = get_pcpinheights_from_pinepoch(PinEpoch),
+                lager:debug("pc pin height: ~p, pc_epoch_from_height: ~p: pc_epoch_to_height: ~p; pc_epoch_length: ~p", [PcHeight, Min, Max, parent_epoch_length()]), % validate it was actually last epoch
+                case {ok, PinHash} =:= aec_chain_state:get_key_block_hash_at_height(PinHeight) of
+                    true ->
+                        {PcMin, PcMax} = get_pcpinheights_from_pinepoch(PinEpoch),
+                        if
+                            PcHeight >= PcMin andalso PcHeight =< PcMax ->
+                                pin_correct;
+                            true ->
+                                {pin_validation_fail, "PC Pin not in sync"}
+                        end;
+                    false -> {pin_validation_fail, "Incorrect Hash pinned to parent chain"}
+                end
             catch
                 Type:Err ->
                     lager:debug("bad pin proof posted: ~p : ~p", [Type, Err]),
-                    pin_validation_fail
+                    {pin_validation_fail, Err}
             end
     end.
 
-pc_epoch_from_height(PcHeight) ->
-    PcStartHeight = pc_start_height(),
-    PcEpochLength  = parent_epoch_length(),
-    ((PcHeight - PcStartHeight) div PcEpochLength) + 1. % start epoch is 1,
+% returns the "ideal"/in-sync PC start and end heights of the epoch where the pin from PinEpoch needs to be (i.e. the next PC epoc),
+% with respect to finality and "margin of sync"
+get_pcpinheights_from_pinepoch(PinEpoch) ->
+    PcEpochLength = parent_epoch_length(),
+    BaseStart = pc_start_height() + (PinEpoch * PcEpochLength),
+    SyncMargin = parent_pin_sync_margin(),
+    PCFinality = parent_finality(),
+    lager:debug("PCStartHeight: ~p, PCBaseStart: ~p, PCSyncMargin: ~p, PCFinality ~p", [pc_start_height(), BaseStart, SyncMargin, PCFinality]),
+    {BaseStart - SyncMargin + PCFinality, BaseStart + (PcEpochLength - 1) + SyncMargin + PCFinality}.
 
 
 add_pin_reward(Trees, TxEnv, Leader, #{epoch := CurEpoch, last := Last}) ->

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1784,6 +1784,7 @@
                                                 },
                                                 "finality": {
                                                     "description": "The number of blocks on the parent chain to reach finality.",
+                                                    "default": 5,
                                                     "type": "integer"
                                                 },
                                                 "parent_epoch_length": {

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1748,6 +1748,11 @@
                                             "default": 0,
                                             "type": "integer"
                                         },
+                                        "parent_pin_sync_margin": {
+                                            "description": "The number of blocks that the parent chain can be out of sync (vs the \"ideal\" height) to still be considered valid for pinning",
+                                            "default": 0,
+                                            "type": "integer"
+                                        },
                                         "default_pinning_behavior": {
                                             "description": "Use the default pinning behavior, where in each epoch, if the last leader has defined pinning/parent chain credentials, they will pin",
                                             "default": false,


### PR DESCRIPTION
Implementation of PC pin height validation, where the pin must be within the "ideal" PC epoch block height (i.e the block heights if the PC and HC are in perfect sync), taking finality and also a configurable "margin-of-sync-error" into account.

The general problem we are trying to solve with pinning is to tie the state of the HC to a particular time, making long-range attacks harder, as they need to be premeditated for as long time as their height. That “time” is the state of a more “properly secure” blockchain at a certain height. If we do this in relation to the state/height of the HC, we end up with a much larger allowed possible time-span, since we can’t be quite sure that the chain is properly in sync. Hence security is weakened.
What we do here is that we tie PC pins explicitly to the PC height, more specifically the epoch after which the hash pinned was taken from. Since the PC epoch length cannot be changed, this is a well defined place on the chain and a well defined period in time. The drawback is that if the timing sync between HC and PC is too off, pinning won’t be possible.
This is implemented simply by checking the height of the proposed PC pin, validating that is is within the proper PC epoch (respecting finality, so the epoch height is essentially “shifted” finality blocks). If it is not, it won’t validate, and no rewards will be given.
In order to accomodate some timing slip - which the chain should eventually be adjusting for with epoch timing changes - we also introduce a parent_pin_sync_margin value, which is the number of blocks outside (earlier and later) that is allowed for a valida pin. This margin can also be used to make up a bit for PC blocktime “wobble”, where the varying PC blocktimes makes epoch timing somewhat unprecise (unless you have very long epochs where varying blocktimes cancel eachother out).

This PR is supported by the AEternity Foundation