### PR TITLE
More accurate block type in OpenApi

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -631,7 +631,7 @@ paths:
       description: Get a key block by hash
       parameters:
         - $ref: '#/components/parameters/intAsString'
-        - $ref: '#/components/parameters/blockHash'
+        - $ref: '#/components/parameters/keyBlockHash'
       responses:
         "200":
           description: Successful operation
@@ -711,7 +711,7 @@ paths:
       description: Get a micro block header by hash
       parameters:
         - $ref: '#/components/parameters/intAsString'
-        - $ref: '#/components/parameters/blockHash'
+        - $ref: '#/components/parameters/microBlockHash'
       responses:
         "200":
           description: Successful operation


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

fixes #4588

After this, `blockHash` is only used in `GetAccountByPubkeyAndHash`
https://github.com/aeternity/aeternity/blob/9c00a3d34c3d8500d64c9afdeaf7eb93d137ddf7/apps/aehttp/priv/oas3.yaml#L78-L88

`GetKeyBlockByHash` doesn't accept a micro block hash:
https://mainnet.aeternity.io/v3/key-blocks/hash/mh_LCGth3tZdPZQ5xyDCdCZYnRWjHKp9gcgkxhthP8wXnnoLSmSJ

`GetMicroBlockHeaderByHash` doesn't accept a key block hash: https://mainnet.aeternity.io/v3/micro-blocks/hash/kh_u2qG4VtJH2MEvQ4ydE8X8q3j3sUrLFmXCYMXvdECW37RjSSQk/header