### PR TITLE
[master port] Serialize signed tx once in aetx_sign:serialize_for_client (cherry-pick of #4644)

### DIFF
--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -71,7 +71,11 @@ new(Tx, Signatures) ->
 
 -spec hash(signed_tx()) -> binary().
 hash(#signed_tx{} = Tx) ->
-    aec_hash:hash(signed_tx, serialize_to_binary(Tx)).
+    hash_from_binary(serialize_to_binary(Tx)).
+
+-spec hash_from_binary(binary_signed_tx()) -> binary().
+hash_from_binary(TxBin) ->
+    aec_hash:hash(signed_tx, TxBin).
 
 -spec add_signatures(signed_tx(), list(binary())) -> signed_tx().
 add_signatures(#signed_tx{signatures = OldSigs} = Tx, NewSigs)
@@ -250,15 +254,26 @@ serialization_template(?SIG_TX_VSN) ->
 -spec serialize_for_client(aec_headers:header(), aetx_sign:signed_tx()) -> binary() | map().
 serialize_for_client(Header, #signed_tx{}=S) ->
     {ok, BlockHash} = aec_headers:hash_header(Header),
-    serialize_for_client(S, aec_headers:height(Header), BlockHash, hash(S)).
+    TxBin = serialize_to_binary(S),
+    serialize_for_client(S, aec_headers:height(Header), BlockHash,
+                         hash_from_binary(TxBin), TxBin).
 
 -spec serialize_for_client_pending(aetx_sign:signed_tx()) -> binary() | map().
 serialize_for_client_pending(#signed_tx{}=S) ->
-    serialize_for_client(S, -1, <<>>, hash(S)).
+    TxBin = serialize_to_binary(S),
+    serialize_for_client(S, -1, <<>>, hash_from_binary(TxBin), TxBin).
 
+-ifdef(TEST).
 -spec serialize_for_client(aetx_sign:signed_tx(), integer(), binary(), binary()) ->
     binary() | map().
 serialize_for_client(#signed_tx{} = SigTx, BlockHeight, BlockHash0, TxHash) ->
+    serialize_for_client(SigTx, BlockHeight, BlockHash0, TxHash,
+                         serialize_to_binary(SigTx)).
+-endif.
+
+-spec serialize_for_client(aetx_sign:signed_tx(), integer(), binary(), binary(),
+                           binary_signed_tx()) -> binary() | map().
+serialize_for_client(#signed_tx{} = SigTx, BlockHeight, BlockHash0, TxHash, TxBin) ->
     BlockHash =
         case BlockHash0 of
             <<>> -> <<"none">>;
@@ -269,7 +284,7 @@ serialize_for_client(#signed_tx{} = SigTx, BlockHeight, BlockHash0, TxHash) ->
           <<"block_height">> => BlockHeight,
           <<"block_hash">>   => BlockHash,
           <<"hash">>         => aeser_api_encoder:encode(tx_hash, TxHash),
-          <<"encoded_tx">>   => aeser_api_encoder:encode(transaction, serialize_to_binary(SigTx))
+          <<"encoded_tx">>   => aeser_api_encoder:encode(transaction, TxBin)
          },
     serialize_for_client_inner(SigTx, MetaData).
 

--- a/apps/aetx/test/aetx_sign_tests.erl
+++ b/apps/aetx/test/aetx_sign_tests.erl
@@ -11,6 +11,8 @@
 
 -define(TEST_MODULE, aetx_sign).
 -define(TEST_HEIGHT, 42).
+-define(BLOCK_HEIGHT, 137).
+-define(FAKE_TX_HASH, <<7:32/unit:8>>).
 
 sign_txs_test_() ->
     {setup,
@@ -77,6 +79,130 @@ sign_txs_test_() ->
                end
        end}
      ]}.
+
+serialize_for_client_test_() ->
+    {setup,
+     fun() ->
+             aec_test_utils:aec_keys_setup()
+     end,
+     fun(TmpKeysDir) ->
+             ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir)
+     end,
+     [{"Pending transaction is hashed as it is handed to the client",
+       fun() ->
+               SignedTx = signed_spend_tx(),
+               Serialized = ?TEST_MODULE:serialize_for_client_pending(SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               assert_signatures(SignedTx, Serialized),
+               ?assertMatch(#{<<"type">> := <<"SpendTx">>},
+                            maps:get(<<"tx">>, Serialized)),
+               ?assertEqual(-1, maps:get(<<"block_height">>, Serialized)),
+               ?assertEqual(<<"none">>, maps:get(<<"block_hash">>, Serialized)),
+               ok
+       end},
+      {"Transaction in a micro block is hashed as it is handed to the client",
+       fun() ->
+               SignedTx = signed_spend_tx(),
+               Header = micro_header(?BLOCK_HEIGHT),
+               {ok, BlockHash} = aec_headers:hash_header(Header),
+               Serialized = ?TEST_MODULE:serialize_for_client(Header, SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               assert_signatures(SignedTx, Serialized),
+               ?assertEqual(?BLOCK_HEIGHT, maps:get(<<"block_height">>, Serialized)),
+               ?assertEqual(aeser_api_encoder:encode(micro_block_hash, BlockHash),
+                            maps:get(<<"block_hash">>, Serialized)),
+               ok
+       end},
+      {"All signatures of a transaction are handed to the client",
+       fun() ->
+               SignedTx = make_signed_mutual_close(),
+               ?assertMatch([_, _], ?TEST_MODULE:signatures(SignedTx)),
+               Serialized = ?TEST_MODULE:serialize_for_client_pending(SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               assert_signatures(SignedTx, Serialized),
+               ok
+       end},
+      {"Generalized account meta transaction is hashed as it is handed to the client",
+       fun() ->
+               SignedTx = signed_meta_tx(),
+               Serialized = ?TEST_MODULE:serialize_for_client_pending(SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               %% Signatures make no sense for a generalized account
+               ?assertNot(maps:is_key(<<"signatures">>, Serialized)),
+               %% The transaction it authenticates does carry its signatures
+               #{<<"tx">> := #{<<"tx">> := InnerTx}} = Serialized,
+               ?assertMatch(#{<<"signatures">> := [<<"sg_", _/binary>>],
+                              <<"tx">> := #{<<"type">> := <<"SpendTx">>}}, InnerTx),
+               ok
+       end},
+      {"Block data and transaction hash are presented as given",
+       fun() ->
+               SignedTx = signed_spend_tx(),
+               Header = micro_header(?BLOCK_HEIGHT),
+               {ok, BlockHash} = aec_headers:hash_header(Header),
+               ?assertEqual(?TEST_MODULE:serialize_for_client(Header, SignedTx),
+                            ?TEST_MODULE:serialize_for_client(SignedTx, ?BLOCK_HEIGHT,
+                                                              BlockHash,
+                                                              ?TEST_MODULE:hash(SignedTx))),
+               %% The caller decides what the transaction is known by, it is
+               %% not recomputed from the transaction itself.
+               Serialized = ?TEST_MODULE:serialize_for_client(SignedTx, ?BLOCK_HEIGHT + 1,
+                                                              BlockHash, ?FAKE_TX_HASH),
+               ?assertEqual(aeser_api_encoder:encode(tx_hash, ?FAKE_TX_HASH),
+                            maps:get(<<"hash">>, Serialized)),
+               ?assertEqual(?BLOCK_HEIGHT + 1, maps:get(<<"block_height">>, Serialized)),
+               ok
+       end}
+     ]}.
+
+%% The client is given the transaction hash and the transaction itself. Both
+%% are derived from one single serialization of the signed tx, so assert that
+%% the hash is indeed the hash of the very bytes the client is handed.
+assert_hash_of_encoded_tx(SignedTx, Serialized) ->
+    {ok, TxBin} = aeser_api_encoder:safe_decode(
+                    transaction, maps:get(<<"encoded_tx">>, Serialized)),
+    ?assertEqual(?TEST_MODULE:serialize_to_binary(SignedTx), TxBin),
+    ?assertEqual(SignedTx, ?TEST_MODULE:deserialize_from_binary(TxBin)),
+    ?assertEqual(aeser_api_encoder:encode(tx_hash, aec_hash:hash(signed_tx, TxBin)),
+                 maps:get(<<"hash">>, Serialized)),
+    ?assertEqual(aeser_api_encoder:encode(tx_hash, ?TEST_MODULE:hash(SignedTx)),
+                 maps:get(<<"hash">>, Serialized)),
+    ?assertEqual(aetx:serialize_for_client(?TEST_MODULE:tx(SignedTx)),
+                 maps:get(<<"tx">>, Serialized)).
+
+%% Signatures are presented in the same canonical order they are serialized in.
+assert_signatures(SignedTx, Serialized) ->
+    ?assertEqual([aeser_api_encoder:encode(signature, S)
+                  || S <- ?TEST_MODULE:signatures(SignedTx)],
+                 maps:get(<<"signatures">>, Serialized)).
+
+signed_spend_tx() ->
+    #{ public := Pubkey, secret := Privkey } = enacl:sign_keypair(),
+    {ok, SpendTx} = make_spend_tx(Pubkey),
+    aec_test_utils:sign_tx(SpendTx, Privkey).
+
+signed_meta_tx() ->
+    #{ public := Pubkey } = enacl:sign_keypair(),
+    {ok, MetaTx} = aega_meta_tx:new(
+                     #{ga_id       => aeser_id:create(account, Pubkey),
+                       auth_data   => <<>>,
+                       abi_version => 1,
+                       gas         => 1,
+                       gas_price   => 1,
+                       fee         => 1,
+                       tx          => signed_spend_tx()}),
+    ?TEST_MODULE:new(MetaTx, []).
+
+micro_header(Height) ->
+    aec_headers:new_micro_header(
+      Height,
+      <<1:?BLOCK_HEADER_HASH_BYTES/unit:8>>, %% prev hash
+      <<2:?BLOCK_HEADER_HASH_BYTES/unit:8>>, %% prev key hash
+      <<3:?STATE_HASH_BYTES/unit:8>>,        %% root hash
+      0,                                     %% time
+      <<4:?TXS_HASH_BYTES/unit:8>>,          %% txs hash
+      <<>>,                                  %% no fraud
+      ?CERES_PROTOCOL_VSN).
 
 make_spend_tx(Sender) ->
     #{ public := OtherPubkey} = enacl:sign_keypair(),


### PR DESCRIPTION
Master (7.3.x) port of #4644, clean cherry-pick (no conflicts against current `master`).

mdw runs the `master`/7.3.x line (not `releases/stable`), so this perf fix doesn't reach mdw until it's ported here too. Note: once this merges, mdw itself will need a corresponding node update/rebuild to actually pick up the change — porting the code alone isn't enough.

Original PR: #4644