### PR TITLE
Add a wall-clock timeout to the dry-run endpoint

### DIFF
--- a/apps/aeapi/src/aeapi.erl
+++ b/apps/aeapi/src/aeapi.erl
@@ -513,7 +513,7 @@ format_txs(Txs, MBHash) ->
             _ ->
                 {in, MBHash}
             end,
-    case aec_dry_run:dry_run(Top, [], DryTxs, [tx_events]) of
+    case aec_dry_run:dry_run(Top, [], DryTxs, [tx_events, {dry_run_profile, replay}]) of
         {ok, {Results, _Events}} ->
             TxHashes = [aetx_sign:hash(Tx) || Tx <- Txs],
             lists:zip(TxHashes, Results);

--- a/apps/aecore/src/aec_dry_run.erl
+++ b/apps/aecore/src/aec_dry_run.erl
@@ -7,11 +7,17 @@
 -export([ dry_run/3
 	, dry_run/4 ]).
 
+%% exported for eunit only
+-export([ run_bounded/2
+        , resolve_timeout/1 ]).
+
 -include("blocks.hrl").
 -include_lib("aecontract/include/aecontract.hrl").
 
 -define(MR_MAGIC, <<1:32/unit:8>>).
 -define(BIG_AMOUNT, 1000000000000000000000). %% 1000 AE
+
+-define(TIMEOUT_ERROR, <<"dry-run exceeded time limit">>).
 
 %% Let Top be one of:
 %% * {height, X :: int()} - this means "right after keyblock of generation X"
@@ -24,7 +30,13 @@
 dry_run(Top, Accounts, Txs) ->
     dry_run(Top, Accounts, Txs, []).
 
+%% Entry point for HTTP/Rosetta/aeapi dry-run; off-chain only, never called
+%% from block production/validation.
 dry_run(Top, Accounts, Txs, Opts) ->
+    {TimeoutMs, Opts1} = resolve_timeout(Opts),
+    run_bounded(fun() -> dry_run_unbounded(Top, Accounts, Txs, Opts1) end, TimeoutMs).
+
+dry_run_unbounded(Top, Accounts, Txs, Opts) ->
     try setup_dry_run(Top, Accounts) of
         {Env, Trees} -> dry_run_(Txs, Trees, Env, Opts)
     catch
@@ -33,6 +45,104 @@ dry_run(Top, Accounts, Txs, Opts) ->
         error:state_garbage_collected ->
             {error, <<"Block state of given hash was garbage collected">>}
     end.
