### PR TITLE
Optimize FATE store map finalization with optimistic reuse fixpoint

### DIFF
--- a/apps/aecore/test/aec_block_generator_tests.erl
+++ b/apps/aecore/test/aec_block_generator_tests.erl
@@ -1,0 +1,290 @@
+-module(aec_block_generator_tests).
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(GENERATOR, aec_block_generator).
+-define(WAIT_MS, 1000).
+
+block_generator_top_change_test_() ->
+    {foreach,
+     fun setup/0,
+     fun teardown/1,
+     [{"rebuilds on deferred micro top after worker returns {error, _}",
+       fun test_rebuilds_after_failed_worker/0},
+      {"rebuilds on deferred micro top after worker crashes",
+       fun test_rebuilds_after_worker_down/0},
+      {"does not reuse a stale candidate after update worker failure",
+       fun test_does_not_reuse_stale_candidate_after_update_failure/0},
+      {"does not publish stale candidate after micro top change",
+       fun test_does_not_publish_stale_candidate_after_top_change/0}]}.
+
+setup() ->
+    meck:new(aec_events, [non_strict]),
+    meck:expect(aec_events, subscribe, fun(_) -> ok end),
+    meck:expect(aec_events, publish, fun(_, _) -> ok end),
+
+    meck:new(aec_chain, [non_strict]),
+    meck:expect(aec_chain, top_block, fun() -> <<"top-0">> end),
+
+    meck:new(aec_block_micro_candidate, [non_strict]),
+    meck:new(aec_blocks, [non_strict]),
+    meck:expect(aec_blocks, txs, fun(_) -> [dummy_tx] end),
+
+    {ok, _Pid} = ?GENERATOR:start_link(),
+    ok.
+
+teardown(_) ->
+    case whereis(?GENERATOR) of
+        undefined -> ok;
+        _Pid -> catch ?GENERATOR:stop()
+    end,
+    meck:unload(aec_blocks),
+    meck:unload(aec_block_micro_candidate),
+    meck:unload(aec_chain),
+    meck:unload(aec_events),
+    flush_test_mailbox(),
+    ok.
+
+test_rebuilds_after_failed_worker() ->
+    TestPid = self(),
+    InitialTop = <<"top-0">>,
+    DeferredTop = <<"top-1">>,
+    ContinueRef = make_ref(),
+
+    meck:expect(
+      aec_block_micro_candidate,
+      create,
+      fun(Top) when Top =:= InitialTop ->
+              TestPid ! {create_called, InitialTop, self()},
+              receive
+                  {continue, ContinueRef} -> {error, simulated_failure}
+              end;
+         (Top) when Top =:= DeferredTop ->
+              TestPid ! {create_called, DeferredTop, self()},
+              receive after infinity -> ok end
+      end),
+
+    ?GENERATOR:start_generation(),
+    WorkerPid = wait_for_create(InitialTop),
+    defer_micro_top(DeferredTop),
+    WorkerPid ! {continue, ContinueRef},
+    wait_for_create(DeferredTop).
+
+test_rebuilds_after_worker_down() ->
+    TestPid = self(),
+    InitialTop = <<"top-0">>,
+    DeferredTop = <<"top-2">>,
+    CrashRef = make_ref(),
+
+    meck:expect(
+      aec_block_micro_candidate,
+      create,
+      fun(Top) when Top =:= InitialTop ->
+              TestPid ! {create_called, InitialTop, self()},
+              receive
+                  {crash, CrashRef} -> exit(simulated_crash)
+              end;
+         (Top) when Top =:= DeferredTop ->
+              TestPid ! {create_called, DeferredTop, self()},
+              receive after infinity -> ok end
+      end),
+
+    ?GENERATOR:start_generation(),
+    WorkerPid = wait_for_create(InitialTop),
+    defer_micro_top(DeferredTop),
+    WorkerPid ! {crash, CrashRef},
+    wait_for_create(DeferredTop).
+
+test_does_not_reuse_stale_candidate_after_update_failure() ->
+    TestPid = self(),
+    InitialTop = <<"top-0">>,
+    DeferredTop = <<"top-1">>,
+    Candidate0 = candidate_0,
+    Candidate1 = candidate_1,
+    State0 = candidate_state_0,
+    State1 = candidate_state_1,
+    Tx1 = tx_1,
+    Tx2 = tx_2,
+    ContinueRef = make_ref(),
+
+    meck:expect(
+      aec_block_micro_candidate,
+      create,
+      fun(Top) when Top =:= InitialTop ->
+              TestPid ! {create_called, InitialTop, self()},
+              {ok, Candidate0, State0};
+         (Top) when Top =:= DeferredTop ->
+              TestPid ! {create_called, DeferredTop, self()},
+              {ok, Candidate1, State1}
+      end),
+    meck:expect(
+      aec_block_micro_candidate,
+      update,
+      fun(Block, Txs, BlockInfo) when Block =:= Candidate0,
+                                      Txs =:= [Tx1],
+                                      BlockInfo =:= State0 ->
+              TestPid ! {update_called, Candidate0, [Tx1], State0, self()},
+              receive
+                  {continue, ContinueRef} -> {error, simulated_failure}
+              end;
+         (Block, Txs, BlockInfo) when Block =:= Candidate1,
+                                      Txs =:= [Tx2],
+                                      BlockInfo =:= State1 ->
+              TestPid ! {update_called, Candidate1, [Tx2], State1, self()},
+              receive after infinity -> ok end;
+         (Block, Txs, BlockInfo) ->
+              TestPid ! {unexpected_update_called, Block, Txs, BlockInfo, self()},
+              receive after infinity -> ok end
+      end),
+
+    ?GENERATOR:start_generation(),
+    wait_for_create(InitialTop),
+    wait_for_candidate(Candidate0),
+
+    send_tx(Tx1),
+    UpdateWorkerPid = wait_for_update(Candidate0, [Tx1], State0),
+    defer_micro_top(DeferredTop),
+    UpdateWorkerPid ! {continue, ContinueRef},
+
+    send_tx(Tx2),
+    assert_progress_uses_fresh_top(DeferredTop, Candidate0, Candidate1, State1, Tx2).
+
+test_does_not_publish_stale_candidate_after_top_change() ->
+    TestPid = self(),
+    InitialTop = <<"top-0">>,
+    DeferredTop = <<"top-1">>,
+    Candidate0 = candidate_0,
+    Candidate1 = candidate_1,
+    State0 = candidate_state_0,
+    State1 = candidate_state_1,
+    ContinueRef = make_ref(),
+
+    meck:expect(
+      aec_events,
+      publish,
+      fun(candidate_block, new_candidate) ->
+              TestPid ! candidate_published,
+              ok;
+         (_, _) ->
+              ok
+      end),
+    meck:expect(
+      aec_block_micro_candidate,
+      create,
+      fun(Top) when Top =:= InitialTop ->
+              TestPid ! {create_called, InitialTop, self()},
+              receive
+                  {continue, ContinueRef} -> {ok, Candidate0, State0}
+              end;
+         (Top) when Top =:= DeferredTop ->
+              TestPid ! {create_called, DeferredTop, self()},
+              {ok, Candidate1, State1}
+      end),
+
+    ?GENERATOR:start_generation(),
+    InitialWorkerPid = wait_for_create(InitialTop),
+    defer_micro_top(DeferredTop),
+    InitialWorkerPid ! {continue, ContinueRef},
+
+    wait_for_create(DeferredTop),
+    wait_for_candidate(Candidate1),
+    ?assertEqual(Candidate1, current_candidate()),
+    ?assertEqual(1, count_candidate_publishes()).
+
+wait_for_create(ExpectedTop) ->
+    receive
+        {create_called, ExpectedTop, WorkerPid} ->
+            WorkerPid
+    after ?WAIT_MS ->
+        ?assert(false)
+    end.
+
+wait_for_update(ExpectedCandidate, ExpectedTxs, ExpectedState) ->
+    receive
+        {update_called, ExpectedCandidate, ExpectedTxs, ExpectedState, WorkerPid} ->
+            WorkerPid
+    after ?WAIT_MS ->
+        ?assert(false)
+    end.
+
+wait_for_candidate(ExpectedCandidate) ->
+    wait_for_candidate(ExpectedCandidate, 50).
+
+wait_for_candidate(_ExpectedCandidate, 0) ->
+    ?assert(false);
+wait_for_candidate(ExpectedCandidate, RetriesLeft) ->
+    case ?GENERATOR:get_candidate() of
+        {ok, ExpectedCandidate} ->
+            ok;
+        _ ->
+            timer:sleep(20),
+            wait_for_candidate(ExpectedCandidate, RetriesLeft - 1)
+    end.
+
+current_candidate() ->
+    case ?GENERATOR:get_candidate() of
+        {ok, Candidate} -> Candidate;
+        {error, no_candidate} -> no_candidate
+    end.
+
+send_tx(Tx) ->
+    ?GENERATOR ! {gproc_ps_event, tx_created, #{info => Tx}},
+    ok.
+
+defer_micro_top(DeferredTop) ->
+    ?GENERATOR ! {gproc_ps_event, top_changed,
+                  #{info => #{block_type => micro, block_hash => DeferredTop}}},
+    ok.
+
+assert_progress_uses_fresh_top(DeferredTop, StaleCandidate, FreshCandidate, FreshState, Tx) ->
+    receive
+        {unexpected_update_called, StaleCandidate, [Tx], _OldState, _WorkerPid} ->
+            ?assert(false);
+        {update_called, StaleCandidate, [Tx], _OldState, _WorkerPid} ->
+            ?assert(false);
+        {create_called, DeferredTop, _WorkerPid} ->
+            wait_for_candidate(FreshCandidate),
+            wait_for_update(FreshCandidate, [Tx], FreshState),
+            assert_no_stale_update_after_fresh_progress(StaleCandidate, Tx);
+        {update_called, FreshCandidate, [Tx], FreshState, _WorkerPid} ->
+            assert_no_stale_update_after_fresh_progress(StaleCandidate, Tx)
+    after ?WAIT_MS ->
+        ?assert(false)
+    end.
+
+assert_no_stale_update_after_fresh_progress(StaleCandidate, Tx) ->
+    assert_no_stale_update_after_fresh_progress(StaleCandidate, Tx, 10).
+
+assert_no_stale_update_after_fresh_progress(_StaleCandidate, _Tx, 0) ->
+    ok;
+assert_no_stale_update_after_fresh_progress(StaleCandidate, Tx, ChecksLeft) ->
+    receive
+        {unexpected_update_called, StaleCandidate, [Tx], _OldState, _WorkerPid} ->
+            ?assert(false);
+        {update_called, StaleCandidate, [Tx], _OldState, _WorkerPid} ->
+            ?assert(false)
+    after 20 ->
+        assert_no_stale_update_after_fresh_progress(StaleCandidate, Tx, ChecksLeft - 1)
+    end.
+
+count_candidate_publishes() ->
+    count_candidate_publishes(0).
+
+count_candidate_publishes(Acc) ->
+    receive
+        candidate_published ->
+            count_candidate_publishes(Acc + 1)
+    after 100 ->
+        Acc
+    end.
+
+flush_test_mailbox() ->
+    receive
+        _Msg -> flush_test_mailbox()
+    after 0 ->
+        ok
+    end.
+
+-endif.

--- a/apps/aefate/src/aefa_stores.erl
+++ b/apps/aefate/src/aefa_stores.erl
@@ -396,24 +396,71 @@ compute_store_updates(Metadata, #cache_entry{terms = TermCache, store = Store}) 
     {Metadata2, lists:sort(Compare, Updates)}.
 
 compute_reuse_fixpoint(Maps, Metadata, Store) ->
-    compute_reuse_fixpoint(unused_maps(Metadata), Maps, Metadata, Store, 100).
+    Unused0 = unused_maps(Metadata),
+    %% Optimistic fast path: run fixpoint using only reuse-branch refcount
+    %% adjustments (no expensive MPT subtree reads). If all store maps end up
+    %% reused in-place, the copy branch would have contributed zero adjustments
+    %% so the optimistic result is exact.
+    {UnusedOpt, ReuseOpt, _MetaOpt} =
+        optimistic_reuse_fixpoint(Unused0, Maps, Metadata, Store, 100),
+    NumStoreMaps = length([1 || {_, ?FATE_STORE_MAP(_, _)} <- maps:to_list(Maps)]),
+    case maps:size(ReuseOpt) =:= NumStoreMaps of
+        true ->
+            {RefCounts1, _} = compute_copy_refcounts(Metadata, ReuseOpt, Maps, Store, #{}),
+            Metadata1 = update_refcounts(RefCounts1, Metadata),
+            {UnusedOpt, ReuseOpt, Metadata1};
+        false ->
+            full_reuse_fixpoint(Unused0, Maps, Metadata, Store, 100, #{})
+    end.
 
-compute_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel) ->
-    Reuse      = compute_inplace_updates(Unused, Maps),
-    RefCounts1 = compute_copy_refcounts(Metadata, Reuse, Maps, Store),
-    Metadata1  = update_refcounts(RefCounts1, Metadata),
-    Unused1    = unused_maps(Metadata1),
+%% Optimistic fixpoint: only computes reuse-branch refcount adjustments.
+%% Skips the copy branch (no subtree reads from MPT).
+optimistic_reuse_fixpoint(Unused, Maps, Metadata, _Store, Fuel) when Fuel =< 0 ->
+    {Unused, compute_inplace_updates(Unused, Maps), Metadata};
+optimistic_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel) ->
+    Reuse = compute_inplace_updates(Unused, Maps),
+    RefCounts1 = compute_reuse_only_refcounts(Metadata, Reuse, Maps, Store),
+    Metadata1 = update_refcounts(RefCounts1, Metadata),
+    Unused1 = unused_maps(Metadata1),
     case Unused1 == Unused of
-        _ when Fuel =< 0 ->
-            ?ASSERT(false, {reuse_fixpoint_out_of_fuel, Metadata, Unused, Maps}),
-            {Unused, Reuse, Metadata1};
+        true  -> {Unused, Reuse, Metadata1};
+        false -> optimistic_reuse_fixpoint(Unused1, Maps, Metadata, Store, Fuel - 1)
+    end.
+
+%% Only compute refcount adjustments for reused maps (lightweight individual lookups).
+%% Copied maps contribute zero adjustments — their subtrees are NOT read.
+compute_reuse_only_refcounts(Meta, Reuse, Maps, Store) ->
+    maps:fold(fun(MapId, ?FATE_STORE_MAP(Cache, Id), Count) ->
+                      case maps:get(Id, Reuse, no_reuse) of
+                          MapId ->
+                              ?METADATA(RawId, _RefCount, _Size) = get_map_meta(Id, Meta),
+                              RemovedValues = [ Val || Key <- maps:keys(Cache),
+                                                       {ok, Val, _} <- [find_in_store(map_data_key(RawId, Key), Store)] ],
+                              Removed = aeb_fate_maps:refcount(RemovedValues),
+                              aeb_fate_maps:refcount_diff(Count, Removed);
+                          _ ->
+                              Count
+                      end;
+                 (_, _, Count) -> Count
+              end, #{}, Maps).
+
+%% Full fixpoint (original algorithm with subtree cache) — used as fallback.
+%% NOTE: We pass Metadata (not Metadata1) to recursive calls. Reason:
+%% compute_copy_refcounts updates refcounts assuming no inplace updates have
+%% been taken into account. So, each iteration updates the original metadata.
+full_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel, SubtreeCache) when Fuel =< 0 ->
+    ?ASSERT(false, {reuse_fixpoint_out_of_fuel, Metadata, Unused, Maps}),
+    {Unused, compute_inplace_updates(Unused, Maps),
+     update_refcounts(element(1, compute_copy_refcounts(Metadata, compute_inplace_updates(Unused, Maps), Maps, Store, SubtreeCache)), Metadata)};
+full_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel, SubtreeCache) ->
+    Reuse = compute_inplace_updates(Unused, Maps),
+    {RefCounts1, SubtreeCache1} = compute_copy_refcounts(Metadata, Reuse, Maps, Store, SubtreeCache),
+    Metadata1 = update_refcounts(RefCounts1, Metadata),
+    Unused1 = unused_maps(Metadata1),
+    case Unused1 == Unused of
         true  -> {Unused, Reuse, Metadata1};
         false ->
-            %% NOTE: Metadata and not Metadata1. Reason: compute_copy_refcounts
-            %% will update refcounts assuming no inplace updates have been
-            %% taken into account. So, each iteration of the loop updates the
-            %% original metadata.
-            compute_reuse_fixpoint(Unused1, Maps, Metadata, Store, Fuel - 1)
+            full_reuse_fixpoint(Unused1, Maps, Metadata, Store, Fuel - 1, SubtreeCache1)
     end.
 
 perform_store_updates(OldMeta, [Update|Left], Meta, GasLeft, Store) ->
@@ -603,8 +650,8 @@ map_refcounts(_Meta, ?FATE_STORE_MAP(Cache, _Id), _Store) ->
 
 %% We need to increase the refcounts of maps contained in maps that are being
 %% copied.
-compute_copy_refcounts(Meta, Reuse, Maps, Store) ->
-    maps:fold(fun(MapId, ?FATE_STORE_MAP(Cache, Id), Count) ->
+compute_copy_refcounts(Meta, Reuse, Maps, Store, SubtreeCache) ->
+    maps:fold(fun(MapId, ?FATE_STORE_MAP(Cache, Id), {Count, SC}) ->
                       case maps:get(Id, Reuse, no_reuse) of
                           MapId ->
                               %% Subtract refcounts for entries overwritten by the Cache.
@@ -612,17 +659,24 @@ compute_copy_refcounts(Meta, Reuse, Maps, Store) ->
                               RemovedValues = [ Val || Key <- maps:keys(Cache),
                                                        {ok, Val, _} <- [find_in_store(map_data_key(RawId, Key), Store)] ],
                               Removed = aeb_fate_maps:refcount(RemovedValues),
-                              aeb_fate_maps:refcount_diff(Count, Removed);
+                              {aeb_fate_maps:refcount_diff(Count, Removed), SC};
                           _ ->
                               %% Note that we already added refcounts for the Cache.
                               ?METADATA(RawId, _RefCount, _Size) = get_map_meta(Id, Meta),
                               NewKeys = [ aeb_fate_encoding:serialize(Key) || Key <- maps:keys(Cache) ],
-                              OldBin = maps:without(NewKeys, aect_contracts_store:subtree(map_data_key(RawId), Store)),
+                              {OldBin, SC1} =
+                                  case maps:find(RawId, SC) of
+                                      {ok, CachedSubtree} ->
+                                          {maps:without(NewKeys, CachedSubtree), SC};
+                                      error ->
+                                          FullSubtree = aect_contracts_store:subtree(map_data_key(RawId), Store),
+                                          {maps:without(NewKeys, FullSubtree), SC#{RawId => FullSubtree}}
+                                  end,
                               Count1 = aeb_fate_maps:refcount([ aeb_fate_encoding:deserialize(Val) || Val <- maps:values(OldBin) ]),
-                              aeb_fate_maps:refcount_union(Count1, Count)
+                              {aeb_fate_maps:refcount_union(Count1, Count), SC1}
                       end;
-                 (_, _, Count) -> Count
-                end, #{}, Maps).
+                 (_, _, Acc) -> Acc
+                end, {#{}, SubtreeCache}, Maps).
 
 %% Compute the difference in reference counts caused by performing a store
 %% update: refcount(Val) - refcount(OldVal).

--- a/apps/aefate/src/aefa_stores.erl
+++ b/apps/aefate/src/aefa_stores.erl
@@ -413,54 +413,46 @@ compute_reuse_fixpoint(Maps, Metadata, Store) ->
             full_reuse_fixpoint(Unused0, Maps, Metadata, Store, 100, #{})
     end.
 
-%% Optimistic fixpoint: only computes reuse-branch refcount adjustments.
-%% Skips the copy branch (no subtree reads from MPT).
-optimistic_reuse_fixpoint(Unused, Maps, Metadata, _Store, Fuel) when Fuel =< 0 ->
-    {Unused, compute_inplace_updates(Unused, Maps), Metadata};
-optimistic_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel) ->
+%% Generic reuse fixpoint loop, parameterised on how refcounts are computed.
+%% RefCountFun(Metadata, Reuse, Maps, Store, Acc) -> {RefCounts, Acc1}
+%% NOTE: Metadata (not the updated Metadata1) is threaded unchanged into
+%% recursive calls — each iteration adjusts the original metadata.
+reuse_fixpoint_loop(_RefCountFun, Unused, _Maps, _Metadata, _Store, Fuel, Acc) when Fuel =< 0 ->
+    {out_of_fuel, Unused, Acc};
+reuse_fixpoint_loop(RefCountFun, Unused, Maps, Metadata, Store, Fuel, Acc) ->
     Reuse = compute_inplace_updates(Unused, Maps),
-    RefCounts1 = compute_reuse_only_refcounts(Metadata, Reuse, Maps, Store),
+    {RefCounts1, Acc1} = RefCountFun(Metadata, Reuse, Maps, Store, Acc),
     Metadata1 = update_refcounts(RefCounts1, Metadata),
     Unused1 = unused_maps(Metadata1),
     case Unused1 == Unused of
-        true  -> {Unused, Reuse, Metadata1};
-        false -> optimistic_reuse_fixpoint(Unused1, Maps, Metadata, Store, Fuel - 1)
+        true  -> {converged, Unused, Reuse, Metadata1, Acc1};
+        false -> reuse_fixpoint_loop(RefCountFun, Unused1, Maps, Metadata, Store, Fuel - 1, Acc1)
     end.
 
-%% Only compute refcount adjustments for reused maps (lightweight individual lookups).
-%% Copied maps contribute zero adjustments — their subtrees are NOT read.
-compute_reuse_only_refcounts(Meta, Reuse, Maps, Store) ->
-    maps:fold(fun(MapId, ?FATE_STORE_MAP(Cache, Id), Count) ->
-                      case maps:get(Id, Reuse, no_reuse) of
-                          MapId ->
-                              ?METADATA(RawId, _RefCount, _Size) = get_map_meta(Id, Meta),
-                              RemovedValues = [ Val || Key <- maps:keys(Cache),
-                                                       {ok, Val, _} <- [find_in_store(map_data_key(RawId, Key), Store)] ],
-                              Removed = aeb_fate_maps:refcount(RemovedValues),
-                              aeb_fate_maps:refcount_diff(Count, Removed);
-                          _ ->
-                              Count
-                      end;
-                 (_, _, Count) -> Count
-              end, #{}, Maps).
+%% Optimistic fixpoint: only computes reuse-branch refcount adjustments.
+%% Skips the copy branch (no subtree reads from MPT).
+optimistic_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel) ->
+    Fun = fun(Meta, Reuse, Ms, St, _Acc) ->
+        {compute_reuse_only_refcounts(Meta, Reuse, Ms, St), ok}
+    end,
+    case reuse_fixpoint_loop(Fun, Unused, Maps, Metadata, Store, Fuel, ok) of
+        {converged, U, R, M, _}  -> {U, R, M};
+        {out_of_fuel, U, _}      -> {U, compute_inplace_updates(U, Maps), Metadata}
+    end.
 
 %% Full fixpoint (original algorithm with subtree cache) — used as fallback.
-%% NOTE: We pass Metadata (not Metadata1) to recursive calls. Reason:
-%% compute_copy_refcounts updates refcounts assuming no inplace updates have
-%% been taken into account. So, each iteration updates the original metadata.
-full_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel, SubtreeCache) when Fuel =< 0 ->
-    ?ASSERT(false, {reuse_fixpoint_out_of_fuel, Metadata, Unused, Maps}),
-    {Unused, compute_inplace_updates(Unused, Maps),
-     update_refcounts(element(1, compute_copy_refcounts(Metadata, compute_inplace_updates(Unused, Maps), Maps, Store, SubtreeCache)), Metadata)};
 full_reuse_fixpoint(Unused, Maps, Metadata, Store, Fuel, SubtreeCache) ->
-    Reuse = compute_inplace_updates(Unused, Maps),
-    {RefCounts1, SubtreeCache1} = compute_copy_refcounts(Metadata, Reuse, Maps, Store, SubtreeCache),
-    Metadata1 = update_refcounts(RefCounts1, Metadata),
-    Unused1 = unused_maps(Metadata1),
-    case Unused1 == Unused of
-        true  -> {Unused, Reuse, Metadata1};
-        false ->
-            full_reuse_fixpoint(Unused1, Maps, Metadata, Store, Fuel - 1, SubtreeCache1)
+    Fun = fun(Meta, Reuse, Ms, St, SC) ->
+        compute_copy_refcounts(Meta, Reuse, Ms, St, SC)
+    end,
+    case reuse_fixpoint_loop(Fun, Unused, Maps, Metadata, Store, Fuel, SubtreeCache) of
+        {converged, U, R, M, _} ->
+            {U, R, M};
+        {out_of_fuel, U, SC} ->
+            ?ASSERT(false, {reuse_fixpoint_out_of_fuel, Metadata, U, Maps}),
+            Reuse = compute_inplace_updates(U, Maps),
+            {RefCounts1, _} = compute_copy_refcounts(Metadata, Reuse, Maps, Store, SC),
+            {U, Reuse, update_refcounts(RefCounts1, Metadata)}
     end.
 
 perform_store_updates(OldMeta, [Update|Left], Meta, GasLeft, Store) ->
@@ -647,6 +639,23 @@ map_refcounts(_Meta, ?FATE_STORE_MAP(Cache, _Id), _Store) ->
                 %% the delta into account.
                 aeb_fate_maps:refcount_union(aeb_fate_maps:refcount(Val), Count)
               end, #{}, Cache).
+
+%% Only compute refcount adjustments for reused maps (lightweight individual lookups).
+%% Copied maps contribute zero adjustments — their subtrees are NOT read.
+compute_reuse_only_refcounts(Meta, Reuse, Maps, Store) ->
+    maps:fold(fun(MapId, ?FATE_STORE_MAP(Cache, Id), Count) ->
+                      case maps:get(Id, Reuse, no_reuse) of
+                          MapId ->
+                              ?METADATA(RawId, _RefCount, _Size) = get_map_meta(Id, Meta),
+                              RemovedValues = [ Val || Key <- maps:keys(Cache),
+                                                       {ok, Val, _} <- [find_in_store(map_data_key(RawId, Key), Store)] ],
+                              Removed = aeb_fate_maps:refcount(RemovedValues),
+                              aeb_fate_maps:refcount_diff(Count, Removed);
+                          _ ->
+                              Count
+                      end;
+                 (_, _, Count) -> Count
+              end, #{}, Maps).
 
 %% We need to increase the refcounts of maps contained in maps that are being
 %% copied.


### PR DESCRIPTION
The `compute_reuse_fixpoint` algorithm in `aefa_stores.erl` performs full MPT subtree reads for store maps not yet proven reusable. For contracts with large store maps (thousands of entries), a single subtree read can take 14+ seconds — only to discover the map was safe to reuse all along.

This PR adds an optimistic fast path that skips the expensive subtree reads entirely. When all store maps end up reused in-place (the common case), the optimistic result is exact. Otherwise, it falls back to the original algorithm with a subtree cache.

**Tested against a production mainnet factory-pattern contract** with 4 large store maps, 7 contracts touched per call, and thousands of accumulated entries:

| Metric | Before | After |
|---|---|---|
| Store finalize (target contract) | 15.1s | 6ms |
| End-to-end dry-run | 14.6s | 57–83ms |

No consensus impact. Bit-identical store writes. No hard fork required.
