### PR TITLE
Reduce CI cost/flakiness: drop otp24/otp25 matrix, skip unrealistic version-compat tests, fix install_otp

### DIFF
--- a/.circleci/config/commands/@install.yml
+++ b/.circleci/config/commands/@install.yml
@@ -21,8 +21,16 @@ install_otp:
     - run:
         name: Install OTP
         command: |
-          # Install OTP package deps
-          sudo apt-get update && sudo apt-get install libncurses5 libwxbase3.0-dev libwxgtk3.0-gtk3-dev libsctp1
+          # Install OTP package deps.
+          # esl-erlang's actual dependencies (per its own control file) are just
+          # procps, libc6, libncurses5, libsctp1, libssl1.1 - libwx* is only a
+          # Recommends (for the optional :observer/:debugger/:wx GUI tools,
+          # never used in headless CI), and even then just the plain runtime
+          # libs, not -dev headers. Installing libwxbase3.0-dev/libwxgtk3.0-gtk3-dev
+          # here pulled in an entire GTK/X11/GNOME desktop dependency chain
+          # (100+MB, 40+ minutes, and prone to transient mirror 503s) for
+          # packages nothing in this pipeline uses - dropped.
+          sudo apt-get update && sudo apt-get install -y libncurses5 libsctp1
           # Install OTP binary package
           PACKAGE_NAME=esl-erlang_${OTP_VERSION}-1~ubuntu~focal_amd64.deb
           OTP_DOWNLOAD_URL=https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/esl-erlang/${PACKAGE_NAME}

--- a/.circleci/config/workflows/commit.yml
+++ b/.circleci/config/workflows/commit.yml
@@ -6,7 +6,7 @@ jobs:
       context: ae-slack
       matrix:
         parameters:
-          otp: ["otp24", "otp25", "otp26"]
+          otp: ["otp26"]
       filters:
         branches:
           ignore:
@@ -25,7 +25,7 @@ jobs:
       context: ae-slack
       matrix:
         parameters:
-          otp: ["otp24", "otp25", "otp26"]
+          otp: ["otp26"]
           target:
             - "ct-roma"
             - "ct-minerva"
@@ -37,26 +37,6 @@ jobs:
             - "ct-latest-no-aci"
             - "ct-mnesia-rocksdb"
             - "ct-mnesia-mrdb"
-        exclude:
-          - {otp: "otp24", target: "ct-roma"}
-          - {otp: "otp24", target: "ct-minerva"}
-          - {otp: "otp24", target: "ct-fortuna"}
-          - {otp: "otp24", target: "ct-lima"}
-          - {otp: "otp24", target: "ct-iris"}
-          - {otp: "otp24", target: "ct-ceres"}
-          - {otp: "otp24", target: "ct-latest-no-aci"}
-          - {otp: "otp24", target: "ct-mnesia-rocksdb"}
-          - {otp: "otp24", target: "ct-mnesia-mrdb"}
-
-          - {otp: "otp25", target: "ct-roma"}
-          - {otp: "otp25", target: "ct-minerva"}
-          - {otp: "otp25", target: "ct-fortuna"}
-          - {otp: "otp25", target: "ct-lima"}
-          - {otp: "otp25", target: "ct-iris"}
-          - {otp: "otp25", target: "ct-ceres"}
-          - {otp: "otp25", target: "ct-latest-no-aci"}
-          - {otp: "otp25", target: "ct-mnesia-rocksdb"}
-          - {otp: "otp25", target: "ct-mnesia-mrdb"}
       requires:
         - build-<< matrix.otp >>
       filters:
@@ -103,7 +83,7 @@ jobs:
       context: ae-slack
       matrix:
         parameters:
-          otp: ["otp24", "otp25", "otp26"]
+          otp: ["otp26"]
       requires:
         - build-<< matrix.otp >>
       filters:

--- a/Makefile
+++ b/Makefile
@@ -295,8 +295,6 @@ smoke-test-run: internal-build
 
 system-smoke-test-deps:
 	$(MAKE) docker
