### PR TITLE
Cache several variables in the fate engine state

### DIFF
--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -138,7 +138,11 @@
             , stores            :: aefa_stores:store()
             , trace             :: list()
             , vm_version        :: non_neg_integer()
+              %% Read from the tx_env once, in new/7. Only values that are fixed
+              %% for the lifetime of the engine state belong here - the tx_env is
+              %% not immutable as a whole, primops keep appending events to it.
             , consensus_version :: non_neg_integer()
+            , in_auth_context   :: boolean()
             , debug_info        :: debug_info()
             }).
 
@@ -174,6 +178,7 @@ new(Gas, Value, Spec, Stores, APIState, CodeCache, VMVersion) ->
        , trace             = []
        , vm_version        = VMVersion
        , consensus_version = aetx_env:consensus_version(TxEnv)
+       , in_auth_context   = undefined =/= aetx_env:ga_tx_hash(TxEnv)
        , debug_info        = disabled
        }.
 
@@ -235,8 +240,8 @@ is_onchain(#es{chain_api = APIState}) ->
     aefa_chain_api:is_onchain(APIState).
 
 -spec in_auth_context(state()) -> boolean().
-in_auth_context(#es{chain_api = APIState}) ->
-    undefined =/= aetx_env:ga_tx_hash(aefa_chain_api:tx_env(APIState)).
+in_auth_context(#es{in_auth_context = X}) ->
+    X.
 
 
 -spec contract_fate_bytecode(pubkey(), state()) -> 'error' |

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -138,6 +138,7 @@
             , stores            :: aefa_stores:store()
             , trace             :: list()
             , vm_version        :: non_neg_integer()
+            , consensus_version :: non_neg_integer()
             , debug_info        :: debug_info()
             }).
 
@@ -149,6 +150,7 @@
 new(Gas, Value, Spec, Stores, APIState, CodeCache, VMVersion) ->
     [error({bad_init_arg, X, Y}) || {X, Y} <- [{gas, Gas}, {value, Value}],
                                     not (is_integer(Y) andalso Y >= 0)],
+    TxEnv = aefa_chain_api:tx_env(APIState),
     #es{ accumulator       = ?FATE_VOID
        , accumulator_stack = []
        , bbs               = #{}
@@ -171,11 +173,11 @@ new(Gas, Value, Spec, Stores, APIState, CodeCache, VMVersion) ->
        , stores            = Stores
        , trace             = []
        , vm_version        = VMVersion
+       , consensus_version = aetx_env:consensus_version(TxEnv)
        , debug_info        = disabled
        }.
 
