### PR TITLE
Reject Hyperchains HOLE/EOE header flags under PoW consensus

### DIFF
--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -683,12 +683,28 @@ deserialize_key_flags(KeyBlock) ->
             Decoded = decode(bytearray, Flags),
             %% Client-supplied flags must not set any unused/reserved bit.
             <<F:?FLAG_BITS>> = Decoded,
-            AllowedMask = ?KEY_HEADER_FLAG bor ?CONTAINS_INFO_FLAG bor ?HOLE_FLAG bor ?EOE_FLAG,
+            Base = ?KEY_HEADER_FLAG bor ?CONTAINS_INFO_FLAG,
+            AllowedMask = case hc_flags_allowed() of
+                              true  -> Base bor ?HOLE_FLAG bor ?EOE_FLAG;
+                              false -> Base
+                          end,
             case F band (bnot AllowedMask) of
                 0 -> Decoded;
                 _ -> error(illegal_flags)
             end
     end.
+
+%% The HOLE and EOE key-header flag bits are Hyperchains constructs, only
+%% meaningful under PoS consensus. On a PoW chain they are reserved bits that
+%% must be zero, exactly as 7.2.2 requires: a PoW-sealed key block with either
+%% bit set would otherwise be accepted here and rejected as malformed_header by
+%% 7.2.2 nodes, splitting the chain. Gating on consensus type rather than
+%% protocol version is deliberate - Hyperchains deployments run on Ceres as well
+%% as Arcus, so a version-based gate would break them. `ae_mainnet` and `ae_uat`
+%% hardcode aec_consensus_bitcoin_ng and cannot be configured into `pos`, so
+%% mainnet can never opt in to accepting these bits.
+hc_flags_allowed() ->
+    aec_consensus:get_consensus_type() =:= pos.
 
 
 -spec serialize_to_signature_binary(header()) -> deterministic_header_binary().
@@ -841,7 +857,11 @@ deserialize_key_from_binary(<<Version:32,
                     info = Info,
                     flags = <<?KEY_HEADER_TAG:1, ContainsInfoFlag:1, HoleFlag:1, EoeFlag:1, 0:28>>
                    },
-    {ok, populate_extra(H)};
+    %% Common case (both bits clear) short-circuits before the consensus lookup.
+    case HoleFlag + EoeFlag =:= 0 orelse hc_flags_allowed() of
+        true  -> {ok, populate_extra(H)};
+        false -> {error, malformed_header}
+    end;
 deserialize_key_from_binary(_Other) ->
     {error, malformed_header}.
 

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -53,15 +53,89 @@ reserved_micro_flag_bits_rejected_test() ->
     ?assertException(error, malformed_header,
                       ?TEST_MODULE:deserialize_from_binary(Tampered)).
 
-hole_and_eoe_flags_roundtrip_test() ->
-    %% Hyperchains-defined flag bits must still round-trip through
-    %% (de)serialization once the reserved bits are strictly enforced.
+%% The HOLE/EOE bits are Hyperchains constructs. Under PoS they must round-trip;
+%% under PoW they are reserved bits that 7.2.2 rejects, so accepting them would
+%% be a chain split. Both directions are pinned here.
+hc_flag_gating_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(aec_consensus, [passthrough]),
+             ok
+     end,
+     fun(_) ->
+             meck:unload(aec_consensus)
+     end,
+     [ {"EOE round-trip under PoS",        fun eoe_flag_roundtrip_pos/0}
+     , {"HOLE accepted under PoS",         fun hole_flag_accepted_pos/0}
+     , {"HOLE rejected under PoW",         fun hole_flag_rejected_pow/0}
+     , {"EOE rejected under PoW",          fun eoe_flag_rejected_pow/0}
+     , {"client HOLE/EOE accepted on PoS", fun client_hc_flags_accepted_pos/0}
+     , {"client HOLE rejected on PoW",     fun client_hole_flag_rejected_pow/0}
+     ]}.
+
+set_consensus_type(Type) ->
+    meck:expect(aec_consensus, get_consensus_type, 0, Type).
+
+%% Only Hyperchains block production sets HOLE (via aec_block_hole_candidate),
+%% so there is no set_hole/2 to build one with - tamper the bit instead.
+key_header_binary_with_flag(Flag) ->
+    <<Version:32, Flags:?FLAG_BITS, Rest/bits>> =
+        ?TEST_MODULE:serialize_to_binary(raw_key_header()),
+    <<Version:32, (Flags bor Flag):?FLAG_BITS, Rest/bits>>.
+
+client_key_header_with_flags(Flags) ->
+    RawKey = raw_key_header(),
+    Serialized = ?TEST_MODULE:serialize_for_client(RawKey, key),
+    Serialized#{<<"nonce">> => ?TEST_MODULE:nonce(RawKey),
+                <<"pow">>   => ?TEST_MODULE:pow(RawKey),
+                <<"flags">> => aeser_api_encoder:encode(bytearray, <<Flags:?FLAG_BITS>>)
+               }.
+
+eoe_flag_roundtrip_pos() ->
+    set_consensus_type(pos),
     Header = ?TEST_MODULE:set_eoe(raw_key_header(), true),
     SerializedHeader = ?TEST_MODULE:serialize_to_binary(Header),
     DeserializedHeader = ?TEST_MODULE:deserialize_from_binary(SerializedHeader),
     ?assertEqual(Header, DeserializedHeader),
     ?assert(?TEST_MODULE:is_eoe(DeserializedHeader)),
     ?assertNot(?TEST_MODULE:is_hole(DeserializedHeader)).