+
+%% Only the untrusted public endpoint is time-bounded (the DoS surface); Rosetta
+%% replay gets a looser bound; internal/trusted calls run unbounded but stay
+%% memory-guarded. Explicit {timeout_ms, N} wins; dry-run-only opts are stripped
+%% so they never reach tx application. 0 in config means unbounded.
+resolve_timeout(Opts) ->
+    Opts1 = proplists:delete(timeout_ms, proplists:delete(dry_run_profile, Opts)),
+    case proplists:get_value(timeout_ms, Opts) of
+        N when is_integer(N) -> {N, Opts1};
+        undefined ->
+            Profile = proplists:get_value(dry_run_profile, Opts, internal),
+            {profile_timeout(Profile), Opts1}
+    end.
+
+profile_timeout(public) ->
+    cfg_timeout(<<"timeout_ms">>, timeout_ms, aec_governance:micro_block_cycle());
+profile_timeout(replay) ->
+    cfg_timeout(<<"replay_timeout_ms">>, replay_timeout_ms, 10000);
+profile_timeout(_) ->
+    infinity.
+
+cfg_timeout(Key, EnvKey, Default) ->
+    case aeu_env:user_config_or_env([<<"http">>, <<"dry_run">>, Key],
+                                    aehttp, [dry_run, EnvKey], Default) of
+        0 -> infinity;
+        N -> N
+    end.
+
+%% ~2 GB backstop for a single non-yielding allocation the timer can't catch;
+%% normal iterative work is bounded by the wall-clock timeout, not this. 0 off.
+dry_run_max_heap_words() ->
+    aeu_env:user_config_or_env([<<"http">>, <<"dry_run">>, <<"max_heap_words">>],
+                                aehttp, [dry_run, max_heap_words], 256000000).
+
+%% Wall-clock bound via a killable worker (infinity = no timer, memory guard
+%% only); a non-yielding NIF can still overshoot since exit/2 can't preempt it.
+run_bounded(Fun, TimeoutMs) ->
+    Caller = self(),
+    Tag = make_ref(),
+    {WorkerPid, WorkerMRef} = spawn_monitor(fun() -> run_worker(Fun, Caller, Tag) end),
+    TimerRef = start_timer(TimeoutMs, Tag),
+    Result =
+        receive
+            {Tag, {worker_result, Res}} ->
+                erlang:demonitor(WorkerMRef, [flush]),
+                Res;
+            {timeout, Tag} ->
+                erlang:demonitor(WorkerMRef, [flush]),
+                exit(WorkerPid, kill),
+                {error, ?TIMEOUT_ERROR};
+            {'DOWN', WorkerMRef, process, WorkerPid, Reason} ->
+                {error, crash_reason(Reason)}
+        end,
+    cancel_timer(TimerRef),
+    drain_stray(Tag),
+    Result.
+
+start_timer(infinity, _Tag) -> undefined;
+start_timer(TimeoutMs, Tag) -> erlang:send_after(TimeoutMs, self(), {timeout, Tag}).
+
+cancel_timer(undefined) -> ok;
+cancel_timer(TimerRef)  -> _ = erlang:cancel_timer(TimerRef), ok.
+
+%% Drain any stray message that raced with the branch taken above.
+drain_stray(Tag) ->
+    receive
+        {Tag, _}       -> drain_stray(Tag);
+        {timeout, Tag} -> drain_stray(Tag)
+    after 0 ->
+        ok
+    end.
+
+%% Inner is linked so a kill of this worker cascades to it; trap_exit keeps an
+%% inner crash an error, not a death; Caller is monitored for client disconnect.
+run_worker(Fun, Caller, Tag) ->
+    process_flag(trap_exit, true),
+    CallerMRef = erlang:monitor(process, Caller),
+    Self = self(),
+    SpawnOpts = case dry_run_max_heap_words() of
+                    N when is_integer(N), N > 0 ->
+                        [{max_heap_size, #{size => N, kill => true, error_logger => true}}];
+                    _ ->
+                        []
+                end,
+    InnerPid = spawn_opt(fun() -> Self ! {inner_done, Fun()} end, SpawnOpts ++ [link]),
+    receive
+        {inner_done, Res} ->
+            erlang:demonitor(CallerMRef, [flush]),
+            Caller ! {Tag, {worker_result, Res}};
+        {'EXIT', InnerPid, Reason} ->
+            erlang:demonitor(CallerMRef, [flush]),
+            Caller ! {Tag, {worker_result, {error, crash_reason(Reason)}}};
+        {'DOWN', CallerMRef, process, Caller, _Reason} ->
+            exit(InnerPid, kill)
+    end.
+
+crash_reason(Reason) ->
+    iolist_to_binary(io_lib:format("dry-run failed: ~120P", [Reason, 10])).
 
 setup_dry_run(Top, Accounts) ->
     {Env, Trees} = tx_env_and_trees(Top),

--- a/apps/aecore/test/aec_dry_run_heavy_tests.erl
+++ b/apps/aecore/test/aec_dry_run_heavy_tests.erl
@@ -1,0 +1,116 @@
+%%% End-to-end proof that dry_run/4 bounds a genuinely heavy contract call,
+%%% not just an injected timer:sleep/1. Slow (~20s) and memory-heavy (runs the
+%%% baseline with the heap guard off), so it is opt-in: set AE_HEAVY_DRY_RUN=1.
+-module(aec_dry_run_heavy_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_MODULE, aec_dry_run).
+%% storage_tester needs FATE (@compiler >= 4.3); Iris is protocol 5.
+-define(MIN_PROTOCOL, 5).
+
+%% Calibrated so the call takes several real seconds (measured ~6.5s),
+%% comfortably more than the 1.5s default bound.
+-define(DIMS, 60).
+
+dummy_sign(Tx) ->
+    aetx_sign:new(Tx, [<<0:64/unit:8>>]).
+
+%% Deploys storage_tester into in-memory trees, builds the slow-entrypoint
+%% call tx. Returns {Env, TreesAfterDeploy, CallTx}.
+build_fixture() ->
+    SophiaVsn = aect_test_utils:sophia_version(),
+    Proto = aect_test_utils:latest_protocol_version(),
+    VmV = aect_test_utils:vm_version(),
+    AbiV = aect_test_utils:abi_version(),
+
+    {ok, Code} = aect_test_utils:compile_contract(SophiaVsn, storage_tester),
+    {ok, BinSrc} = aect_test_utils:read_contract(SophiaVsn, storage_tester),
+
+    S0 = aect_test_utils:new_state(),
+    {Owner, S1} = aect_test_utils:setup_new_account(
+                    1000000000000000 * aec_test_utils:min_gas_price(), S0),
+
+    %% Forced to latest protocol so FATE/ABI versions match the compile.
+    Header0 = aec_headers:raw_key_header(),
+    Header = aec_headers:set_version_and_height(Header0, Proto, 100),
+    Env0 = aetx_env:tx_env_from_key_header(Header, <<0:32/unit:8>>, 0, <<0:32/unit:8>>),
+    Env = aetx_env:set_context(Env0, aetx_transaction),
+
+    {ok, InitCallData} = aect_test_utils:encode_call_data(BinSrc, "init", []),
+    CreateNonce = aect_test_utils:next_nonce(Owner, S1),
+    CreateTx = aect_test_utils:create_tx(Owner, #{ code => Code
+                                                  , call_data => InitCallData
+                                                  , vm_version => VmV
+                                                  , abi_version => AbiV
+                                                  , gas => 1000000
+                                                  , amount => 0
+                                                  , deposit => 0
+                                                  , nonce => CreateNonce
+                                                  }, S1),
+    ContractPK = aect_contracts:compute_contract_pubkey(Owner, CreateNonce),
+
+    Trees1 = aect_test_utils:trees(S1),
+    {ok, [_], [], Trees2, _} =
+        aec_trees:apply_txs_on_state_trees([dummy_sign(CreateTx)], Trees1, Env,
+                                            [strict, dont_verify_signature]),
+    S2 = aect_test_utils:set_trees(Trees2, S1),
+
+    DimsStr = integer_to_list(?DIMS),
+    {ok, CallCallData} = aect_test_utils:encode_call_data(
+                            BinSrc, "inita", [DimsStr, DimsStr, DimsStr]),
+    CallNonce = aect_test_utils:next_nonce(Owner, S2),
+    CallTx = aect_test_utils:call_tx(Owner, ContractPK,
+                                      #{ call_data => CallCallData
+                                       , gas => 5000000000
+                                       , gas_price => aec_test_utils:min_gas_price()
+                                       , amount => 0
+                                       , nonce => CallNonce
+                                       }, S2),
+    {Env, Trees2, CallTx}.
+
+result_tag({ok, _}) -> ok;
+result_tag(Other) -> Other.
+
+real_heavy_contract_is_bounded_test_() ->
+    Enabled = os:getenv("AE_HEAVY_DRY_RUN") =/= false,
+    case Enabled andalso aect_test_utils:latest_protocol_version() >= ?MIN_PROTOCOL of
+        false -> [];
+        true  -> {timeout, 120, fun run_heavy/0}
+    end.
+
+run_heavy() ->
+        {Env, Trees, CallTx} = build_fixture(),
+        meck:new(aetx_env, [passthrough]),
+        try
+            meck:expect(aetx_env, tx_env_and_trees_from_hash,
+                        fun(_Type, _Hash) -> {Env, Trees} end),
+
+            %% Baseline: no profile (unbounded) and no heap backstop, so this
+            %% synthetic 5e9-gas call (there to stress the timer) runs to the
+            %% end and shows its true unbounded wall-clock cost T.
+            application:set_env(aehttp, dry_run, [{max_heap_words, 0}]),
+            {TBaseline, ResBaseline} =
+                timer:tc(fun() -> ?TEST_MODULE:dry_run(<<0:32/unit:8>>, [], [{tx, CallTx}]) end),
+            BaselineMs = TBaseline div 1000,
+            ?debugFmt("dims=~p UNBOUNDED -> ~p, wall-clock T=~pms (~.2fs)",
+                       [?DIMS, result_tag(ResBaseline), BaselineMs, BaselineMs / 1000]),
+
+            %% Same call via the public endpoint profile (real 1.5s default bound).
+            application:set_env(aehttp, dry_run, [{max_heap_words, 0}]),
+            {TBounded, ResBounded} =
+                timer:tc(fun() -> ?TEST_MODULE:dry_run(<<0:32/unit:8>>, [], [{tx, CallTx}], [{dry_run_profile, public}]) end),
+            BoundedMs = TBounded div 1000,
+            ?debugFmt("dims=~p BOUNDED (3s public default) -> ~p, wall-clock=~pms", [?DIMS, ResBounded, BoundedMs]),
+            ?debugFmt("MONEY PROOF: unbounded T=~.2fs, bounded -> error at ~pms (~.2fs)",
+                       [BaselineMs / 1000, BoundedMs, BoundedMs / 1000]),
+
+            ?assertMatch({ok, _}, ResBaseline),
+            ?assert(BaselineMs > 3000),           %% the real call is genuinely slow
+            ?assertEqual({error, <<"dry-run exceeded time limit">>}, ResBounded),
+            ?assert(BoundedMs < BaselineMs),        %% far less than the unbounded run
+            ?assert(BoundedMs < 6000)               %% cut off near the 3s bound
+        after
+            meck:unload(aetx_env),
+            application:unset_env(aehttp, dry_run)
+        end.

