### PR TITLE
CI: insecure-retry fallback for expired erlang-solutions.com cert on OTP download (stable)

### DIFF
--- a/.circleci/config/commands/@install.yml
+++ b/.circleci/config/commands/@install.yml
@@ -26,7 +26,14 @@ install_otp:
           # Install OTP binary package
           PACKAGE_NAME=esl-erlang_${OTP_VERSION}-1~ubuntu~focal_amd64.deb
           OTP_DOWNLOAD_URL=https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/esl-erlang/${PACKAGE_NAME}
-          curl -fsSL -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"
+          # TODO: drop the insecure fallback once binaries2.erlang-solutions.com
+          # renews its edge cert (expired 2026-07-29, tracked as a third-party
+          # outage - no alternate mirror serves this exact package/path).
+          if ! curl -fsSL -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"; then
+            echo "WARNING: verified HTTPS download failed, retrying with TLS verification disabled" \
+                 "due to known upstream cert expiry on binaries2.erlang-solutions.com" >&2
+            curl -fsSLk -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"
+          fi
           sudo dpkg -i ${PACKAGE_NAME}
 
 install_libsodium:


### PR DESCRIPTION
## Problem

Same issue as https://github.com/aeternity/aeternity/pull/4676 (master counterpart PR, see it for full details): CI's `Install OTP` step downloads the `esl-erlang` `.deb` from `https://binaries2.erlang-solutions.com/...`, whose CloudFront edge cert expired 2026-07-29:

```
curl: (60) SSL certificate problem: certificate has expired
```

Third-party outage, no code change, no alternate mirror serves this exact package path currently.

## Fix

`install_otp` now attempts the normal verified `curl -fsSL` first, and only retries once with `-k` (insecure) if that fails, with a clear stderr warning. `TODO` left to remove the fallback once the upstream cert is renewed.

Scope: `.circleci/config/commands/@install.yml` only.
