### PR TITLE
Avoid redundant block hash recomputation (master port)

### DIFF
--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -128,13 +128,26 @@
 
 -ifdef(TEST).
 -export([calc_rewards/6,
-         internal_insert_transaction/4
+         internal_insert_transaction/4,
+         wrap_block/2
         ]).
 -endif.
 
 -include("aec_block_insertion.hrl").
 -include("blocks.hrl").
 -include("aec_db.hrl").
+
+%% In TEST builds, assert that a hash threaded into wrap_block/2 (e.g. one
+%% precomputed by the conductor) really is the header's hash. This catches a
+%% future upstream change that derives the hash from different bytes: without
+%% it such a bug would silently index the block under the wrong key. Compiles
+%% to a no-op in production, where recomputing the hash would defeat the point
+%% of threading it in.
+-ifdef(TEST).
+-define(assert_block_hash(Header, Hash), {ok, Hash} = aec_headers:hash_header(Header)).
+-else.
+-define(assert_block_hash(Header, Hash), ok).
+-endif.
 
 -type events() :: aetx_env:events().
 
@@ -464,6 +477,7 @@ wrap_block(Block) ->
 
 wrap_block(Block, Hash) ->
     Header = aec_blocks:to_header(Block),
+    ?assert_block_hash(Header, Hash),
     Type = aec_headers:type(Header),
     Txs = block_txs(Type, Block),
     #node{ header = Header

--- a/apps/aecore/src/aec_chain_state.erl
+++ b/apps/aecore/src/aec_chain_state.erl
@@ -87,6 +87,7 @@
         , insert_block/1
         , insert_block/2
         , insert_block_conductor/2
+        , insert_block_conductor/3
         , repair_block_state/1
         , gossip_allowed_height_from_top/0
         , proof_of_fraud_report_delay/0
@@ -164,16 +165,25 @@ get_n_key_headers_backward_from(Header, N) ->
                                         | {'pof', aec_pof:pof(), events()}
                                         | {'error', any()}.
 insert_block(Block) ->
-    insert_block_strip_res(do_insert_block(Block, undefined)).
+    insert_block_strip_res(do_insert_block(Block, undefined, undefined)).
 
 -spec insert_block_conductor(aec_blocks:block(), atom()) ->
     {'ok', boolean(), aec_headers:key_header() | undefined, events()}
     | {'pof', boolean(), aec_headers:key_header() | undefined, aec_pof:pof(), events()}
     | {'error', any()}.
-insert_block_conductor(Block, block_synced) ->
-    do_insert_block(Block, sync);
-insert_block_conductor(Block, _Origin) ->
-    do_insert_block(Block, undefined).
+insert_block_conductor(Block, Origin) ->
+    insert_block_conductor(Block, undefined, Origin).
+
+%% The conductor has already computed the block's header hash; thread it in to
+%% avoid recomputing it in wrap_block/1.
+-spec insert_block_conductor(aec_blocks:block(), aec_blocks:block_header_hash() | undefined, atom()) ->
+    {'ok', boolean(), aec_headers:key_header() | undefined, events()}
+    | {'pof', boolean(), aec_headers:key_header() | undefined, aec_pof:pof(), events()}
+    | {'error', any()}.
+insert_block_conductor(Block, Hash, block_synced) ->
+    do_insert_block(Block, sync, Hash);
+insert_block_conductor(Block, Hash, _Origin) ->
+    do_insert_block(Block, undefined, Hash).
 
 %% We should not check the height distance to top for synced block, so
 %% we have to keep track of the origin here.
@@ -182,9 +192,9 @@ insert_block_conductor(Block, _Origin) ->
       | {'pof', aec_pof:pof(), events()}
       | {'error', any()}.
 insert_block(Block, block_synced) ->
-    insert_block_strip_res(do_insert_block(Block, sync));
+    insert_block_strip_res(do_insert_block(Block, sync, undefined));
 insert_block(Block, _Origin) ->
-    insert_block_strip_res(do_insert_block(Block, undefined)).
+    insert_block_strip_res(do_insert_block(Block, undefined, undefined)).
 
 insert_block_strip_res({ok, _, _, Events}) -> {ok, Events};
 insert_block_strip_res({pof, _, _, PoF, Events}) -> {pof, PoF, Events};
@@ -195,9 +205,12 @@ repair_block_state(Block) ->
     lager:info("Repair block state (~p us): ~p", [Time, Res]),
     Res.
 
-do_insert_block(Block, Origin) ->
+do_insert_block(Block, Origin, Hash) ->
     aec_blocks:assert_block(Block),
