### PR TITLE
Add node-local mining.micro_reanchor option

### DIFF
--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -909,7 +909,9 @@ preempt_on_new_top(#state{ top_block_hash = OldHash,
                      PoW =:= stratum ->
                 case BlockType of
                     micro when OldKeyHash =:= KeyHash ->
-                        false;
+                        %% Stock: false (keep grinding the pre-micro candidate).
+                        %% micro_reanchor: re-anchor the key candidate onto the micro.
+                        micro_reanchor_enabled();
                     _ -> true
                 end
         end,
@@ -932,6 +934,12 @@ preempt_on_new_top(#state{ top_block_hash = OldHash,
 
             {changed, BlockType, NewBlock, create_key_block_candidate(State5)}
     end.
+
+%% Node-local mining policy (default false = byte-identical stock behaviour).
+%% When true, a same-generation micro re-anchors the key candidate onto that micro.
+micro_reanchor_enabled() ->
+    aeu_env:user_config_or_env([<<"mining">>, <<"micro_reanchor">>],
+                               aecore, micro_reanchor, false) =:= true.
 
 %% GH3283: If we start storing more kinds of tx_events - we have to expand this
 %% function. I don't think we necessarily wants to publish the internal

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -2038,6 +2038,11 @@
                     "type" : "boolean",
                     "default": false
                 },
+                "micro_reanchor" : {
+                    "description" : "Node-local mining policy (non-consensus). If true, a same-generation micro-block re-anchors the key-block candidate onto that micro (rebuilds candidate + restarts PoW workers) instead of the stock no-reset. Default false = byte-identical stock behaviour.",
+                    "type" : "boolean",
+                    "default": false
+                },
                 "cuckoo" : {
                     "type" : "object",
                     "additionalProperties" : false,


### PR DESCRIPTION
When enabled, a same-generation micro-block top change re-anchors the key-block candidate onto that micro (rebuild + PoW worker restart) instead of the stock no-reset, so a winning key block extends the generation's micro-chain rather than orphaning it.

Node-local mining policy only: no header-validation, acceptance-rule, gas, or serialization surface is touched. Default false is byte-identical stock behaviour.