### PR TITLE
Add X-Ae-Height response header with chain state version (master port)

### DIFF
--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -1,6 +1,22 @@
 openapi: 3.0.0
 info:
-  description: This is the [Aeternity](https://www.aeternity.com/) node API.
+  description: |
+    This is the [Aeternity](https://www.aeternity.com/) node API.
+
+    ### State version
+
+    Every response carries an `X-Ae-Height` header with the height of the node's
+    chain top at the moment the request was accepted. The response body reflects
+    a chain state at or after that height, so the value is a lower bound and may
+    be compared across nodes: a client querying a pool of nodes behind a load
+    balancer can discard an answer from a node that is behind a state it has
+    already observed, instead of retrying blindly. The header is also present on
+    error responses, so a `404` for a not-yet-mined transaction tells the client
+    how far the answering node actually is.
+
+    Resolution is one generation - micro blocks applied within the current
+    generation do not change the value, which keeps it cache friendly. The
+    header is omitted while the node's chain is not readable yet.
   version: x.y.z
   title: Aeternity node
   termsOfService: https://www.aeternity.com/terms/

--- a/apps/aehttp/priv/swagger.yaml
+++ b/apps/aehttp/priv/swagger.yaml
@@ -1,6 +1,22 @@
 swagger: '2.0'
 info:
-  description: 'This is the [Aeternity](https://www.aeternity.com/) node API. The swagger version of this API will be deprecated and replaced by an openAPI 3.x specification'
+  description: |
+    This is the [Aeternity](https://www.aeternity.com/) node API. The swagger version of this API will be deprecated and replaced by an openAPI 3.x specification
+
+    ### State version
+
+    Every response carries an `X-Ae-Height` header with the height of the node's
+    chain top at the moment the request was accepted. The response body reflects
+    a chain state at or after that height, so the value is a lower bound and may
+    be compared across nodes: a client querying a pool of nodes behind a load
+    balancer can discard an answer from a node that is behind a state it has
+    already observed, instead of retrying blindly. The header is also present on
+    error responses, so a `404` for a not-yet-mined transaction tells the client
+    how far the answering node actually is.
+
+    Resolution is one generation - micro blocks applied within the current
+    generation do not change the value, which keeps it cache friendly. The
+    header is omitted while the node's chain is not readable yet.
   version: x.y.z
   title: Aeternity node
   termsOfService: 'https://www.aeternity.com/terms/'

--- a/apps/aehttp/src/aehttp_api_handler.erl
+++ b/apps/aehttp/src/aehttp_api_handler.erl
@@ -42,6 +42,9 @@ init(Req, {SpecVsn, OperationId, AllowedMethod, LogicHandler, Context}) ->
         endpoints = Mod,
         context = Context
     },
+    %% The X-Ae-Height marker (GH-4186) is stamped earlier, in
+    %% aehttp_cors_middleware:execute/2, so it is also present on CORS
+    %% preflight replies that never reach this handler.
     {cowboy_rest, Req, State}.
 
 

--- a/apps/aehttp/src/aehttp_cors_middleware.erl
+++ b/apps/aehttp/src/aehttp_cors_middleware.erl
@@ -15,17 +15,18 @@
 -define(ACCESS_CONTROL_ALLOW_METHODS     , <<"DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT">>).
 -define(ACCESS_CONTROL_MAX_AGE           , 30 * 60). %% 30 minutes
 -define(ACCESS_CONTROL_ALLOW_CREDENTIALS , <<"true">>).
-%% Retry-After is not a CORS-safelisted response header, so browser clients
-%% cannot read the back-off hint sent with a 503 unless it is exposed here.
--define(ACCESS_CONTROL_EXPOSE_HEADERS    , <<"retry-after">>).
 
 %%%===================================================================
 %%% Behaviour API
 %%%===================================================================
 
 -spec execute(cowboy_req:req(), cowboy_middleware:env()) -> {ok, cowboy_req:req(), cowboy_middleware:env()}.
-execute(Req, Env) ->
-    Req2 = set_cors_headers(Req),
+execute(Req0, Env) ->
+    %% Stamped here, ahead of routing, so it is on every response this
+    %% listener sends - including the OPTIONS preflight reply below, which
+    %% never reaches the route handler. See GH-4186.
+    Req1 = aehttp_state_version:set_resp_header(Req0),
+    Req2 = set_cors_headers(Req1),
     case cowboy_req:method(Req2) of
         <<"OPTIONS">> -> {stop, cowboy_req:reply(200, Req2)};
         _             -> {ok, Req2, Env}
@@ -68,14 +69,14 @@ set_cors_headers(Req, Origin) ->
 
 cors_headers(Req, Origin) ->
     CorsConfig   = aeu_env:user_config([<<"http">>, <<"cors">>], #{}),
-    AllowMethods = concat_methods(maps:get(<<"allow_methods">> , CorsConfig, ?ACCESS_CONTROL_ALLOW_METHODS)),
+    AllowMethods = concat_values(maps:get(<<"allow_methods">> , CorsConfig, ?ACCESS_CONTROL_ALLOW_METHODS)),
     MaxAge       = maps:get(<<"max_age">>       , CorsConfig, ?ACCESS_CONTROL_MAX_AGE),
     CorsHeaders =
         [{<<"vary">>                             , <<"origin">>},
          {<<"access-control-allow-origin">>      , Origin},
          {<<"access-control-allow-methods">>     , AllowMethods},
          {<<"access-control-allow-credentials">> , ?ACCESS_CONTROL_ALLOW_CREDENTIALS},
-         {<<"access-control-expose-headers">>    , ?ACCESS_CONTROL_EXPOSE_HEADERS},
+         {<<"access-control-expose-headers">>    , concat_values(exposed_headers())},
          {<<"access-control-max-age">>           , integer_to_list(MaxAge)}],
     case cowboy_req:header(<<"access-control-request-headers">>, Req) of
         undefined ->
@@ -85,11 +86,17 @@ cors_headers(Req, Origin) ->
             [{<<"access-control-allow-headers">>, AllowHeaders} | CorsHeaders]
     end.
 
-concat_methods(Methods) when is_binary(Methods) -> Methods;
-concat_methods(Methods) when is_list(Methods) ->
-    [Method | T] = Methods,
-    concat_methods(Method, T).
+%% Non-safelisted response headers the node emits and browser clients are
+%% expected to read: the chain-state height marker (GH-4186) and the 503
+%% Retry-After back-off hint.
+exposed_headers() ->
+    [<<"retry-after">>, aehttp_state_version:header_name()].
 
-concat_methods(Accum, []) -> Accum;
-concat_methods(Accum, [Method | T]) ->
-    concat_methods(<<Accum/binary, ", ", Method/binary>>, T).
+concat_values(Values) when is_binary(Values) -> Values;
+concat_values(Values) when is_list(Values) ->
+    [Value | T] = Values,
+    concat_values(Value, T).
+
+concat_values(Accum, []) -> Accum;
+concat_values(Accum, [Value | T]) ->
+    concat_values(<<Accum/binary, ", ", Value/binary>>, T).

--- a/apps/aehttp/src/aehttp_state_version.erl
+++ b/apps/aehttp/src/aehttp_state_version.erl
@@ -22,18 +22,37 @@
 %%%=============================================================================
 -module(aehttp_state_version).
 
--export([ header_name/0
+-behaviour(gen_server).
+
+%% API
+-export([ start_link/0
+        , header_name/0
         , set_resp_header/1
         , top_height/0
+        ]).
+
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
         ]).
 
 %% Not RFC 6648 clean, but the name agreed on in GH-4186 and the one SDKs look
 %% for. Cowboy expects response header names lowercased.
 -define(HEIGHT_HEADER, <<"x-ae-height">>).
+-define(SERVER, ?MODULE).
+-define(TAB, ?MODULE).
+-define(HEIGHT_KEY, height).
 
 %%%===================================================================
 %%% API
 %%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 -spec header_name() -> binary().
 header_name() ->
@@ -54,22 +73,74 @@ set_resp_header(Req) ->
                                        integer_to_binary(Height), Req)
     end.
 
-%% @doc Height of the node's chain top, or undefined if it is not readable.
+%% @doc Height of the node's chain top, or undefined if it is not known yet.
 %%
-%% Deliberately a dirty read - it runs once per request and must not start a
-%% transaction. Micro block headers carry the height of their generation, so
-%% this is the current generation height regardless of the top block type.
+%% Hot path: a single ETS read of the value this server caches from
+%% `top_changed' events, so the per-request cost is O(1) with no dirty chain
+%% read or header decode. Falls back to a one-off dirty read while the cache is
+%% not populated (startup, or the maintainer process restarting). Micro block
+%% headers carry the height of their generation, so this is the current
+%% generation height regardless of the top block type.
 -spec top_height() -> undefined | aec_blocks:height().
 top_height() ->
+    try ets:lookup(?TAB, ?HEIGHT_KEY) of
+        [{?HEIGHT_KEY, Height}] -> Height;
+        []                      -> dirty_top_height()
+    catch
+        %% Table not created yet (this server not started). Fall back so the
+        %% marker still works even if the cache is unavailable.
+        error:badarg -> dirty_top_height()
+    end.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    _ = ets:new(?TAB, [named_table, public, {read_concurrency, true}]),
+    %% aec_events:subscribe/1 returns `true', not `ok'.
+    true = aec_events:subscribe(top_changed),
+    %% Seed from the current top so the header is populated before the first
+    %% `top_changed' after start, rather than falling back on every early request.
+    case dirty_top_height() of
+        undefined -> ok;
+        Height    -> ets:insert(?TAB, {?HEIGHT_KEY, Height})
+    end,
+    {ok, #{}}.
+
+handle_call(_Req, _From, State) ->
+    {reply, ignored, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% One generation resolution: every top change (key or micro) carries the
+%% generation height, so caching it here keeps the marker a cheap ETS read.
+handle_info({gproc_ps_event, top_changed, #{info := #{height := Height}}}, State) ->
+    true = ets:insert(?TAB, {?HEIGHT_KEY, Height}),
+    {noreply, State};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal
+%%%===================================================================
+
+%% Dirty read of the chain top height; returns undefined if the chain tables
+%% are not readable (e.g. during startup) or aec_chain errors.
+-spec dirty_top_height() -> undefined | aec_blocks:height().
+dirty_top_height() ->
     try aec_chain:dirty_top_header() of
         undefined -> undefined;
         Header    -> aec_headers:height(Header)
     catch
         Class:Reason ->
-            %% Expected during the startup window before chain tables are
-            %% readable; logged at debug so an unrelated regression in
-            %% aec_chain is still discoverable instead of silently reading
-            %% as "unknown" on every request.
             lager:debug("Chain top not readable for X-Ae-Height: ~p:~p", [Class, Reason]),
             undefined
     end.

--- a/apps/aehttp/src/aehttp_state_version.erl
+++ b/apps/aehttp/src/aehttp_state_version.erl
@@ -1,0 +1,75 @@
+%%%=============================================================================
+%%% @copyright (C) 2026, Aeternity Anstalt
+%%% @doc
+%%%    Chain state version marker attached to HTTP API responses.
+%%%
+%%%    A client talking to a pool of nodes behind a load balancer cannot tell a
+%%%    response computed from an up-to-date chain from one computed by a lagging
+%%%    or still syncing node. Every API response therefore carries the height of
+%%%    the node's chain top, which lets a client discard answers from a node
+%%%    that is behind a state it has already observed.
+%%%
+%%%    The marker is read *before* the request handler reads any chain data, so
+%%%    the body always reflects a chain state at or after the advertised height,
+%%%    never before it. Clients may treat the value as a lower bound.
+%%%
+%%%    Resolution is one generation: micro blocks applied within the current
+%%%    generation do not bump it. That is the deliberate trade-off from GH-4186
+%%%    - a marker that changes rarely stays cache-friendly for reverse proxies
+%%%    in front of the node, and computing a micro block position would cost a
+%%%    height index lookup plus a walk back to the key block on every request.
+%%% @end
+%%%=============================================================================
+-module(aehttp_state_version).
+
+-export([ header_name/0
+        , set_resp_header/1
+        , top_height/0
+        ]).
+
+%% Not RFC 6648 clean, but the name agreed on in GH-4186 and the one SDKs look
+%% for. Cowboy expects response header names lowercased.
+-define(HEIGHT_HEADER, <<"x-ae-height">>).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec header_name() -> binary().
+header_name() ->
+    ?HEIGHT_HEADER.
+
+%% @doc Attach the state version marker to the response headers of Req.
+%%
+%% The marker is left out when the chain top cannot be read - during startup
+%% the chain tables are not readable yet, and no marker is a better answer than
+%% a wrong one. Clients are expected to treat a missing header as "unknown".
+-spec set_resp_header(cowboy_req:req()) -> cowboy_req:req().
+set_resp_header(Req) ->
+    case top_height() of
+        undefined ->
+            Req;
+        Height ->
+            cowboy_req:set_resp_header(?HEIGHT_HEADER,
+                                       integer_to_binary(Height), Req)
+    end.
+
+%% @doc Height of the node's chain top, or undefined if it is not readable.
+%%
+%% Deliberately a dirty read - it runs once per request and must not start a
+%% transaction. Micro block headers carry the height of their generation, so
+%% this is the current generation height regardless of the top block type.
+-spec top_height() -> undefined | aec_blocks:height().
+top_height() ->
+    try aec_chain:dirty_top_header() of
+        undefined -> undefined;
+        Header    -> aec_headers:height(Header)
+    catch
+        Class:Reason ->
+            %% Expected during the startup window before chain tables are
+            %% readable; logged at debug so an unrelated regression in
+            %% aec_chain is still discoverable instead of silently reading
+            %% as "unknown" on every request.
+            lager:debug("Chain top not readable for X-Ae-Height: ~p:~p", [Class, Reason]),
+            undefined
+    end.

--- a/apps/aehttp/src/aehttp_sup.erl
+++ b/apps/aehttp/src/aehttp_sup.erl
@@ -28,7 +28,16 @@ start_link() ->
 
 %% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
 init([]) ->
-    {ok, { {one_for_one, 5, 10}, []} }.
+    %% Maintains the cached chain-state height for the X-Ae-Height response
+    %% header (GH-4186), updated from `top_changed' events so the header is a
+    %% cheap ETS read on the request hot path.
+    StateVersion = #{ id       => aehttp_state_version
+                    , start    => {aehttp_state_version, start_link, []}
+                    , restart  => permanent
+                    , shutdown => 5000
+                    , type     => worker
+                    , modules  => [aehttp_state_version] },
+    {ok, { {one_for_one, 5, 10}, [StateVersion]} }.
 
 %%====================================================================
 %% Internal functions

--- a/apps/aehttp/test/aehttp_cors_middleware_SUITE.erl
+++ b/apps/aehttp/test/aehttp_cors_middleware_SUITE.erl
@@ -63,7 +63,7 @@ defaults(Config) ->
     Headers = headers(Origin),
     "origin" = proplists:get_value("vary", Headers),
     "true" = proplists:get_value("access-control-allow-credentials", Headers),
-    "retry-after" = proplists:get_value("access-control-expose-headers", Headers),
+    "retry-after, x-ae-height" = proplists:get_value("access-control-expose-headers", Headers),
     "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" = proplists:get_value("access-control-allow-methods", Headers),
     "1800" = proplists:get_value("access-control-max-age", Headers),
     Origin = proplists:get_value("access-control-allow-origin", Headers),
@@ -81,7 +81,7 @@ set_allow_domains(Config) ->
     Headers = headers(Origin1),
     "origin" = proplists:get_value("vary", Headers),
     "true" = proplists:get_value("access-control-allow-credentials", Headers),
-    "retry-after" = proplists:get_value("access-control-expose-headers", Headers),
+    "retry-after, x-ae-height" = proplists:get_value("access-control-expose-headers", Headers),
     "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" = proplists:get_value("access-control-allow-methods", Headers),
     "1800" = proplists:get_value("access-control-max-age", Headers),
     Origin1 = proplists:get_value("access-control-allow-origin", Headers),
@@ -99,7 +99,7 @@ set_allow_any_domain(Config) ->
     Headers = headers(Origin),
     "origin" = proplists:get_value("vary", Headers),
     "true" = proplists:get_value("access-control-allow-credentials", Headers),
-    "retry-after" = proplists:get_value("access-control-expose-headers", Headers),
+    "retry-after, x-ae-height" = proplists:get_value("access-control-expose-headers", Headers),
     "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" = proplists:get_value("access-control-allow-methods", Headers),
     "1800" = proplists:get_value("access-control-max-age", Headers),
     Origin = proplists:get_value("access-control-allow-origin", Headers),
@@ -117,7 +117,7 @@ set_allow_methods(Config) ->
     Headers = headers(Origin),
     "origin" = proplists:get_value("vary", Headers),
     "true" = proplists:get_value("access-control-allow-credentials", Headers),
-    "retry-after" = proplists:get_value("access-control-expose-headers", Headers),
+    "retry-after, x-ae-height" = proplists:get_value("access-control-expose-headers", Headers),
     "GET, POST" = proplists:get_value("access-control-allow-methods", Headers),
     "1800" = proplists:get_value("access-control-max-age", Headers),
     Origin = proplists:get_value("access-control-allow-origin", Headers),
@@ -137,7 +137,7 @@ set_max_age(Config) ->
     Headers = headers(Origin),
     "origin" = proplists:get_value("vary", Headers),
     "true" = proplists:get_value("access-control-allow-credentials", Headers),
-    "retry-after" = proplists:get_value("access-control-expose-headers", Headers),
+    "retry-after, x-ae-height" = proplists:get_value("access-control-expose-headers", Headers),
     "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" = proplists:get_value("access-control-allow-methods", Headers),
     "1234" = proplists:get_value("access-control-max-age", Headers),
     Origin = proplists:get_value("access-control-allow-origin", Headers),
@@ -179,6 +179,13 @@ headers_(ReqH) ->
     %% crash
     {ok, {{_, 500, _}, Headers3, _}} =
         aecore_suite_utils:httpc_request(get, {InternalHost ++ "/v3/debug/crash", ReqH}, [], []),
+    %% Not a CORS header, but it must be on every response - see GH-4186
+    lists:foreach(fun(Hs) ->
+                          case proplists:get_value("x-ae-height", Hs) of
+                              undefined -> ct:fail("missing x-ae-height header");
+                              _         -> ok
+                          end
+                  end, [Headers, Headers1, Headers2, Headers3]),
     H  = trim_not_common_headers(Headers),
     H1 = trim_not_common_headers(Headers1),
     H2 = trim_not_common_headers(Headers2),
@@ -195,6 +202,7 @@ assert_no_headers_if_no_origin() ->
     undefined = proplists:get_value("access-control-expose-headers", Headers0),
     undefined = proplists:get_value("access-control-allow-methods", Headers0),
     undefined = proplists:get_value("access-control-max-age", Headers0),
+    undefined = proplists:get_value("access-control-expose-headers", Headers0),
     undefined = proplists:get_value("access-control-allow-origin", Headers0),
     ok.
 
@@ -206,10 +214,13 @@ assert_no_headers_if_unauthorised_origin() ->
     undefined = proplists:get_value("access-control-expose-headers", Headers1),
     undefined = proplists:get_value("access-control-allow-methods", Headers1),
     undefined = proplists:get_value("access-control-max-age", Headers1),
+    undefined = proplists:get_value("access-control-expose-headers", Headers1),
     undefined = proplists:get_value("access-control-allow-origin", Headers1),
     ok.
 
 trim_not_common_headers(Headers) ->
     lists:foldl(fun proplists:delete/2,
                 Headers,
-                ["date", "content-length", "content-type"]).
+                %% x-ae-height is common to all responses, but its value moves
+                %% with the chain, so it cannot be compared across requests
+                ["date", "content-length", "content-type", "x-ae-height"]).

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -130,7 +130,8 @@
 
 -export(
    [
-    get_status/1
+    get_status/1,
+    state_version_header/1
    ]).
 
 %% test case exports