-    Node = wrap_block(Block),
+    Node = case Hash of
+               undefined -> wrap_block(Block);
+               _         -> wrap_block(Block, Hash)
+           end,
     {Time, Res} = timer:tc(fun() -> internal_insert(Node, Block, Origin) end),
     Type = node_type(Node),
     case Res of
@@ -446,8 +459,11 @@ node_is_genesis(Node) ->
     node_hash(Node) =:= aec_consensus:get_genesis_hash().
 
 wrap_block(Block) ->
+    {ok, Hash} = aec_headers:hash_header(aec_blocks:to_header(Block)),
+    wrap_block(Block, Hash).
+
+wrap_block(Block, Hash) ->
     Header = aec_blocks:to_header(Block),
-    {ok, Hash} = aec_headers:hash_header(Header),
     Type = aec_headers:type(Header),
     Txs = block_txs(Type, Block),
     #node{ header = Header

--- a/apps/aecore/src/aec_conductor.erl
+++ b/apps/aecore/src/aec_conductor.erl
@@ -1626,7 +1626,7 @@ handle_add_block(Block, Hash, Prev, #state{top_block_hash = TopBlockHash, consen
     %% external (gossip/sync) blocks and we trust the ones we
     %% produce ourselves.
     ConsensusModule = Consensus#consensus.consensus_module,
-    case aec_chain_state:insert_block_conductor(Block, Origin) of
+    case aec_chain_state:insert_block_conductor(Block, Hash, Origin) of
         {ok, TopChanged, PrevKeyHeader, Events} = OkResult  ->
             case ConsensusModule of
                 aec_consensus_hc ->

--- a/apps/aecore/test/aec_chain_state_tests.erl
+++ b/apps/aecore/test/aec_chain_state_tests.erl
@@ -514,7 +514,8 @@ accept_existing_db_node_test_() ->
              ok = mnesia:delete_schema([node()])
      end,
      [
-      {"Accept existing DB node even if is is already present", fun accept_existing_db_node/0}
+      {"Accept existing DB node even if is is already present", fun accept_existing_db_node/0},
+      {"wrap_block/2 trusts a matching hash and rejects a mismatched one", fun wrap_block_hash_consistency/0}
      ]}.
 
 accept_existing_db_node() ->
@@ -526,4 +527,17 @@ accept_existing_db_node() ->
     {ok, _} = ?TEST_MODULE:insert_block(B3),
     ?TEST_MODULE:internal_insert_transaction(Node, B3, undefined, Ctx),
 
+    ok.
+
+%% wrap_block/2 lets a caller (the conductor) thread in an already-computed
+%% header hash instead of recomputing it. Verify the fast path agrees with
+%% wrap_block/1 for a correct hash, and that a mismatched hash is caught rather
+%% than silently indexing the block under the wrong key.
+wrap_block_hash_consistency() ->
+    [B | _] = prep_micro_blocks(1),
+    {ok, Hash} = aec_headers:hash_header(aec_blocks:to_header(B)),
+    ?assertEqual(?TEST_MODULE:wrap_block(B), ?TEST_MODULE:wrap_block(B, Hash)),
+    <<First, Rest/binary>> = Hash,
+    WrongHash = <<(First bxor 1), Rest/binary>>,
+    ?assertError({badmatch, {ok, Hash}}, ?TEST_MODULE:wrap_block(B, WrongHash)),
     ok.


### PR DESCRIPTION
Master port of #4635 (cherry-pick of `7a918419` + `a52485b6`).

## What

The conductor already computes a block's header hash before insertion; this threads it through `insert_block_conductor/3` → `do_insert_block/3` → `wrap_block/2` so the hash is not recomputed in `wrap_block`. A TEST-only `?assert_block_hash/2` macro verifies the threaded hash matches the header's hash (no-op in production). Adds `wrap_block_hash_consistency` unit coverage.

## Notes on the port

- Cherry-pick of `7a918419` and `a52485b6` from #4635 onto `master`.
- **One conflict**, in `apps/aecore/src/aec_conductor.erl`: master added a `ConsensusModule = Consensus#consensus.consensus_module,` line (hyperchain logging) at the exact call site where #4635 threads the `Hash` argument into `insert_block_conductor/3`. Resolved by keeping both — master's `ConsensusModule` binding plus the threaded `Hash` (already a parameter of `handle_add_block/5`, so in scope). `aec_chain_state.erl` and the test auto-merged cleanly.
- No overlap with the other open ports (#4661/#4662/#4663 aehttp; #4665/#4666 aec_tx_pool) — orthogonal, no cross-PR conflict.

## Validation

- Compiles cleanly.
- `aec_chain_state_tests` EUnit passes (incl. the new `wrap_block_hash_consistency`).