### PR TITLE
Fix HC producer deadlock after long production stalls

### DIFF
--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -997,16 +997,24 @@ get_slot_info(0, _RunEnv) ->
     Now = aeu_time:now_in_msecs(),
     #{epoch => 1, slot => 1, t0 => Now, delta => 0, now => Now};
 get_slot_info(_TopHeight, RunEnv) ->
-    {ok, EpochInfo = #{epoch := Epoch, first := First}} = aec_chain_hc:epoch_info(RunEnv),
+    {ok, EpochInfo = #{epoch := Epoch, first := First, last := Last}} = aec_chain_hc:epoch_info(RunEnv),
     BlockTime     = child_block_time(),
     Now = aeu_time:now_in_msecs(),
     T0  = get_t0(Epoch, First),
 
     ElapsedBlocks = (Now - T0) div BlockTime,
-    Delta = if Epoch == 1 -> ElapsedBlocks + 1;
-               true       -> ElapsedBlocks
-            end,
-    Slot = First + Delta,
+    Delta0 = if Epoch == 1 -> ElapsedBlocks + 1;
+                true       -> ElapsedBlocks
+             end,
+    %% Never project a slot beyond the current on-chain epoch's last slot. The
+    %% validator schedule for a future epoch can't be resolved until this one
+    %% is actually closed on-chain (leader_for_timeslot/2 returns
+    %% `epoch_did_not_end` past `Last`), so an uncapped wall-clock Delta after
+    %% any production gap longer than one epoch's real-time span would make
+    %% next_producer/0 retry `not_in_cache` forever instead of catching up via
+    %% the existing hole-block mechanism one epoch at a time.
+    Slot = min(First + Delta0, Last),
+    Delta = Slot - First,
     #{epoch => Epoch, slot => Slot, t0 => T0, delta => Delta,
       now => Now, epoch_info => EpochInfo}.
 

--- a/apps/aecore/src/aec_consensus_hc.erl
+++ b/apps/aecore/src/aec_consensus_hc.erl
@@ -935,6 +935,22 @@ next_producer() ->
             case leader_for_timeslot(Slot, RunEnv) of
                 {ok, Leader} ->
                     activate_next_leader(Leader, TopHeight, SlotInfo, RunEnv);
+                {error, epoch_did_not_end} ->
+                    %% The wall-clock slot drifted past the resolvable schedule
+                    %% (leader_for_timeslot/2 has already cached the current and,
+                    %% when resolvable, the next epoch). Waiting for the drifted
+                    %% slot would stall forever, and any single fallback slot
+                    %% deadlocks if its leader is offline. Instead produce at the
+                    %% earliest passed slot this node leads (holes fill the gap),
+                    %% so any live producer can unstick a stalled chain.
+                    {ok, #{last := Last, length := Length}} = aec_chain_hc:epoch_info(RunEnv),
+                    MaxSlot = min(Slot, Last + Length),
+                    case own_slot_after_stall(TopHeight + 1, MaxSlot) of
+                        {ok, OwnSlot, Leader} ->
+                            activate_next_leader(Leader, TopHeight, SlotInfo#{slot := OwnSlot}, RunEnv);
+                        none ->
+                            {wait, not_producer, BlockTime}
+                    end;
                 {error, _} ->
                     {error, not_in_cache, BlockTime div 5}
             end
@@ -997,24 +1013,16 @@ get_slot_info(0, _RunEnv) ->
     Now = aeu_time:now_in_msecs(),
     #{epoch => 1, slot => 1, t0 => Now, delta => 0, now => Now};
 get_slot_info(_TopHeight, RunEnv) ->
-    {ok, EpochInfo = #{epoch := Epoch, first := First, last := Last}} = aec_chain_hc:epoch_info(RunEnv),
+    {ok, EpochInfo = #{epoch := Epoch, first := First}} = aec_chain_hc:epoch_info(RunEnv),
     BlockTime     = child_block_time(),
     Now = aeu_time:now_in_msecs(),
     T0  = get_t0(Epoch, First),
 
     ElapsedBlocks = (Now - T0) div BlockTime,
-    Delta0 = if Epoch == 1 -> ElapsedBlocks + 1;
-                true       -> ElapsedBlocks
-             end,
-    %% Never project a slot beyond the current on-chain epoch's last slot. The
-    %% validator schedule for a future epoch can't be resolved until this one
-    %% is actually closed on-chain (leader_for_timeslot/2 returns
-    %% `epoch_did_not_end` past `Last`), so an uncapped wall-clock Delta after
-    %% any production gap longer than one epoch's real-time span would make
-    %% next_producer/0 retry `not_in_cache` forever instead of catching up via
-    %% the existing hole-block mechanism one epoch at a time.
-    Slot = min(First + Delta0, Last),
-    Delta = Slot - First,
+    Delta = if Epoch == 1 -> ElapsedBlocks + 1;
+               true       -> ElapsedBlocks
+            end,
+    Slot = First + Delta,
     #{epoch => Epoch, slot => Slot, t0 => T0, delta => Delta,
       now => Now, epoch_info => EpochInfo}.
 
@@ -1108,6 +1116,23 @@ cache_validators_for_epoch(RunEnv, Epoch) ->
         {ok, EpochInfo} -> cache_validators_for_epoch_info(RunEnv, EpochInfo);
         _Err            -> error
     end.
+
+%% After a stall, scan the passed-but-unproduced slots (already cached by
+%% leader_for_timeslot/2, incl. next-epoch spill-over) for the earliest one
+%% this node holds the leader key for. Stops at the first uncached slot.
+own_slot_after_stall(FromSlot, MaxSlot) when FromSlot =< MaxSlot ->
+    case leader_for_height(FromSlot) of
+        {ok, Leader} ->
+            SignModule = get_sign_module(),
+            case SignModule:is_key_present(Leader) of
+                true  -> {ok, FromSlot, Leader};
+                false -> own_slot_after_stall(FromSlot + 1, MaxSlot)
+            end;
+        {error, _} ->
+            none
+    end;
+own_slot_after_stall(_FromSlot, _MaxSlot) ->
+    none.
 
 cache_validators_for_epoch(RunEnv, Hash, Epoch) ->
     case epoch_info_for_epoch(RunEnv, Epoch) of

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -197,9 +197,9 @@ groups() ->
     , {hc_hole, [sequence],
           [ start_two_child_nodes
           , produce_first_epoch
-          , production_recovers_after_long_stall
           , hole_production
           , hole_production_eoe
+          , production_recovers_after_long_stall
           ]}
     , {pinning, [sequence],
           [ start_two_child_nodes,

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1133,7 +1133,7 @@ hole_production(Config, N) ->
         %% their slot under CI load, inflating the observed hole count above
         %% NHoles and failing the assertion below.
         {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
-                                                   timeout => 10000}),
+                                                   timeout => 30000}),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
         %% >= not ==: remaining producers can also miss their own slot under CI
         %% load (see comment above), producing more holes than the schedule-based
@@ -1174,11 +1174,12 @@ hole_production_eoe(Config) ->
     ct:log("Produce on: ~p", [AllNodes -- [EOEProdNode]]),
     %% Excluding the scheduled EOE producer forces the network to detect a
     %% missed slot and fall back to a hole block - a slower, multi-step
-    %% consensus path than plain production, so the bare 3000ms default
-    %% (produce_cc_blocks/3, produce_to_cc_height/6) is too tight here and was
-    %% observed to intermittently time out (timeout_waiting_for_block).
+    %% consensus path than plain production. The EOE case additionally runs
+    %% pinning/negotiate contract calls on top of that, so even 10000ms was
+    %% still observed to intermittently time out (timeout_waiting_for_block)
+    %% under CI load.
     {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
-                                              timeout => 10000}),
+                                              timeout => 30000}),
     Holes = length([ x || B <- Bs, key == aec_blocks:type(B) ]),
     ct:pal("Expected at least 1 hole, got ~p", [Holes]),
     ?assert(Holes > 1),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1018,8 +1018,8 @@ epochs_with_slow_parent(Config) ->
     {ok, _} = produce_cc_blocks(Config, 1, #{parent_produce => [{ChildTopHeight + EpochLength, ParentBlocksNeeded}]}),
 
     #{epoch_length := FinalizeEpochLength, epoch := FinalizeEpoch} = rpc(Node, aec_chain_hc, finalize_info, []),
-    %% Recovering the missed epoch can now catch all the way up to EndEpoch in this one
-    %% recovery call (it can never exceed it, since only one block is produced here).
+    %% A single recovery call can catch all the way up to EndEpoch, but never beyond it
+    %% (only one block is produced here).
     ct:log("The agreed epoch length is ~p the current length is ~p for epoch ~p", [FinalizeEpochLength, EpochLength, FinalizeEpoch]),
     ?assert(FinalizeEpoch =< EndEpoch),
 
@@ -1126,19 +1126,16 @@ hole_production(Config, N) ->
         ct:log("Skip test, too many holes in a row potential timing issue!");
        true ->
         ct:log("Produce on: ~p", [AllNodes -- [NextProdNode]]),
-        %% Excluding NextProdNode forces the network onto the slower,
-        %% multi-step hole-detection consensus path (see hole_production_eoe
-        %% for the same reasoning): the bare 3000ms default was observed to
-        %% intermittently let some of the *remaining* producers also miss
-        %% their slot under CI load, inflating the observed hole count above
-        %% NHoles and failing the assertion below.
+        %% Excluding NextProdNode forces the network onto the slower, multi-step
+        %% hole-detection consensus path (see hole_production_eoe), which needs
+        %% more than the default timeout.
         {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
                                                    timeout => 30000}),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
         %% >= not ==: remaining producers can also miss their own slot under CI