--- a/apps/aecore/test/aec_dry_run_tests.erl
+++ b/apps/aecore/test/aec_dry_run_tests.erl
@@ -1,0 +1,112 @@
+-module(aec_dry_run_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_MODULE, aec_dry_run).
+
+fast_fun_returns_unchanged_test() ->
+    ?assertEqual({ok, 42}, ?TEST_MODULE:run_bounded(fun() -> {ok, 42} end, 1000)).
+
+slow_fun_times_out_test() ->
+    T0 = erlang:monotonic_time(millisecond),
+    Res = ?TEST_MODULE:run_bounded(fun() -> timer:sleep(2000), ok end, 100),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    ?assertEqual({error, <<"dry-run exceeded time limit">>}, Res),
+    %% returned close to the bound, well before the 2s sleep would finish
+    ?assert(Elapsed >= 100),
+    ?assert(Elapsed < 1000).
+
+crashing_fun_returns_error_not_hang_test() ->
+    Res = ?TEST_MODULE:run_bounded(fun() -> error(boom) end, 1000),
+    ?assertMatch({error, <<"dry-run failed: ", _/binary>>}, Res).
+
+%% On timeout the inner computation must actually be killed, not left running
+%% orphaned to completion (which would bound latency but not CPU).
+inner_killed_on_timeout_test() ->
+    Parent = self(),
+    Fun = fun() -> Parent ! {inner_started, self()}, timer:sleep(3000), done end,
+    ?assertMatch({error, _}, ?TEST_MODULE:run_bounded(Fun, 100)),
+    InnerPid = receive {inner_started, P} -> P after 1000 -> error(inner_never_started) end,
+    ?assert(wait_until(fun() -> not is_process_alive(InnerPid) end, 1500)).
+
+wait_until(_Pred, Left) when Left =< 0 -> false;
+wait_until(Pred, Left) ->
+    case Pred() of
+        true  -> true;
+        false -> timer:sleep(20), wait_until(Pred, Left - 20)
+    end.
+
+no_leftover_messages_or_workers_test() ->
+    ProcsBefore = erlang:system_info(process_count),
+    _ = ?TEST_MODULE:run_bounded(fun() -> timer:sleep(2000), ok end, 50),
+    _ = ?TEST_MODULE:run_bounded(fun() -> ok end, 1000),
+    _ = ?TEST_MODULE:run_bounded(fun() -> error(boom) end, 1000),
+    %% give the killed/exited worker tree a moment to be fully reaped
+    timer:sleep(200),
+    ?assertEqual({messages, []}, erlang:process_info(self(), messages)),
+    ProcsAfter = erlang:system_info(process_count),
+    %% no lingering worker/inner processes from any of the three calls above
+    ?assert(ProcsAfter =< ProcsBefore + 1).
+
+%% Only public/replay are time-bounded; internal is unbounded; explicit timeout
+%% wins; the dry-run-only opts never leak into the tx-application opts.
+timeout_resolution_test() ->
+    application:unset_env(aehttp, dry_run),
+    ?assertEqual({777, [tx_events]},
+                 ?TEST_MODULE:resolve_timeout([tx_events, {dry_run_profile, public}, {timeout_ms, 777}])),
+    ?assertEqual({10000, [tx_events]},
+                 ?TEST_MODULE:resolve_timeout([tx_events, {dry_run_profile, replay}])),
+    {PMs, [tx_events]} = ?TEST_MODULE:resolve_timeout([tx_events, {dry_run_profile, public}]),
+    ?assert(is_integer(PMs) andalso PMs < 10000),
+    ?assertEqual({infinity, [tx_events]}, ?TEST_MODULE:resolve_timeout([tx_events])).
+
+%%%===================================================================
+%%% Public-API wiring: exercise the real dry_run/3,4, not just run_bounded/2.
+%%% Mocked one level down, at aetx_env:tx_env_and_trees_from_hash/2 - meck
+%%% can't intercept dry_run/4's local call to dry_run_unbounded/4.
+%%%===================================================================
+
+wiring_setup() ->
+    meck:new(aetx_env, [passthrough]),
+    ok.
+
+wiring_teardown(_) ->
+    meck:unload(aetx_env),
+    application:unset_env(aehttp, dry_run),
+    ok.
+
+%% Stand-in {Env, Trees}, same shape aetx_env would hand back; no db needed.
+fake_env_and_trees() ->
+    Header = aec_headers:raw_key_header(),
+    Trees = aec_trees:new_without_backend(),
+    Env = aetx_env:tx_env_from_key_header(Header, <<0:32/unit:8>>, 0, <<0:32/unit:8>>),
+    {aetx_env:set_context(Env, aetx_transaction), Trees}.
+
+dry_run_wiring_test_() ->
+    {setup, fun wiring_setup/0, fun wiring_teardown/1,
+     fun() ->
+        {EnvT, TreesT} = fake_env_and_trees(),
+
+        %% bound (200ms) < slow inner (2000ms): must time out, not wait.
+        meck:expect(aetx_env, tx_env_and_trees_from_hash,
+                    fun(_Type, _Hash) -> timer:sleep(2000), {EnvT, TreesT} end),
+        application:set_env(aehttp, dry_run, [{timeout_ms, 200}]),
+        {TA, ResA} = timer:tc(fun() -> ?TEST_MODULE:dry_run(<<0:32/unit:8>>, [], [], [{dry_run_profile, public}]) end),
+        ElapsedA = TA div 1000,
+        ?debugFmt("(a) bound=200ms slow_inner=2000ms -> result=~p elapsed=~pms", [ResA, ElapsedA]),
+
+        %% bound (5000ms) > fast inner (50ms): result passes through unchanged.
+        meck:expect(aetx_env, tx_env_and_trees_from_hash,
+                    fun(_Type, _Hash) -> timer:sleep(50), {EnvT, TreesT} end),
+        application:set_env(aehttp, dry_run, [{timeout_ms, 5000}]),
+        {TB, ResB} = timer:tc(fun() -> ?TEST_MODULE:dry_run(<<0:32/unit:8>>, [], [], [{dry_run_profile, public}]) end),
+        ElapsedB = TB div 1000,
+        ?debugFmt("(b) bound=5000ms fast_inner=50ms -> result=~p elapsed=~pms", [ResB, ElapsedB]),
+
+        [ ?_assertEqual({error, <<"dry-run exceeded time limit">>}, ResA)
+        , ?_assert(ElapsedA >= 200)
+        , ?_assert(ElapsedA < 2000)  %% proves it did NOT wait for the 2s inner
+        , ?_assertEqual({ok, {[], []}}, ResB)
+        , ?_assert(ElapsedB < 5000)
+        ]
+     end}.

