### PR TITLE
Fix js-sdk-smoke-test: replace flaky NodeSource install with official Node tarball

### DIFF
--- a/.circleci/config/jobs/@docker-tests.yml
+++ b/.circleci/config/jobs/@docker-tests.yml
@@ -105,8 +105,19 @@ js-sdk-smoke-test:
     - run:
         name: Install OS Deps
         command: |
-          curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-          sudo apt-get update && sudo apt-get install -y nodejs libsodium23 libtinfo5 libssl1.0
+          sudo apt-get update && sudo apt-get install -y libsodium23 libtinfo5 libssl1.0 xz-utils
+          # NodeSource's setup_20.x script depends on a live curl+GPG-key fetch
+          # from NodeSource's own server, which failed with a 403 and (worse)
+          # let the script exit 0 anyway - apt then silently fell back to
+          # focal's bundled nodejs 10.19, which doesn't ship npm at all.
+          # Fetch the official upstream Node 20 (matching the node:20-buster-slim
+          # tag already used by docker-js-sdk-smoke-test) tarball directly instead,
+          # removing that external repo/GPG dependency entirely.
+          curl -fsSL -o node.tar.xz https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz
+          sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1
+          rm node.tar.xz
+          node --version
+          npm --version
     - attach_workspace:
         at: << pipeline.parameters.packages_workspace >>
     - run:


### PR DESCRIPTION
Fixes `js-sdk-smoke-test` failing on `Install JS SDK` with `npm: command not found`.

## Root cause (confirmed, not guessed)

The job's "Install OS Deps" step ran NodeSource's `setup_20.x` script, which fetches its GPG signing key over a live `curl` call to NodeSource's own server. That request returned **403** in the failing run, and the script logs the error but **still exits 0** — so "Install OS Deps" reported success even though the NodeSource repo was never actually added:
```
curl: (22) The requested URL returned error: 403
gpg: no valid OpenPGP data found.
2026-07-27 23:07:54 - Error: Failed to download and import the NodeSource signing key (Exit Code: 0)
```
`apt-get install -y nodejs ...` then silently resolved `nodejs` to **focal's own bundled 10.19.0 package** instead (from `focal-updates/universe`), which does not ship `npm` at all — it's a separate, merely-*suggested* package for that old build. Hence the later `npm ci` step failed with exit 127.

I reproduced this directly: pulled `circleci/buildpack-deps:focal` fresh (no cache) and reran the same steps, getting the identical 403 / silent-fallback-to-focal's-nodejs sequence.

## Fix

Replaced the NodeSource script with a direct download+extract of the **official upstream Node 20 tarball** (`node-v20.11.1-linux-x64.tar.xz` from `nodejs.org`) — the same official build the `node:20-buster-slim` image (already used successfully by the sibling job `docker-js-sdk-smoke-test`) is based on. This removes the external NodeSource GPG-key fetch as a point of failure entirely.

Didn't switch to running this job inside a `node:20-buster-slim` container (like `docker-js-sdk-smoke-test` does), because that job's aeternity node runs *inside Docker* on the same Docker network as the Node container — trivial to network together. This job (`js-sdk-smoke-test`) runs the release as a **native process** directly on the CI host (`./node/bin/aeternity start`), not in a container, so bringing in a separate Node container would need nontrivial Docker-in-Docker network wiring back to the host's `localhost`. Fetching the official tarball directly gets the same Node 20 binary with none of that complexity.

Also considered switching the whole job to CircleCI's next-gen `cimg/node:20.x` image, but that's Ubuntu 22.04 (jammy)-based, and I confirmed jammy has dropped `libssl1.0`/`libtinfo5` — packages this job also installs to run the release binary (built via `builder_container_otp26` = `aeternity/builder:focal-otp26`). Switching the base OS wholesale risked trading this failure for an unverified runtime-library incompatibility with the focal-built binary, so I kept the base image as `circleci/buildpack-deps:focal` and only replaced the Node install method.

## Validation

- `.circleci/config/jobs/@docker-tests.yml` parses as valid YAML.
- Reproduced the failure and verified the fix end-to-end in a fresh `circleci/buildpack-deps:focal` container (no cache): `node --version` → `v20.11.1`, `npm --version` → `10.2.4`, both resolve cleanly after the new install step.
- Confirmed no other job in this file uses the NodeSource pattern, so this was the only place affected.