### PR TITLE
[master port] Batch of clean cherry-picks from recent releases/stable optimization PRs (#4632, #4633, #4634, #4640, #4642, #4643, #4644)

### DIFF
--- a/apps/aeapi/src/aeapi.erl
+++ b/apps/aeapi/src/aeapi.erl
@@ -423,9 +423,9 @@ generation_at_height(Height) when is_integer(Height) ->
                             {ok, encode_generation(KeyBlock, MicroBlocks, key)};
                         _ ->
                             PrevBlockHash = aec_blocks:prev_hash(KeyBlock),
-                            case aec_chain:get_block(PrevBlockHash) of
-                                {ok, PrevBlock} ->
-                                    PrevBlockType = aec_blocks:type(PrevBlock),
+                            case aec_chain:get_header(PrevBlockHash) of
+                                {ok, PrevHeader} ->
+                                    PrevBlockType = aec_headers:type(PrevHeader),
                                     {ok, encode_generation(KeyBlock, MicroBlocks, PrevBlockType)};
                                 error ->
                                     {error, "Block not found"}

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -436,14 +436,6 @@ get_top_block_node(#{top_block_node := N}) -> N.
 
 set_top_block_node(#node{} = N, State) -> State#{top_block_node => N}.
 
-prev_version(Node) ->
-    H = node_height(Node),
-    case H =:= aec_block_genesis:height() of
-        true  -> undefined;
-        %% Might return different protocols for the same height due to block signaling
-        false -> node_version(db_get_node(node_prev_hash(Node)))
-    end.
-
 maybe_add_pof(State, Block) ->
     case aec_blocks:type(Block) of
         key   -> State#{pof => no_fraud};
@@ -734,11 +726,12 @@ assert_height_delta(undefined, Height, TopHeight) ->
     Height >= ( TopHeight - gossip_allowed_height_from_top() ).
 
 update_state_tree(Node, State, Ctx) ->
-    {ok, Trees, ForkInfoIn} = get_state_trees_in(Node, aec_block_insertion:ctx_prev(Ctx), true),
+    PrevNode = aec_block_insertion:ctx_prev(Ctx),
+    {ok, Trees, ForkInfoIn} = get_state_trees_in(Node, PrevNode, true),
     {ForkInfo, MicSibHeaders, KeySibHeaders} = maybe_set_new_fork_id(Node, ForkInfoIn, State),
     State1 = update_found_pof(Node, MicSibHeaders, State, Ctx),
     State2 = update_found_pogf(Node, KeySibHeaders, State1),
-    {State3, NewTopDifficulty, Events} = update_state_tree(Node, Trees, ForkInfo, State2),
+    {State3, NewTopDifficulty, Events} = update_state_tree(Node, PrevNode, Trees, ForkInfo, State2),
     OldTopNode = get_top_block_node(State),
     handle_top_block_change(OldTopNode, NewTopDifficulty, Node, Events, State3).
 
@@ -746,8 +739,7 @@ repair_state_tree(Node, PrevNode, State) ->
     {ok, TreesIn, ForkInfoIn} = get_state_trees_in(Node, true),
     apply_and_repair_trees(Node, PrevNode, TreesIn, ForkInfoIn, State).
 
-update_state_tree(Node, TreesIn, ForkInfo, State) ->
-    PrevNode = db_get_node(node_prev_hash(Node)),
+update_state_tree(Node, PrevNode, TreesIn, ForkInfo, State) ->
     case db_find_state(node_hash(Node), true) of
         {ok, FoundTrees, FoundForkInfo} ->
             {Trees, _Fees, Events} = apply_node_transactions(Node, PrevNode, TreesIn,
@@ -945,7 +937,9 @@ apply_node_transactions(Node, PrevNode, Trees, ForkInfo, State) ->
             #fork_info{fees = FeesIn, fraud = FraudStatus} = ForkInfo,
             Height = node_height(Node),
             PrevConsensus = aec_consensus:get_consensus_module_at_height(Height-1),
-            PrevVersion = prev_version(Node),
+            %% Might be a different protocol than derived from height due to
+            %% block signaling, so use the actual previous node's version.
+            PrevVersion = node_version(PrevNode),
             GasFees = calculate_gas_fee(aec_trees:calls(Trees)),
             TotalFees = GasFees + FeesIn,
             Header = node_header(Node),

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -150,8 +150,8 @@ tx_pool_sync_finish(PeerId, Done) ->
 send_tx(PeerId, SerTx) ->
     cast(PeerId, {send_tx, SerTx}).
 
-send_block(PeerId, SerBlock) ->
-    cast(PeerId, {send_block, SerBlock}).
+send_block(PeerId, WireMsg) ->
+    cast(PeerId, {send_gossip, WireMsg}).
 
 %% Indicate that we are syncing, and that gossips should be dropped.
 set_sync_height(PeerId, Height) ->
@@ -281,8 +281,8 @@ handle_call(Request, From, State) ->
 handle_cast({send_tx, SerTx}, State) ->
     send_send_tx(State, SerTx),
     {noreply, State};
-handle_cast({send_block, SerBlock}, State) ->
-    send_send_block(State, SerBlock),
+handle_cast({send_gossip, WireMsg}, State) ->
+    send_gossip(State, WireMsg),
     {noreply, State};
 handle_cast({set_sync_height, none}, State) ->
     {noreply, maps:remove(sync_height, State)};
@@ -1225,17 +1225,13 @@ handle_tx_pool_sync_rsp(S, Action, {tx_pool, From, _TRef}, MsgObj) ->
 
 %% -- Send Block --------------------------------------------------------------
 
-send_send_block(#{ status := error }, _SerBlock) ->
-    ok;
-send_send_block(#{ status := {disconnecting, _ESock} }, _SerBlock) ->
-    ok;
-send_send_block(S = #{ status := {connected, _ESock} }, {Type, SerBlock}) ->
-    {MsgType, Msg} =
-        case Type of
-            key_block         -> {key_block, #{ key_block => SerBlock }};
-            light_micro_block -> {micro_block, #{ micro_block => SerBlock, light => true }}
-        end,
-    send_msg(S, MsgType, aec_peer_messages:serialize(MsgType, Msg)).
+%% The wire message is pre-encoded once per gossip (see gossip_serialize_block/1)
+%% since it is byte-identical for every peer, so here we only need to push the
+%% finished bytes onto the socket, reusing do_send's fragmentation logic.
+send_gossip(#{ status := {connected, ESock} }, WireMsg) ->
+    do_send(ESock, WireMsg);
+send_gossip(_S, _WireMsg) ->
+    ok.
 
 handle_new_key_block(S, Msg) ->
     try
@@ -1534,11 +1530,18 @@ ping_connected_peer_percentage() ->
 
 %% -- Helper functions -------------------------------------------------------
 
+%% Produce the finished wire message (<<Tag:16, Msg/binary>>) once per gossip.
+%% It is byte-identical for every peer (fixed protocol version, pure function),
+%% so encoding it here avoids re-encoding the full block once per gossip target.
 gossip_serialize_block(Block) ->
-    case aec_blocks:type(Block) of
-        key   -> {key_block, serialize_key_block(Block)};
-        micro -> {light_micro_block, serialize_light_micro_block(Block)}
-    end.
+    {MsgType, Msg} =
+        case aec_blocks:type(Block) of
+            key   -> {key_block, #{ key_block => serialize_key_block(Block) }};
+            micro -> {micro_block, #{ micro_block => serialize_light_micro_block(Block),
+                                      light => true }}
+        end,
+    SerMsg = aec_peer_messages:serialize(MsgType, Msg),
+    <<(aec_peer_messages:tag(MsgType)):16, SerMsg/binary>>.
 
 gossip_serialize_tx(Tx) ->
     aetx_sign:serialize_to_binary(Tx).

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -780,8 +780,9 @@ enqueue(Kind, Data, PeerIds) ->
     case Kind of
         block ->
             %% Getting blocks to spread is a priority, bypass the gossip queue
-            SerBlock = aec_peer_connection:gossip_serialize_block(Data),
-            [ do_forward_block(SerBlock, PId) || PId <- PeerIds ];
+            %% The wire message is encoded once here and reused for every peer.
+            WireBlock = aec_peer_connection:gossip_serialize_block(Data),
+            [ do_forward_block(WireBlock, PId) || PId <- PeerIds ];
         tx ->
             SerTx = aec_peer_connection:gossip_serialize_tx(Data),
             aec_jobs_queues:run(sync_gossip, fun() -> [ do_forward_tx(SerTx, PId) || PId <- PeerIds ] end)
@@ -797,8 +798,8 @@ ping_peer(PeerId) ->
             aec_peers:log_ping(PeerId, error)
     end.
 
-do_forward_block(SerBlock, PeerId) ->
-    Res = aec_peer_connection:send_block(PeerId, SerBlock),
+do_forward_block(WireBlock, PeerId) ->
+    Res = aec_peer_connection:send_block(PeerId, WireBlock),
     epoch_sync:debug("send_block to (~p): ~p", [ppp(PeerId), Res]).
 
 do_forward_tx(SerTx, PeerId) ->

--- a/apps/aecore/src/aec_sync.erl
+++ b/apps/aecore/src/aec_sync.erl
@@ -332,24 +332,23 @@ handle_info({gproc_ps_event, Event, #{info := Info}},
     %% FUTURE: Forward blocks only to outbound connections.
     %% Take a random subset (possibly empty) of peers that agree with us
     %% on chain height to forward blocks and transactions to.
-    MaxGossip = max_gossip(),
-    PeerIds = [ aec_peer:id(P) || P <- aec_peers:get_random_connected(MaxGossip) ],
-    NonSyncingPeerIds = [ P || P <- PeerIds, not peer_in_sync(State, P) ],
     case Event of
         block_to_publish ->
             case Info of
                 {created, Block} ->
-                    PeerIds1 = [ aec_peer:id(P) || P <- aec_peers:connected_peers(all) ],
-                    enqueue(block, Block, PeerIds1);
+                    PeerIds = [ aec_peer:id(P) || P <- aec_peers:connected_peers(all) ],
+                    enqueue(block, Block, PeerIds);
                 {received, Block} ->
+                    NonSyncingPeerIds = [ P || P <- gossip_peer_ids(),
+                                               not peer_in_sync(State, P) ],
                     enqueue(block, Block, NonSyncingPeerIds)
             end;
         tx_created when GossipTxs ->
             %% If we allow http requests creating transactions when we are catching up
             %% with other chains, we just keep them in mempool
-            enqueue(tx, Info, PeerIds);
+            enqueue(tx, Info, gossip_peer_ids());
         tx_received when GossipTxs ->
-            enqueue(tx, Info, PeerIds);
+            enqueue(tx, Info, gossip_peer_ids());
         _             -> ignore
     end,
     {noreply, State};
@@ -1263,6 +1262,9 @@ max_gossip() ->
     aeu_env:user_config_or_env([<<"sync">>, <<"max_gossip">>],
                                aecore, sync_max_gossip,
                                ?DEFAULT_MAX_GOSSIP).
+
+gossip_peer_ids() ->
+    [ aec_peer:id(P) || P <- aec_peers:get_random_connected(max_gossip()) ].
 
 is_syncing(#state{sync_tasks = SyncTasks}) ->
     [1 || #sync_task{suspect = false} <- SyncTasks] =/= [].

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -64,6 +64,7 @@
         , pool_db/0
         , pool_db_nonce/0
         , pool_db_key/1
+        , pool_db_key/2
         , pool_db_gc/0
         , pool_db_peek/4
         , raw_delete/2
@@ -404,7 +405,7 @@ handle_call(Req, From, St) ->
 handle_call_({get_max_nonce, Sender}, _From, #state{dbs = #dbs{db = Db}} = State) ->
     {reply, int_get_max_nonce(Db, Sender), State};
 handle_call_({push, Tx, Hash, Event}, _From, State) ->
-    {Res, State1} = do_pool_db_put(pool_db_key(Tx), Tx, Hash, Event, State),
+    {Res, State1} = do_pool_db_put(pool_db_key(Tx, Hash), Tx, Hash, Event, State),
     {reply, Res, State1};
 handle_call_({top_change, Info}, _From, State) ->
     {_, State1} = do_top_change(Info, State),
@@ -424,7 +425,7 @@ handle_call_({delete, TxHash}, _From, #state{dbs = Dbs} = State) ->
             {BlockHash, _} when is_binary(BlockHash) ->
                 {error, already_accepted};
             {mempool, Tx} ->
-                Key = pool_db_key(Tx),
+                Key = pool_db_key(Tx, TxHash),
                 pool_db_raw_delete(Dbs, Key),
                 aec_tx_pool_gc:delete_hash(GCDb, TxHash),
                 aec_db:remove_tx_from_mempool(TxHash),
@@ -438,7 +439,7 @@ handle_call_({failures_cnt, TxHash}, _From, #state{dbs = Dbs} = State) ->
             {BlockHash, _} when is_binary(BlockHash) ->
                 {error, already_accepted};
             {mempool, Tx} ->
-                Key = pool_db_key(Tx),
+                Key = pool_db_key(Tx, TxHash),
                 #dbs{db = Db, visited_db = VisitedDb} = Dbs,
                 case ets:lookup(Db, Key) of
                     [{Key, #tx{failures = Failures}}] ->
@@ -743,6 +744,12 @@ do_update_sync_top(NewSyncTop, GCHeight, Parent, Dbs) ->
 
 -spec pool_db_key(aetx_sign:signed_tx()) -> pool_db_key().
 pool_db_key(SignedTx) ->
+    pool_db_key(SignedTx, aetx_sign:hash(SignedTx)).
+
+%% Same as pool_db_key/1, but takes the already-computed tx hash to avoid a
+%% redundant serialization + Blake2b at call sites where the hash is in scope.
+-spec pool_db_key(aetx_sign:signed_tx(), tx_hash()) -> pool_db_key().
+pool_db_key(SignedTx, TxHash) ->
     Tx = aetx_sign:tx(SignedTx),
     %% INFO: Sort by fee, then by gas price, then by origin, then by nonce
 
@@ -752,7 +759,7 @@ pool_db_key(SignedTx) ->
     %%         transactions at the beginning
     %%       * ordered_set type enables implicit overwrite of the same txs
     ?KEY(-aetx:deep_fee(Tx), -int_gas_price(Tx),
-         aetx:origin(Tx), aetx:nonce(Tx), aetx_sign:hash(SignedTx)).
+         aetx:origin(Tx), aetx:nonce(Tx), TxHash).
 
 -spec pool_db_open(DbName :: atom()) -> {ok, pool_db()}.
 pool_db_open(DbName) ->
@@ -881,12 +888,12 @@ update_pool_on_tx_hash(TxHash, {#dbs{gc_db = GCDb} = Dbs, OriginsCache, GCHeight
             case aec_db:is_in_tx_pool(TxHash) of
                 false ->
                     %% Added to chain
-                    Key = pool_db_key(Tx),
+                    Key = pool_db_key(Tx, TxHash),
                     pool_db_raw_delete(Dbs, Key),
                     aec_tx_pool_gc:delete_hash(GCDb, TxHash),
                     add_to_origins_cache(OriginsCache, Tx);
                 true ->
-                    Key = pool_db_key(Tx),
+                    Key = pool_db_key(Tx, TxHash),
                     pool_db_raw_put(Dbs, GCHeight, Key, Tx, TxHash)
             end
     end.

--- a/apps/aecore/src/aec_tx_pool_gc.erl
+++ b/apps/aecore/src/aec_tx_pool_gc.erl
@@ -351,7 +351,7 @@ remove_txs_from_dbs([SignedTx | Rest], Dbs) ->
     TxHash = aetx_sign:hash(SignedTx),
     case aec_db:gc_tx(TxHash) of
         ok ->
-            aec_tx_pool:raw_delete(Dbs, aec_tx_pool:pool_db_key(SignedTx)),
+            aec_tx_pool:raw_delete(Dbs, aec_tx_pool:pool_db_key(SignedTx, TxHash)),
             delete_hash(aec_tx_pool:gc_db(Dbs), TxHash),
             aec_metrics:try_update([ae,epoch,aecore,tx_pool,origin_gced], 1);
         {error, Reason} ->

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -138,7 +138,11 @@
             , stores            :: aefa_stores:store()
             , trace             :: list()
             , vm_version        :: non_neg_integer()
+              %% Read from the tx_env once, in new/7. Only values that are fixed
+              %% for the lifetime of the engine state belong here - the tx_env is
+              %% not immutable as a whole, primops keep appending events to it.
             , consensus_version :: non_neg_integer()
+            , in_auth_context   :: boolean()
             , debug_info        :: debug_info()
             }).
 
@@ -174,6 +178,7 @@ new(Gas, Value, Spec, Stores, APIState, CodeCache, VMVersion) ->
        , trace             = []
        , vm_version        = VMVersion
        , consensus_version = aetx_env:consensus_version(TxEnv)
+       , in_auth_context   = undefined =/= aetx_env:ga_tx_hash(TxEnv)
        , debug_info        = disabled
        }.
 
@@ -235,8 +240,8 @@ is_onchain(#es{chain_api = APIState}) ->
     aefa_chain_api:is_onchain(APIState).
 
 -spec in_auth_context(state()) -> boolean().
-in_auth_context(#es{chain_api = APIState}) ->
-    undefined =/= aetx_env:ga_tx_hash(aefa_chain_api:tx_env(APIState)).
+in_auth_context(#es{in_auth_context = X}) ->
+    X.
 
 
 -spec contract_fate_bytecode(pubkey(), state()) -> 'error' |

--- a/apps/aefate/src/aefa_engine_state.erl
+++ b/apps/aefate/src/aefa_engine_state.erl
@@ -138,6 +138,7 @@
             , stores            :: aefa_stores:store()
             , trace             :: list()
             , vm_version        :: non_neg_integer()
+            , consensus_version :: non_neg_integer()
             , debug_info        :: debug_info()
             }).
 
@@ -149,6 +150,7 @@
 new(Gas, Value, Spec, Stores, APIState, CodeCache, VMVersion) ->
     [error({bad_init_arg, X, Y}) || {X, Y} <- [{gas, Gas}, {value, Value}],
                                     not (is_integer(Y) andalso Y >= 0)],
+    TxEnv = aefa_chain_api:tx_env(APIState),
     #es{ accumulator       = ?FATE_VOID
        , accumulator_stack = []
        , bbs               = #{}
@@ -171,11 +173,11 @@ new(Gas, Value, Spec, Stores, APIState, CodeCache, VMVersion) ->
        , stores            = Stores
        , trace             = []
        , vm_version        = VMVersion
+       , consensus_version = aetx_env:consensus_version(TxEnv)
        , debug_info        = disabled
        }.
 
-aefa_stores(#es{ chain_api = APIState }) ->
-    Protocol = aetx_env:consensus_version(aefa_chain_api:tx_env(APIState)),
+aefa_stores(#es{ consensus_version = Protocol }) ->
     case Protocol >= ?IRIS_PROTOCOL_VSN of
         true  -> aefa_stores;
         false -> aefa_stores_lima
@@ -580,8 +582,7 @@ spend_gas_for_traversal(Term, CostModel, ES) ->
                               cost_model(),
                               {fun((integer()) -> non_neg_integer()), fun((integer()) -> aeb_fate_data:fate_type())},
                               state()) -> state().
-spend_gas_for_traversal(Term, CostModel, Unfold, ES = #es{gas = Gas, chain_api = APIState}) ->
-    Protocol = aetx_env:consensus_version(aefa_chain_api:tx_env(APIState)),
+spend_gas_for_traversal(Term, CostModel, Unfold, ES = #es{gas = Gas, consensus_version = Protocol}) ->
     case Protocol < ?IRIS_PROTOCOL_VSN of
         true  -> ES;
         false ->
@@ -887,9 +888,8 @@ vm_version(#es{vm_version = X}) ->
 
 %%%------------------
 -spec consensus_version(state()) -> non_neg_integer().
-consensus_version(#es{chain_api = Api}) ->
-    TxEnv = aefa_chain_api:tx_env(Api),
-    aetx_env:consensus_version(TxEnv).
+consensus_version(#es{consensus_version = X}) ->
+    X.
 
 %%%------------------
 

--- a/apps/aega/test/aega_SUITE.erl
+++ b/apps/aega/test/aega_SUITE.erl
@@ -26,6 +26,7 @@
         , simple_failed_auth/1
         , simple_contract_create/1
         , simple_contract_call/1
+        , simple_contract_call_spend/1
         , simple_re_attach_fail/1
         , simple_spend_from_fail/1
         , simple_attach_after_spend/1
@@ -143,6 +144,7 @@ groups() ->
                    , simple_failed_auth
                    , simple_contract_create
                    , simple_contract_call
+                   , simple_contract_call_spend
                    , simple_re_attach_fail
                    , simple_spend_from_fail
                    , simple_attach_after_spend
@@ -361,6 +363,33 @@ simple_contract_call(_Cfg) ->
     {ok, #{tx_res := ok, call_res := ok, call_val := Val}} =
         ?call(ga_call, Acc1, AuthOpts2, Ct, "identity", "main_", ["42"]),
     ?assertMatch(42, decode_call_result("identity", "main_", ok, Val)),
+
+    ok.
+
+%% The inner transaction of a meta tx runs outside the auth context, so it may
+%% use the operations that are forbidden while authenticating. Chain.spend is
+%% one of them - cripple_auth checks that it is rejected in the auth call, this
+%% checks that the very same operation goes through in the inner call.
+simple_contract_call_spend(_Cfg) ->
+    state(aect_test_utils:new_state()),
+    MinGP = aec_test_utils:min_gas_price(),
+    Acc1 = ?call(new_account, 1000000000 * MinGP),
+    Acc2 = ?call(new_account, 1000000000 * MinGP),
+    {ok, _} = ?call(attach, Acc1, "simple_auth", "authorize", ["123"]),
+
+    AuthOpts = #{ prep_fun => fun(_) -> simple_auth(["123", "1"]) end },
+    {ok, #{tx_res := ok, init_res := ok, ct_pubkey := Ct}} =
+        ?call(ga_create, Acc1, AuthOpts, "spend_test", [], #{amount => 100000}),
+
+    Acc2Lit    = binary_to_list(aeser_api_encoder:encode(account_pubkey, Acc2)),
+    AuthOpts2  = #{ prep_fun => fun(_) -> simple_auth(["123", "2"]) end },
+    PreBalance = ?call(account_balance, Acc2),
+    %% Chain.spend needs more than the 10000 gas the call tx defaults to on AEVM.
+    {ok, #{tx_res := ok, call_res := ok}} =
+        ?call(ga_call, Acc1, AuthOpts2, Ct, "spend_test", "spend", [Acc2Lit, "500"],
+              #{gas => 100000}),
+    PostBalance = ?call(account_balance, Acc2),
+    ?assertMatch({X, Y} when X + 500 == Y, {PreBalance, PostBalance}),
 
     ok.
 

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -129,9 +129,8 @@ handle_request_('GetTopBlock', _, _Context) ->
                     {200, [], #{key_block => aec_headers:serialize_for_client(Header, key)}};
                 _ ->
                     PrevBlockHash = aec_blocks:prev_hash(Block),
-                    case aec_chain:get_block(PrevBlockHash) of
-                        {ok, PrevBlock} ->
-                            PrevBlockType = aec_blocks:type(PrevBlock),
+                    case prev_block_type(PrevBlockHash) of
+                        {ok, PrevBlockType} ->
                             Header = aec_blocks:to_header(Block),
                             Type =
                                 case aec_headers:type(Header) of
@@ -157,9 +156,8 @@ handle_request_('GetTopHeader', _, _Context) ->
                     {200, [], aec_headers:serialize_for_client(Header, key)};
                 _ ->
                     PrevBlockHash = aec_blocks:prev_hash(Block),
-                    case aec_chain:get_block(PrevBlockHash) of
-                        {ok, PrevBlock} ->
-                            PrevBlockType = aec_blocks:type(PrevBlock),
+                    case prev_block_type(PrevBlockHash) of
+                        {ok, PrevBlockType} ->
                             Header = aec_blocks:to_header(Block),
                             SerHeader = aec_headers:serialize_for_client(Header, PrevBlockType),
                             {200, [], SerHeader};
@@ -181,9 +179,8 @@ handle_request_('GetCurrentKeyBlock', _Req, _Context) ->
                     {200, [], aec_headers:serialize_for_client(Header, key)};
                 _Height ->
                     PrevBlockHash = aec_blocks:prev_hash(Block),
-                    case aec_chain:get_block(PrevBlockHash) of
-                        {ok, PrevBlock} ->
-                            PrevBlockType = aec_blocks:type(PrevBlock),
+                    case prev_block_type(PrevBlockHash) of
+                        {ok, PrevBlockType} ->
                             Header = aec_blocks:to_header(Block),
                             {200, [], aec_headers:serialize_for_client(Header, PrevBlockType)};
                         error ->
@@ -208,9 +205,8 @@ handle_request_('GetPendingKeyBlock', _Req, _Context) ->
     case aec_conductor:get_key_block_candidate() of
         {ok, Block} ->
             PrevBlockHash = aec_blocks:prev_hash(Block),
-            case aec_chain:get_block(PrevBlockHash) of
-                {ok, PrevBlock} ->
-                    PrevBlockType = aec_blocks:type(PrevBlock),
+            case prev_block_type(PrevBlockHash) of
+                {ok, PrevBlockType} ->
                     Header = aec_blocks:to_header(Block),
                     {200, [], aec_headers:serialize_for_client(Header, PrevBlockType)};
                 error ->
@@ -238,9 +234,8 @@ handle_request_('GetKeyBlockByHash', Params, _Context) ->
                                     {200, [], aec_headers:serialize_for_client(Header, key)};
                                 _ ->
                                     PrevBlockHash = aec_blocks:prev_hash(Block),
-                                    case aec_chain:get_block(PrevBlockHash) of
-                                        {ok, PrevBlock} ->
-                                            PrevBlockType = aec_blocks:type(PrevBlock),
+                                    case prev_block_type(PrevBlockHash) of
+                                        {ok, PrevBlockType} ->
                                             {200, [], aec_headers:serialize_for_client(Header, PrevBlockType)};
                                         error ->
                                             {404, [], #{reason => <<"Block not found">>}}
@@ -265,9 +260,8 @@ handle_request_('GetKeyBlockByHeight', Params, _Context) ->
                     {200, [], aec_headers:serialize_for_client(Header, key)};
                 _ ->
                     PrevBlockHash = aec_blocks:prev_hash(Block),
-                    case aec_chain:get_block(PrevBlockHash) of
-                        {ok, PrevBlock} ->
-                            PrevBlockType = aec_blocks:type(PrevBlock),
+                    case prev_block_type(PrevBlockHash) of
+                        {ok, PrevBlockType} ->
                             {200, [], aec_headers:serialize_for_client(Header, PrevBlockType)};
                         error ->
                             {404, [], #{reason => <<"Block not found">>}}
@@ -284,9 +278,8 @@ handle_request_('GetMicroBlockHeaderByHash', Params, _Context) ->
             case aehttp_logic:get_micro_block_by_hash(Hash) of
                 {ok, Block} ->
                     PrevBlockHash = aec_blocks:prev_hash(Block),
-                    case aec_chain:get_block(PrevBlockHash) of
-                        {ok, PrevBlock} ->
-                            PrevBlockType = aec_blocks:type(PrevBlock),
+                    case prev_block_type(PrevBlockHash) of
+                        {ok, PrevBlockType} ->
                             Header = aec_blocks:to_header(Block),
                             {200, [], aec_headers:serialize_for_client(Header, PrevBlockType)};
                         error ->
@@ -933,13 +926,21 @@ generation_rsp({ok, #{ key_block := KeyBlock, micro_blocks := MicroBlocks }}) ->
             {200, [], encode_generation(KeyBlock, MicroBlocks, key)};
         _ ->
             PrevBlockHash = aec_blocks:prev_hash(KeyBlock),
-            case aec_chain:get_block(PrevBlockHash) of
-                {ok, PrevBlock} ->
-                    PrevBlockType = aec_blocks:type(PrevBlock),
+            case prev_block_type(PrevBlockHash) of
+                {ok, PrevBlockType} ->
                     {200, [], encode_generation(KeyBlock, MicroBlocks, PrevBlockType)};
                 error ->
                     {404, [], #{reason => <<"Block not found">>}}
             end
+    end.
+
+%% Only the block type of the previous block is needed to serialize a header
+%% for a client, so read just the header - reading the full block would also
+%% fetch and deserialize every transaction of a micro block.
+prev_block_type(PrevBlockHash) ->
+    case aec_chain:get_header(PrevBlockHash) of
+        {ok, PrevHeader} -> {ok, aec_headers:type(PrevHeader)};
+        error -> error
     end.
 
 deserialize_transaction(Tx) ->

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -71,7 +71,11 @@ new(Tx, Signatures) ->
 
 -spec hash(signed_tx()) -> binary().
 hash(#signed_tx{} = Tx) ->
-    aec_hash:hash(signed_tx, serialize_to_binary(Tx)).
+    hash_from_binary(serialize_to_binary(Tx)).
+
+-spec hash_from_binary(binary_signed_tx()) -> binary().
+hash_from_binary(TxBin) ->
+    aec_hash:hash(signed_tx, TxBin).
 
 -spec add_signatures(signed_tx(), list(binary())) -> signed_tx().
 add_signatures(#signed_tx{signatures = OldSigs} = Tx, NewSigs)
@@ -250,15 +254,26 @@ serialization_template(?SIG_TX_VSN) ->
 -spec serialize_for_client(aec_headers:header(), aetx_sign:signed_tx()) -> binary() | map().
 serialize_for_client(Header, #signed_tx{}=S) ->
     {ok, BlockHash} = aec_headers:hash_header(Header),
-    serialize_for_client(S, aec_headers:height(Header), BlockHash, hash(S)).
+    TxBin = serialize_to_binary(S),
+    serialize_for_client(S, aec_headers:height(Header), BlockHash,
+                         hash_from_binary(TxBin), TxBin).
 
 -spec serialize_for_client_pending(aetx_sign:signed_tx()) -> binary() | map().
 serialize_for_client_pending(#signed_tx{}=S) ->
-    serialize_for_client(S, -1, <<>>, hash(S)).
+    TxBin = serialize_to_binary(S),
+    serialize_for_client(S, -1, <<>>, hash_from_binary(TxBin), TxBin).
 
+-ifdef(TEST).
 -spec serialize_for_client(aetx_sign:signed_tx(), integer(), binary(), binary()) ->
     binary() | map().
 serialize_for_client(#signed_tx{} = SigTx, BlockHeight, BlockHash0, TxHash) ->
+    serialize_for_client(SigTx, BlockHeight, BlockHash0, TxHash,
+                         serialize_to_binary(SigTx)).
+-endif.
+
+-spec serialize_for_client(aetx_sign:signed_tx(), integer(), binary(), binary(),
+                           binary_signed_tx()) -> binary() | map().
+serialize_for_client(#signed_tx{} = SigTx, BlockHeight, BlockHash0, TxHash, TxBin) ->
     BlockHash =
         case BlockHash0 of
             <<>> -> <<"none">>;
@@ -269,7 +284,7 @@ serialize_for_client(#signed_tx{} = SigTx, BlockHeight, BlockHash0, TxHash) ->
           <<"block_height">> => BlockHeight,
           <<"block_hash">>   => BlockHash,
           <<"hash">>         => aeser_api_encoder:encode(tx_hash, TxHash),
-          <<"encoded_tx">>   => aeser_api_encoder:encode(transaction, serialize_to_binary(SigTx))
+          <<"encoded_tx">>   => aeser_api_encoder:encode(transaction, TxBin)
          },
     serialize_for_client_inner(SigTx, MetaData).
 

--- a/apps/aetx/test/aetx_sign_tests.erl
+++ b/apps/aetx/test/aetx_sign_tests.erl
@@ -11,6 +11,8 @@
 
 -define(TEST_MODULE, aetx_sign).
 -define(TEST_HEIGHT, 42).
+-define(BLOCK_HEIGHT, 137).
+-define(FAKE_TX_HASH, <<7:32/unit:8>>).
 
 sign_txs_test_() ->
     {setup,
@@ -77,6 +79,130 @@ sign_txs_test_() ->
                end
        end}
      ]}.
+
+serialize_for_client_test_() ->
+    {setup,
+     fun() ->
+             aec_test_utils:aec_keys_setup()
+     end,
+     fun(TmpKeysDir) ->
+             ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir)
+     end,
+     [{"Pending transaction is hashed as it is handed to the client",
+       fun() ->
+               SignedTx = signed_spend_tx(),
+               Serialized = ?TEST_MODULE:serialize_for_client_pending(SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               assert_signatures(SignedTx, Serialized),
+               ?assertMatch(#{<<"type">> := <<"SpendTx">>},
+                            maps:get(<<"tx">>, Serialized)),
+               ?assertEqual(-1, maps:get(<<"block_height">>, Serialized)),
+               ?assertEqual(<<"none">>, maps:get(<<"block_hash">>, Serialized)),
+               ok
+       end},
+      {"Transaction in a micro block is hashed as it is handed to the client",
+       fun() ->
+               SignedTx = signed_spend_tx(),
+               Header = micro_header(?BLOCK_HEIGHT),
+               {ok, BlockHash} = aec_headers:hash_header(Header),
+               Serialized = ?TEST_MODULE:serialize_for_client(Header, SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               assert_signatures(SignedTx, Serialized),
+               ?assertEqual(?BLOCK_HEIGHT, maps:get(<<"block_height">>, Serialized)),
+               ?assertEqual(aeser_api_encoder:encode(micro_block_hash, BlockHash),
+                            maps:get(<<"block_hash">>, Serialized)),
+               ok
+       end},
+      {"All signatures of a transaction are handed to the client",
+       fun() ->
+               SignedTx = make_signed_mutual_close(),
+               ?assertMatch([_, _], ?TEST_MODULE:signatures(SignedTx)),
+               Serialized = ?TEST_MODULE:serialize_for_client_pending(SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               assert_signatures(SignedTx, Serialized),
+               ok
+       end},
+      {"Generalized account meta transaction is hashed as it is handed to the client",
+       fun() ->
+               SignedTx = signed_meta_tx(),
+               Serialized = ?TEST_MODULE:serialize_for_client_pending(SignedTx),
+               assert_hash_of_encoded_tx(SignedTx, Serialized),
+               %% Signatures make no sense for a generalized account
+               ?assertNot(maps:is_key(<<"signatures">>, Serialized)),
+               %% The transaction it authenticates does carry its signatures
+               #{<<"tx">> := #{<<"tx">> := InnerTx}} = Serialized,
+               ?assertMatch(#{<<"signatures">> := [<<"sg_", _/binary>>],
+                              <<"tx">> := #{<<"type">> := <<"SpendTx">>}}, InnerTx),
+               ok
+       end},
+      {"Block data and transaction hash are presented as given",
+       fun() ->
+               SignedTx = signed_spend_tx(),
+               Header = micro_header(?BLOCK_HEIGHT),
+               {ok, BlockHash} = aec_headers:hash_header(Header),
+               ?assertEqual(?TEST_MODULE:serialize_for_client(Header, SignedTx),
+                            ?TEST_MODULE:serialize_for_client(SignedTx, ?BLOCK_HEIGHT,
+                                                              BlockHash,
+                                                              ?TEST_MODULE:hash(SignedTx))),
+               %% The caller decides what the transaction is known by, it is
+               %% not recomputed from the transaction itself.
+               Serialized = ?TEST_MODULE:serialize_for_client(SignedTx, ?BLOCK_HEIGHT + 1,
+                                                              BlockHash, ?FAKE_TX_HASH),
+               ?assertEqual(aeser_api_encoder:encode(tx_hash, ?FAKE_TX_HASH),
+                            maps:get(<<"hash">>, Serialized)),
+               ?assertEqual(?BLOCK_HEIGHT + 1, maps:get(<<"block_height">>, Serialized)),
+               ok
+       end}
+     ]}.
+
+%% The client is given the transaction hash and the transaction itself. Both
+%% are derived from one single serialization of the signed tx, so assert that
+%% the hash is indeed the hash of the very bytes the client is handed.
+assert_hash_of_encoded_tx(SignedTx, Serialized) ->
+    {ok, TxBin} = aeser_api_encoder:safe_decode(
+                    transaction, maps:get(<<"encoded_tx">>, Serialized)),
+    ?assertEqual(?TEST_MODULE:serialize_to_binary(SignedTx), TxBin),
+    ?assertEqual(SignedTx, ?TEST_MODULE:deserialize_from_binary(TxBin)),
+    ?assertEqual(aeser_api_encoder:encode(tx_hash, aec_hash:hash(signed_tx, TxBin)),
+                 maps:get(<<"hash">>, Serialized)),
+    ?assertEqual(aeser_api_encoder:encode(tx_hash, ?TEST_MODULE:hash(SignedTx)),
+                 maps:get(<<"hash">>, Serialized)),
+    ?assertEqual(aetx:serialize_for_client(?TEST_MODULE:tx(SignedTx)),
+                 maps:get(<<"tx">>, Serialized)).
+
+%% Signatures are presented in the same canonical order they are serialized in.
+assert_signatures(SignedTx, Serialized) ->
+    ?assertEqual([aeser_api_encoder:encode(signature, S)
+                  || S <- ?TEST_MODULE:signatures(SignedTx)],
+                 maps:get(<<"signatures">>, Serialized)).
+
+signed_spend_tx() ->
+    #{ public := Pubkey, secret := Privkey } = enacl:sign_keypair(),
+    {ok, SpendTx} = make_spend_tx(Pubkey),
+    aec_test_utils:sign_tx(SpendTx, Privkey).
+
+signed_meta_tx() ->
+    #{ public := Pubkey } = enacl:sign_keypair(),
+    {ok, MetaTx} = aega_meta_tx:new(
+                     #{ga_id       => aeser_id:create(account, Pubkey),
+                       auth_data   => <<>>,
+                       abi_version => 1,
+                       gas         => 1,
+                       gas_price   => 1,
+                       fee         => 1,
+                       tx          => signed_spend_tx()}),
+    ?TEST_MODULE:new(MetaTx, []).
+
+micro_header(Height) ->
+    aec_headers:new_micro_header(
+      Height,
+      <<1:?BLOCK_HEADER_HASH_BYTES/unit:8>>, %% prev hash
+      <<2:?BLOCK_HEADER_HASH_BYTES/unit:8>>, %% prev key hash
+      <<3:?STATE_HASH_BYTES/unit:8>>,        %% root hash
+      0,                                     %% time
+      <<4:?TXS_HASH_BYTES/unit:8>>,          %% txs hash
+      <<>>,                                  %% no fraud
+      ?CERES_PROTOCOL_VSN).
 
 make_spend_tx(Sender) ->
     #{ public := OtherPubkey} = enacl:sign_keypair(),


### PR DESCRIPTION
Composite master (7.3.x) port replacing the individual port PRs (#4647, #4648, #4649, #4650, #4651, #4652, #4653, #4654), which were closed in favor of this one to keep review/merge to a single PR instead of 8.

**Update**: #4632, #4633, #4634, #4640, #4642, #4643, #4644 have since been merged to `releases/stable`. This branch was rebuilt (force-pushed) to drop the **#4641** cherry-pick — it has an unresolved ordering-behavior concern (changes account-scoped mempool `peek/2,3` from fee-order to nonce-order, unconfirmed with the author) and would need a rebase against the now-updated `releases/stable` anyway. Will re-add it as its own follow-up port once #4641 lands and stabilizes.

Currently includes cherry-picks of:
- #4632 — Avoid redundant prev-node DB reads during block insertion
- #4633 — Avoid redundant tx hash recomputation in aec_tx_pool
- #4634 — Avoid unnecessary peer lookups in gossip event handler
- #4640 — Encode gossip wire message once per block instead of once per peer
- #4642 — Read only the header of the previous block for type lookups
- #4643 — Cache several variables in the fate engine state
- #4644 — Serialize signed tx once in aetx_sign:serialize_for_client

mdw runs the `master`/7.3.x line, so these fixes don't reach mdw until merged here — and mdw itself will need a corresponding node update/rebuild afterward to actually pick them up, porting the code alone isn't sufficient.