### PR TITLE
Fix `speficied` -> `specified` typo in docs/configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,7 @@ fork_management:
 ### Hardforks
 
 Hardforks allow the specification of consensus protocol versions with their respective heights for custom chains.
-Optionally, prefunded account and contract files can be speficied which will be effective at these heights.
+Optionally, prefunded account and contract files can be specified which will be effective at these heights.
 The files can be specified using the absolute path or a path relative to the home of the node in the directory data/aecore.
 
 ```yaml


### PR DESCRIPTION
Line 149 of docs/configuration.md has `speficied` (transposed letters) in the hardforks documentation. The next sentence already uses `specified` correctly, so this is a localized typo.