### PR TITLE
chore(ci): Update mac builder resource class for CircleCI

### DIFF
--- a/.circleci/config/jobs/@packages.yml
+++ b/.circleci/config/jobs/@packages.yml
@@ -75,8 +75,8 @@ macos-tarball:
     package_name:
       type: string
   macos:
-    xcode: "14.3.1" # macOS 12.6.3
-  resource_class: macos.m1.medium.gen1
+    xcode: "14.3.1" # macOS 13.2.1
+  resource_class: m4pro.medium
   working_directory: /Users/distiller/aeternity
   steps:
     - fixed_checkout
@@ -117,8 +117,8 @@ macos-standalone:
     package_name:
       type: string
   macos:
-    xcode: "14.3.1" # macOS 12.6.3
-  resource_class: macos.m1.medium.gen1
+    xcode: "14.3.1" # macOS 13.2.1
+  resource_class: m4pro.medium
   working_directory: /Users/distiller/aeternity
   steps:
     - fixed_checkout


### PR DESCRIPTION
Update mac builder resource class for CircleCI as the older one is no longer available