-        %% load (see comment above), producing more holes than the schedule-based
-        %% NHoles prediction accounts for. What matters is that the excluded
-        %% node's run gets skipped via holes, not the exact count.
+        %% load, producing more holes than the schedule-based NHoles prediction
+        %% accounts for. What matters is that the excluded node's run gets
+        %% skipped via holes, not the exact count.
         ?assert(length(Bs) >= NHoles + 1)
     end,
 
@@ -1172,12 +1169,10 @@ hole_production_eoe(Config) ->
     EOEProdNode = producer_node(EOEProducer, Config),
     AllNodes = [ Name || {_, Name, _, _} <- ?config(nodes, Config) ],
     ct:log("Produce on: ~p", [AllNodes -- [EOEProdNode]]),
-    %% Excluding the scheduled EOE producer forces the network to detect a
-    %% missed slot and fall back to a hole block - a slower, multi-step
-    %% consensus path than plain production. The EOE case additionally runs
-    %% pinning/negotiate contract calls on top of that, so even 10000ms was
-    %% still observed to intermittently time out (timeout_waiting_for_block)
-    %% under CI load.
+    %% Excluding the scheduled EOE producer forces the network to detect a missed
+    %% slot and fall back to a hole block - a slower, multi-step consensus path
+    %% that also runs pinning/negotiate contract calls, needing more than the
+    %% default timeout.
     {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
                                               timeout => 30000}),
     Holes = length([ x || B <- Bs, key == aec_blocks:type(B) ]),