-	docker pull "aeternity/aeternity:v1.4.0"
-	docker pull "aeternity/aeternity:v6.9.0"
 
 local-system-test: KIND=system_test
 local-system-test: internal-build
@@ -305,13 +303,26 @@ local-system-test: internal-build
 system-test-deps:
 	$(MAKE) system-smoke-test-deps
 	docker pull "aeternity/aeternity:v2.3.0"
-	docker pull "aeternity/aeternity:v4.0.0"
-	docker pull "aeternity/aeternity:v4.2.0"
 	docker pull "aeternity/aeternity:latest"
 
 system-test: KIND=system_test
 system-test: internal-build
 	@$(REBAR) as $(KIND) do ct $(ST_CT_DIR) $(ST_CT_FLAGS) $(CT_TEST_FLAGS)
+
+# Old-version peer/sync compatibility tests (new_node_joins_network in
+# aest_sync_SUITE, test_old_peer_discovery in aest_peers_SUITE) pull historical
+# release images and are opt-in only (see AE_SYSTEM_TEST_OLD_VERSION_COMPAT in
+# the suites' init_per_testcase/2) - they do NOT run as part of smoke-test or
+# system-test. Run them manually with: make system-test-old-version-compat
+system-test-old-version-compat-deps:
+	$(MAKE) docker
+	docker pull "aeternity/aeternity:v1.4.0"
+	docker pull "aeternity/aeternity:v6.9.0"
+
+system-test-old-version-compat: KIND=system_test
+system-test-old-version-compat: system-test-old-version-compat-deps internal-build
+	@AE_SYSTEM_TEST_OLD_VERSION_COMPAT=1 $(REBAR) as $(KIND) do ct $(ST_CT_DIR) $(ST_CT_FLAGS) --suite=aest_sync_SUITE --case=new_node_joins_network
+	@AE_SYSTEM_TEST_OLD_VERSION_COMPAT=1 $(REBAR) as $(KIND) do ct $(ST_CT_DIR) $(ST_CT_FLAGS) --suite=aest_peers_SUITE --case=test_old_peer_discovery
 
 aevm-test: VERSION aevm-test-deps
 	@$(REBAR) eunit --application=aevm
@@ -496,6 +507,7 @@ test-arch-os-dependencies:
 	dialyzer \
 	docker docker-clean dockerignore-check \
 	test smoke-test smoke-test-run system-test aevm-test-deps \
+	system-test-old-version-compat system-test-old-version-compat-deps \
 	ct-% ct-latest ct-mnesia-% \
 	eunit-% eunit-latest \
 	system-smoke-test-deps system-test-deps \

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ eunit-latest: eunit-$(LATEST_PROTOCOL)
 all-tests: eunit-$(LATEST_PROTOCOL) ct-$(LATEST_PROTOCOL)
 
 docker: dockerignore-check
-	@docker pull aeternity/builder:focal-otp24
+	@docker pull aeternity/builder:focal-otp26
 	@docker build -t aeternity/aeternity:local .
 
 dockerignore-check: | .gitignore .dockerignore
@@ -302,7 +302,6 @@ local-system-test: internal-build
 
 system-test-deps:
 	$(MAKE) system-smoke-test-deps
-	docker pull "aeternity/aeternity:v2.3.0"
 	docker pull "aeternity/aeternity:latest"
 
 system-test: KIND=system_test

--- a/apps/aecore/src/aec_peer_connection.erl
+++ b/apps/aecore/src/aec_peer_connection.erl
@@ -47,6 +47,7 @@
 -ifdef(TEST).
 -export([is_node_info_sharing_enabled/0]).
 -export([deserialize_tx/1]).
+-export([use_latest_common_ping_version/2]).
 -endif.
 
 -include("aec_peer_messages.hrl").

--- a/apps/aecore/test/aec_peer_connection_tests.erl
+++ b/apps/aecore/test/aec_peer_connection_tests.erl
@@ -32,6 +32,25 @@ deserialize_tx_test_() ->
       end}
     ].
 
