### PR TITLE
Allow more external endpoints in config schema to be disabled

### DIFF
--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -79,7 +79,12 @@ check_env() ->
                       <<"oracle">>        => Default0,
                       <<"name_service">>  => Default0,
                       <<"channel">>       => Default0,
-                      <<"node_info">>     => Default0,
+                      %% node_info is always enabled by default so that /status and
+                      %% other health/monitoring endpoints remain reachable even when
+                      %% other groups are disabled.  Users may still override this
+                      %% explicitly via http.endpoints.node_info: false.
+                      <<"node_info">>     => true,
+                      <<"hyperchain">>    => false,
                       <<"debug">>         => true,
                       <<"dry-run">>       => false,
                       <<"node-operator">> => false,

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1395,9 +1395,34 @@
                             "description" : "Chain state inspection endpoints",
                             "type" : "boolean"
                         },
-                        "transactions" : {
-                            "description" : "Transactions inspection endpoints",
+                        "transaction": {
+                            "description": "Transaction endpoints (POST /transactions, GET /transactions/*)",
+                            "type": "boolean"
+                        },
+                        "account": {
+                            "description": "Account endpoints (/accounts/*)",
+                            "type": "boolean"
+                        },
+                        "contract": {
+                            "description": "Contract endpoints (/contracts/*)",
+                            "type": "boolean"
+                        },
+                        "oracle": {
+                            "description": "Oracle endpoints (/oracles/*)",
+                            "type": "boolean"
+                        },
+                        "channel": {
+                            "description": "State channel endpoints (/channels/*)",
+                            "type": "boolean"
+                        },
+                        "node_info": {
+                            "description": "Node information endpoints (/status, /sync-status, /peers/pubkey, /currency). Disabling removes health and monitoring endpoints - use with care.",
                             "type" : "boolean"
+                        },
+                        "hyperchain": {
+                            "description": "Hyperchain specific endpoints",
+                            "type": "boolean",
+                            "default": false
                         },
                         "node-operator" : {
                             "description" : "Node operator endpoints",


### PR DESCRIPTION
Certain groups of external endpoints were missing in the runtime config schema, although they are supported, yet users couldn't configure and turn them off. That would allow more flexible configuration for various scenarios and instance purpose. This only configure http endpoints, not functionality
e.g.
```
http:
  endpoints:
    contract: false
    channel: false
...
```