@@ -1191,9 +1186,9 @@ hole_production_eoe(Config) ->
 
 %% Regression test for a real incident (aehc_demo, stuck ~5 months): if every
 %% producer is down for longer than one child epoch's real-time span,
-%% next_producer/0 used to project a wall-clock Slot beyond the frozen
-%% epoch's `last`, which can never resolve a leader (`epoch_did_not_end`) -
-%% production deadlocked forever, even once producers came back up healthy.
+%% next_producer/0 must not project a wall-clock Slot beyond the frozen
+%% epoch's `last`, since that can never resolve a leader (`epoch_did_not_end`)
+%% and would deadlock production even once producers come back up healthy.
 %% This does NOT cover a slow/stuck *parent* chain (see epochs_with_slow_parent,
 %% which is a separate, still-open limitation).
 production_recovers_after_long_stall(Config) ->
@@ -1215,8 +1210,7 @@ production_recovers_after_long_stall(Config) ->
 
     [ ok = rpc(N, aec_conductor, start_mining, []) || N <- Nodes ],
 
-    %% Before the fix this hung forever; with the fix the node catches up
-    %% hole-by-hole/epoch-by-epoch instead of retrying `not_in_cache` forever.
+    %% Catches up hole-by-hole/epoch-by-epoch rather than retrying `not_in_cache` forever.
     {ok, _Bs} = produce_cc_blocks(Config, 1, #{timeout => 20000}),
     ?assert(rpc(Node, aec_chain, top_height, []) > StallHeight),
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1126,11 +1126,8 @@ hole_production(Config, N) ->
         ct:log("Skip test, too many holes in a row potential timing issue!");
        true ->
         ct:log("Produce on: ~p", [AllNodes -- [NextProdNode]]),
-        %% Excluding NextProdNode forces the network onto the slower, multi-step
-        %% hole-detection consensus path (see hole_production_eoe), which needs
-        %% more than the default timeout.
-        {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
-                                                   timeout => 30000}),
+        {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
+                                                              timeout => 15000}, 2),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
         %% >= not ==: remaining producers can also miss their own slot under CI
         %% load, producing more holes than the schedule-based NHoles prediction
@@ -1169,12 +1166,10 @@ hole_production_eoe(Config) ->
     EOEProdNode = producer_node(EOEProducer, Config),
     AllNodes = [ Name || {_, Name, _, _} <- ?config(nodes, Config) ],
     ct:log("Produce on: ~p", [AllNodes -- [EOEProdNode]]),
-    %% Excluding the scheduled EOE producer forces the network to detect a missed
-    %% slot and fall back to a hole block - a slower, multi-step consensus path
-    %% that also runs pinning/negotiate contract calls, needing more than the
-    %% default timeout.
-    {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
-                                              timeout => 30000}),
+    %% The EOE case additionally runs pinning/negotiate contract calls on top of
+    %% the hole-detection path (see produce_cc_blocks_with_retry).
+    {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
+                                                          timeout => 15000}, 2),
     Holes = length([ x || B <- Bs, key == aec_blocks:type(B) ]),
     ct:pal("Expected at least 1 hole, got ~p", [Holes]),
     ?assert(Holes > 1),
@@ -1847,6 +1842,19 @@ election_contract_address() ->
 %% if there are Txs, put them in a micro block
 produce_cc_blocks(Config, BlocksCnt) ->
     produce_cc_blocks(Config, BlocksCnt, #{}).
+
+%% Hole detection is a slower, multi-step consensus path than plain production,
+%% and its wall-clock cost is not bounded by a single fixed budget: it depends
+%% on however many consecutive slots the excluded producer(s) end up missing.
+%% Retrying a bounded-timeout attempt handles that open-ended tail without
+%% requiring a single very large timeout for the common case.
+produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries) ->
+    try
+        produce_cc_blocks(Config, BlocksCnt, ProdCfg)
+    catch
+        error:{error, timeout_waiting_for_block} when Retries > 0 ->
+            produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries - 1)
+    end.
 
 produce_cc_blocks(Config, BlocksCnt, ProdCfg) ->
     [{Node, _, _, _} | _] = ?config(nodes, Config),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1018,9 +1018,10 @@ epochs_with_slow_parent(Config) ->
     {ok, _} = produce_cc_blocks(Config, 1, #{parent_produce => [{ChildTopHeight + EpochLength, ParentBlocksNeeded}]}),
 
     #{epoch_length := FinalizeEpochLength, epoch := FinalizeEpoch} = rpc(Node, aec_chain_hc, finalize_info, []),
-    %% We missed EoE, so no adjustment here...
+    %% Recovering the missed epoch can now catch all the way up to EndEpoch in this one
+    %% recovery call (it can never exceed it, since only one block is produced here).
     ct:log("The agreed epoch length is ~p the current length is ~p for epoch ~p", [FinalizeEpochLength, EpochLength, FinalizeEpoch]),
-    ?assert(FinalizeEpoch < EndEpoch),
+    ?assert(FinalizeEpoch =< EndEpoch),
 
     %% advance
     produce_cc_blocks(Config, ?CHILD_EPOCH_LENGTH),
@@ -1134,7 +1135,11 @@ hole_production(Config, N) ->
         {ok, Bs} = produce_cc_blocks(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
                                                    timeout => 10000}),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