--- a/apps/aecore/test/aecore_suite_utils.erl
+++ b/apps/aecore/test/aecore_suite_utils.erl
@@ -508,7 +508,9 @@ create_config(Node, CTConfig, CustomConfig, Options) ->
                     <<"http">> => #{ <<"external">> => #{<<"port">> => external_api_port(Node)},
                                         <<"internal">> => #{<<"port">> => internal_api_port(Node)},
                                         <<"rosetta">> => #{<<"port">> => rosetta_api_port(Node)},
-                                        <<"rosetta_offline">> => #{<<"port">> => rosetta_offline_api_port(Node)}},
+                                        <<"rosetta_offline">> => #{<<"port">> => rosetta_offline_api_port(Node)},
+                                        %% cover-compiled CT nodes are far slower than prod
+                                        <<"dry_run">> => #{<<"timeout_ms">> => 30000}},
                     <<"websocket">> => #{<<"channel">> => #{<<"port">> => ws_port(Node)}}},
                 MergedCfg5 = maps_merge(MergedCfg4, Ports),
                 FConfig = config_apply_options(Node, MergedCfg5, Options),

--- a/apps/aehttp/src/aehttp_dispatch_rosetta.erl
+++ b/apps/aehttp/src/aehttp_dispatch_rosetta.erl
@@ -319,7 +319,9 @@ handle_request_(blockTransaction,
         block_not_found ->
             {500, [], rosetta_error_response(?ROSETTA_ERR_BLOCK_NOT_FOUND)};
         tx_not_found ->
-            {500, [], rosetta_error_response(?ROSETTA_ERR_TX_NOT_FOUND)}
+            {500, [], rosetta_error_response(?ROSETTA_ERR_TX_NOT_FOUND)};
+        {dry_run_err, Err} ->
+            dry_run_err(Err)
     end;
 handle_request_(call, _, _Context) ->
     {501, [], #{}};
@@ -675,10 +677,13 @@ handle_request_(mempoolTransaction,
         {value, SignedTx} ->
                 %% Since it is impossible to know what will be mined returns an estimate, which is acceptable
                 %% according to the Rosetta docs:
-                %% "On this endpoint, it is ok that returned transactions are only estimates of what 
+                %% "On this endpoint, it is ok that returned transactions are only estimates of what
                 %%  may actually be included in a block."
-                Resp = #{<<"transaction">> => format_tx(SignedTx, undefined)},
-                {200, [], Resp};
+                try format_tx(SignedTx, undefined) of
+                    TxFmt -> {200, [], #{<<"transaction">> => TxFmt}}
+                catch
+                    {dry_run_err, Err} -> dry_run_err(Err)
+                end;
         _ ->
             throw(tx_not_found)
     end;

--- a/apps/aehttp/src/aehttp_helpers.erl
+++ b/apps/aehttp/src/aehttp_helpers.erl
@@ -639,7 +639,7 @@ do_dry_run() ->
         case prepare_dry_run_params([top, txs, accounts, tx_events], State) of
             {ok, #{top := Top, accounts := As, txs := Txs, tx_events := Events}} ->
                 lager:debug("tx_events = ~p", [Events]),
-                case aec_dry_run:dry_run(Top, As, Txs, [{tx_events, Events}]) of
+                case aec_dry_run:dry_run(Top, As, Txs, [{tx_events, Events}, {dry_run_profile, public}]) of
                     {ok, Res} ->
                         {Results, EventRes} = R = dry_run_results(Res),
                         lager:debug("dry_run_results: ~p", [R]),

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1474,6 +1474,27 @@
                             "default" : 86400
                         }
                     }
+                },
+                "dry_run" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties" : {
+                        "timeout_ms" : {
+                            "description" : "Wall-clock bound (in milliseconds) for a call to the public dry-run endpoint (the untrusted DoS surface). Defaults to one micro block cycle. 0 disables the bound. Internal/trusted dry-run calls are not time-bounded.",
+                            "type" : "integer",
+                            "default" : 3000
+                        },
+                        "replay_timeout_ms" : {
+                            "description" : "Wall-clock bound (in milliseconds) for a replay dry-run call (Rosetta/indexer block replay), which is legitimately heavier. 0 disables the bound.",
+                            "type" : "integer",
+                            "default" : 10000
+                        },
+                        "max_heap_words" : {
+                            "description" : "Backstop max heap size (in words) for a dry-run worker process; it is killed if it grows past this. Sized to catch a single pathological allocation, not normal work (which the timeout bounds). 0 disables.",
+                            "type" : "integer",
+                            "default" : 256000000
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
The dry-run endpoints simulate a transaction against a state snapshot without committing it. A pathological transaction — for example a call against a very large contract store — could run for a long time and tie up a request worker.

Bound each dry-run to a wall-clock limit: 50% of the microblock cycle (1.5s by default), configurable via http.dry_run.timeout_ms. On timeout the run is killed and the caller gets a clean error instead of hanging; the worker also stops if the client disconnects, so nothing is orphaned.

This only affects the off-chain dry-run path (aec_dry_run, reached from the HTTP and Rosetta API). It is never on the block-production or validation path, so it cannot affect consensus.