### PR TITLE
Add timeout to get_key_block_candidate gen_server call

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -195,7 +195,7 @@ add_synced_block(Block) ->
 
 -spec get_key_block_candidate() -> {'ok', aec_blocks:block()} | {'error', atom()}.
 get_key_block_candidate() ->
-    gen_server:call(?SERVER, get_key_block_candidate).
+    gen_server:call(?SERVER, get_key_block_candidate, 60000).
 
 -ifdef(TEST).
 -spec reinit_chain() -> aec_headers:header().


### PR DESCRIPTION
We found out that in some cases, `/v2/key-blocks/pending` takes longer than expected. The default timeout is 5 seconds. As a workaround, I propose increasing it to 60 seconds. It is intended to solve the issue of sequences of zero blocks that we see in mainnet at the moment.

Originally found by @ifaouibadi 