### PR TITLE
Adapt some Chain-inspecting FATE operations for PoS/HC

### DIFF
--- a/apps/aecore/src/aec_block_micro_candidate.erl
+++ b/apps/aecore/src/aec_block_micro_candidate.erl
@@ -67,6 +67,7 @@ get_blocks(Block) ->
             end
     end.
 
+-ifdef(TEST).
 -spec create_with_state(aec_blocks:block(), aec_blocks:block(),
     list(aetx_sign:signed_tx()), aec_trees:trees()) ->
     {aec_blocks:block(), aec_trees:trees()}.
@@ -79,6 +80,7 @@ create_with_state(Block, KeyBlock, Txs, Trees) ->
     {ok, NewBlock, #{ trees := NewTrees}} =
         int_create_block(Height, MBEnv, TxEnv, Txs, Trees),
     {NewBlock, NewTrees}.
+-endif.
 
 -spec apply_block_txs(list(aetx_sign:signed_tx()), aec_trees:trees(),
                       aetx_env:env()) ->
@@ -120,7 +122,6 @@ trees(#{trees := Trees}) ->
     {ok, Trees}.
 
 %% -- Internal functions -----------------------------------------------------
-
 
 int_create(PrevBlock, KeyBlock) ->
     MaxGas = aec_governance:block_gas_limit(),
@@ -172,10 +173,12 @@ int_pack_block(Height, GasAvailable, TxHashes, Txs, MBEnv, TxEnv, Trees, Events)
                            Txs ++ Txs1, MBEnv, TxEnv, Trees1, Events ++ Events1)
     end.
 
+-ifdef(TEST).
 int_create_block(Height, MBEnv, TxEnv, Txs, Trees) ->
     {ok, Txs1, InvalidTxs, Trees1, Events1} = int_apply_block_txs(Txs, Trees, TxEnv, false),
     report_failed_txs(InvalidTxs),
     int_create_block(Height, MBEnv, TxEnv, Txs1, Trees1, Events1).
+-endif.
 
 int_create_block(Height, MBEnv, TxEnv, Txs, Trees, Events) ->
     #{key_block := KeyBlock, key_hash := KeyBlockHash,

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1483,10 +1483,8 @@ hc_create_microblock(TopHash, Leader, VoteResults) ->
 hc_create_microblock_candidate(TopHash, VoteResults) ->
     hc_create_microblock_candidate(TopHash, VoteResults, 0).
 
-hc_create_microblock_candidate(TopHash, [], 0) ->
-    aec_block_micro_candidate:create(TopHash);
 hc_create_microblock_candidate(TopHash, [], Gas) ->
-    aec_block_micro_candidate:create(TopHash, Gas);
+    aec_block_micro_candidate:create_pos(TopHash, Gas);
 hc_create_microblock_candidate(TopHash, [{ok, VoteTx}|VoteResults], CurrentGas) ->
     Tx = aetx_sign:tx(VoteTx),
     Gas = case aec_chain:get_block(TopHash) of


### PR DESCRIPTION
Make the following adjustments:
 - `Chain.block_hash` returns `None` for current height since MicroBlock comes before KeyBlock in PoS/HC.
 - `Chain.difficulty` returns 0 - it doesn't mean anything (yet) on PoS/HC.
 - `Chain.coinbase` aborts contract execution. 

This PR is supported by Æternity Foundation