@@ -420,7 +421,8 @@ groups() ->
      %% /status/*
      {status_endpoints, [],
       [
-       get_status
+       get_status,
+       state_version_header
       ]},
 
      {external_endpoints, [sequence],
@@ -1910,6 +1912,29 @@ get_status(_Config) ->
                       ?assertMatch(X when is_binary(X), maps:get(<<"version">>, P)),
                       ?assertMatch(X when is_binary(X), maps:get(<<"effective_at_height">>, P))
                   end, ProtocolsStr),
+    ok.
+
+%% GH-4186: every response advertises the chain state it was computed from, so
+%% that a client querying a pool of nodes can recognise a lagging one.
+state_version_header(_Config) ->
+    Host = external_address(),
+    Before = rpc(aec_chain, top_height, []),
+    {ok, {{_, 200, _}, OkHeaders, _}} =
+        httpc_request(get, {Host ++ "/v3/status", []}, [], []),
+    %% also on errors - a 404 for a not yet mined entry has to say how far the
+    %% answering node actually is, otherwise the client can only retry blindly
+    {ok, {{_, 404, _}, ErrHeaders, _}} =
+        httpc_request(get, {Host ++ "/v3/names/nonExistentName.chain", []}, [], []),
+    After = rpc(aec_chain, top_height, []),
+    lists:foreach(
+      fun(Headers) ->
+              Value = proplists:get_value("x-ae-height", Headers),
+              ?assertMatch(V when is_list(V), Value),
+              Height = list_to_integer(Value),
+              %% the marker is taken before the body is computed, so it never
+              %% runs ahead of the state the body reflects
+              ?assert(Height >= Before andalso Height =< After)
+      end, [OkHeaders, ErrHeaders]),
     ok.
 
 get_status_sut() ->

--- a/apps/aehttp/test/aehttp_state_version_tests.erl
+++ b/apps/aehttp/test/aehttp_state_version_tests.erl
@@ -1,0 +1,93 @@
+%%%=============================================================================
+%%% @copyright (C) 2026, Aeternity Anstalt
+%%% @doc
+%%%    Unit tests for the X-Ae-Height chain-state height cache
+%%%    (aehttp_state_version).
+%%% @end
+%%%=============================================================================
+-module(aehttp_state_version_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+state_version_test_() ->
+    {foreach,
+     fun setup/0,
+     fun cleanup/1,
+     [ {"top_height falls back to a dirty read when the cache is unavailable",
+        fun fallback_dirty_read/0}
+     , {"top_height is undefined when the chain top is not readable",
+        fun undefined_when_no_top/0}
+     , {"top_height serves the cached value without hitting the chain",
+        fun cached_read_skips_dirty/0}
+     , {"a top_changed event updates the cached height",
+        fun top_changed_updates_cache/0}
+     ]}.
+
+setup() ->
+    ok = meck:new(aec_events, [passthrough]),
+    ok = meck:new(aec_chain, [passthrough]),
+    ok = meck:new(aec_headers, [passthrough]),
+    %% subscribe/1 returns `true' - init/1 relies on that exact value.
+    meck:expect(aec_events, subscribe, fun(top_changed) -> true end),
+    %% A mock header is just a tagged height; height/1 unwraps it.
+    meck:expect(aec_headers, height, fun({mock_header, H}) -> H end),
+    ok.
+
+cleanup(_) ->
+    stop_server(),
+    meck:unload().
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+%% No server has been started, so the ETS cache table does not exist and
+%% top_height/0 must fall back to a dirty chain read rather than crash.
+fallback_dirty_read() ->
+    set_top(42),
+    ?assertEqual(42, aehttp_state_version:top_height()).
+
+undefined_when_no_top() ->
+    set_no_top(),
+    ?assertEqual(undefined, aehttp_state_version:top_height()).
+
+%% Once the server has seeded the cache, top_height/0 reads it and does not
+%% consult the chain again - proven by making a fresh dirty read return a
+%% different answer (undefined) while the cached value still wins.
+cached_read_skips_dirty() ->
+    set_top(100),
+    start_server(),
+    ?assertEqual(100, aehttp_state_version:top_height()),
+    set_no_top(),
+    ?assertEqual(100, aehttp_state_version:top_height()).
+
+top_changed_updates_cache() ->
+    set_top(100),
+    start_server(),
+    ?assertEqual(100, aehttp_state_version:top_height()),
+    aehttp_state_version ! {gproc_ps_event, top_changed,
+                            #{info => #{height => 150}}},
+    %% A synchronous call flushes the mailbox: the info message above is
+    %% handled before this call is answered.
+    _ = gen_server:call(aehttp_state_version, sync),
+    ?assertEqual(150, aehttp_state_version:top_height()).
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+set_top(Height) ->
+    meck:expect(aec_chain, dirty_top_header, fun() -> {mock_header, Height} end).
+
+set_no_top() ->
+    meck:expect(aec_chain, dirty_top_header, fun() -> undefined end).
+
+start_server() ->
+    {ok, _Pid} = aehttp_state_version:start_link(),
+    ok.
+
+stop_server() ->
+    case whereis(aehttp_state_version) of
+        undefined -> ok;
+        Pid       -> gen_server:stop(Pid)
+    end.

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,3 +3,34 @@
 Aeternity node API is documented in the [protocol repository](https://github.com/aeternity/protocol/blob/master/node/api/README.md).
 
 Swagger API documentation is available online at [Aeternity node API documentation](https://api-docs.aeternity.io)
+
+# Response headers
+
+## `X-Ae-Height`
+
+Every HTTP API response — external, internal and Rosetta, successful or not —
+carries an `X-Ae-Height` header holding the height of the node's chain top at
+the moment the request was accepted.
+
+The marker is read before the request handler touches any chain data, so the
+response body always reflects a chain state **at or after** the advertised
+height. Clients may treat the value as a lower bound.
+
+It exists so that a client talking to a pool of nodes behind a load balancer can
+tell an answer computed from an up-to-date chain from one computed by a lagging
+or still syncing node. Comparing the header against the highest value seen so
+far lets the client discard a stale answer outright, instead of retrying blindly
+and adding load to nodes that are already behind. Because the header is present
+on error responses too, a `404` for a not-yet-mined transaction also says how
+far the answering node actually is.
+
+Resolution is one generation: micro blocks applied within the current generation
+do not change the value. That keeps the header cache friendly for reverse
+proxies sitting in front of the node — it changes about once per key block.
+
+The header is omitted while the node's chain is not readable yet, e.g. early in
+startup. Clients should treat its absence as "unknown".
+
+Browsers can read the header on cross-origin requests: it is listed in
+`access-control-expose-headers` whenever CORS headers are sent (see the
+`http.cors` configuration section).


### PR DESCRIPTION
Master port of #4662 (cherry-pick of `f2fa6482` + `e330d27e` + `1c972cbc`).

## What

Adds an `X-Ae-Height` response header (GH-4186) carrying the node's chain-state (generation) height, stamped in the CORS middleware ahead of routing so it's on every response including OPTIONS preflights. Clients behind a load balancer can use it to discard answers from a lagging node (lower bound). Includes the hot-path cache and its unit tests.

## Notes on the port

- Cherry-pick of the three feature commits from #4662 onto `master`.
- **One conflict**, in `apps/aehttp/src/aehttp_cors_middleware.erl`: master already carries `retry-after` in `access-control-expose-headers` (from #4663), and #4662 adds `x-ae-height` on the same line. Resolved by folding both into the list-based `exposed_headers()` → the header is `retry-after, x-ae-height`. The CORS test suite auto-merged but with contradictory single-value assertions, so it's set to the combined value. (master's `aehttp_cors_middleware.erl` and its suite are byte-identical to stable's, so this is the same resolution as on #4662.) `oas3.yaml`/`swagger.yaml` auto-merged.
- The cache commit (`aehttp_state_version` gen_server + `aehttp_sup` child) and the test commit cherry-picked with no conflict.

## Hot-path cache

`aehttp_state_version` is a small supervised gen_server that subscribes to `top_changed` and caches the generation height in an ETS row, so `top_height/0` is an O(1) ETS read per request instead of a dirty chain read + header decode — falling back to the dirty read only while the cache is unpopulated (startup / maintainer restart).

## Validation

- Compiles cleanly in the CI-matching `aeternity/builder:focal-otp26` container.
- `aehttp_cors_middleware_SUITE` (CT): 5/5 pass — node starts, `access-control-expose-headers` is `retry-after, x-ae-height`, and `x-ae-height` is present on responses.
- `aehttp_state_version_tests` (EUnit): 4/4 pass — cached read vs dirty-read fallback, `undefined` when no top, cache serves without re-reading the chain, and `top_changed` updates the cached height.