### PR TITLE
fix: add config schema definition for hyperchain staking_contract

### DIFF
--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1720,6 +1720,10 @@
                                             "description": "The address of the smart contract that will be used for reward distributions. For a new chain this contract should be loaded at genesis",
                                             "type": "string"
                                         },
+                                        "staking_contract": {
+                                            "description": "The address of the smart contract that will be used for staking. For a new chain this contract should be loaded at genesis",
+                                            "type": "string"
+                                        },
                                         "genesis_start_time": {
                                             "description": "Timestamp for genesis",
                                             "default": 0,


### PR DESCRIPTION
this config value is used in the code but missing from the schema definition