+%% Coverage for the ping-version negotiation that only ever takes a real
+%% "downgrade" branch when talking to an older peer (aest_peers_SUITE's
+%% test_old_peer_discovery is the only place that exercises this against a
+%% real historical binary; this covers the same policy without needing one).
+use_latest_common_ping_version_test_() ->
+    [{"Negotiates down to the only version an older peer advertises",
+      fun() ->
+              PingObj = #{versions => [#{protocol => <<"ping">>, vsns => [1]}]},
+              #{use_ping_vsn := Vsn} = ?TEST_MODULE:use_latest_common_ping_version(#{}, PingObj),
+              ?assertEqual(1, Vsn)
+      end},
+     {"Picks the latest version both sides support",
+      fun() ->
+              PingObj = #{versions => [#{protocol => <<"ping">>, vsns => [1, 2]}]},
+              #{use_ping_vsn := Vsn} = ?TEST_MODULE:use_latest_common_ping_version(#{}, PingObj),
+              ?assertEqual(2, Vsn)
+      end}
+    ].
+
 make_spend_tx(Sender) ->
     #{ public := OtherPubkey } = enacl:sign_keypair(),
     SenderId = aeser_id:create(account, Sender),

--- a/docs/build.md
+++ b/docs/build.md
@@ -16,7 +16,7 @@ The commands below assume you are logged in with `sudo` user.
 
 The node have couple of main dependencies that have to be installed to build it from source:
 
