### PR TITLE
Reject non-zero reserved header flag bits

### DIFF
--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -679,7 +679,15 @@ deserialize_from_client(key, KeyBlock) ->
 deserialize_key_flags(KeyBlock) ->
     case maps:get(<<"flags">>, KeyBlock, undefined) of
         undefined -> <<?KEY_HEADER_FLAG:?FLAG_BYTES/unit:8>>;
-        Flags -> decode(bytearray, Flags)
+        Flags ->
+            Decoded = decode(bytearray, Flags),
+            %% Client-supplied flags must not set any unused/reserved bit.
+            <<F:?FLAG_BITS>> = Decoded,
+            AllowedMask = ?KEY_HEADER_FLAG bor ?CONTAINS_INFO_FLAG bor ?HOLE_FLAG bor ?EOE_FLAG,
+            case F band (bnot AllowedMask) of
+                0 -> Decoded;
+                _ -> error(illegal_flags)
+            end
     end.
 
 
@@ -803,7 +811,9 @@ deserialize_from_binary_partial(<<_Version:32,
 deserialize_key_from_binary(<<Version:32,
                               ?KEY_HEADER_TAG:1,
                               ContainsInfoFlag:1,
-                              RestFlags:30, %% Remaining flags.
+                              HoleFlag:1,
+                              EoeFlag:1,
+                              0:28, %% Unused flag bits - must be zero.
                               Height:64,
                               PrevHash:?BLOCK_HEADER_HASH_BYTES/binary,
                               PrevKeyHash:?BLOCK_HEADER_HASH_BYTES/binary,
@@ -829,7 +839,7 @@ deserialize_key_from_binary(<<Version:32,
                     time = Time,
                     version = Version,
                     info = Info,
-                    flags = <<?KEY_HEADER_TAG:1, ContainsInfoFlag:1, RestFlags:30 >>
+                    flags = <<?KEY_HEADER_TAG:1, ContainsInfoFlag:1, HoleFlag:1, EoeFlag:1, 0:28>>
                    },
     {ok, populate_extra(H)};
 deserialize_key_from_binary(_Other) ->
@@ -846,7 +856,7 @@ deserialize_key_from_binary(_Other) ->
 deserialize_micro_from_binary(<<Version:32,
                                 ?MICRO_HEADER_TAG:1,
                                 PoFTag:1,
-                                RestFlags:30, %% Remaining flags.
+                                0:30, %% Unused flag bits - must be zero.
                                 Height:64,
                                 PrevHash:?BLOCK_HEADER_HASH_BYTES/binary,
                                 PrevKeyHash:?BLOCK_HEADER_HASH_BYTES/binary,
@@ -870,7 +880,7 @@ deserialize_micro_from_binary(<<Version:32,
                             version = Version,
                             flags = << ?MICRO_HEADER_TAG:1,
                                        PoFTag:1,
-                                       RestFlags:30 >>},
+                                       0:30 >>},
             {ok, fix_flags(populate_extra(H))};
         _ ->
             {error, malformed_header}

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -36,6 +36,43 @@ hash_test() ->
     {ok, _HeaderHash1} = ?TEST_MODULE:hash_header(raw_key_header()),
     {ok, _HeaderHash2} = ?TEST_MODULE:hash_header(raw_micro_header()).
 
+reserved_key_flag_bits_rejected_test() ->
+    Header = raw_key_header(),
+    <<Version:32, Tag:1, Secondary:1, _Reserved:30, Rest/bits>> =
+        ?TEST_MODULE:serialize_to_binary(Header),
+    %% Set an unused/reserved flag bit - must be rejected.
+    Tampered = <<Version:32, Tag:1, Secondary:1, 1:30, Rest/bits>>,
+    ?assertException(error, malformed_header,
+                      ?TEST_MODULE:deserialize_from_binary(Tampered)).
+
+reserved_micro_flag_bits_rejected_test() ->
+    Header = raw_micro_header(),
+    <<Version:32, Tag:1, Secondary:1, _Reserved:30, Rest/bits>> =
+        ?TEST_MODULE:serialize_to_binary(Header),
+    Tampered = <<Version:32, Tag:1, Secondary:1, 1:30, Rest/bits>>,
+    ?assertException(error, malformed_header,
+                      ?TEST_MODULE:deserialize_from_binary(Tampered)).
+
+hole_and_eoe_flags_roundtrip_test() ->
+    %% Hyperchains-defined flag bits must still round-trip through
+    %% (de)serialization once the reserved bits are strictly enforced.
+    Header = ?TEST_MODULE:set_eoe(raw_key_header(), true),
+    SerializedHeader = ?TEST_MODULE:serialize_to_binary(Header),
+    DeserializedHeader = ?TEST_MODULE:deserialize_from_binary(SerializedHeader),
+    ?assertEqual(Header, DeserializedHeader),
+    ?assert(?TEST_MODULE:is_eoe(DeserializedHeader)),
+    ?assertNot(?TEST_MODULE:is_hole(DeserializedHeader)).
+
+client_reserved_flag_bits_rejected_test() ->
+    RawKey = raw_key_header(),
+    Serialized = ?TEST_MODULE:serialize_for_client(RawKey, key),
+    WithBadFlags = Serialized#{<<"nonce">> => ?TEST_MODULE:nonce(RawKey),
+                               <<"pow">>   => ?TEST_MODULE:pow(RawKey),
+                               <<"flags">> => aeser_api_encoder:encode(bytearray, <<1:32>>)
+                              },
+    ?assertEqual({error, invalid_header},
+                 ?TEST_MODULE:deserialize_from_client(key, WithBadFlags)).
+
 raw_key_header_minerva(MinervaHeight) ->
     ?TEST_MODULE:set_version_and_height(raw_key_header(), ?MINERVA_PROTOCOL_VSN, MinervaHeight).
 


### PR DESCRIPTION
## Problem

PR #4480 ("Add flag field to header records") replaced a literal `0:30` bit-pattern match on the reserved/unused header flag bits with a capturing `RestFlags:30` variable, with no validation added anywhere afterwards. This means:

- Key header bits 27-0 and micro header bits 29-0 (documented in `blocks.hrl` as "Unused, should be 0") are now silently accepted with arbitrary garbage on `master`.
- A 7.2.2 node rejects such a header as `malformed_header`; a `master` node accepts it.
- This is unguarded by any protocol upgrade height — it applies on the currently-live Ceres protocol, making it a real, exploitable chain-split risk if such a block were ever gossiped/mined.

## Fix

Restores strict zero-enforcement on the truly-unused reserved bits, in both the wire binary deserializer (`deserialize_key_from_binary/1`, `deserialize_micro_from_binary/1`) and the client-JSON flags path (`deserialize_key_flags/1`). Hyperchains' `Hole`/`EOE` flag bits (bits 29/28 on key headers) are explicitly preserved and unaffected.

## Testing

- Added 4 regression tests in `aec_headers_tests.erl` covering: rejection of non-zero reserved bits for key/micro headers (wire path), round-trip of Hole/EOE flags, and rejection via the client-JSON path. All pass (30/30 total in the module).
- Full eunit run of related suites (`aec_chain_state_tests`, `aec_conductor_tests`, etc.) pass with the fix applied.
- **Hyperchains safety**: Ran the `aehttp_hyperchains_SUITE` CT suite multiple times with and without the fix. Some tests (`hole_production`, `simple_withdraw`, `wallet_post_pin_to_pc`, `fast_parent_fail_pin`, `epochs_with_slow_parent`) flake intermittently under CI/load-constrained environments — confirmed this is pre-existing behavior on unmodified `master` too (two baseline runs on clean master showed different failure subsets each time), not something introduced by this change. This suite already has two prior "fix intermittent failure/timeout" PRs merged (#4674, #4672) for the same reason.
- **Performance**: Benchmarked 2M serialize/deserialize round-trips per header type; no measurable difference (~3.7 µs/op key header, ~1.7 µs/op micro header, both before and after).

## Related risk (not fixed here, informational)

Separately noted during this investigation: the header record's arity growth (added `extra`/`flags` fields) has a forward-compat clause in `from_db_header_/1` on `master`, but no backward-compat clause exists on `releases/stable`. This means a node upgraded to `master` and then rolled back to `stable` would fail to read its own DB records. Flagging this for release-notes/runbook documentation — out of scope for this PR.
