### PR TITLE
fix: delay key-block mining restart until first microblock attempt

### DIFF
--- a/apps/aecore/src/aec_block_generator.erl
+++ b/apps/aecore/src/aec_block_generator.erl
@@ -91,14 +91,13 @@ handle_cast(start_generation, State) ->
     {noreply, do_start_generation(State)};
 handle_cast({worker_done, Pid, {candidate, Candidate, CandidateState}},
             State = #state{ worker = {Pid, _} }) ->
-    %% Only publish non-empty micro-blocks
     case aec_blocks:txs(Candidate) of
         [] ->
-            lager:debug("New empty microblock candidate generated, and discarded", []),
-            ok;
+            lager:debug("Empty microblock candidate prepared", []),
+            publish_candidate(empty_candidate);
         _  ->
-            epoch_mining:info("New microblock candidate generated", []),
-            publish_candidate(Candidate)
+            epoch_mining:info("New microblock candidate ready", []),
+            publish_candidate(new_candidate)
     end,
     State1 = finish_worker(State),
     State2 = State1#state{ candidate = Candidate
@@ -156,7 +155,7 @@ do_start_generation(S = #state{ generating = false }) ->
     S1#state{ generating = true };
 do_start_generation(S = #state{ candidate = Candidate }) ->
     %% If we are asked to start generation and already have a block, signal this.
-    [ publish_candidate(Candidate)
+    [ publish_candidate(new_candidate)
       || Candidate /= undefined andalso aec_blocks:txs(Candidate) /= [] ],
     S.
 
@@ -237,5 +236,5 @@ failed_attempt(Reason) ->
 new_candidate(NewBlock, NewBlockInfo) ->
     gen_server:cast(?MODULE, {worker_done, self(), {candidate, NewBlock, NewBlockInfo}}).
 
-publish_candidate(_Block) ->
-    aec_events:publish(candidate_block, new_candidate).
+publish_candidate(Info) ->
+    aec_events:publish(candidate_block, Info).

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -108,6 +108,17 @@
 
 -define(DEFAULT_MINING_ATTEMPT_TIMEOUT, 60 * 60 * 1000). %% milliseconds
 
+%% Grace period after winning a key-block with an empty tx pool before
+%% key-block mining resumes; a transaction arriving within it pauses mining
+%% until the first microblock attempt of the new generation completes.
+-define(DEFAULT_FIRST_MICRO_RESTART_GRACE_MS, 100).
+%% Upper bound on how long a deferred key-block mining restart may wait for
+%% the first microblock attempt. Normally the attempt completes within
+%% milliseconds and this timer is never acted upon; it only fires if the
+%% attempt never completes (e.g. the candidate worker failed), so block
+%% production cannot stall indefinitely.
+-define(DEFAULT_FIRST_MICRO_RESTART_FAILSAFE_MS, 1000).
+
 %%%===================================================================
 %%% API
 %%%===================================================================
@@ -257,6 +268,13 @@ init(Options) ->
                            aec_blocks:height(aec_chain:top_block())),
     epoch_mining:info("Miner process initialized ~p", [State5]),
     aec_events:subscribe(candidate_block),
+    %% Tx events let the conductor pause freshly resumed key-block mining when
+    %% a transaction shows up before the first microblock attempt of a newly
+    %% won generation has completed (see the tx_created/tx_received clauses in
+    %% handle_info/2). Otherwise a quick key-block could leave the previous
+    %% generation without any microblocks.
+    aec_events:subscribe(tx_created),
+    aec_events:subscribe(tx_received),
     %% NOTE: The init continues at handle_info(init_continue, State).
     self() ! init_continue,
     {ok, State5}.
@@ -443,14 +461,64 @@ handle_cast(Other, State) ->
 handle_info({gproc_ps_event, candidate_block, _}, State = #state{consensus = #consensus{leader = false}}) ->
     %% ignore new candidates if we are not a leader any more.
     {noreply, State};
+handle_info({gproc_ps_event, candidate_block, #{info := empty_candidate}},
+            State = #state{awaiting_first_micro_candidate = AwaitingFirstMicro,
+                           restart_mining_after_first_micro = RestartAfterMicro})
+  when AwaitingFirstMicro; RestartAfterMicro ->
+    %% The first microblock attempt for a freshly won generation completed
+    %% without any transactions to sign, so key-block mining can resume.
+    State1 = State#state{micro_block_candidate = undefined,
+                         restart_mining_after_first_micro = false,
+                         awaiting_first_micro_candidate = false},
+    {noreply, start_block_production_(State1)};
+handle_info({gproc_ps_event, candidate_block, #{info := empty_candidate}}, State) ->
+    {noreply, State#state{micro_block_candidate = undefined}};
 handle_info({gproc_ps_event, candidate_block, #{info := new_candidate}}, State) ->
     case try_fetch_and_make_candidate() of
         {ok, Candidate} ->
-            State1 = State#state{ micro_block_candidate = Candidate },
+            State1 = State#state{ micro_block_candidate = Candidate,
+                                  awaiting_first_micro_candidate = false },
             {noreply, start_micro_signing(State1)};
         {error, no_candidate} ->
-            {noreply, State#state{ micro_block_candidate = undefined }}
+            {noreply, State#state{ micro_block_candidate = undefined,
+                                   awaiting_first_micro_candidate = false }}
     end;
+handle_info({gproc_ps_event, Event, _},
+            State = #state{consensus = #consensus{leader = true},
+                           awaiting_first_micro_candidate = true,
+                           restart_mining_after_first_micro = false})
+  when Event =:= tx_created; Event =:= tx_received ->
+    %% A transaction arrived just after we won a keyblock while keyblock mining
+    %% had already been allowed to resume. Pause that mining and finish the
+    %% first microblock attempt first. The failsafe timer bounds the pause in
+    %% case that attempt never completes.
+    State1 = kill_all_workers_with_tag(mining, State),
+    State2 = schedule_restart_after_first_micro(failsafe, State1),
+    {noreply, State2#state{restart_mining_after_first_micro = true}};
+handle_info({gproc_ps_event, Event, _}, State)
+  when Event =:= tx_created; Event =:= tx_received ->
+    {noreply, State};
+handle_info({maybe_restart_after_first_micro, grace, TopHash},
+            State = #state{top_block_hash = TopHash,
+                           awaiting_first_micro_candidate = true,
+                           restart_mining_after_first_micro = false}) ->
+    %% The grace period after winning a key-block with an empty tx pool
+    %% expired without any transaction showing up; resume key-block mining.
+    {noreply, start_block_production_(State)};
+handle_info({maybe_restart_after_first_micro, failsafe, TopHash},
+            State = #state{top_block_hash = TopHash,
+                           awaiting_first_micro_candidate = AwaitingFirstMicro,
+                           restart_mining_after_first_micro = RestartAfterMicro})
+  when AwaitingFirstMicro; RestartAfterMicro ->
+    %% The first microblock attempt of the freshly won generation did not
+    %% complete in time (e.g. the candidate worker failed without publishing
+    %% a candidate_block event). Resume key-block mining rather than letting
+    %% block production stall.
+    epoch_mining:info("First microblock attempt did not complete in time; "
+                      "resuming key-block mining", []),
+    {noreply, start_block_production_(State#state{restart_mining_after_first_micro = false})};
+handle_info({maybe_restart_after_first_micro, _Mode, _TopHash}, State) ->
+    {noreply, State};
 handle_info(init_continue, State) ->
     {noreply, start_block_production_(State)};
 handle_info({worker_reply, Pid, Res}, State) ->
@@ -930,7 +998,16 @@ preempt_on_new_top(#state{ top_block_hash = OldHash,
 
             [ SignModule:promote_candidate(aec_blocks:miner(NewBlock)) || BlockType == key ],
 
-            {changed, BlockType, NewBlock, create_key_block_candidate(State5)}
+            NextState =
+                case {BlockType, Origin} of
+                    {key, block_created} ->
+                        %% Delay creating the next key-block candidate until the first
+                        %% microblock attempt has completed for the freshly won generation.
+                        State5;
+                    _ ->
+                        create_key_block_candidate(State5)
+                end,
+            {changed, BlockType, NewBlock, NextState}
     end.
 
 %% GH3283: If we start storing more kinds of tx_events - we have to expand this
@@ -1489,26 +1566,63 @@ is_leader(NewTopBlock, PrevKeyHeader, ConsensusModule) ->
 
 setup_loop(State = #state{ consensus = Cons }, RestartMining, IsLeader, Origin) ->
     State1 = State#state{ consensus = Cons#consensus{ leader = IsLeader } },
-    State2 =
+    {State2, RestartMining1} =
         case Origin of
-            Origin when IsLeader, Origin =:= block_created
-                        orelse Origin =:= block_received ->
+            block_created when IsLeader ->
+                DelayRestart = should_delay_mining_restart(RestartMining),
                 aec_block_generator:start_generation(),
-                start_micro_signing(State1);
+                StateA = start_micro_signing(State1#state{restart_mining_after_first_micro = DelayRestart,
+                                                          awaiting_first_micro_candidate = true}),
+                StateB =
+                    case {RestartMining, DelayRestart} of
+                        {true, false} ->
+                            schedule_restart_after_first_micro(grace, StateA);
+                        {true, true} ->
+                            schedule_restart_after_first_micro(failsafe, StateA);
+                        {false, _} ->
+                            StateA
+                    end,
+                {StateB, false};
+            block_received when IsLeader ->
+                aec_block_generator:start_generation(),
+                {start_micro_signing(State1#state{restart_mining_after_first_micro = false,
+                                                  awaiting_first_micro_candidate = false}),
+                 RestartMining};
             block_received when not IsLeader ->
                 aec_block_generator:stop_generation(),
-                State1;
+                {State1#state{restart_mining_after_first_micro = false,
+                              awaiting_first_micro_candidate = false}, false};
             micro_block_created when IsLeader ->
-                start_micro_sleep(State1);
+                {start_micro_sleep(State1#state{restart_mining_after_first_micro = false,
+                                                awaiting_first_micro_candidate = false}),
+                 RestartMining orelse State1#state.restart_mining_after_first_micro};
             Origin when Origin =:= block_created; Origin =:= micro_block_created;
                         Origin =:= block_received; Origin =:= micro_block_received;
                         Origin =:= block_synced ->
-                State1
+                {State1#state{restart_mining_after_first_micro = false,
+                              awaiting_first_micro_candidate = false}, RestartMining}
         end,
-    case RestartMining of
+    case RestartMining1 of
         true  -> start_block_production_(State2);
         false -> State2
     end.
+
+schedule_restart_after_first_micro(Mode, State = #state{top_block_hash = TopHash}) ->
+    erlang:send_after(restart_after_first_micro_delay(Mode), self(),
+                      {maybe_restart_after_first_micro, Mode, TopHash}),
+    State.
+
+restart_after_first_micro_delay(grace) ->
+    aeu_env:get_env(aecore, first_micro_restart_grace,
+                    ?DEFAULT_FIRST_MICRO_RESTART_GRACE_MS);
+restart_after_first_micro_delay(failsafe) ->
+    aeu_env:get_env(aecore, first_micro_restart_failsafe,
+                    ?DEFAULT_FIRST_MICRO_RESTART_FAILSAFE_MS).
+
+%% Defer restarting key-block mining after winning a keyblock while there are
+%% pending transactions, so the first microblock gets a chance to include them.
+should_delay_mining_restart(RestartMining) ->
+    RestartMining andalso aec_tx_pool:size() > 0.
 
 get_pending_key_block(undefined, State) ->
     {{error, not_found}, State};

--- a/apps/aecore/src/aec_conductor.hrl
+++ b/apps/aecore/src/aec_conductor.hrl
@@ -41,6 +41,13 @@
 -type mode() :: local_pow | stratum | pos.
 -record(state, {key_block_candidates                :: list({candidate_hash(), #candidate{}}) | 'undefined',
                 micro_block_candidate               :: #candidate{} | 'undefined',
+                %% True while the first microblock attempt of a freshly won
+                %% generation has not yet produced a candidate (empty or not).
+                awaiting_first_micro_candidate = false :: boolean(),
+                %% True when restarting key-block mining is deferred until the
+                %% first microblock attempt of the new generation completes,
+                %% so pending transactions get included before the next key-block.
+                restart_mining_after_first_micro = false :: boolean(),
                 blocked_tags            = []        :: ordsets:ordset(atom()),
                 keys_ready              = false     :: boolean(),
                 block_producing_state   = stopped   :: block_producing_state(),

--- a/apps/aecore/test/aec_conductor_tests.erl
+++ b/apps/aecore/test/aec_conductor_tests.erl
@@ -433,9 +433,12 @@ generation_test_() ->
              ok
      end,
      [
-        {timeout, 10, {"Start signing after mined block", fun test_mined_block_signing/0}},
-        {timeout, 10, {"Start signing after two mined block", fun test_two_mined_block_signing/0}},
-        {timeout, 10, {"Start signing after received block", fun test_received_block_signing/0}}
+        {timeout, 30, {"Start signing after mined block", fun test_mined_block_signing/0}},
+        {timeout, 30, {"Delay restart until first microblock", fun test_delay_restart_until_first_micro_block/0}},
+        {timeout, 30, {"Delay restart when tx arrives after keyblock", fun test_delay_restart_for_late_tx/0}},
+        {timeout, 30, {"Failsafe restart when first microblock attempt fails", fun test_failsafe_restart_when_first_micro_fails/0}},
+        {timeout, 30, {"Start signing after two mined block", fun test_two_mined_block_signing/0}},
+        {timeout, 30, {"Start signing after received block", fun test_received_block_signing/0}}
      ]}.
 
 test_mined_block_signing() ->
@@ -457,6 +460,120 @@ test_mined_block_signing() ->
 
     ok = prev_on_chain(MicroBlock, KeyBlock),
     ok.
+
+test_delay_restart_until_first_micro_block() ->
+    Keys = beneficiary_keys(),
+    ok = meck:new(aec_block_micro_candidate, [passthrough]),
+    ok = meck:expect(aec_block_micro_candidate, create,
+                     fun(BlockInfo) ->
+                             timer:sleep(250),
+                             meck:passthrough([BlockInfo])
+                     end),
+    try
+        true = aec_events:subscribe(block_created),
+        true = aec_events:subscribe(micro_block_created),
+        true = aec_events:subscribe(start_mining),
+        ok = aec_tx_pool:push(tx(Keys)),
+
+        ?TEST_MODULE:start_mining(),
+        wait_for_start_mining_timeout(5000),
+
+        KeyBlock = wait_for_block_created(),
+        KeyBlockHash = block_hash(KeyBlock),
+        wait_for_top_block_hash(KeyBlockHash),
+        assert_no_start_mining(KeyBlockHash, 100),
+
+        MicroBlock = wait_for_micro_block_created(),
+        wait_for_top_block_hash(block_hash(MicroBlock)),
+        wait_for_start_mining(block_hash(MicroBlock), 5000),
+
+        ok = prev_on_chain(MicroBlock, KeyBlock),
+        ok
+    after
+        meck:unload(aec_block_micro_candidate)
+    end.
+
+test_delay_restart_for_late_tx() ->
+    Keys = beneficiary_keys(),
+    MiningCalls = ets:new(mining_calls, [set, public]),
+    true = ets:insert(MiningCalls, {count, 0}),
+    ok = meck:expect(aec_mining, generate,
+                     fun(_, _, Nonce, _, _) ->
+                             case ets:update_counter(MiningCalls, count, 1) of
+                                 1 ->
+                                     {ok, {Nonce, []}};
+                                 _ ->
+                                     timer:sleep(1000),
+                                     {error, no_solution}
+                             end
+                     end),
+    ok = meck:new(aec_block_micro_candidate, [passthrough]),
+    ok = meck:expect(aec_block_micro_candidate, create,
+                     fun(BlockInfo) ->
+                             timer:sleep(250),
+                             meck:passthrough([BlockInfo])
+                     end),
+    %% Widen the grace period so the tx below reliably arrives within it,
+    %% even on a slow machine.
+    ok = application:set_env(aecore, first_micro_restart_grace, 2000),
+    try
+        true = aec_events:subscribe(block_created),
+        true = aec_events:subscribe(micro_block_created),
+        true = aec_events:subscribe(start_mining),
+
+        ?TEST_MODULE:start_mining(),
+        wait_for_start_mining_timeout(5000),
+
+        KeyBlock = wait_for_block_created(),
+        KeyBlockHash = block_hash(KeyBlock),
+        wait_for_top_block_hash(KeyBlockHash),
+
+        ok = aec_tx_pool:push(tx(Keys)),
+        assert_no_start_mining(KeyBlockHash, 200),
+
+        MicroBlock = wait_for_micro_block_created(),
+        wait_for_top_block_hash(block_hash(MicroBlock)),
+        wait_for_start_mining(block_hash(MicroBlock), 5000),
+
+        ok = prev_on_chain(MicroBlock, KeyBlock),
+        ok
+    after
+        application:unset_env(aecore, first_micro_restart_grace),
+        ets:delete(MiningCalls),
+        meck:unload(aec_block_micro_candidate)
+    end.
+
+test_failsafe_restart_when_first_micro_fails() ->
+    Keys = beneficiary_keys(),
+    %% Make every microblock candidate attempt fail, so the generator never
+    %% publishes a candidate_block event for the freshly won generation.
+    ok = meck:new(aec_block_micro_candidate, [passthrough]),
+    ok = meck:expect(aec_block_micro_candidate, create,
+                     fun(_BlockInfo) -> {error, test_induced_failure} end),
+    %% Pin the failsafe delay so the test does not depend on the default.
+    ok = application:set_env(aecore, first_micro_restart_failsafe, 1000),
+    try
+        true = aec_events:subscribe(block_created),
+        true = aec_events:subscribe(start_mining),
+        ok = aec_tx_pool:push(tx(Keys)),
+
+        ?TEST_MODULE:start_mining(),
+        wait_for_start_mining_timeout(5000),
+
+        KeyBlock = wait_for_block_created(),
+        KeyBlockHash = block_hash(KeyBlock),
+        wait_for_top_block_hash(KeyBlockHash),
+
+        %% Key-block mining restart is deferred (non-empty tx pool) and the
+        %% first microblock attempt fails silently; the failsafe timer must
+        %% resume key-block mining anyway.
+        assert_no_start_mining(KeyBlockHash, 200),
+        wait_for_start_mining(KeyBlockHash, 5000),
+        ok
+    after
+        application:unset_env(aecore, first_micro_restart_failsafe),
+        meck:unload(aec_block_micro_candidate)
+    end.
 
 test_two_mined_block_signing() ->
     Keys = beneficiary_keys(),
@@ -949,14 +1066,39 @@ wait_for_block_created() ->
 wait_for_micro_block_created() ->
     wait_for_gproc(micro_block_created, 30000).
 
-wait_for_start_mining() ->
-    wait_for_gproc(start_mining, 1000).
+wait_for_start_mining_timeout(Timeout) ->
+    wait_for_gproc(start_mining, Timeout).
 
 wait_for_start_mining(Hash) ->
-    Info = wait_for_start_mining(),
+    wait_for_start_mining(Hash, 1000).
+
+wait_for_start_mining(Hash, Timeout) ->
+    Info = wait_for_start_mining_timeout(Timeout),
     case proplists:get_value(top_block_hash, Info) of
         Hash -> ok;
-        _Other -> wait_for_start_mining(Hash)
+        _Other -> wait_for_start_mining(Hash, Timeout)
+    end.
+
+assert_no_start_mining(Hash, Timeout) ->
+    Deadline = erlang:monotonic_time(millisecond) + Timeout,
+    assert_no_start_mining_loop(Hash, Deadline).
+
+assert_no_start_mining_loop(Hash, Deadline) ->
+    case Deadline - erlang:monotonic_time(millisecond) of
+        Timeout when Timeout > 0 ->
+            receive
+                {gproc_ps_event, start_mining, #{info := Info}} = Event ->
+                    case proplists:get_value(top_block_hash, Info) of
+                        Hash ->
+                            error({unexpected_event, Event});
+                        _OtherHash ->
+                            assert_no_start_mining_loop(Hash, Deadline)
+                    end
+            after Timeout ->
+                ok
+            end;
+        _ ->
+            ok
     end.
 
 wait_for_gproc(Event, Timeout) ->


### PR DESCRIPTION
After winning a key-block the conductor restarted key-block mining immediately. If the next key-block was then found quickly, the freshly won generation ended up without any microblocks (a "zero block") and the pending transactions only appeared in the next leader's first microblock.

Now, when the winning node is the leader:
- the block generator publishes an explicit empty_candidate / new_candidate event instead of silently discarding empty candidates, so the conductor knows when the first microblock attempt completed;
- key-block mining resumes only once the first microblock attempt of the new generation has completed, or after a short grace period when the tx pool is empty;
- a transaction arriving during that grace period pauses key-block mining again until the first microblock attempt completes.

Cleaner version of #4598 