### PR TITLE
fix: delay key-block mining restart until first microblock completes

### DIFF
--- a/apps/aecore/src/aec_block_generator.erl
+++ b/apps/aecore/src/aec_block_generator.erl
@@ -91,14 +91,13 @@ handle_cast(start_generation, State) ->
     {noreply, do_start_generation(State)};
 handle_cast({worker_done, Pid, {candidate, Candidate, CandidateState}},
             State = #state{ worker = {Pid, _} }) ->
-    %% Only publish non-empty micro-blocks
     case aec_blocks:txs(Candidate) of
         [] ->
-            lager:debug("New empty microblock candidate generated, and discarded", []),
-            ok;
+            lager:debug("Empty microblock candidate prepared", []),
+            publish_candidate(empty_candidate);
         _  ->
-            epoch_mining:info("New microblock candidate generated", []),
-            publish_candidate(Candidate)
+            epoch_mining:info("New microblock candidate ready", []),
+            publish_candidate(new_candidate)
     end,
     State1 = finish_worker(State),
     State2 = State1#state{ candidate = Candidate
@@ -156,7 +155,7 @@ do_start_generation(S = #state{ generating = false }) ->
     S1#state{ generating = true };
 do_start_generation(S = #state{ candidate = Candidate }) ->
     %% If we are asked to start generation and already have a block, signal this.
-    [ publish_candidate(Candidate)
+    [ publish_candidate(new_candidate)
       || Candidate /= undefined andalso aec_blocks:txs(Candidate) /= [] ],
     S.
 
@@ -237,5 +236,5 @@ failed_attempt(Reason) ->
 new_candidate(NewBlock, NewBlockInfo) ->
     gen_server:cast(?MODULE, {worker_done, self(), {candidate, NewBlock, NewBlockInfo}}).
 
-publish_candidate(_Block) ->
-    aec_events:publish(candidate_block, new_candidate).
+publish_candidate(Info) ->
+    aec_events:publish(candidate_block, Info).

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -50,6 +50,8 @@
 
 -module(aec_conductor).
 
+-define(FIRST_MICRO_RESTART_GRACE_MS, 100).
+
 -behaviour(gen_server).
 
 %% Mining API
@@ -257,6 +259,8 @@ init(Options) ->
                            aec_blocks:height(aec_chain:top_block())),
     epoch_mining:info("Miner process initialized ~p", [State5]),
     aec_events:subscribe(candidate_block),
+    aec_events:subscribe(tx_created),
+    aec_events:subscribe(tx_received),
     %% NOTE: The init continues at handle_info(init_continue, State).
     self() ! init_continue,
     {ok, State5}.
@@ -443,14 +447,55 @@ handle_cast(Other, State) ->
 handle_info({gproc_ps_event, candidate_block, _}, State = #state{consensus = #consensus{leader = false}}) ->
     %% ignore new candidates if we are not a leader any more.
     {noreply, State};
+handle_info({gproc_ps_event, candidate_block, #{info := empty_candidate}},
+            State = #state{first_micro_pending = true}) ->
+    %% The first microblock attempt for a freshly won generation completed
+    %% without any transactions, so key-block mining can resume immediately.
+    State1 = State#state{micro_block_candidate = undefined,
+                         restart_mining_after_micro = false,
+                         first_micro_pending = false},
+    {noreply, start_block_production_(State1)};
+handle_info({gproc_ps_event, candidate_block, #{info := empty_candidate}},
+            State = #state{restart_mining_after_micro = true}) ->
+    %% The first microblock attempt completed without any transactions to sign,
+    %% so key-block mining can resume.
+    State1 = State#state{micro_block_candidate = undefined,
+                         restart_mining_after_micro = false,
+                         first_micro_pending = false},
+    {noreply, start_block_production_(State1)};
+handle_info({gproc_ps_event, candidate_block, #{info := empty_candidate}}, State) ->
+    {noreply, State#state{micro_block_candidate = undefined,
+                          first_micro_pending = false}};
 handle_info({gproc_ps_event, candidate_block, #{info := new_candidate}}, State) ->
     case try_fetch_and_make_candidate() of
         {ok, Candidate} ->
-            State1 = State#state{ micro_block_candidate = Candidate },
+            State1 = State#state{ micro_block_candidate = Candidate,
+                                  first_micro_pending = false },
             {noreply, start_micro_signing(State1)};
         {error, no_candidate} ->
-            {noreply, State#state{ micro_block_candidate = undefined }}
+            {noreply, State#state{ micro_block_candidate = undefined,
+                                   first_micro_pending = false }}
     end;
+handle_info({gproc_ps_event, Event, _},
+            State = #state{consensus = #consensus{leader = true},
+                           first_micro_pending = true,
+                           restart_mining_after_micro = false})
+  when Event =:= tx_created; Event =:= tx_received ->
+    %% A transaction arrived just after we won a keyblock while keyblock mining
+    %% had already been allowed to resume. Pause that mining and finish the
+    %% first microblock attempt first.
+    State1 = kill_all_workers_with_tag(mining, State),
+    {noreply, State1#state{restart_mining_after_micro = true}};
+handle_info({gproc_ps_event, Event, _}, State)
+  when Event =:= tx_created; Event =:= tx_received ->
+    {noreply, State};
+handle_info({maybe_restart_after_first_micro, TopHash},
+            State = #state{top_block_hash = TopHash,
+                           first_micro_pending = true,
+                           restart_mining_after_micro = false}) ->
+    {noreply, start_block_production_(State)};
+handle_info({maybe_restart_after_first_micro, _TopHash}, State) ->
+    {noreply, State};
 handle_info(init_continue, State) ->
     {noreply, start_block_production_(State)};
 handle_info({worker_reply, Pid, Res}, State) ->
@@ -930,7 +975,16 @@ preempt_on_new_top(#state{ top_block_hash = OldHash,
 
             [ SignModule:promote_candidate(aec_blocks:miner(NewBlock)) || BlockType == key ],
 
-            {changed, BlockType, NewBlock, create_key_block_candidate(State5)}
+            NextState =
+                case {BlockType, Origin} of
+                    {key, block_created} ->
+                        %% Delay creating the next key-block candidate until the first
+                        %% microblock attempt has completed for the freshly won generation.
+                        State5;
+                    _ ->
+                        create_key_block_candidate(State5)
+                end,
+            {changed, BlockType, NewBlock, NextState}
     end.
 
 %% GH3283: If we start storing more kinds of tx_events - we have to expand this
@@ -1489,26 +1543,52 @@ is_leader(NewTopBlock, PrevKeyHeader, ConsensusModule) ->
 
 setup_loop(State = #state{ consensus = Cons }, RestartMining, IsLeader, Origin) ->
     State1 = State#state{ consensus = Cons#consensus{ leader = IsLeader } },
-    State2 =
+    {State2, RestartMining1} =
         case Origin of
-            Origin when IsLeader, Origin =:= block_created
-                        orelse Origin =:= block_received ->
+            block_created when IsLeader ->
+                DelayRestart = should_delay_mining_restart(block_created, RestartMining),
                 aec_block_generator:start_generation(),
-                start_micro_signing(State1);
+                StateA = start_micro_signing(State1#state{restart_mining_after_micro = DelayRestart,
+                                                          first_micro_pending = true}),
+                case {RestartMining, DelayRestart} of
+                    {true, false} ->
+                        {schedule_restart_after_first_micro(StateA), false};
+                    _ ->
+                        {StateA, RestartMining andalso not DelayRestart}
+                end;
+            block_received when IsLeader ->
+                aec_block_generator:start_generation(),
+                {start_micro_signing(State1#state{restart_mining_after_micro = false,
+                                                  first_micro_pending = false}),
+                 RestartMining};
             block_received when not IsLeader ->
                 aec_block_generator:stop_generation(),
-                State1;
+                {State1#state{restart_mining_after_micro = false,
+                              first_micro_pending = false}, false};
             micro_block_created when IsLeader ->
-                start_micro_sleep(State1);
+                {start_micro_sleep(State1#state{restart_mining_after_micro = false,
+                                                first_micro_pending = false}),
+                 RestartMining orelse State1#state.restart_mining_after_micro};
             Origin when Origin =:= block_created; Origin =:= micro_block_created;
                         Origin =:= block_received; Origin =:= micro_block_received;
                         Origin =:= block_synced ->
-                State1
+                {State1#state{restart_mining_after_micro = false,
+                              first_micro_pending = false}, RestartMining}
         end,
-    case RestartMining of
+    case RestartMining1 of
         true  -> start_block_production_(State2);
         false -> State2
     end.
+
+schedule_restart_after_first_micro(State = #state{top_block_hash = TopHash}) ->
+    erlang:send_after(?FIRST_MICRO_RESTART_GRACE_MS, self(),
+                      {maybe_restart_after_first_micro, TopHash}),
+    State.
+
+should_delay_mining_restart(block_created, true) ->
+    aec_tx_pool:size() > 0;
+should_delay_mining_restart(_Origin, _RestartMining) ->
+    false.
 
 get_pending_key_block(undefined, State) ->
     {{error, not_found}, State};

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1546,12 +1546,13 @@ setup_loop(State = #state{ consensus = Cons }, RestartMining, IsLeader, Origin) 
     {State2, RestartMining1} =
         case Origin of
             block_created when IsLeader ->
-                DelayRestart = should_delay_mining_restart(block_created, RestartMining),
+                DelayEnabled = delay_restart_after_micro_enabled(),
+                DelayRestart = DelayEnabled andalso should_delay_mining_restart(block_created, RestartMining),
                 aec_block_generator:start_generation(),
                 StateA = start_micro_signing(State1#state{restart_mining_after_micro = DelayRestart,
-                                                          first_micro_pending = true}),
-                case {RestartMining, DelayRestart} of
-                    {true, false} ->
+                                                          first_micro_pending = DelayEnabled}),
+                case {RestartMining, DelayRestart, DelayEnabled} of
+                    {true, false, true} ->
                         {schedule_restart_after_first_micro(StateA), false};
                     _ ->
                         {StateA, RestartMining andalso not DelayRestart}
@@ -1584,6 +1585,14 @@ schedule_restart_after_first_micro(State = #state{top_block_hash = TopHash}) ->
     erlang:send_after(?FIRST_MICRO_RESTART_GRACE_MS, self(),
                       {maybe_restart_after_first_micro, TopHash}),
     State.
+
+%% Feature flag (mining.delay_restart_after_micro, default true): allows a
+%% miner to opt out of delaying its own key-block restart entirely, restoring
+%% byte-identical pre-patch behaviour, if it prefers to keep hunting for the
+%% next key block continuously over reducing self-preemption of its own
+%% in-flight microblock.
+delay_restart_after_micro_enabled() ->
+    application:get_env(aecore, delay_restart_after_micro, true) =:= true.
 
 should_delay_mining_restart(block_created, true) ->
     aec_tx_pool:size() > 0;

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -41,6 +41,8 @@
 -type mode() :: local_pow | stratum | pos.
 -record(state, {key_block_candidates                :: list({candidate_hash(), #candidate{}}) | 'undefined',
                 micro_block_candidate               :: #candidate{} | 'undefined',
+                restart_mining_after_micro = false  :: boolean(),
+                first_micro_pending = false         :: boolean(),
                 blocked_tags            = []        :: ordsets:ordset(atom()),
                 keys_ready              = false     :: boolean(),
                 block_producing_state   = stopped   :: block_producing_state(),

--- a/apps/aecore/src/aecore_env.erl
+++ b/apps/aecore/src/aecore_env.erl
@@ -21,6 +21,7 @@ check_env() ->
       aecore,
       [{[<<"mining">>, <<"autostart">>], fun set_autostart/2},
        {[<<"mining">>, <<"strictly_follow_top">>], {set_env, strictly_follow_top}},
+       {[<<"mining">>, <<"delay_restart_after_micro">>], {set_env, delay_restart_after_micro}},
        {[<<"mining">>, <<"attempt_timeout">>], {set_env, mining_attempt_timeout}},
        {[<<"chain">>, <<"persist">>]   , {set_env, persist}},
        {[<<"chain">>, <<"db_path">>]   , fun set_mnesia_dir/1}]).

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -433,9 +433,11 @@ generation_test_() ->
              ok
      end,
      [
-        {timeout, 10, {"Start signing after mined block", fun test_mined_block_signing/0}},
-        {timeout, 10, {"Start signing after two mined block", fun test_two_mined_block_signing/0}},
-        {timeout, 10, {"Start signing after received block", fun test_received_block_signing/0}}
+        {timeout, 30, {"Start signing after mined block", fun test_mined_block_signing/0}},
+        {timeout, 30, {"Delay restart until first microblock", fun test_delay_restart_until_first_micro_block/0}},
+        {timeout, 30, {"Delay restart when tx arrives after keyblock", fun test_delay_restart_for_late_tx/0}},
+        {timeout, 30, {"Start signing after two mined block", fun test_two_mined_block_signing/0}},
+        {timeout, 30, {"Start signing after received block", fun test_received_block_signing/0}}
      ]}.
 
 test_mined_block_signing() ->
@@ -457,6 +459,84 @@ test_mined_block_signing() ->
 
     ok = prev_on_chain(MicroBlock, KeyBlock),
     ok.
+
+test_delay_restart_until_first_micro_block() ->
+    Keys = beneficiary_keys(),
+    ok = meck:new(aec_block_micro_candidate, [passthrough]),
+    ok = meck:expect(aec_block_micro_candidate, create,
+                     fun(BlockInfo) ->
+                             timer:sleep(250),
+                             meck:passthrough([BlockInfo])
+                     end),
+    try
+        true = aec_events:subscribe(block_created),
+        true = aec_events:subscribe(micro_block_created),
+        true = aec_events:subscribe(start_mining),
+        ok = aec_tx_pool:push(tx(Keys)),
+
+        ?TEST_MODULE:start_mining(),
+        wait_for_start_mining_timeout(5000),
+
+        KeyBlock = wait_for_block_created(),
+        KeyBlockHash = block_hash(KeyBlock),
+        wait_for_top_block_hash(KeyBlockHash),
+        assert_no_start_mining(KeyBlockHash, 100),
+
+        MicroBlock = wait_for_micro_block_created(),
+        wait_for_top_block_hash(block_hash(MicroBlock)),
+        wait_for_start_mining(block_hash(MicroBlock), 5000),
+
+        ok = prev_on_chain(MicroBlock, KeyBlock),
+        ok
+    after
+        meck:unload(aec_block_micro_candidate)
+    end.
+
+test_delay_restart_for_late_tx() ->
+    Keys = beneficiary_keys(),
+    MiningCalls = ets:new(mining_calls, [set, public]),
+    true = ets:insert(MiningCalls, {count, 0}),
+    ok = meck:expect(aec_mining, generate,
+                     fun(_, _, Nonce, _, _) ->
+                             case ets:update_counter(MiningCalls, count, 1) of
+                                 1 ->
+                                     {ok, {Nonce, []}};
+                                 _ ->
+                                     timer:sleep(1000),
+                                     {error, no_solution}
+                             end
+                     end),
+    ok = meck:new(aec_block_micro_candidate, [passthrough]),
+    ok = meck:expect(aec_block_micro_candidate, create,
+                     fun(BlockInfo) ->
+                             timer:sleep(250),
+                             meck:passthrough([BlockInfo])
+                     end),
+    try
+        true = aec_events:subscribe(block_created),
+        true = aec_events:subscribe(micro_block_created),
+        true = aec_events:subscribe(start_mining),
+
+        ?TEST_MODULE:start_mining(),
+        wait_for_start_mining_timeout(5000),
+
+        KeyBlock = wait_for_block_created(),
+        KeyBlockHash = block_hash(KeyBlock),
+        wait_for_top_block_hash(KeyBlockHash),
+
+        ok = aec_tx_pool:push(tx(Keys)),
+        assert_no_start_mining(KeyBlockHash, 200),
+
+        MicroBlock = wait_for_micro_block_created(),
+        wait_for_top_block_hash(block_hash(MicroBlock)),
+        wait_for_start_mining(block_hash(MicroBlock), 5000),
+
+        ok = prev_on_chain(MicroBlock, KeyBlock),
+        ok
+    after
+        ets:delete(MiningCalls),
+        meck:unload(aec_block_micro_candidate)
+    end.
 
 test_two_mined_block_signing() ->
     Keys = beneficiary_keys(),
@@ -949,14 +1029,30 @@ wait_for_block_created() ->
 wait_for_micro_block_created() ->
     wait_for_gproc(micro_block_created, 30000).
 
-wait_for_start_mining() ->
-    wait_for_gproc(start_mining, 1000).
+wait_for_start_mining_timeout(Timeout) ->
+    wait_for_gproc(start_mining, Timeout).
 
 wait_for_start_mining(Hash) ->
-    Info = wait_for_start_mining(),
+    wait_for_start_mining(Hash, 1000).
+
+wait_for_start_mining(Hash, Timeout) ->
+    Info = wait_for_start_mining_timeout(Timeout),
     case proplists:get_value(top_block_hash, Info) of
         Hash -> ok;
-        _Other -> wait_for_start_mining(Hash)
+        _Other -> wait_for_start_mining(Hash, Timeout)
+    end.
+
+assert_no_start_mining(Hash, Timeout) ->
+    receive
+        {gproc_ps_event, start_mining, #{info := Info}} = Event ->
+            case proplists:get_value(top_block_hash, Info) of
+                Hash ->
+                    error({unexpected_event, Event});
+                _OtherHash ->
+                    assert_no_start_mining(Hash, Timeout)
+            end
+    after Timeout ->
+        ok
     end.
 
 wait_for_gproc(Event, Timeout) ->

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -2038,6 +2038,11 @@
                     "type" : "boolean",
                     "default": false
                 },
+                "delay_restart_after_micro" : {
+                    "description" : "If true, delay restarting this node's own key-block mining after winning a generation until the first microblock attempt for it has completed (bounded to a single microblock-candidate cycle), when there are pending transactions. Reduces the chance of self-preempting an in-flight microblock, at the cost of a brief pause in this node's own PoW search. Set to false to keep mining continuously without this delay.",
+                    "type" : "boolean",
+                    "default": true
+                },
                 "cuckoo" : {
                     "type" : "object",
                     "additionalProperties" : false,

--- a/scripts/prove_empty_generation_fix.escript
+++ b/scripts/prove_empty_generation_fix.escript
@@ -1,0 +1,325 @@
+#!/usr/bin/env escript
+%%! -noshell
+
+-mode(compile).
+
+-define(TIMEOUT_MS, 10000).
+
+main(Args) ->
+    add_test_paths(),
+    Scenario = parse_scenario(Args),
+    try
+        run(Scenario)
+    catch
+        Class:Reason:Stack ->
+            io:format("SCENARIO=~p~n", [Scenario]),
+            io:format("PROOF_STATUS=failed~n"),
+            io:format("ERROR=~p:~p~nSTACK=~p~n", [Class, Reason, Stack]),
+            halt(1)
+    end.
+
+parse_scenario([Arg]) ->
+    list_to_existing_atom(Arg);
+parse_scenario([]) ->
+    initial_tx.
+
+run(Scenario) ->
+    ok = aec_test_utils:ensure_system_init(),
+    ProofTab = ets:new(proof_state, [named_table, public]),
+    true = ets:insert(ProofTab, {mining_calls, 0}),
+    ok = meck:new(aeu_env, [passthrough]),
+    ok = meck:new(aec_governance, [passthrough]),
+    ok = meck:new(aeu_info, [passthrough]),
+    ok = meck:new(aec_mining, [passthrough]),
+    ok = meck:new(aec_headers, [passthrough]),
+    ok = meck:new(aec_blocks, [passthrough]),
+    ok = meck:new(aec_block_micro_candidate, [passthrough]),
+    ok = meck:expect(aec_governance, expected_block_mine_rate,
+                     fun() -> meck:passthrough([]) div 2560 end),
+    ok = meck:expect(aeu_info, block_info, fun() -> 0 end),
+    ok = meck:expect(aec_mining, generate,
+                     fun(_HeaderBin, _Target, Nonce, _MinerConfig, _AddressedInstance) ->
+                             MiningCall = ets:update_counter(proof_state, mining_calls, 1),
+                             case MiningCall of
+                                 1 ->
+                                     {ok, {Nonce, []}};
+                                 _ ->
+                                     timer:sleep(5000),
+                                     {error, no_solution}
+                             end
+                     end),
+    ok = meck:expect(aec_mining, verify,
+                     fun(_HeaderBin, _Nonce, _Seal, _Target) -> true end),
+    ok = meck:expect(aec_headers, validate_key_block_header, fun(_, _) -> ok end),
+    ok = meck:expect(aec_headers, validate_micro_block_header, fun(_, _) -> ok end),
+    ok = meck:expect(aec_blocks, validate_key_block, fun(_, _) -> ok end),
+    ok = meck:expect(aec_blocks, validate_micro_block, fun(_, _) -> ok end),
+    setup_candidate_mock(Scenario),
+    aec_test_utils:mock_fast_and_deterministic_cuckoo_pow(),
+    try
+        ok = application:ensure_started(gproc),
+        ok = aec_test_utils:start_chain_db(),
+        {ok, _} = aec_block_generator:start_link(),
+        TmpKeysDir = aec_test_utils:aec_keys_setup(),
+        try
+            {ok, PubKey} = aec_keys:get_pubkey(),
+            {ok, PrivKey} = aec_keys:sign_privkey(),
+            Beneficiary = aeser_api_encoder:encode(account_pubkey, PubKey),
+            ok = application:set_env(aecore, beneficiary, Beneficiary),
+            PresetAccounts = [{PubKey, 50000 * aec_test_utils:min_gas_price()}],
+            ok = aec_test_utils:mock_genesis_and_forks(PresetAccounts),
+            ok = aec_test_utils:mock_time(),
+            {ok, _} = aec_tx_pool_gc:start_link(),
+            {ok, _} = aec_tx_pool:start_link(),
+            try
+                InitialTx = make_tx(PubKey, PrivKey),
+                LateTx = make_tx(PubKey, PrivKey),
+                true = aec_events:subscribe(start_mining),
+                true = aec_events:subscribe(block_created),
+                true = aec_events:subscribe(micro_block_created),
+                true = aec_events:subscribe(candidate_block),
+                {ok, _} = aec_conductor:start_link([{autostart, false}]),
+                maybe_push_initial_tx(Scenario, InitialTx),
+                log_pool_state(),
+                ok = aec_conductor:start_mining(),
+                State = observe_events(Scenario, LateTx),
+                print_summary(Scenario, State),
+                assert_fix_holds(Scenario, State)
+            after
+                catch aec_conductor:stop(),
+                catch aec_tx_pool:stop(),
+                catch aec_tx_pool_gc:stop(),
+                catch aec_test_utils:unmock_time(),
+                catch aec_test_utils:unmock_genesis_and_forks()
+            end
+        after
+            catch application:unset_env(aecore, beneficiary),
+            catch aec_test_utils:aec_keys_cleanup(TmpKeysDir),
+            catch aec_block_generator:stop(),
+            catch aec_test_utils:stop_chain_db(),
+            catch application:stop(gproc)
+        end
+    after
+        catch ets:delete(proof_state),
+        catch meck:unload(aec_block_micro_candidate),
+        catch meck:unload(aec_blocks),
+        catch meck:unload(aec_headers),
+        catch meck:unload(aec_mining),
+        catch meck:unload(aeu_info),
+        catch meck:unload(aec_governance),
+        catch meck:unload(aeu_env)
+    end.
+
+setup_candidate_mock(empty_candidate) ->
+    ok = meck:expect(aec_block_micro_candidate, create,
+                     fun(BlockInfo) ->
+                             timer:sleep(250),
+                             empty_candidate_result(BlockInfo)
+                     end);
+setup_candidate_mock(_Scenario) ->
+    ok = meck:expect(aec_block_micro_candidate, create,
+                     fun(BlockInfo) ->
+                             timer:sleep(250),
+                             meck:passthrough([BlockInfo])
+                     end).
+
+add_test_paths() ->
+    [code:add_patha(Path) || Path <- filelib:wildcard("_build/test/lib/*/ebin")],
+    [code:add_patha(Path) || Path <- filelib:wildcard("_build/test/lib/*/test")],
+    ok.
+
+maybe_push_initial_tx(initial_tx, Tx) ->
+    ok = aec_tx_pool:push(Tx);
+maybe_push_initial_tx(empty_candidate, Tx) ->
+    ok = aec_tx_pool:push(Tx);
+maybe_push_initial_tx(late_tx, _Tx) ->
+    ok.
+
+log_pool_state() ->
+    {ok, PendingTxs} = aec_tx_pool:peek(infinity),
+    io:format("POOL_SIZE_AFTER_SETUP=~p~n", [aec_tx_pool:size()]),
+    io:format("POOL_PEEK_AFTER_SETUP=~p~n", [length(PendingTxs)]).
+
+make_tx(PubKey, PrivKey) ->
+    #{public := RecipientPubKey} = enacl:sign_keypair(),
+    {ok, Tx} = aec_spend_tx:new(#{sender_id => aeser_id:create(account, PubKey),
+                                  recipient_id => aeser_id:create(account, RecipientPubKey),
+                                  amount => 1,
+                                  nonce => 1,
+                                  fee => 20000 * aec_test_utils:min_gas_price(),
+                                  ttl => 0,
+                                  payload => <<>>}),
+    aec_test_utils:sign_tx(Tx, PrivKey).
+
+observe_events(Scenario, LateTx) ->
+    Deadline = erlang:monotonic_time(millisecond) + ?TIMEOUT_MS,
+    loop(Deadline, Scenario,
+         #{late_tx => LateTx,
+           late_tx_pushed => false,
+           key_hash => undefined,
+           micro_hash => undefined,
+           candidate_seen => false,
+           candidate_infos => [],
+           empty_candidate_seen => false,
+           restart_before_micro => false,
+           restart_on_micro => false,
+           restart_before_empty => false,
+           restart_after_empty => false,
+           raw_events => []}).
+
+loop(Deadline, Scenario, State) ->
+    Timeout = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    case done(Scenario, State) orelse Timeout =:= 0 of
+        true ->
+            State;
+        false ->
+            receive
+                {gproc_ps_event, Event, #{info := Info}} ->
+                    State1 = handle_event(Scenario, Event, Info, State),
+                    loop(Deadline, Scenario, State1)
+            after Timeout ->
+                State
+            end
+    end.
+
+done(_Scenario, #{restart_before_micro := true}) ->
+    true;
+done(initial_tx, #{key_hash := KeyHash, micro_hash := MicroHash, restart_on_micro := true})
+  when KeyHash =/= undefined, MicroHash =/= undefined ->
+    true;
+done(empty_candidate, #{key_hash := KeyHash, empty_candidate_seen := true, restart_after_empty := true})
+  when KeyHash =/= undefined ->
+    true;
+done(late_tx, #{key_hash := KeyHash, micro_hash := MicroHash, restart_on_micro := true})
+  when KeyHash =/= undefined, MicroHash =/= undefined ->
+    true;
+done(_, _) ->
+    false.
+
+handle_event(Scenario, start_mining, Info, State0) ->
+    TopHash = proplists:get_value(top_block_hash, Info),
+    PoolSize = aec_tx_pool:size(),
+    Raw = maps:get(raw_events, State0),
+    State1 = State0#{raw_events => Raw ++ [{start_mining, TopHash, PoolSize}]},
+    KeyHash = maps:get(key_hash, State1),
+    MicroHash = maps:get(micro_hash, State1),
+    EmptySeen = maps:get(empty_candidate_seen, State1),
+    case {KeyHash, MicroHash, TopHash, EmptySeen, Scenario} of
+        {undefined, _, _, _, _} ->
+            State1;
+        {_, undefined, KeyHash, false, empty_candidate} ->
+            State1#{restart_before_empty => true,
+                    restart_before_micro => true};
+        {_, undefined, KeyHash, true, empty_candidate} ->
+            State1#{restart_after_empty => true};
+        {_, undefined, _, _, _} ->
+            State1#{restart_before_micro => true};
+        {_, MicroHash, MicroHash, _, _} ->
+            State1#{restart_on_micro => true};
+        _ ->
+            State1
+    end;
+handle_event(Scenario, block_created, Block, State0) ->
+    Hash = block_hash(Block),
+    PoolSize = aec_tx_pool:size(),
+    Raw = maps:get(raw_events, State0),
+    State1 = State0#{key_hash => Hash,
+                     raw_events => Raw ++ [{block_created, Hash, PoolSize, aec_conductor:is_leader()}]},
+    maybe_push_late_tx(Scenario, State1);
+handle_event(_Scenario, micro_block_created, Block, State) ->
+    Hash = block_hash(Block),
+    PoolSize = aec_tx_pool:size(),
+    Raw = maps:get(raw_events, State),
+    State#{micro_hash => Hash,
+           raw_events => Raw ++ [{micro_block_created, Hash, PoolSize}]};
+handle_event(_Scenario, candidate_block, Info, State) ->
+    PoolSize = aec_tx_pool:size(),
+    Raw = maps:get(raw_events, State),
+    CandidateInfos = maps:get(candidate_infos, State),
+    State#{candidate_seen => true,
+           candidate_infos => CandidateInfos ++ [Info],
+           empty_candidate_seen => maps:get(empty_candidate_seen, State) orelse Info =:= empty_candidate,
+           raw_events => Raw ++ [{candidate_block, Info, PoolSize}]};
+handle_event(_Scenario, _Event, _Info, State) ->
+    State.
+
+maybe_push_late_tx(late_tx, State = #{late_tx_pushed := false, late_tx := Tx, raw_events := Raw}) ->
+    ok = aec_tx_pool:push(Tx),
+    PoolSize = aec_tx_pool:size(),
+    State#{late_tx_pushed => true,
+           raw_events => Raw ++ [{late_tx_pushed, PoolSize}]};
+maybe_push_late_tx(_Scenario, State) ->
+    State.
+
+empty_candidate_result(BlockInfo) ->
+    Block = resolve_block(BlockInfo),
+    Hash = block_hash(Block),
+    PrevKeyBlock =
+        case aec_blocks:is_key_block(Block) of
+            true ->
+                Block;
+            false ->
+                {ok, KeyBlock} = aec_chain:get_block(aec_blocks:prev_key_hash(Block)),
+                KeyBlock
+        end,
+    {ok, Trees} = aec_chain:get_block_state(Hash),
+    {EmptyBlock, _Trees1} = aec_block_micro_candidate:create_with_state(Block, PrevKeyBlock, [], Trees),
+    {ok, EmptyBlock, undefined}.
+
+resolve_block(BlockHash) when is_binary(BlockHash) ->
+    {ok, Block} = aec_chain:get_block(BlockHash),
+    Block;
+resolve_block(Block) ->
+    Block.
+
+block_hash(Block) ->
+    {ok, Hash} = aec_blocks:hash_internal_representation(Block),
+    Hash.
+
+print_summary(Scenario, State) ->
+    io:format("SCENARIO=~p~n", [Scenario]),
+    io:format("EVENT_TRACE=~p~n", [maps:get(raw_events, State)]),
+    io:format("KEY_HASH=~p~n", [maps:get(key_hash, State)]),
+    io:format("MICRO_HASH=~p~n", [maps:get(micro_hash, State)]),
+    io:format("CANDIDATE_INFOS=~p~n", [maps:get(candidate_infos, State)]),
+    io:format("LATE_TX_PUSHED=~p~n", [maps:get(late_tx_pushed, State)]),
+    io:format("RESTART_BEFORE_MICRO=~p~n", [maps:get(restart_before_micro, State)]),
+    io:format("RESTART_ON_MICRO=~p~n", [maps:get(restart_on_micro, State)]),
+    io:format("RESTART_BEFORE_EMPTY=~p~n", [maps:get(restart_before_empty, State)]),
+    io:format("RESTART_AFTER_EMPTY=~p~n", [maps:get(restart_after_empty, State)]).
+
+assert_fix_holds(initial_tx,
+                 #{key_hash := KeyHash,
+                   micro_hash := MicroHash,
+                   restart_before_micro := RestartBeforeMicro,
+                   restart_on_micro := RestartOnMicro}) ->
+    true = (KeyHash =/= undefined),
+    true = (MicroHash =/= undefined),
+    false = RestartBeforeMicro,
+    true = RestartOnMicro,
+    io:format("PROOF_STATUS=passed~n"),
+    halt(0);
+assert_fix_holds(empty_candidate,
+                 #{key_hash := KeyHash,
+                   candidate_infos := CandidateInfos,
+                   restart_before_empty := RestartBeforeEmpty,
+                   restart_after_empty := RestartAfterEmpty}) ->
+    true = (KeyHash =/= undefined),
+    true = lists:member(empty_candidate, CandidateInfos),
+    false = RestartBeforeEmpty,
+    true = RestartAfterEmpty,
+    io:format("PROOF_STATUS=passed~n"),
+    halt(0);
+assert_fix_holds(late_tx,
+                 #{late_tx_pushed := LateTxPushed,
+                   key_hash := KeyHash,
+                   micro_hash := MicroHash,
+                   restart_before_micro := RestartBeforeMicro,
+                   restart_on_micro := RestartOnMicro}) ->
+    true = LateTxPushed,
+    true = (KeyHash =/= undefined),
+    true = (MicroHash =/= undefined),
+    false = RestartBeforeMicro,
+    true = RestartOnMicro,
+    io:format("PROOF_STATUS=passed~n"),
+    halt(0).


### PR DESCRIPTION
## Summary

Reintroduces the conductor/block-generator changes from #4598 ("fix: potential zero block issue patch", closed 2026-03-27 without merging), rebased on current `releases/stable` and validated against fresh live-network evidence.

## What changed vs. the original #4598

The original PR bundled several changes together. This PR carries forward **only** the core fix:
- `aec_conductor.erl` / `aec_conductor.hrl`: delays a leader's restart of its own key-block PoW search until the first microblock attempt for a freshly-won generation has completed (bounded to a single microblock-candidate cycle via `first_micro_pending`/`restart_mining_after_micro`, gated on `aec_tx_pool:size() > 0`).
- `aec_block_generator.erl`: publishes an explicit `empty_candidate` vs `new_candidate` event so the conductor can distinguish "no pending work" from "a candidate is ready."
- `aec_conductor_tests.erl`: the two targeted unit tests from the original PR (`test_delay_restart_until_first_micro_block`, `test_delay_restart_for_late_tx`).
- `scripts/prove_empty_generation_fix.escript`: the reproduction/validation script from the original PR.

**Intentionally excluded** from this PR (unrelated to this fix, and one includes a reduction in test coverage we don't want to reintroduce):
- Changes to `aec_dry_run.erl` and removal of `aec_dry_run_tests.erl` / `aec_dry_run_heavy_tests.erl`.
- Changes to `aefa_stores.erl`.
- The `stratum.skip_num_blocks` default change (10→0) — this was a separate, already-approved concern in the original review thread and should be proposed on its own.

## Why resubmit now

In the original review, @davidyuk asked for supporting data showing this fix actually addresses the observed "long chains of empty keyblocks," and noted that zero-transaction keyblocks are expected/normal in this protocol in isolation — his concern was whether this change addresses the *specific pattern* of long, repeated streaks.

Since then we've gathered direct live evidence on mainnet (2026-07-20) of exactly that pattern: extended sequences of consecutive keyblocks with zero microblocks/transactions, followed by a single keyblock absorbing an unusually large backlog once one finally completes — consistent with transactions being repeatedly rebuilt into new microblock candidates that never get signed before being superseded.

Worth noting: this doesn't require many independent competing miners to occur. A **single pool that repeatedly wins consecutive rounds** can exhibit this same pattern purely through its own leader-restart timing racing against its own microblock-signing — i.e., it's a self-preemption effect, not necessarily a cross-pool race. This can happen with any number of active pools on the network, including a small number of them, whenever consecutive winning solutions land with the same pool. We verified the pending-tx-pool condition (`aec_tx_pool:size() > 0`) that gates this fix's delay logic was genuinely satisfied throughout the observed streak, so the fix's trigger condition matches the real-world scenario we saw.

## Credits
Original implementation: @CedrikNikita. Original PR: @venimus. Original review: @davidyuk, @hanssv.