### PR TITLE
Read max_auth_fun_gas once per GA meta tx chain (master port)

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -1073,14 +1073,23 @@ int_check_account(Tx, Source, Event) ->
     end.
 
 int_check_meta_gas(SignedTx) ->
+    int_check_meta_gas(SignedTx, undefined).
+
+int_check_meta_gas(SignedTx, MaxAuthFunGas0) ->
     Aetx = aetx_sign:tx(SignedTx),
     {Mod, Tx} = aetx:specialize_callback(Aetx),
     case Mod of
         aega_meta_tx ->
+            %% Read the config lazily, only when a meta tx is seen, and
+            %% reuse the value for the nested meta txs.
+            MaxAuthFunGas = case MaxAuthFunGas0 of
+                                undefined -> aec_tx_pool:maximum_auth_fun_gas();
+                                _ -> MaxAuthFunGas0
+                            end,
             Gas = aega_meta_tx:gas(Tx),
-            case Gas =< aec_tx_pool:maximum_auth_fun_gas() of
+            case Gas =< MaxAuthFunGas of
                 true ->
-                    int_check_meta_gas(aega_meta_tx:tx(Tx));
+                    int_check_meta_gas(aega_meta_tx:tx(Tx), MaxAuthFunGas);
                 false -> {error, too_much_gas_for_auth_function}
             end;
         _ -> ok


### PR DESCRIPTION
Master port of #4660 (cherry-pick of `fc774527`).

## What

`int_check_meta_gas/1` reads `maximum_auth_fun_gas()` (a config/env lookup) once per GA meta-tx chain and threads the value through the nested meta-tx recursion, instead of re-reading it at every nesting level. Behavior-preserving optimization.

## Notes on the port

- Clean cherry-pick of `fc774527` from #4660 onto `master` — no conflict (master still had the old per-level `aec_tx_pool:maximum_auth_fun_gas()` read).
- Touches only `apps/aecore/src/aec_tx_pool.erl`. Shares that file with #4666, but the two edit **different functions** (this → `int_check_meta_gas`; #4666 → nonce index / `pool_db_peek` / `get_max_nonce`), so they're separate hunks and auto-merge. No overlap with the other ports.

## Validation

- Compiles cleanly.
- `aec_tx_pool_tests` EUnit passes.