### PR TITLE
Gate Hole/EOE header flags on consensus type, not protocol version

### DIFF
--- a/apps/aecore/src/aec_db.erl
+++ b/apps/aecore/src/aec_db.erl
@@ -408,6 +408,8 @@ encoding(aec_chain_state, _, _) -> {sext, {object, term}};
 encoding(_Tab, set, 2) -> {raw, {value, term}};
 encoding(_Tab, set, _) -> {raw, {object, term}}.
 
+%% Do not bump until check_table_vsn/4 is fixed: its mismatch branch badmatches, so a bump blocks
+%% the upgrade direction rather than the downgrade one.
 tab_vsn(_) -> 1.
 
 tab_type(_) -> set.

--- a/apps/aecore/src/aec_headers.erl
+++ b/apps/aecore/src/aec_headers.erl
@@ -683,7 +683,11 @@ deserialize_key_flags(KeyBlock) ->
             Decoded = decode(bytearray, Flags),
             %% Client-supplied flags must not set any unused/reserved bit.
             <<F:?FLAG_BITS>> = Decoded,
-            AllowedMask = ?KEY_HEADER_FLAG bor ?CONTAINS_INFO_FLAG bor ?HOLE_FLAG bor ?EOE_FLAG,
+            AllowedMask =
+                case hc_flags_permitted(maps:get(<<"version">>, KeyBlock)) of
+                    true  -> ?KEY_HEADER_FLAG bor ?CONTAINS_INFO_FLAG bor ?HOLE_FLAG bor ?EOE_FLAG;
+                    false -> ?KEY_HEADER_FLAG bor ?CONTAINS_INFO_FLAG
+                end,
             case F band (bnot AllowedMask) of
                 0 -> Decoded;
                 _ -> error(illegal_flags)
@@ -826,25 +830,42 @@ deserialize_key_from_binary(<<Version:32,
                               Time:64,
                               Info/binary
                             >>) ->
-    PowEvidence = deserialize_pow_evidence_from_binary(PowEvidenceBin),
-    H = #key_header{height = Height,
-                    prev_hash = PrevHash,
-                    prev_key = PrevKeyHash,
-                    root_hash = RootHash,
-                    miner = Miner,
-                    beneficiary = Beneficiary,
-                    target = Target,
-                    key_seal = PowEvidence,
-                    nonce = Nonce,
-                    time = Time,
-                    version = Version,
-                    info = Info,
-                    flags = <<?KEY_HEADER_TAG:1, ContainsInfoFlag:1, HoleFlag:1, EoeFlag:1, 0:28>>
-                   },
-    {ok, populate_extra(H)};
+    case hc_flags_permitted(Version, HoleFlag, EoeFlag) of
+        false ->
+            {error, malformed_header};
+        true ->
+            PowEvidence = deserialize_pow_evidence_from_binary(PowEvidenceBin),
+            H = #key_header{height = Height,
+                            prev_hash = PrevHash,
+                            prev_key = PrevKeyHash,
+                            root_hash = RootHash,
+                            miner = Miner,
+                            beneficiary = Beneficiary,
+                            target = Target,
+                            key_seal = PowEvidence,
+                            nonce = Nonce,
+                            time = Time,
+                            version = Version,
+                            info = Info,
+                            flags = <<?KEY_HEADER_TAG:1, ContainsInfoFlag:1,
+                                      HoleFlag:1, EoeFlag:1, 0:28>>
+                           },
+            {ok, populate_extra(H)}
+    end;
 deserialize_key_from_binary(_Other) ->
     {error, malformed_header}.
 
+%% Hole/EOE (bits 29/28) are Hyperchains flags: meaningless under PoW, and rejected outright by
+%% v7.2.x nodes, so accepting one forks this node onto a chain they can never follow.
+hc_flags_permitted(_Version, 0, 0) ->
+    true;
+hc_flags_permitted(Version, _HoleFlag, _EoeFlag) ->
+    hc_flags_permitted(Version).
+
+%% Gated on consensus type, not protocol version: Arcus is activated on no network, so Hyperchains
+%% legitimately emits these flags at Ceres. The version check is the forward path for Arcus.
+hc_flags_permitted(Version) ->
+    Version >= ?ARCUS_PROTOCOL_VSN orelse aec_consensus:get_consensus_type() =/= pow.
 
 %% The function does not check the validity of the protocol version based on
 %% height. It gets the protocol version from the block header. The protocol

--- a/apps/aecore/test/aec_headers_tests.erl
+++ b/apps/aecore/test/aec_headers_tests.erl
@@ -53,15 +53,54 @@ reserved_micro_flag_bits_rejected_test() ->
     ?assertException(error, malformed_header,
                       ?TEST_MODULE:deserialize_from_binary(Tampered)).
 
+raw_key_header_arcus() ->
+    ?TEST_MODULE:set_version_and_height(raw_key_header(), ?ARCUS_PROTOCOL_VSN, 1).
+
 hole_and_eoe_flags_roundtrip_test() ->