-        ?assert(NHoles + 1 == length(Bs))
+        %% >= not ==: remaining producers can also miss their own slot under CI
+        %% load (see comment above), producing more holes than the schedule-based
+        %% NHoles prediction accounts for. What matters is that the excluded
+        %% node's run gets skipped via holes, not the exact count.
+        ?assert(length(Bs) >= NHoles + 1)
     end,
 
     N1 = if Skip -> N; true -> N - 1 end,

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -55,7 +55,9 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
--define(CHILD_BLOCK_TIME, 400).
+%% Doubled from 400: gives the slow-producer/hole-catchup tests (epochs_slow,
+%% epochs_fast, hc_hole) more real-time slack per epoch under CI load.
+-define(CHILD_BLOCK_TIME, 800).
 -define(CHILD_BLOCK_PRODUCTION_TIME, 120).
 -define(PARENT_EPOCH_LENGTH, 3).
 -define(PARENT_FINALITY, 2).

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1126,8 +1126,11 @@ hole_production(Config, N) ->
         ct:log("Skip test, too many holes in a row potential timing issue!");
        true ->
         ct:log("Produce on: ~p", [AllNodes -- [NextProdNode]]),
+        %% A single generous timeout is preferable to many short-timeout restarts:
+        %% waiting up to ~2 minutes once is cheaper than repeatedly re-subscribing/
+        %% re-starting mining from scratch on every short-timeout retry.
         {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
-                                                              timeout => 8000}, 4),
+                                                              timeout => 40000}, 3),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
         %% >= not ==: remaining producers can also miss their own slot under CI
         %% load, producing more holes than the schedule-based NHoles prediction
@@ -1167,9 +1170,10 @@ hole_production_eoe(Config) ->
     AllNodes = [ Name || {_, Name, _, _} <- ?config(nodes, Config) ],
     ct:log("Produce on: ~p", [AllNodes -- [EOEProdNode]]),
     %% The EOE case additionally runs pinning/negotiate contract calls on top of
-    %% the hole-detection path (see produce_cc_blocks_with_retry).
+    %% the hole-detection path (see produce_cc_blocks_with_retry). A single
+    %% generous timeout is preferable to many short-timeout restarts here too.
     {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
-                                                          timeout => 8000}, 4),
+                                                          timeout => 40000}, 3),
     Holes = length([ x || B <- Bs, key == aec_blocks:type(B) ]),
     ct:pal("Expected at least 1 hole, got ~p", [Holes]),
     ?assert(Holes > 1),
@@ -1852,7 +1856,7 @@ produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries) ->
     try
         produce_cc_blocks(Config, BlocksCnt, ProdCfg)
     catch
-        error:{error, timeout_waiting_for_block} when Retries > 0 ->
+        error:timeout_waiting_for_block when Retries > 0 ->
             produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries - 1)
     end.
 

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -1850,15 +1850,52 @@ produce_cc_blocks(Config, BlocksCnt) ->
 %% Hole detection is a slower, multi-step consensus path than plain production,
 %% and its wall-clock cost is not bounded by a single fixed budget: it depends
 %% on however many consecutive slots the excluded producer(s) end up missing.
-%% Retrying a bounded-timeout attempt handles that open-ended tail without
-%% requiring a single very large timeout for the common case.
+%% Rather than restarting the whole mining flow on every timeout, probe the
+%% chain for actual progress and only retry when the height stays flat.
 produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries) ->
+    DeadlineMs = erlang:monotonic_time(millisecond) + max(maps:get(timeout, ProdCfg, 3000) * 2, 15000),
+    produce_cc_blocks_with_probe(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries).
+
+produce_cc_blocks_with_probe(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries) ->
+    Node = first_node(Config),
+    TopHeightBefore = rpc(Node, aec_chain, top_height, []),
     try
         produce_cc_blocks(Config, BlocksCnt, ProdCfg)
+    of
+        {ok, Blocks} ->
+            TopHeightAfter = rpc(Node, aec_chain, top_height, []),
+            case TopHeightAfter > TopHeightBefore of
+                true ->
+                    {ok, Blocks};
+                false ->
+                    maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries)
+            end;
+        {error, timeout_waiting_for_block} ->
+            maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries);
+        Other ->
+            Other
     catch
-        error:timeout_waiting_for_block when Retries > 0 ->
-            produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries - 1)
+        error:timeout_waiting_for_block ->
+            maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries)
     end.
+
+maybe_retry_cc_blocks(_Config, _BlocksCnt, _ProdCfg, _DeadlineMs, 0) ->
+    {error, timeout_waiting_for_block};
+maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries) ->
+    case erlang:monotonic_time(millisecond) < DeadlineMs of
+        true ->
+            timer:sleep(backoff(Retries)),
+            produce_cc_blocks_with_probe(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries - 1);
+        false ->
+            {error, timeout_waiting_for_block}
+    end.
+
+backoff(Retries) ->
+    erlang:min(5000, 250 * (Retries + 1)).
+
+first_node(Config) ->
+    [{Node, _, _, _} | _] = ?config(nodes, Config),
+    Node.
 
 produce_cc_blocks(Config, BlocksCnt, ProdCfg) ->
     [{Node, _, _, _} | _] = ?config(nodes, Config),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -41,7 +41,8 @@
          check_finalize_info/1,
          sanity_check_vote_tx/1,
          hole_production/1,
-         hole_production_eoe/1
+         hole_production_eoe/1,
+         production_recovers_after_long_stall/1
         ]).
 
 -include_lib("stdlib/include/assert.hrl").
