### PR TITLE
fix: don't crash sc_ws_handler:terminate/3 on not-yet-initialized state

### DIFF
--- a/apps/aehttp/src/sc_ws_handler.erl
+++ b/apps/aehttp/src/sc_ws_handler.erl
@@ -332,10 +332,18 @@ jobs_done(#handler{job_id = JobId} = H) when JobId =/= undefined ->
 jobs_done(H) ->
     H.
 
--spec fsm_pid(handler() | undefined) -> pid() | undefined.
+-spec fsm_pid(handler() | undefined | term()) -> pid() | undefined.
 fsm_pid(undefined) -> undefined;
 fsm_pid(#handler{fsm_pid = Pid}) ->
-    Pid.
+    Pid;
+fsm_pid(_NotYetInitialized) ->
+    %% terminate/3 can be invoked before websocket_init/1 ever produced a full
+    %% #handler{} (e.g. the connection is closed/rejected during the initial
+    %% handshake). In that case State may still be whatever init/2 handed to
+    %% cowboy_websocket (a plain map) or another placeholder value. Treat any
+    %% such not-yet-initialized state as having no linked fsm, instead of
+    %% crashing the request process with a function_clause error.
+    undefined.
 
 -spec start_link_fsm(handler(), map()) -> {ok, pid()} | {error, atom()}.
 start_link_fsm(#handler{role = initiator, host=Host, port=Port}, Opts) ->


### PR DESCRIPTION
## Summary

`sc_ws_handler:terminate/3` crashes with a `function_clause` error when the state-channel websocket connection is closed/rejected before `websocket_init/1` has produced a full `#handler{}` record — e.g. when a client opens a `/channel` connection without the required handshake parameters (role, port, party keys, etc.). The second `terminate/3` clause calls `fsm_pid(State)`, but `fsm_pid/1` only had clauses for `undefined` and `#handler{}` — not for whatever placeholder state (observed as `[]`) exists at that point.

Reproduced live against our own `api_main_channel` node:
```
CRASH REPORT Process <0.305652.0> with 0 neighbours crashed with reason:
no function clause matching sc_ws_handler:fsm_pid([]) line 336
Cowboy stream 1 with ranch listener channels_socket and connection process
<0.305650.0> had its request process exit with reason: no function clause
matching sc_ws_handler:fsm_pid([]) line 336
```

The visible symptom to a client is a bare, content-length-0 HTTP 500, instead of a clean rejection/close — this affects any request to the `/channel` endpoint that doesn't complete the full valid handshake.

## Fix

Add a catch-all clause to `fsm_pid/1` so any not-yet-initialized state is treated as "no linked fsm" instead of crashing:

```erlang
fsm_pid(_NotYetInitialized) ->
    undefined.
```

This is the only call site (`terminate/3`), so the change is narrowly scoped. No behavior change for the already-handled cases (`undefined`, fully-initialized `#handler{}`).

## Testing

Verified against a live reproduction (crash log excerpt above, reproduced by opening a `/channel` connection without required parameters). No existing eunit/CT test coverage exists for `sc_ws_handler.erl` specifically (only the larger `aehttp_sc_SUITE` integration suite, which exercises full valid channel flows) — adding a dedicated regression test for this specific early-termination path is a good follow-up but is left out here to keep this fix minimal and low-risk.