+
+hole_flag_accepted_pos() ->
+    set_consensus_type(pos),
+    Header = ?TEST_MODULE:deserialize_from_binary(
+                key_header_binary_with_flag(?HOLE_FLAG)),
+    ?assert(?TEST_MODULE:is_hole(Header)),
+    ?assertNot(?TEST_MODULE:is_eoe(Header)).
+
+hole_flag_rejected_pow() ->
+    set_consensus_type(pow),
+    ?assertException(error, malformed_header,
+                     ?TEST_MODULE:deserialize_from_binary(
+                       key_header_binary_with_flag(?HOLE_FLAG))).
+
+eoe_flag_rejected_pow() ->
+    set_consensus_type(pow),
+    ?assertException(error, malformed_header,
+                     ?TEST_MODULE:deserialize_from_binary(
+                       key_header_binary_with_flag(?EOE_FLAG))).
+
+%% Also the control for client_hole_flag_rejected_pow/0: the same map must
+%% deserialize cleanly under pos, so the pow failure is attributable to the
+%% consensus gate rather than to a malformed fixture - deserialize_from_client
+%% catches every exception and reports the same invalid_header either way.
+client_hc_flags_accepted_pos() ->
+    set_consensus_type(pos),
+    WithHcFlags = client_key_header_with_flags(
+                    ?KEY_HEADER_FLAG bor ?HOLE_FLAG bor ?EOE_FLAG),
+    {ok, Header} = ?TEST_MODULE:deserialize_from_client(key, WithHcFlags),
+    ?assert(?TEST_MODULE:is_hole(Header)),
+    ?assert(?TEST_MODULE:is_eoe(Header)).
+
+client_hole_flag_rejected_pow() ->
+    set_consensus_type(pow),
+    WithHoleFlag = client_key_header_with_flags(?KEY_HEADER_FLAG bor ?HOLE_FLAG),
+    ?assertEqual({error, invalid_header},
+                 ?TEST_MODULE:deserialize_from_client(key, WithHoleFlag)).
 
 client_reserved_flag_bits_rejected_test() ->
     RawKey = raw_key_header(),


### PR DESCRIPTION
#4676 restored zero-enforcement on the reserved key-header flag bits but deliberately preserved the Hyperchains HOLE (bit 29) and EOE (bit 28) bits, ungated. On a PoW chain those two bits are still reserved: 7.2.2 rejects any key header with them set as malformed_header, while master accepts it. A miner who grinds valid PoW with either bit set therefore produces a block that master nodes accept and 7.2.2 nodes reject - an unguarded chain split on live Ceres. Nothing downstream closes the gap; validate_key_block_header/2 checks only protocol, seal and max time.

Gate acceptance on consensus type, matching how #4586 gated PoF/PogF: the bits are honoured under pos and rejected under pow, in both the wire binary deserializer and the client-JSON flags path. Gating on protocol version would be wrong - Hyperchains deployments run on Ceres as well as Arcus, so a
>= ARCUS gate would break them. ae_mainnet and ae_uat hardcode
aec_consensus_bitcoin_ng and cannot be configured into pos, so mainnet can never opt in.

The common case (both bits clear) short-circuits before the consensus lookup, which is a cached persistent_term read.

Converts the #4676 round-trip test into a meck fixture, since eunit runs under local_<protocol>_testnet, which resolves to pow for every protocol, so the unmocked test would now correctly expect rejection. Pins both directions: rejection under pow for each bit and for the client path, acceptance under pos for the binary path (HOLE has no setter, so the bit is tampered in) and for the client path. The client pos case is also the control for the client pow case - deserialize_from_client catches every exception and reports invalid_header regardless of cause, so without it the rejection test would pass vacuously on a malformed fixture.