### PR TITLE
Fix intermittent timeout in hole_production_eoe hyperchain test

### DIFF
--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1156,7 +1156,13 @@ hole_production_eoe(Config) ->
     EOEProdNode = producer_node(EOEProducer, Config),
     AllNodes = [ Name || {_, Name, _, _} <- ?config(nodes, Config) ],
     ct:log("Produce on: ~p", [AllNodes -- [EOEProdNode]]),
-    {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode]}),
+    %% Excluding the scheduled EOE producer forces the network to detect a
+    %% missed slot and fall back to a hole block - a slower, multi-step
+    %% consensus path than plain production, so the bare 3000ms default
+    %% (produce_cc_blocks/3, produce_to_cc_height/6) is too tight here and was
+    %% observed to intermittently time out (timeout_waiting_for_block).
+    {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
+                                              timeout => 10000}),
     Holes = length([ x || B <- Bs, key == aec_blocks:type(B) ]),
     ct:pal("Expected at least 1 hole, got ~p", [Holes]),
     ?assert(Holes > 1),


### PR DESCRIPTION
Fixes an intermittent CI failure:
```
%%% aehttp_hyperchains_SUITE ==> hole_production_eoe: FAILED
{timeout_waiting_for_block, [{aecore_suite_utils,hc_mine_blocks,4,...},
 {aehttp_hyperchains_SUITE,produce_to_cc_height,6,...},
 {aehttp_hyperchains_SUITE,produce_cc_blocks,3,...},
 {aehttp_hyperchains_SUITE,hole_production_eoe,1,...}]}
```

## Root cause

`produce_to_cc_height/6` waits for each key block with a flat, unscaled default:
```erlang
Timeout = maps:get(timeout, ProdCfg, 3000),
...
{ok, Blocks} = mine_cc_blocks(PNodes, 1, Timeout),
```
which feeds `aecore_suite_utils:wait_for_new_block_mined/1` — a plain `receive ... after 3000 -> {error, timeout_waiting_for_block}`.

`hole_production_eoe/1` deliberately excludes the scheduled end-of-epoch producer from `prod_nodes`:
```erlang
{ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode]}),
```
forcing the network to detect a missed slot and fall back to producing a hole block instead — a slower, multi-step consensus path than plain production. The test also asserts `Holes > 1`, so it may need several such rounds. No custom `timeout` was passed for this call, so it silently inherited the bare 3000ms default and intermittently timed out.

Checked the shared 3000ms default isn't a deliberate reference to mainnet's `micro_block_cycle` (also 3000ms, `aec_governance.erl`) — this suite runs its own much faster child chain (`?CHILD_BLOCK_TIME = 400`, `micro_block_cycle => 1`, `expected_mine_rate => 2000`), so the shared numeral is coincidental.

## Fix

Bumped the timeout to 10000ms for this one call only — not a blanket change to the shared default, to avoid masking real regressions in the plain-production path that the 3000ms budget otherwise still protects.

## Validation

- Compiles cleanly (`rebar3 ct --compile_only`) in the CI-matching `aeternity/builder:focal-otp26` container.
- Not reproduced end-to-end here (needs a full multi-node hyperchain + parent-chain system-test cluster); this is a targeted fix based on tracing the timeout mechanism and the scenario's extra complexity, not an empirical repro. Will rely on CI re-runs to confirm the intermittent failure clears.

## Scope

`apps/aehttp/test/aehttp_hyperchains_SUITE.erl` doesn't exist on `releases/stable` (hyperchain test suites are master-only), so no stable port is needed.