### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-1. Installation
+# 1. Installation
 
 # Introduction
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,5 @@
+1. Installation
+
 # Introduction
 
 This document describes how to install an Aeternity node using a release binary either by:


### PR DESCRIPTION
added the title 1. Installation 

the number is to keep it in on order that mirrors the table of contents in the GitBook Documentation Hub

the title "Installation" is needed because GitBook pulls from the first line of the document for the title of the page