### PR TITLE
Fix intermittent failure in aehttp_hyperchains_SUITE:hole_production/1

### DIFF
--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1121,7 +1121,14 @@ hole_production(Config, N) ->
         ct:log("Skip test, too many holes in a row potential timing issue!");
        true ->
         ct:log("Produce on: ~p", [AllNodes -- [NextProdNode]]),
-        {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode]}),
+        %% Excluding NextProdNode forces the network onto the slower,
+        %% multi-step hole-detection consensus path (see hole_production_eoe
+        %% for the same reasoning): the bare 3000ms default was observed to
+        %% intermittently let some of the *remaining* producers also miss
+        %% their slot under CI load, inflating the observed hole count above
+        %% NHoles and failing the assertion below.
+        {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
+                                                   timeout => 10000}),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
         ?assert(NHoles + 1 == length(Bs))
     end,


### PR DESCRIPTION
## Problem

`aehttp_hyperchains_SUITE:hole_production/1` intermittently fails on CI, e.g. in the `ci/circleci: test-otp26-ct-mnesia-rocksdb` job on PR #4586's latest run:

```
Expected 2 holes, got 3
Failure/Error: ?assert(NHoles + 1 == length(Bs))
```

## Root cause

The test deliberately excludes the next scheduled producer (`NextProdNode`) to force a "hole" block, then calls:

```erlang
{ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode]}),
```

without a `timeout` override, so it inherits `produce_cc_blocks/3`'s bare 3000ms default.

Excluding a producer forces the network onto the slower, multi-step hole-detection consensus path (same root cause already fixed for `hole_production_eoe` in #4672). Under CI load, 3000ms isn't always enough time for the *remaining* (non-excluded) producers to complete their own production either, so they can also miss their slot and produce an extra, unintended hole — inflating the observed hole count above the deliberately-forced `NHoles` and failing the assertion.

## Fix

Bump the timeout for this specific `produce_cc_blocks` call to 10000ms, mirroring the fix already applied to `hole_production_eoe`.

## Validation

- Compiles cleanly (`./rebar3 as test compile`).
- No behavioral change to production code; test-only timeout adjustment.