-aefa_stores(#es{ chain_api = APIState }) ->
-    Protocol = aetx_env:consensus_version(aefa_chain_api:tx_env(APIState)),
+aefa_stores(#es{ consensus_version = Protocol }) ->
     case Protocol >= ?IRIS_PROTOCOL_VSN of
         true  -> aefa_stores;
         false -> aefa_stores_lima
@@ -580,8 +582,7 @@ spend_gas_for_traversal(Term, CostModel, ES) ->
                               cost_model(),
                               {fun((integer()) -> non_neg_integer()), fun((integer()) -> aeb_fate_data:fate_type())},
                               state()) -> state().
-spend_gas_for_traversal(Term, CostModel, Unfold, ES = #es{gas = Gas, chain_api = APIState}) ->
-    Protocol = aetx_env:consensus_version(aefa_chain_api:tx_env(APIState)),
+spend_gas_for_traversal(Term, CostModel, Unfold, ES = #es{gas = Gas, consensus_version = Protocol}) ->
     case Protocol < ?IRIS_PROTOCOL_VSN of
         true  -> ES;
         false ->
@@ -887,9 +888,8 @@ vm_version(#es{vm_version = X}) ->
 
 %%%------------------
 -spec consensus_version(state()) -> non_neg_integer().
-consensus_version(#es{chain_api = Api}) ->
-    TxEnv = aefa_chain_api:tx_env(Api),
-    aetx_env:consensus_version(TxEnv).
+consensus_version(#es{consensus_version = X}) ->
+    X.
 
 %%%------------------
 

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -26,6 +26,7 @@
         , simple_failed_auth/1
         , simple_contract_create/1
         , simple_contract_call/1
+        , simple_contract_call_spend/1
         , simple_re_attach_fail/1
         , simple_spend_from_fail/1
         , simple_attach_after_spend/1
@@ -143,6 +144,7 @@ groups() ->
                    , simple_failed_auth
                    , simple_contract_create
                    , simple_contract_call
+                   , simple_contract_call_spend
                    , simple_re_attach_fail
                    , simple_spend_from_fail
                    , simple_attach_after_spend
@@ -361,6 +363,33 @@ simple_contract_call(_Cfg) ->
     {ok, #{tx_res := ok, call_res := ok, call_val := Val}} =
         ?call(ga_call, Acc1, AuthOpts2, Ct, "identity", "main_", ["42"]),
     ?assertMatch(42, decode_call_result("identity", "main_", ok, Val)),
+
+    ok.
+
+%% The inner transaction of a meta tx runs outside the auth context, so it may
+%% use the operations that are forbidden while authenticating. Chain.spend is
+%% one of them - cripple_auth checks that it is rejected in the auth call, this
+%% checks that the very same operation goes through in the inner call.
+simple_contract_call_spend(_Cfg) ->
+    state(aect_test_utils:new_state()),
+    MinGP = aec_test_utils:min_gas_price(),
+    Acc1 = ?call(new_account, 1000000000 * MinGP),
+    Acc2 = ?call(new_account, 1000000000 * MinGP),
+    {ok, _} = ?call(attach, Acc1, "simple_auth", "authorize", ["123"]),
+
+    AuthOpts = #{ prep_fun => fun(_) -> simple_auth(["123", "1"]) end },
+    {ok, #{tx_res := ok, init_res := ok, ct_pubkey := Ct}} =
+        ?call(ga_create, Acc1, AuthOpts, "spend_test", [], #{amount => 100000}),
+
+    Acc2Lit    = binary_to_list(aeser_api_encoder:encode(account_pubkey, Acc2)),
+    AuthOpts2  = #{ prep_fun => fun(_) -> simple_auth(["123", "2"]) end },
+    PreBalance = ?call(account_balance, Acc2),
+    %% Chain.spend needs more than the 10000 gas the call tx defaults to on AEVM.
+    {ok, #{tx_res := ok, call_res := ok}} =
+        ?call(ga_call, Acc1, AuthOpts2, Ct, "spend_test", "spend", [Acc2Lit, "500"],
+              #{gas => 100000}),
+    PostBalance = ?call(account_balance, Acc2),
+    ?assertMatch({X, Y} when X + 500 == Y, {PreBalance, PostBalance}),
 
     ok.
 


### PR DESCRIPTION
Isolated microbenchmark (20M iterations each, real records via the actual constructors, in the CI builder container):

| Accessor | Old path | New path | Saved | Speedup |
|---|---|---|---|---|
| `consensus_version/1` | 7.64 ns/call | 6.15 ns/call | **1.49 ns** | 1.2x |
| `in_auth_context/1` | 8.36 ns/call | 5.89 ns/call | **2.47 ns** | 1.4x |

Call frequency, traced with `dbg` across the real `aefate_engine_test` + `aefa_sophia_test` suites (216 tests spanning arithmetic, tuples, patterns, records, variants, maps, higher-order calls, remote calls — 1,390 FATE instructions executed total):

- `consensus_version/1`: 443 calls → **0.32 calls per instruction**
- `in_auth_context/1`: 22 calls → **0.016 calls per instruction**

**Combined estimate:** weighted average savings ≈ `0.32 × 1.49ns + 0.016 × 2.47ns` ≈ **0.51 nanoseconds per FATE instruction executed**.
