### PR TITLE
Deserialize gossiped txs independently instead of all-or-nothing

### DIFF
--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -1413,7 +1413,9 @@ send_send_tx(S = #{ status := {connected, _ESock} }, SerTx) ->
 handle_new_txs(S, Msg) ->
     try
         #{ txs := EncSignedTxs } = Msg,
-        SignedTxs = [ aetx_sign:deserialize_from_binary(Tx) || Tx <- EncSignedTxs ],
+        %% Deserialize each tx independently - a single malformed/malicious
+        %% entry must not cause the whole batch to be discarded.
+        SignedTxs = lists:filtermap(fun deserialize_tx/1, EncSignedTxs),
         %% Offload the handling to a temporary worker process - it might block
         %% on the tx_pool_push queue.
         spawn(fun() -> [ tx_push(SignedTx) || SignedTx <- SignedTxs ] end)
@@ -1421,6 +1423,13 @@ handle_new_txs(S, Msg) ->
         ok
     end,
     S.
+
+deserialize_tx(Tx) ->
+    try {true, aetx_sign:deserialize_from_binary(Tx)}
+    catch _:_ ->
+        lager:debug("Failed to deserialize gossiped tx, dropping just this entry", []),
+        false
+    end.
 
 tx_push(STx) ->
     try aec_tx_pool:push(STx, tx_received)

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -46,6 +46,7 @@
 
 -ifdef(TEST).
 -export([is_node_info_sharing_enabled/0]).
+-export([deserialize_tx/1]).
 -endif.
 
 -include("aec_peer_messages.hrl").

--- a/apps/aecore/test/aec_peer_connection_tests.erl
+++ b/apps/aecore/test/aec_peer_connection_tests.erl
@@ -1,0 +1,46 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2026, Aeternity Anstalt
+%%%-------------------------------------------------------------------
+
+-module(aec_peer_connection_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_MODULE, aec_peer_connection).
+
+deserialize_tx_test_() ->
+    [{"A well-formed serialized signed tx deserializes successfully",
+      fun() ->
+              #{ public := Pubkey, secret := Privkey } = enacl:sign_keypair(),
+              {ok, SpendTx} = make_spend_tx(Pubkey),
+              Signed = aec_test_utils:sign_tx(SpendTx, Privkey),
+              Bin = aetx_sign:serialize_to_binary(Signed),
+              ?assertEqual({true, Signed}, ?TEST_MODULE:deserialize_tx(Bin))
+      end},
+     {"A malformed binary is dropped instead of raising",
+      fun() ->
+              ?assertEqual(false, ?TEST_MODULE:deserialize_tx(<<"not a valid signed tx">>))
+      end},
+     {"One malformed entry does not prevent deserializing the rest of a batch",
+      fun() ->
+              #{ public := Pubkey, secret := Privkey } = enacl:sign_keypair(),
+              {ok, SpendTx} = make_spend_tx(Pubkey),
+              Signed = aec_test_utils:sign_tx(SpendTx, Privkey),
+              Bin = aetx_sign:serialize_to_binary(Signed),
+              Batch = [Bin, <<"garbage">>, Bin],
+              ?assertEqual([Signed, Signed], lists:filtermap(fun ?TEST_MODULE:deserialize_tx/1, Batch))
+      end}
+    ].
+
+make_spend_tx(Sender) ->
+    #{ public := OtherPubkey } = enacl:sign_keypair(),
+    SenderId = aeser_id:create(account, Sender),
+    Recipient = aeser_id:create(account, OtherPubkey),
+    aec_spend_tx:new(#{ sender_id    => SenderId
+                       , recipient_id => Recipient
+                       , amount       => 4
+                       , fee          => 1
+                       , ttl          => 100
+                       , nonce        => 1
+                       , payload      => <<>>
+                       }).


### PR DESCRIPTION
Fixes #4601.

`handle_new_txs/2` deserialized a gossiped `txs` batch via a single list comprehension over `aetx_sign:deserialize_from_binary/1`, wrapped in a blanket `catch _:_ -> ok`. `deserialize_from_binary/1` has no internal try/catch and throws (`badmatch`) on a malformed binary, so one bad/malformed entry aborted the whole comprehension — silently dropping every other (valid) tx in that batch, with no logging or peer penalty. Unchanged since 2018.

Fix: deserialize each tx independently via `lists:filtermap/2`, dropping only the malformed entry (with a debug log) instead of the entire batch.

Low risk / minimal diff, no behavior change for the all-valid case.