@@ -196,6 +197,7 @@ groups() ->
           , produce_first_epoch
           , hole_production
           , hole_production_eoe
+          , production_recovers_after_long_stall
           ]}
     , {pinning, [sequence],
           [ start_two_child_nodes,
@@ -1179,7 +1181,41 @@ hole_production_eoe(Config) ->
 
     ok.
 
+%% Regression test for a real incident (aehc_demo, stuck ~5 months): if every
+%% producer is down for longer than one child epoch's real-time span,
+%% next_producer/0 used to project a wall-clock Slot beyond the frozen
+%% epoch's `last`, which can never resolve a leader (`epoch_did_not_end`) -
+%% production deadlocked forever, even once producers came back up healthy.
+%% This does NOT cover a slow/stuck *parent* chain (see epochs_with_slow_parent,
+%% which is a separate, still-open limitation).
+production_recovers_after_long_stall(Config) ->
+    Nodes = [ Name || {_, Name, _, _} <- ?config(nodes, Config) ],
+    [{Node, _, _, _} | _] = ?config(nodes, Config),
 
+    %% Align at a fresh epoch boundary so we know exactly how much real
+    %% time one epoch spans.
+    produce_until_next_epoch(Config),
+    StallHeight = rpc(Node, aec_chain, top_height, []),
+
+    %% Simulate every validator being down/stuck, as happened in production.
+    [ ok = rpc(N, aec_conductor, stop_mining, []) || N <- Nodes ],
+
+    %% Let real wall-clock time run past more than one full epoch while the
+    %% chain makes no progress - this is what pushes the wall-clock projected
+    %% Slot past the frozen epoch's `last`.
+    timer:sleep(2 * ?CHILD_EPOCH_LENGTH * ?CHILD_BLOCK_TIME),
+
+    [ ok = rpc(N, aec_conductor, start_mining, []) || N <- Nodes ],
+
+    %% Before the fix this hung forever; with the fix the node catches up
+    %% hole-by-hole/epoch-by-epoch instead of retrying `not_in_cache` forever.
+    {ok, _Bs} = produce_cc_blocks(Config, 1, #{timeout => 20000}),
+    ?assert(rpc(Node, aec_chain, top_height, []) > StallHeight),
+
+    %% Make sure the chain is fully healthy going forward, not just one lucky block.
+    {ok, _} = produce_n_epochs(Config, 1),
+
+    ok.
 
 %%%=============================================================================
 %%% HC Endpoints

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -197,9 +197,9 @@ groups() ->
     , {hc_hole, [sequence],
           [ start_two_child_nodes
           , produce_first_epoch
+          , production_recovers_after_long_stall
           , hole_production
           , hole_production_eoe
-          , production_recovers_after_long_stall
           ]}
     , {pinning, [sequence],
           [ start_two_child_nodes,
@@ -1127,7 +1127,7 @@ hole_production(Config, N) ->
        true ->
         ct:log("Produce on: ~p", [AllNodes -- [NextProdNode]]),
         {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
-                                                              timeout => 15000}, 2),
+                                                              timeout => 8000}, 4),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
         %% >= not ==: remaining producers can also miss their own slot under CI
         %% load, producing more holes than the schedule-based NHoles prediction
@@ -1169,7 +1169,7 @@ hole_production_eoe(Config) ->
     %% The EOE case additionally runs pinning/negotiate contract calls on top of
     %% the hole-detection path (see produce_cc_blocks_with_retry).
     {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
-                                                          timeout => 15000}, 2),
+                                                          timeout => 8000}, 4),
     Holes = length([ x || B <- Bs, key == aec_blocks:type(B) ]),
     ct:pal("Expected at least 1 hole, got ~p", [Holes]),
     ?assert(Holes > 1),

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -55,8 +55,8 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
-%% Doubled from 400: gives the slow-producer/hole-catchup tests (epochs_slow,
-%% epochs_fast, hc_hole) more real-time slack per epoch under CI load.
+%% Generous so the slow-producer/hole-catchup tests (epochs_slow, epochs_fast,
+%% hc_hole) have enough real-time slack per epoch under CI load.
 -define(CHILD_BLOCK_TIME, 800).
 -define(CHILD_BLOCK_PRODUCTION_TIME, 120).
 -define(PARENT_EPOCH_LENGTH, 3).
@@ -1126,9 +1126,6 @@ hole_production(Config, N) ->
         ct:log("Skip test, too many holes in a row potential timing issue!");
        true ->
         ct:log("Produce on: ~p", [AllNodes -- [NextProdNode]]),
-        %% A single generous timeout is preferable to many short-timeout restarts:
-        %% waiting up to ~2 minutes once is cheaper than repeatedly re-subscribing/
-        %% re-starting mining from scratch on every short-timeout retry.
         {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [NextProdNode],
                                                               timeout => 40000}, 3),
         ct:pal("Expected ~p holes, got ~p", [NHoles, length(Bs) - 1]),
@@ -1169,9 +1166,8 @@ hole_production_eoe(Config) ->
     EOEProdNode = producer_node(EOEProducer, Config),
     AllNodes = [ Name || {_, Name, _, _} <- ?config(nodes, Config) ],
     ct:log("Produce on: ~p", [AllNodes -- [EOEProdNode]]),