-    %% Hyperchains-defined flag bits must still round-trip through
-    %% (de)serialization once the reserved bits are strictly enforced.
-    Header = ?TEST_MODULE:set_eoe(raw_key_header(), true),
+    %% Hyperchains-defined flag bits must still round-trip through (de)serialization once the
+    %% reserved bits are strictly enforced — but only from Arcus, the protocol that defines them.
+    Header = ?TEST_MODULE:set_eoe(raw_key_header_arcus(), true),
     SerializedHeader = ?TEST_MODULE:serialize_to_binary(Header),
     DeserializedHeader = ?TEST_MODULE:deserialize_from_binary(SerializedHeader),
     ?assertEqual(Header, DeserializedHeader),
     ?assert(?TEST_MODULE:is_eoe(DeserializedHeader)),
     ?assertNot(?TEST_MODULE:is_hole(DeserializedHeader)).
+
+hc_flags_rejected_on_pow_test_() ->
+    %% On a PoW chain, a header with Hole/EOE set must be refused: a v7.2.x node rejects it, so
+    %% accepting one would follow a chain such a node can never follow — a split for the price of
+    %% one block. eunit runs with pow consensus, so every pre-Arcus protocol must refuse them here.
+    %% (Hyperchains runs pos consensus and legitimately sets these at Ceres — covered by
+    %% aehttp_hyperchains_SUITE, not by a unit test.)
+    [{lists:flatten(io_lib:format("~s at protocol ~p", [Name, Vsn])),
+      fun() ->
+          Base = ?TEST_MODULE:set_version_and_height(raw_key_header(), Vsn, 1),
+          Header = Setter(Base),
+          %% serialize_to_binary/1 writes the bit; deserialization is what must refuse it.
+          Bin = ?TEST_MODULE:serialize_to_binary(Header),
+          ?assertException(error, malformed_header,
+                           ?TEST_MODULE:deserialize_from_binary(Bin))
+      end}
+     || Vsn <- [?ROMA_PROTOCOL_VSN, ?MINERVA_PROTOCOL_VSN, ?FORTUNA_PROTOCOL_VSN,
+                ?LIMA_PROTOCOL_VSN, ?IRIS_PROTOCOL_VSN, ?CERES_PROTOCOL_VSN],
+        {Name, Setter} <- [{"eoe", fun(H) -> ?TEST_MODULE:set_eoe(H, true) end}]].
+
+hc_flags_accepted_from_arcus_test() ->
+    Header = ?TEST_MODULE:set_eoe(raw_key_header_arcus(), true),
+    ?assertEqual(Header,
+                 ?TEST_MODULE:deserialize_from_binary(
+                    ?TEST_MODULE:serialize_to_binary(Header))).
+
+client_hc_flags_rejected_on_pow_test() ->
+    %% Same rule on the client-JSON path: Hole/EOE below Arcus must not be accepted.
+    RawKey = ?TEST_MODULE:set_version_and_height(raw_key_header(), ?CERES_PROTOCOL_VSN, 1),
+    Serialized = ?TEST_MODULE:serialize_for_client(RawKey, key),
+    HcFlags = <<1:1, 0:1, 0:1, 1:1, 0:28>>,          % key tag + EOE, no reserved bits
+    WithHcFlags = Serialized#{<<"nonce">> => ?TEST_MODULE:nonce(RawKey),
+                              <<"pow">>   => ?TEST_MODULE:pow(RawKey),
+                              <<"flags">> => aeser_api_encoder:encode(bytearray, HcFlags)},
+    ?assertEqual({error, invalid_header},
+                 ?TEST_MODULE:deserialize_from_client(key, WithHcFlags)).
 
 client_reserved_flag_bits_rejected_test() ->
     RawKey = raw_key_header(),


### PR DESCRIPTION
#4676 (merged) restored strict zero-enforcement on the reserved header bits and closed the micro-header path completely, but still accepts bits 29/28 (Hole/EOE) on every protocol. On a PoW chain those bits carry no meaning and a v7.2.x node rejects any header that sets them, so accepting one makes this node follow a chain such a node can never follow, at any depth, however much work accumulates -- a split for the price of one mined block.

Measured in a 3-node lab before the gate: an unmodified master node followed a Hole-flagged producer onto a separate chain while v7.2.2 stayed on its own, both still mining -- the fleet silently partitions rather than halting. Measured after: the node sides with v7.2.2 and orphans the flagged blocks.

The discriminator is the CONSENSUS TYPE, not the protocol version. Arcus is defined but activated on no network (commented out of every aec_hard_forks table), so latest_protocol_version() is Ceres and Hyperchains legitimately produces Hole/EOE blocks AT CERES. A 'protocol >= Arcus' gate alone would therefore have broken Hyperchains. The protocol check is kept as the forward path for when Arcus activates.

#4676's hole_and_eoe_flags_roundtrip_test asserted a successful round-trip of EOE on a pre-Arcus header -- which a PoW node must now refuse -- so it is re-pointed at an Arcus header, with refusal asserted across all six earlier protocols and on the client-JSON path.