### PR TITLE
Deprecate mainnet us-east-2 nodes (releases/stable cherry-pick of #4301)

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -50,12 +50,9 @@
       {peers, []},
       {mainnet_peers, [
         <<"aenode://pp_2gPZjuPnJnTVEbrB9Qgv7f4MdhM4Jh6PD22mB2iBA1g7FRvHTk@52.220.198.72:3015">>,
-        <<"aenode://pp_H4ooofyixJE6weqsgzKMKTdjZwEWb2BMSWqdFqbwZjssvtUEZ@18.217.69.24:3015">>,
-        <<"aenode://pp_2eu9njAqnd2s9nfSHNCHMbw96dajSATz1rgT6PokH2Lsa531Sp@3.17.15.122:3015">>,
         <<"aenode://pp_21DNLkjdBuoN7EajkK3ePfRMHbyMkhcuW5rJYBQsXNPDtu3v9n@35.166.231.86:3015">>,
         <<"aenode://pp_RKVZjm7UKPLGvyKWqVZN1pXN6CTCxfmYz2HkNL2xiAhLVd2ho@52.11.110.179:3015">>,
         <<"aenode://pp_sGegC48UrvDA7cvvUU3GPTze9wNUnnK1P4q46mL5jAFddNrbD@13.250.144.60:3015">>,
-        <<"aenode://pp_2R7a7JHzfZQU5Ta7DJnFiqRr7ayCcAVakqYzJ2mvZj5k4ms5mV@3.17.15.239:3015">>,
         <<"aenode://pp_8nn6ypcwkaXxJfPGq7DCpBpf9FNfmkXPvGCjJFnLzvwjhCMEH@52.26.157.37:3015">>,
         <<"aenode://pp_QkNjQbJL3Ab1TVG5GesKuZTixBdXEutUtxG677mVu9D4mMNRr@13.228.202.140:3015">>,
         <<"aenode://pp_7N7dkCbg39MYzQv3vCrmjVNfy6QkoVmJe3VtiZ3HRncvTWAAX@13.53.114.199:3015">>,


### PR DESCRIPTION
`releases/stable` cherry-pick of #4301 (clean, no conflicts).

Removes the 3 dead `us-east-2` mainnet seed peers (`18.217.69.24`, `3.17.15.122`, `3.17.15.239`) from the default `mainnet_peers` list. Verified before opening this:
- The corresponding `terraform-aws-mainnet` `aws_deploy-main-us-east-2` module is already commented out/decommissioned (part of the general shrinking strategy #4301 references).
- All 3 IPs are confirmed unreachable (direct TCP check on port 3015) — genuinely dead, not just deprioritized.
- Both `master` and `releases/stable` still carry these entries unchanged, so this is a real, live cleanup, not stale.

Original PR: #4301