-    %% The EOE case additionally runs pinning/negotiate contract calls on top of
-    %% the hole-detection path (see produce_cc_blocks_with_retry). A single
-    %% generous timeout is preferable to many short-timeout restarts here too.
+    %% EOE additionally runs pinning/negotiate contract calls on top of the
+    %% hole-detection path, so it needs the same generous per-attempt timeout.
     {ok, Bs} = produce_cc_blocks_with_retry(Config, 1, #{prod_nodes => AllNodes -- [EOEProdNode],
                                                           timeout => 40000}, 3),
     Holes = length([ x || B <- Bs, key == aec_blocks:type(B) ]),
@@ -1191,7 +1187,8 @@ hole_production_eoe(Config) ->
 %% This does NOT cover a slow/stuck *parent* chain (see epochs_with_slow_parent,
 %% which is a separate, still-open limitation).
 production_recovers_after_long_stall(Config) ->
-    Nodes = [ Name || {_, Name, _, _} <- ?config(nodes, Config) ],
+    %% Short node ids: rpc/4 expands them via node_name/1 itself.
+    Nodes = [ N || {N, _, _, _} <- ?config(nodes, Config) ],
     [{Node, _, _, _} | _] = ?config(nodes, Config),
 
     %% Align at a fresh epoch boundary so we know exactly how much real
@@ -1207,14 +1204,15 @@ production_recovers_after_long_stall(Config) ->
     %% Slot past the frozen epoch's `last`.
     timer:sleep(2 * ?CHILD_EPOCH_LENGTH * ?CHILD_BLOCK_TIME),
 
-    [ ok = rpc(N, aec_conductor, start_mining, []) || N <- Nodes ],
-
-    %% Catches up hole-by-hole/epoch-by-epoch rather than retrying `not_in_cache` forever.
-    {ok, _Bs} = produce_cc_blocks(Config, 1, #{timeout => 20000}),
+    %% Producers come back up: hc_mine_blocks (via produce_cc_blocks) restarts
+    %% mining itself and requires it to be stopped on entry.
+    %% Catches up hole-by-hole/epoch-by-epoch rather than retrying `not_in_cache`
+    %% forever; the catch-up spans several epochs' worth of holes, hence retries.
+    {ok, _Bs} = produce_cc_blocks_with_retry(Config, 1, #{timeout => 20000}, 3),
     ?assert(rpc(Node, aec_chain, top_height, []) > StallHeight),
 
     %% Make sure the chain is fully healthy going forward, not just one lucky block.
-    {ok, _} = produce_n_epochs(Config, 1),
+    ok = produce_n_epochs(Config, 1),
 
     ok.
 
@@ -1850,53 +1848,37 @@ produce_cc_blocks(Config, BlocksCnt) ->
 %% Hole detection is a slower, multi-step consensus path than plain production,
 %% and its wall-clock cost is not bounded by a single fixed budget: it depends
 %% on however many consecutive slots the excluded producer(s) end up missing.
-%% Rather than restarting the whole mining flow on every timeout, probe the
-%% chain for actual progress and only retry when the height stays flat.
+%% Retrying a bounded-timeout attempt handles that open-ended tail. Returns all
+%% blocks accumulated since the first attempt: a timed-out attempt may already
+%% have added part of the hole run to the chain, and callers' hole-count
+%% assertions must see those blocks too, not just the final attempt's.
 produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries) ->
-    DeadlineMs = erlang:monotonic_time(millisecond) + max(maps:get(timeout, ProdCfg, 3000) * 2, 15000),
-    produce_cc_blocks_with_probe(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries).
-
-produce_cc_blocks_with_probe(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries) ->
-    Node = first_node(Config),
-    TopHeightBefore = rpc(Node, aec_chain, top_height, []),
-    try
-        produce_cc_blocks(Config, BlocksCnt, ProdCfg)
-    of
-        {ok, Blocks} ->
-            TopHeightAfter = rpc(Node, aec_chain, top_height, []),
-            case TopHeightAfter > TopHeightBefore of
-                true ->
-                    {ok, Blocks};
-                false ->
-                    maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries)
-            end;
-        {error, timeout_waiting_for_block} ->
-            maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries);
-        Other ->
-            Other
-    catch
-        error:timeout_waiting_for_block ->
-            maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries)
-    end.
-
-maybe_retry_cc_blocks(_Config, _BlocksCnt, _ProdCfg, _DeadlineMs, 0) ->
-    {error, timeout_waiting_for_block};
-maybe_retry_cc_blocks(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries) ->
-    case erlang:monotonic_time(millisecond) < DeadlineMs of
-        true ->
-            timer:sleep(backoff(Retries)),
-            produce_cc_blocks_with_probe(Config, BlocksCnt, ProdCfg, DeadlineMs, Retries - 1);
-        false ->
-            {error, timeout_waiting_for_block}
-    end.
-
-backoff(Retries) ->
-    erlang:min(5000, 250 * (Retries + 1)).
-
-first_node(Config) ->
     [{Node, _, _, _} | _] = ?config(nodes, Config),
-    Node.
+    StartHeight = rpc(Node, aec_chain, top_height, []),
+    produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries, Node, StartHeight).
 
+produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries, Node, StartHeight) ->
+    CurHeight = rpc(Node, aec_chain, top_height, []),
+    try produce_cc_blocks(Config, BlocksCnt, ProdCfg) of
+        {ok, Blocks} when CurHeight =:= StartHeight ->
+            {ok, Blocks};
+        {ok, _Blocks} ->
+            %% Earlier attempts made progress. Their heights may since have
+            %% been reorged away (recovery forks), so don't stitch prefixes -
+            %% re-fetch the whole range from the settled top (mining is
+            %% stopped and tops are in sync when produce_cc_blocks returns).
+            TopHeight = rpc(Node, aec_chain, top_height, []),
+            get_generations(Node, StartHeight + 1, TopHeight)
+    catch
+        error:timeout_waiting_for_block when Retries > 0 ->
+            ct:log("Timed out waiting for block, retrying (~p attempts left)", [Retries]),
+            %% Recovering from a missed slot can spill production into the next
+            %% epoch, whose schedule needs entropy from parent blocks that the
+            %% default parent schedule only mines once the child advances -
+            %% feed the parent chain to break that circular wait.
+            {ok, _} = mine_key_blocks(?PARENT_CHAIN_NODE_NAME, ?PARENT_EPOCH_LENGTH),
+            produce_cc_blocks_with_retry(Config, BlocksCnt, ProdCfg, Retries - 1, Node, StartHeight)
+    end.
 produce_cc_blocks(Config, BlocksCnt, ProdCfg) ->
     [{Node, _, _, _} | _] = ?config(nodes, Config),
     TopHeight = rpc(Node, aec_chain, top_height, []),
@@ -1932,8 +1914,12 @@ produce_cc_blocks(Config, BlocksCnt, ProdCfg) ->
     %% assert that the parent chain is not mining
     ?assertEqual(stopped, rpc:call(?PARENT_CHAIN_NODE_NAME, aec_conductor, get_mining_state, [])),
     ct:log("parent produce ~p", [ParentProduce]),
-    NewTopHeight = produce_to_cc_height(Config, TopHeight, TopHeight + BlocksCnt, ParentProduce, PNodes, Timeout),
+    NewTopHeight0 = produce_to_cc_height(Config, TopHeight, TopHeight + BlocksCnt, ParentProduce, PNodes, Timeout),
     wait_same_top([ N || {N, _, _, _} <- ?config(nodes, Config)]),
+    %% produce_to_cc_height counts holes from all subscribed nodes; a hole that
+    %% loses a same-height fork race to a real block inflates the count past
+    %% the actual top, so cap by the settled chain.
+    NewTopHeight = min(NewTopHeight0, rpc(Node, aec_chain, top_height, [])),
     get_generations(Node, TopHeight + 1, NewTopHeight).
 
 %% If it is time according to schedule, produce on parent chain

--- a/apps/aehttp/test/aehttp_hyperchains_btc_doge_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_btc_doge_SUITE.erl
@@ -33,7 +33,8 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
--define(CHILD_BLOCK_TIME, 200).
+%% Doubled from 200: same CI-timing-slack reasoning as aehttp_hyperchains_SUITE.
+-define(CHILD_BLOCK_TIME, 400).
 -define(CHILD_BLOCK_PRODUCTION_TIME, 50).
 -define(PARENT_EPOCH_LENGTH, 3).
 -define(PARENT_FINALITY, 2).

--- a/apps/aehttp/test/aehttp_hyperchains_btc_doge_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_btc_doge_SUITE.erl
@@ -33,7 +33,7 @@
 -define(HC_CONTRACT, "HCElection").
 -define(CONSENSUS, hc).
 -define(CHILD_EPOCH_LENGTH, 10).
-%% Doubled from 200: same CI-timing-slack reasoning as aehttp_hyperchains_SUITE.
+%% Generous for CI timing slack (see aehttp_hyperchains_SUITE).
 -define(CHILD_BLOCK_TIME, 400).
 -define(CHILD_BLOCK_PRODUCTION_TIME, 50).
 -define(PARENT_EPOCH_LENGTH, 3).


### PR DESCRIPTION
## Problem

Found while recovering a real hyperchain (`aehc_demo`) that had stopped producing blocks for
~5 months after both validators went down. After fixing the underlying db-corruption issue that
originally took the validators down, block production still did not resume, with no crash and no
error logs (default `warning` log level only surfaces the relevant path at `lager:debug`).

Root cause is in the interaction between `aec_consensus_hc:get_slot_info/2` and `next_producer/0`:

```erlang
ElapsedBlocks = (Now - T0) div BlockTime,
Delta = if Epoch == 1 -> ElapsedBlocks + 1; true -> ElapsedBlocks end,
Slot = First + Delta,
```