-- [Erlang/OTP 24.3.4.15](http://erlang.org/doc/installation_guide/INSTALL.html)
+- [Erlang/OTP 26.2.1](http://erlang.org/doc/installation_guide/INSTALL.html)
 - [Libsodium](https://download.libsodium.org/doc/installation/)
 - [Libgmp](https://gmplib.org)
 

--- a/system_test/common/aest_db_SUITE.erl
+++ b/system_test/common/aest_db_SUITE.erl
@@ -69,8 +69,15 @@ groups() ->
 init_per_suite(Config) ->
     Config.
 
-init_per_group(minerva_compatibility, Config) ->
-    [{tx_mempool_vsn, "v2.3.0"} | Config];
+init_per_group(minerva_compatibility, _Config) ->
+    %% Verifies a "local" node can reuse a v2.3.0 node's on-disk mempool DB.
+    %% Nobody realistically jumps straight from a Minerva-era (v2.3.0) node to
+    %% the latest release without any intermediate upgrades, so this no longer
+    %% reflects a real upgrade path - skipped to stop paying the Docker
+    %% pull/boot cost on every system-test run. See git history for the
+    %% previous [{tx_mempool_vsn, "v2.3.0"} | Config] implementation if this
+    %% ever needs reviving with a more realistic version pair.
+    {skip, unrealistic_upgrade_path_v2_3_0_to_local};
 init_per_group(lima_compatibility, _Config) ->
     %%[{state_channels_vsn, "v5.1.0"} | Config];
     {skip, no_backwards_compatibility_until_5_1};

--- a/system_test/common/aest_peers_SUITE.erl
+++ b/system_test/common/aest_peers_SUITE.erl
@@ -84,6 +84,18 @@ init_per_suite(Config) ->
       {node_shutdown_time, 20000} %% Time it may take to stop node cleanly
     | Config].
 
+init_per_testcase(test_old_peer_discovery, Config) ->
+    %% Pulls and boots an old (v6.9.0) release image alongside the branch
+    %% build - real network/Docker cost for coverage of the ping-version
+    %% negotiation downgrade path only (see aec_peer_connection_tests for
+    %% the equivalent unit-level coverage). Opt-in only, so it doesn't run
+    %% automatically in CI; set AE_SYSTEM_TEST_OLD_VERSION_COMPAT=1 to run it.
+    case os:getenv("AE_SYSTEM_TEST_OLD_VERSION_COMPAT") of
+        false ->
+            {skip, "old-version compat test - opt-in via AE_SYSTEM_TEST_OLD_VERSION_COMPAT=1 (pulls aeternity/aeternity:v6.9.0)"};
+        _ ->
+            aest_nodes:ct_setup(Config)
+    end;
 init_per_testcase(_TC, Config) ->
     aest_nodes:ct_setup(Config).
 

--- a/system_test/common/aest_sync_SUITE.erl
+++ b/system_test/common/aest_sync_SUITE.erl
@@ -144,6 +144,17 @@ init_per_suite(Config) ->
 
 init_per_testcase(quick_start_stop, Config) ->
     aest_nodes:ct_setup([{verify_logs, false}|Config]);
+init_per_testcase(new_node_joins_network, Config) ->
+    %% Pulls and boots an old (v1.4.0) release image alongside the branch
+    %% build to prove sync compatibility with older peers - real network/Docker
+    %% cost. Opt-in only, so it doesn't run automatically in CI; set
+    %% AE_SYSTEM_TEST_OLD_VERSION_COMPAT=1 to run it.
+    case os:getenv("AE_SYSTEM_TEST_OLD_VERSION_COMPAT") of
+        false ->
+            {skip, "old-version compat test - opt-in via AE_SYSTEM_TEST_OLD_VERSION_COMPAT=1 (pulls aeternity/aeternity:v1.4.0)"};
+        _ ->
+            aest_nodes:ct_setup(Config)
+    end;
 init_per_testcase(_TC, Config) ->
     aest_nodes:ct_setup(Config).
 


### PR DESCRIPTION
Four related CI-cost/reliability changes, discussed together.

## 1. Drop otp24/otp25 from the commit CI matrix

Trims `build`, `test`, `static-analysis` in `commit.yml` to `["otp26"]`.

- Every release artifact (tarball, `.deb`, Docker image) is already built exclusively on `builder_container_otp26` — hardcoded in `@packages.yml` and the default `docker_builder_image` parameter — regardless of what the commit-workflow matrix tests. Nothing about the shipped node changes.
- No OTP-version-conditional code (`-if OTP_RELEASE` etc.) exists anywhere in the source tree.
- `eunit` already only ran on `otp26`; this brings `build`/`test`/`static-analysis` in line with that.
- Precedent: the `otp23` executor is defined but entirely unused in every workflow already.
- Removes 6 parallel jobs per commit/PR: 2 `build`, 2 `test` (otp24/otp25 were already excluded from 9 of the 10 CT targets — they only ever ran `ct-latest`), 2 `static-analysis` (dialyzer, typically the slowest of the three per extra OTP).
- Bundled: `docs/build.md` still stated **Erlang/OTP 24.3.4.15** as the documented build-from-source dependency even though nothing tests or ships that toolchain. Bumped to **26.2.1** to match reality.
- Also fixed `make docker` pre-fetching `aeternity/builder:focal-otp24` when the `Dockerfile` itself is `FROM aeternity/builder:focal-otp26` — the otp24 pull was for an image nothing uses, and the actually-needed otp26 image got pulled implicitly/uncached during `docker build` anyway. Now pre-fetches otp26.

## 2. Make old-version peer/sync compatibility system tests opt-in

Two system-test cases boot an actual historical release image alongside the branch build **on every commit**, via `docker-system-smoke-test` (unfiltered in `commit.yml`):
- `new_node_joins_network` (`aest_sync_SUITE`, pulls `aeternity/aeternity:v1.4.0`)
- `test_old_peer_discovery` (`aest_peers_SUITE`, pulls `aeternity/aeternity:v6.9.0`)

Investigated what these actually cover before touching them:
- `test_old_peer_discovery` only exercises peer-discovery/`GetPeers` — not a chain-sync assertion. v6.9.0 predates the Ceres hard fork and genuinely cannot sync the current chain, but the P2P/ping-handshake layer (`?P2P_PROTOCOL_VSN`, ping-version negotiation) is unconditional/fork-independent, so the test is real but narrowly scoped to that layer, not general sync compatibility.
- Confirmed it's the **only** test anywhere that exercises the ping-version-negotiation "downgrade to an older peer" branch (`aec_peer_connection:use_latest_common_ping_version/2`) — no existing unit coverage of that logic.

Given that narrow scope plus the real per-commit Docker/network cost, both are now gated behind `AE_SYSTEM_TEST_OLD_VERSION_COMPAT` (checked in each suite's `init_per_testcase/2`, `{skip, ...}` otherwise) so they no longer run automatically, but remain available as an explicit manual target: `make system-test-old-version-compat`. `system-smoke-test-deps`/`system-test-deps` no longer pull `v1.4.0`/`v6.9.0` by default; a new `system-test-old-version-compat-deps` pulls them only for the opt-in target.

To not lose the coverage entirely, added a unit test for the same negotiation policy in `aec_peer_connection_tests.erl` (`use_latest_common_ping_version/2`, exported under `-ifdef(TEST)`), covering "negotiate down to an older peer's ping version" without the network/Docker dependency.

Also dropped `docker pull aeternity/aeternity:v4.0.0` and `v4.2.0` from `system-test-deps` — confirmed via repo-wide search that neither tag is referenced by any test suite; pure dead weight (network + storage, zero coverage).

## 3. Skip the v2.3.0 mempool-DB-reuse compatibility test

`aest_db_SUITE`'s `minerva_compatibility` group (`force_progress_mempool`) pulls `aeternity/aeternity:v2.3.0` to prove a `local` node can reuse a v2.3.0 node's on-disk mempool DB. Nobody realistically jumps straight from a Minerva-era (2019) node to the latest release without intermediate upgrades, so this no longer reflects a real upgrade path — real per-run Docker pull/boot cost for an unrealistic scenario.

Skipped it the same way the file *already* skips its `lima_compatibility` group (`{skip, no_backwards_compatibility_until_5_1}` — a near-identical existing precedent in the same file), rather than deleting the code: `{skip, unrealistic_upgrade_path_v2_3_0_to_local}`. The implementation stays in git history if a more realistic version pair is ever needed. Also drops the now-dead `docker pull aeternity/aeternity:v2.3.0` from `system-test-deps`.

## 4. Fix install_otp: stop installing libwx*-dev

`docker-system-test`/`docker-system-smoke-test`'s "Install OTP" step (`machine_2004` executor, no caching) was observed taking **42 minutes** and fetching **104MB**, then failing outright with `E: Unable to fetch some archives` from transient 503s on the regional Ubuntu mirror.

Root cause: checked `esl-erlang`'s actual `.deb` control file — its real dependencies are just `procps, libc6, libncurses5, libsctp1, libssl1.1`. `libwx*` is only a `Recommends`, purely for the optional `:observer`/`:debugger`/`:wx` GUI tools — never used in headless CI (this repo's own `rebar.config` explicitly does `{exclude_apps, [wx]}` with the comment *"Make sure wx doesn't get included"*) — and even that `Recommends` only points at the plain runtime libs, not the `-dev` header packages this command was installing. `libwxbase3.0-dev`/`libwxgtk3.0-gtk3-dev` pull in an entire GTK/X11/GNOME desktop dependency chain (xorg-server, gdm3, gnome-session, printer/bluetooth/media stacks…) — that's the actual source of the slow, flaky install. Dropped both; kept `libncurses5`/`libsctp1` (genuine hard `Depends`).

## Validation

- `commit.yml`/`Makefile`/`@install.yml` changes are mechanical/minimal; `make -n` dry-runs on touched targets confirm the right command sequences.
- `aest_sync_SUITE.erl`/`aest_peers_SUITE.erl`/`aest_db_SUITE.erl` compile cleanly (`rebar3 ct --compile_only`) in the CI-matching `aeternity/builder:focal-otp26` container.
- `aec_peer_connection_tests`: 5/5 pass (3 pre-existing + 2 new).
- Reproduced the 42-minute `install_otp` failure directly from the job's own CircleCI log, and confirmed `esl-erlang`'s real dependency list via its `.deb` control file before removing the wx packages.
- `docs/build.md` and all touched CI YAML validated.

## Not changed

- `builder_container_otp24`/`otp25` executors left in place (unused, like the already-orphaned `otp23`) to keep the OTP-matrix diff minimal.
- `docker pull aeternity/aeternity:latest` in `system-test-deps` left as-is — it is actually referenced (`aest_channels_SUITE`), and whether to pin it to an explicit tag for reproducibility vs. keep testing "whatever's currently live" is a team judgment call, not addressed here.