### PR TITLE
CI: insecure-retry fallback for expired erlang-solutions.com cert on OTP download

### DIFF
--- a/.circleci/config/commands/@install.yml
+++ b/.circleci/config/commands/@install.yml
@@ -34,7 +34,14 @@ install_otp:
           # Install OTP binary package
           PACKAGE_NAME=esl-erlang_${OTP_VERSION}-1~ubuntu~focal_amd64.deb
           OTP_DOWNLOAD_URL=https://binaries2.erlang-solutions.com/ubuntu/pool/contrib/e/esl-erlang/${PACKAGE_NAME}
-          curl -fsSL -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"
+          # TODO: drop the insecure fallback once binaries2.erlang-solutions.com
+          # renews its edge cert (expired 2026-07-29, tracked as a third-party
+          # outage - no alternate mirror serves this exact package/path).
+          if ! curl -fsSL -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"; then
+            echo "WARNING: verified HTTPS download failed, retrying with TLS verification disabled" \
+                 "due to known upstream cert expiry on binaries2.erlang-solutions.com" >&2
+            curl -fsSLk -o ${PACKAGE_NAME} "$OTP_DOWNLOAD_URL"
+          fi
           sudo dpkg -i ${PACKAGE_NAME}
 
 install_libsodium:


### PR DESCRIPTION
## Problem

CI's `Install OTP` step downloads the `esl-erlang` `.deb` package via `curl -fsSL` from `https://binaries2.erlang-solutions.com/...`. That host's CloudFront edge certificate (`CN=*.erlang-solutions.com`) expired on **2026-07-29**, breaking every CI job that installs OTP (e.g. https://app.circleci.com/pipelines/github/aeternity/aeternity/15705/workflows/e72ecb9b-a4b1-48a8-bbd3-23b59ba0fffd/jobs/293067):

```
curl: (60) SSL certificate problem: certificate has expired
```

This is a third-party outage, not caused by anything in this repo. Checked for an alternate mirror: `binaries.erlang-solutions.com` / `packages.erlang-solutions.com` sit on a different, already-renewed CloudFront distribution, but they 502 on this exact package path — no working drop-in alternate URL exists currently.

## Fix

`install_otp` now first attempts the normal, fully-verified `curl -fsSL` download. Only if that fails does it retry once with `-k` (TLS verification disabled), printing a clear warning to stderr. Once Erlang Solutions renews the cert, the primary verified path succeeds again and the fallback is never exercised. Left a `TODO` to remove the fallback once confirmed fixed upstream.

Scope: `.circleci/config/commands/@install.yml` only, no code changes.