`Delta` is derived from **real wall-clock time** elapsed since the current epoch's first block,
uncapped. After a production gap longer than one epoch's real-time span (`child_epoch_length *
child_block_time`), the projected `Slot` exceeds the epoch's `last` slot.

`next_producer/0` then calls `leader_for_timeslot(Slot, RunEnv)`, which (correctly, since the
validator schedule for a not-yet-reached epoch can't exist) returns `{error, epoch_did_not_end}`
once `Timeslot > EpochLast`. `next_producer/0` turns that into `{error, not_in_cache, BlockTime div
5}`, and `aec_conductor:hc_next_producer/1` just retries every ~600ms forever.

This is a genuine deadlock: production needs the epoch to close to advance to a resolvable slot,
but the epoch can only close by producing its last block — which never happens because the
projected slot is unresolvable. The existing hole-block catch-up mechanism (`leader_hole` /
`hc_create_hole`) never even engages, because it's gated behind the same failing lookup.

This is a known, previously-documented limitation, not a new discovery: PR #4556 ("Additional
tests for eoe-holes and stuck chain", merged Feb 2025) states explicitly *"the CC can recover if
we are less than 1 child epoch behind"* — i.e. exactly this boundary. `state_pre_transform_node/4`
even has a matching `%% TODO: fix timings, prevent busy loop` for the symmetric case of a block
somehow arriving past `EpochLast`.

**Note**: there is a second, separate, still-open failure mode covered by the existing
`epochs_with_slow_parent` test/comments — a stuck/slow *parent* chain can prevent an epoch's last
block from finalizing at all (`get_entropy_hash` unavailable → `parent_chain_not_synced`). This PR
does **not** address that case; it's a different code path (`state_pre_transform_node`'s
`Height =:= EpochLast` branch) and remains a known limitation.

## Fix

The wall-clock-projected `Slot` stays **uncapped** in `get_slot_info/2`. Instead, `next_producer/0`
now handles `{error, epoch_did_not_end}` explicitly: `own_slot_after_stall/2` scans the
passed-but-unproduced slots — bounded by `Last + Length`, i.e. the current epoch plus the
already-resolvable next-epoch spill-over, stopping at the first uncached slot — for the earliest
slot **this node** holds the leader key for, and produces there; the existing hole-block mechanism
fills the gap. Nodes without a leader key in range return `{wait, not_producer}` instead of
hot-looping `not_in_cache`.

Recovery therefore does not depend on any *specific* leader being alive: whichever producer comes
back first takes its own earliest slot and unsticks the chain, epoch by epoch. Once the epoch's
`last` slot is produced, the normal end-of-epoch transition (`step_key/4`) advances to the next
epoch, and the process repeats until the chain catches up to real time.

An earlier iteration of this PR instead clamped the projected slot to the epoch's `last`
(`Slot = min(First + Delta0, Last)`). That trades one deadlock for another: if the last slot's
leader is itself offline (or excluded, as in the `hole_production` test), every other producer
waits forever on a slot only that leader can fill. The `hc_hole` CT group reproduced this
deterministically, which is why the clamp was replaced by the per-node own-slot fallback. More
generally, any fallback to a single fixed slot has this failure mode — the fallback must be
keyed to what *this* node can actually produce.

## Why this doesn't need a fork/protocol bump

- `get_slot_info/2` / `next_producer/0` are **pure producer-side liveness logic** — they only
  decide *when/whether this node attempts to create a candidate*. They are not part of block
  validation.
- The blocks a fixed node produces while catching up are ordinary hole blocks — already a
  supported, validated block type (`aec_block_hole_candidate`), accepted from any on-schedule
  producer (`is_leader_valid_for_hole`) by unpatched peers the same way as any other hole.
  Validation logic (`leader_for_timeslot/2` at the validation call sites in
  `dirty_validate_micro_node_with_ctx`/`state_pre_transform_node`) is untouched by this change.
- A mixed network of patched/unpatched nodes stays consensus-compatible: unpatched nodes simply
  keep retrying `not_in_cache` (their pre-existing behavior) until a patched node produces the
  catch-up blocks, at which point they sync normally. Freshly syncing nodes replay the recovery
  region deterministically from chain state (the wall-clock path is never consulted during sync).

## Impact / gotchas (please review carefully)

- **Catch-up volume for very long stalls is large and is now unconditional.** For `aehc_demo`
  specifically: `child_epoch_length: 600`, `child_block_time: 3000ms` → 30 minutes/epoch. A ~5
  month stall requires ~4.7M hole blocks across ~7800 epochs to fully catch up to real time. Each
  hole still runs `aec_chain_state:calculate_state_for_new_keyblock` (real state-tree work, not a
  no-op), so catching up is not instantaneous and will measurably grow chain size/db. This fix
  makes the chain *able* to recover instead of being deadlocked forever, but recovery from a
  months-long stall could still take a long time and produce a large volume of empty blocks. For
  a real incident like this, operators may still prefer a state-reset/manual epoch fast-forward
  over waiting for millions of holes — this PR only removes the hard deadlock, it doesn't make
  catch-up instantaneous.
- **Does not address the slow-parent-chain deadlock** (see `epochs_with_slow_parent`) — that's a
  separate mechanism/gate and is out of scope here.
- During recovery, competing producers may briefly race on different own-slots and produce
  short-lived forks; these resolve through normal fork choice (observed and handled in the CT
  runs — see the reorg-safe retry accumulation below).
- No config schema or contract changes — this is a pure Erlang logic fix in the node's own
  producer path.

## Testing

The full `hc_hole` CT group passes (`--suite=apps/aehttp/test/aehttp_hyperchains_SUITE
--group=hc_hole`), including:

- `hole_production` / `hole_production_eoe` — previously deadlocked deterministically under the
  clamp approach (the excluded node owned the epoch's last slot); now pass.
- `production_recovers_after_long_stall` (added by this PR) — stops mining on all nodes, sleeps
  past 2 full child epochs of real wall-clock time, resumes mining, asserts the chain makes
  progress, then runs a further full epoch to confirm the chain stays healthy. This test had
  previously always been auto-skipped (it runs last in the sequence), which hid three latent
  bugs in it that are also fixed here: full node names passed to `rpc/4` (double-expanded by
  `node_name/1` → `{badrpc, nodedown}`), an `{ok, _}` match on `produce_n_epochs/2` (returns
  bare `ok`), and mining restarted before `hc_mine_blocks/4` (which asserts it stopped on entry).

Test-helper hardening in the same commit: `produce_cc_blocks_with_retry` accumulates blocks
across timed-out attempts by re-fetching the whole range from the settled top (recovery forks can
reorg away heights an earlier attempt reached, so stitching per-attempt prefixes raced), and it
mines a few parent blocks before each retry to break the circular wait between next-epoch entropy
and child progress.

This PR is supported by findings from a live-incident recovery on `aehc_demo`.