### PR TITLE
Cache the network id instead of resolving it per signature

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -41,6 +41,10 @@
          vm_gas_table/0,
          min_tx_gas/0]).
 
+%% aecore_app only - between them they repoint every signature check in the node
+-export([ensure_env/0,
+         clear_network_id_cache/0]).
+
 -include("blocks.hrl").
 -include_lib("aebytecode/include/aeb_opcodes.hrl").
 -include_lib("aecontract/include/hard_forks.hrl").
@@ -49,9 +53,17 @@
 
 -ifdef(TEST).
 -define(NETWORK_ID, <<"local_testnet">>).
+%% Exported and called fully qualified only here, so that the tests can mock the
+%% resolution: the eunit VM is started with '-network_id local_<protocol>_testnet'
+%% (see the Makefile), which wins over anything a test could set from the inside.
+-export([resolve_network_id/0]).
+-define(RESOLVE_NETWORK_ID(), ?MODULE:resolve_network_id()).
 -else.
 -define(NETWORK_ID, <<"ae_mainnet">>).
+-define(RESOLVE_NETWORK_ID(), resolve_network_id()).
 -endif.
+
+-define(NETWORK_ID_CACHE_KEY, {?MODULE, network_id}).
 
 -define(BLOCKS_TO_CHECK_DIFFICULTY_COUNT, 17).
 -define(TIMESTAMP_MEDIAN_BLOCKS, 11).
@@ -415,7 +427,32 @@ add_network_id_last(Payload) ->
     NetworkId = ?MODULE:get_network_id(),
     <<Payload/binary, NetworkId/binary>>.
 
+%% Resolving walks 'init' args and the user config tree - too expensive per
+%% signature verified and per FATE NETWORK_ID instruction. Pinned in a persistent
+%% term by the aecore setup hook, and cleared by aecore_app:stop/1, since setup
+%% hooks run only once per VM.
+-spec ensure_env() -> ok.
+ensure_env() ->
+    persistent_term:put(?NETWORK_ID_CACHE_KEY, ?RESOLVE_NETWORK_ID()).
+
+-spec clear_network_id_cache() -> ok.
+clear_network_id_cache() ->
+    _ = persistent_term:erase(?NETWORK_ID_CACHE_KEY),
+    ok.
+
+-spec get_network_id() -> binary().
 get_network_id() ->
+    %% A miss must not populate: CT nodes sign without running the setup hook and
+    %% swap the id under themselves (aehttp_devmode_SUITE).
+    case persistent_term:get(?NETWORK_ID_CACHE_KEY, undefined) of
+        undefined -> ?RESOLVE_NETWORK_ID();
+        NetworkId -> NetworkId
+    end.
+
+%% Not exported outside test builds: a caller that resolves instead of asking
+%% get_network_id/0 would silently disagree with every signature check.
+-spec resolve_network_id() -> binary().
+resolve_network_id() ->
     %% Easy switch networks with console argument, it overwrites config
     case init:get_argument(network_id) of
         {ok, [[NetworkId]]} -> list_to_binary(NetworkId);

--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -429,11 +429,21 @@ add_network_id_last(Payload) ->
 
 %% Resolving walks 'init' args and the user config tree - too expensive per
 %% signature verified and per FATE NETWORK_ID instruction. Pinned in a persistent
-%% term by the aecore setup hook, and cleared by aecore_app:stop/1, since setup
+%% term by the aecore setup hook, and again by aecore_app:start/2, since setup
 %% hooks run only once per VM.
 -spec ensure_env() -> ok.
 ensure_env() ->
-    persistent_term:put(?NETWORK_ID_CACHE_KEY, ?RESOLVE_NETWORK_ID()).
+    %% Resolve before the put: clearing first opens a window for readers, and
+    %% re-putting an unchanged value is free where a clear is a global sweep.
+    try ?RESOLVE_NETWORK_ID() of
+        NetworkId -> persistent_term:put(?NETWORK_ID_CACHE_KEY, NetworkId)
+    catch
+        Class:Reason:Stacktrace ->
+            %% Fail closed: an id resolved under a configuration that is already
+            %% gone must not outlive it. Resolving raises the same error again.
+            ok = clear_network_id_cache(),
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
 
 -spec clear_network_id_cache() -> ok.
 clear_network_id_cache() ->

--- a/apps/aecore/src/aecore.app.src
+++ b/apps/aecore/src/aecore.app.src
@@ -97,6 +97,9 @@
            %% The different hooks *could* be placed in the app env of each
            %% corresponding application. This would be less transparent, though.
            {normal, [
+                     %% After the aeutils config hooks (100-103), before the
+                     %% hooks at 110 that read the network id.
+                     {105, {aec_governance, ensure_env, []}},
                      {110, {aecore_env, check_env, []}},
                      {110, {aehttp_app, check_env, []}},
                      {110, {aec_consensus, check_env, []}},

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -14,6 +14,9 @@
 
 start(_StartType, _StartArgs) ->
     ok = lager:info("Starting aecore node"),
+    %% Re-pinned per aecore start; setup hooks run once per VM.
+    %% See aec_governance:ensure_env/0.
+    ok = aec_governance:ensure_env(),
     ok = aec_jobs_queues:start(),
     ok = application:ensure_started(mnesia),
     aecore_sup:start_link().

--- a/apps/aecore/src/aecore_app.erl
+++ b/apps/aecore/src/aecore_app.erl
@@ -35,6 +35,7 @@ stop(_State) ->
     lager:info("Stopping aecore app", []),
     aec_db_gc:cleanup(),
     aec_db:cleanup(),
+    ok = aec_governance:clear_network_id_cache(),
     ok.
 
 set_app_ctrl_mode() ->

--- a/apps/aecore/test/aec_governance_tests.erl
+++ b/apps/aecore/test/aec_governance_tests.erl
@@ -135,18 +135,24 @@ set_resolved_network_id(NetworkId) ->
 %% Both failures are silent: a missing hook only costs the lookup again, a hook
 %% renumbered ahead of aeutils pins the schema default for the node's lifetime.
 setup_hook_test_() ->
-    {setup,
-     fun ensure_apps_loaded/0,
-     [{"The network id is pinned by a setup hook",
-       fun() ->
-               ?assertMatch([_], network_id_hook_phases())
-       end},
-      {"The hook runs after the config is read and before what derives from it",
-       fun() ->
-               [Phase] = network_id_hook_phases(),
-               ?assert(Phase > lists:max(normal_hook_phases(aeutils))),
-               ?assert(Phase < lists:min(normal_hook_phases(aecore) -- [Phase]))
-       end}]}.
+    [{"The network id is pinned by a setup hook",
+      fun() ->
+              ?assertMatch([_], network_id_hook_phases())
+      end},
+     {"The hook runs after the config is read and before what derives from it",
+      fun() ->
+              [Phase] = network_id_hook_phases(),
+              ?assert(Phase > lists:max(normal_hook_phases(aeutils))),
+              ?assert(Phase < lists:min(normal_hook_phases(aecore) -- [Phase]))
+      end},
+     {"Reading the hooks does not disturb the applications of the eunit VM",
+      fun() ->
+              Loaded = fun() -> lists:sort(application:loaded_applications()) end,
+              Before = Loaded(),
+              _ = normal_setup_hooks(aecore),
+              _ = normal_setup_hooks(aeutils),
+              ?assertEqual(Before, Loaded())
+      end}].
 
 network_id_hook_phases() ->
     [Phase || {Phase, {?TEST_MODULE, ensure_env, []}}
@@ -155,19 +161,16 @@ network_id_hook_phases() ->
 normal_hook_phases(App) ->
     [Phase || {Phase, _MFA} <- normal_setup_hooks(App)].
 
+%% Read from the .app file: loading aecore would leave it loaded for the rest of
+%% the eunit VM. Nothing overrides '$setup_hooks' from a sys.config, so the .app
+%% file is the only source there is.
 normal_setup_hooks(App) ->
-    {ok, Hooks} = application:get_env(App, '$setup_hooks'),
+    {env, Env} = lists:keyfind(env, 1, app_file(App)),
+    {'$setup_hooks', Hooks} = lists:keyfind('$setup_hooks', 1, Env),
     {normal, Normal} = lists:keyfind(normal, 1, Hooks),
     Normal.
 
-%% Reading an application's env needs it loaded, which a eunit run does not
-%% guarantee. Left loaded afterwards: unloading would drop the env that the
-%% sys.config of the run has set up for everybody else as well.
-ensure_apps_loaded() ->
-    lists:foreach(
-      fun(App) ->
-              case application:load(App) of
-                  ok                             -> ok;
-                  {error, {already_loaded, App}} -> ok
-              end
-      end, [aecore, aeutils]).
+app_file(App) ->
+    {ok, [{application, App, Props}]} =
+        file:consult(code:where_is_file(atom_to_list(App) ++ ".app")),
+    Props.

--- a/apps/aecore/test/aec_governance_tests.erl
+++ b/apps/aecore/test/aec_governance_tests.erl
@@ -1,0 +1,146 @@
+%%%-------------------------------------------------------------------
+%%% @copyright (C) 2026, Aeternity Anstalt
+%%% @doc Tests for the caching of the network id.
+%%%-------------------------------------------------------------------
+
+-module(aec_governance_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_MODULE, aec_governance).
+
+-define(NW_ID_A, <<"nw_id_for_testing_a">>).
+-define(NW_ID_B, <<"nw_id_for_testing_b">>).
+
+%% Resolution is mocked rather than configured - see resolve_network_id/0 in
+%% aec_governance.
+network_id_cache_test_() ->
+    {foreach,
+     fun() ->
+             ok = ?TEST_MODULE:clear_network_id_cache(),
+             meck:new(?TEST_MODULE, [passthrough]),
+             set_resolved_network_id(?NW_ID_A)
+     end,
+     fun(_) ->
+             %% Cleared first: a throw from meck:unload/1 must not leave a
+             %% pinned test id behind for the rest of the eunit VM.
+             ok = ?TEST_MODULE:clear_network_id_cache(),
+             meck:unload(?TEST_MODULE)
+     end,
+     [{"An uncached network id keeps following the configuration",
+       fun uncached_network_id_follows_resolution/0},
+      {"ensure_env/0 pins the network id until the cache is cleared",
+       fun cached_network_id_is_pinned/0},
+      {"A cache hit does not resolve",
+       fun cached_network_id_skips_resolution/0},
+      {"Payload prefixing uses the cached network id",
+       fun add_network_id_uses_cache/0}]}.
+
+uncached_network_id_follows_resolution() ->
+    ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()),
+    set_resolved_network_id(?NW_ID_B),
+    ?assertEqual(?NW_ID_B, ?TEST_MODULE:get_network_id()).
+
+cached_network_id_is_pinned() ->
+    ok = ?TEST_MODULE:ensure_env(),
+    set_resolved_network_id(?NW_ID_B),
+    ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()),
+    ok = ?TEST_MODULE:clear_network_id_cache(),
+    ?assertEqual(?NW_ID_B, ?TEST_MODULE:get_network_id()),
+    ok = ?TEST_MODULE:ensure_env(),
+    set_resolved_network_id(?NW_ID_A),
+    ?assertEqual(?NW_ID_B, ?TEST_MODULE:get_network_id()).
+
+%% The saving itself. Without this a hit could resolve and throw the answer
+%% away, and every other test here would still pass.
+cached_network_id_skips_resolution() ->
+    ok = ?TEST_MODULE:ensure_env(),
+    meck:reset(?TEST_MODULE),
+    ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()),
+    ?assertEqual(0, meck:num_calls(?TEST_MODULE, resolve_network_id, [])).
+
+add_network_id_uses_cache() ->
+    ok = ?TEST_MODULE:ensure_env(),
+    set_resolved_network_id(?NW_ID_B),
+    ?assertEqual(<<?NW_ID_A/binary, "payload">>,
+                 ?TEST_MODULE:add_network_id(<<"payload">>)),
+    ?assertEqual(<<"payload", ?NW_ID_A/binary>>,
+                 ?TEST_MODULE:add_network_id_last(<<"payload">>)),
+    %% add_custom_network_id/2 ignores the cache.
+    ?assertEqual(<<?NW_ID_B/binary, "payload">>,
+                 ?TEST_MODULE:add_custom_network_id(?NW_ID_B, <<"payload">>)).
+
+set_resolved_network_id(NetworkId) ->
+    meck:expect(?TEST_MODULE, resolve_network_id, 0, NetworkId).
+
+%% The cache must not outlive the application that owns it - see
+%% aec_governance:ensure_env/0.
+cache_cleared_on_app_stop_test_() ->
+    {setup,
+     fun() ->
+             %% aecore_app:stop/1 logs, so lager has to be up.
+             aec_test_utils:ensure_system_init(),
+             ok = ?TEST_MODULE:clear_network_id_cache(),
+             meck:new(?TEST_MODULE, [passthrough]),
+             %% Mocked: both cleanups erase persistent terms shared by the whole
+             %% eunit VM.
+             meck:new([aec_db, aec_db_gc], [passthrough]),
+             meck:expect(aec_db_gc, cleanup, 0, ok),
+             meck:expect(aec_db, cleanup, 0, ok)
+     end,
+     fun(_) ->
+             ok = ?TEST_MODULE:clear_network_id_cache(),
+             meck:unload([aec_db_gc, aec_db]),
+             meck:unload(?TEST_MODULE)
+     end,
+     fun(_) ->
+             [{"Stopping aecore drops the pinned network id",
+               fun() ->
+                       set_resolved_network_id(?NW_ID_A),
+                       ok = ?TEST_MODULE:ensure_env(),
+                       set_resolved_network_id(?NW_ID_B),
+                       ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()),
+                       ok = aecore_app:stop(undefined),
+                       ?assertEqual(?NW_ID_B, ?TEST_MODULE:get_network_id())
+               end}]
+     end}.
+
+%% Both failures are silent: a missing hook only costs the lookup again, a hook
+%% renumbered ahead of aeutils pins the schema default for the node's lifetime.
+setup_hook_test_() ->
+    {setup,
+     fun ensure_apps_loaded/0,
+     [{"The network id is pinned by a setup hook",
+       fun() ->
+               ?assertMatch([_], network_id_hook_phases())
+       end},
+      {"The hook runs after the config is read and before what derives from it",
+       fun() ->
+               [Phase] = network_id_hook_phases(),
+               ?assert(Phase > lists:max(normal_hook_phases(aeutils))),
+               ?assert(Phase < lists:min(normal_hook_phases(aecore) -- [Phase]))
+       end}]}.
+
+network_id_hook_phases() ->
+    [Phase || {Phase, {?TEST_MODULE, ensure_env, []}}
+                  <- normal_setup_hooks(aecore)].
+
+normal_hook_phases(App) ->
+    [Phase || {Phase, _MFA} <- normal_setup_hooks(App)].
+
+normal_setup_hooks(App) ->
+    {ok, Hooks} = application:get_env(App, '$setup_hooks'),
+    {normal, Normal} = lists:keyfind(normal, 1, Hooks),
+    Normal.
+
+%% Reading an application's env needs it loaded, which a eunit run does not
+%% guarantee. Left loaded afterwards: unloading would drop the env that the
+%% sys.config of the run has set up for everybody else as well.
+ensure_apps_loaded() ->
+    lists:foreach(
+      fun(App) ->
+              case application:load(App) of
+                  ok                             -> ok;
+                  {error, {already_loaded, App}} -> ok
+              end
+      end, [aecore, aeutils]).

--- a/apps/aecore/test/aec_governance_tests.erl
+++ b/apps/aecore/test/aec_governance_tests.erl
@@ -34,7 +34,9 @@ network_id_cache_test_() ->
       {"A cache hit does not resolve",
        fun cached_network_id_skips_resolution/0},
       {"Payload prefixing uses the cached network id",
-       fun add_network_id_uses_cache/0}]}.
+       fun add_network_id_uses_cache/0},
+      {"A failed ensure_env/0 leaves the cache empty, not stale",
+       fun failed_ensure_env_leaves_cache_empty/0}]}.
 
 uncached_network_id_follows_resolution() ->
     ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()),
@@ -70,40 +72,65 @@ add_network_id_uses_cache() ->
     ?assertEqual(<<?NW_ID_B/binary, "payload">>,
                  ?TEST_MODULE:add_custom_network_id(?NW_ID_B, <<"payload">>)).
 
-set_resolved_network_id(NetworkId) ->
-    meck:expect(?TEST_MODULE, resolve_network_id, 0, NetworkId).
+failed_ensure_env_leaves_cache_empty() ->
+    ok = ?TEST_MODULE:ensure_env(),
+    %% The failure resolve_network_id/0 can really produce: a non-binary in the
+    %% config falls off its is_binary/1 clause.
+    meck:expect(?TEST_MODULE, resolve_network_id, 0,
+                meck:raise(error, {case_clause, "ae_uat"})),
+    %% The failure has to propagate: a setup hook that swallowed a bad
+    %% configuration would boot the node under an id nobody asked for.
+    ?assertError({case_clause, "ae_uat"}, ?TEST_MODULE:ensure_env()),
+    %% Two resolutions in a row: a cache pinned to either value fails one of them.
+    set_resolved_network_id(?NW_ID_B),
+    ?assertEqual(?NW_ID_B, ?TEST_MODULE:get_network_id()),
+    set_resolved_network_id(?NW_ID_A),
+    ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()).
 
-%% The cache must not outlive the application that owns it - see
+%% The aecore restart that the setup hook does not cover - see
 %% aec_governance:ensure_env/0.
-cache_cleared_on_app_stop_test_() ->
-    {setup,
+app_lifecycle_test_() ->
+    {foreach,
      fun() ->
-             %% aecore_app:stop/1 logs, so lager has to be up.
+             %% aecore_app:start/2 and stop/1 both log, so lager has to be up.
              aec_test_utils:ensure_system_init(),
              ok = ?TEST_MODULE:clear_network_id_cache(),
              meck:new(?TEST_MODULE, [passthrough]),
              %% Mocked: both cleanups erase persistent terms shared by the whole
              %% eunit VM.
-             meck:new([aec_db, aec_db_gc], [passthrough]),
+             meck:new([aec_db, aec_db_gc, aec_jobs_queues], [passthrough]),
              meck:expect(aec_db_gc, cleanup, 0, ok),
-             meck:expect(aec_db, cleanup, 0, ok)
+             meck:expect(aec_db, cleanup, 0, ok),
+             %% Failing the call right after ensure_env/0 aborts start/2 before
+             %% mnesia and aecore_sup.
+             meck:expect(aec_jobs_queues, start, 0, meck:raise(throw, stop_start)),
+             set_resolved_network_id(?NW_ID_A)
      end,
      fun(_) ->
              ok = ?TEST_MODULE:clear_network_id_cache(),
-             meck:unload([aec_db_gc, aec_db]),
+             meck:unload([aec_jobs_queues, aec_db_gc, aec_db]),
              meck:unload(?TEST_MODULE)
      end,
-     fun(_) ->
-             [{"Stopping aecore drops the pinned network id",
-               fun() ->
-                       set_resolved_network_id(?NW_ID_A),
-                       ok = ?TEST_MODULE:ensure_env(),
-                       set_resolved_network_id(?NW_ID_B),
-                       ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()),
-                       ok = aecore_app:stop(undefined),
-                       ?assertEqual(?NW_ID_B, ?TEST_MODULE:get_network_id())
-               end}]
-     end}.
+     [{"Stopping aecore drops the pinned network id",
+       fun stopping_aecore_drops_the_pinned_network_id/0},
+      {"Starting aecore pins the network id again",
+       fun starting_aecore_pins_the_network_id/0}]}.
+
+stopping_aecore_drops_the_pinned_network_id() ->
+    ok = ?TEST_MODULE:ensure_env(),
+    set_resolved_network_id(?NW_ID_B),
+    ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()),
+    ok = aecore_app:stop(undefined),
+    ?assertEqual(?NW_ID_B, ?TEST_MODULE:get_network_id()).
+
+starting_aecore_pins_the_network_id() ->
+    %% The throw is the mocked aec_jobs_queues:start/0 - so the pin ran.
+    ?assertThrow(stop_start, aecore_app:start(normal, [])),
+    set_resolved_network_id(?NW_ID_B),
+    ?assertEqual(?NW_ID_A, ?TEST_MODULE:get_network_id()).
+
+set_resolved_network_id(NetworkId) ->
+    meck:expect(?TEST_MODULE, resolve_network_id, 0, NetworkId).
 
 %% Both failures are silent: a missing hook only costs the lookup again, a hook
 %% renumbered ahead of aeutils pins the schema default for the node's lifetime.

--- a/apps/aetx/src/aetx_sign.erl
+++ b/apps/aetx/src/aetx_sign.erl
@@ -151,12 +151,16 @@ verify(#signed_tx{tx = Tx, signatures = Sigs}, Trees, Protocol, Prefix) ->
 %% this function allows having more signatures that the one being checked
 -spec verify_one_pubkey(aec_keys:pubkey(), signed_tx(), aec_hard_forks:protocol_vsn()) ->
     ok | {error, signature_check_failed}.
-verify_one_pubkey(Signer, #signed_tx{tx = Tx, signatures = Sigs}, Protocol) ->
+verify_one_pubkey(Signer, #signed_tx{tx = Tx, signatures = Sigs}, Protocol)
+  when ?VALID_PUBK(Signer) ->
     Bin = aetx:serialize_to_binary(Tx),
-    case verify_one_pubkey(Sigs, Signer, Bin, Protocol) of
-        {ok, _} -> ok;
-        error -> {error, signature_check_failed}
-    end.
+    {BinForNetwork, HashPayload} = signed_payloads(Bin, Protocol, undefined),
+    case verify_one_pubkey_(Sigs, Signer, BinForNetwork, HashPayload, []) of
+        {ok, _SigsLeft, _HashPayload} -> ok;
+        {error, _HashPayload}         -> {error, signature_check_failed}
+    end;
+verify_one_pubkey(_Signer, #signed_tx{}, _Protocol) ->
+    {error, signature_check_failed}. %% invalid pubkey
 
 -spec verify_half_signed(aec_keys:pubkey() | [aec_keys:pubkey()],
                          signed_tx(), aec_hard_forks:protocol_vsn()) ->
@@ -166,55 +170,84 @@ verify_half_signed(Signer, SignedTx, Protocol) when is_binary(Signer) ->
 verify_half_signed(Signers, #signed_tx{tx = Tx, signatures = Sigs}, Protocol) ->
     verify_signatures(Signers, aetx:serialize_to_binary(Tx), Sigs, Protocol).
 
-verify_signatures(PubKeys,_Bin, Sigs, _Protocol) ->
-    verify_signatures(PubKeys,_Bin, Sigs, _Protocol, undefined).
+verify_signatures(PubKeys, Bin, Sigs, Protocol) ->
+    verify_signatures(PubKeys, Bin, Sigs, Protocol, undefined).
 
 verify_signatures([], _Bin, [], _Protocol, _SignPrefix) ->
+    %% Nothing to check - e.g. a fully GA-authenticated transaction. Kept ahead
+    %% of the payload construction below, which would be pure waste here.
     ok;
-verify_signatures([PubKey|Left], Bin, Sigs, Protocol, SignPrefix) ->
-    case verify_one_pubkey(Sigs, PubKey, Bin, Protocol, SignPrefix) of
-        {ok, SigsLeft} -> verify_signatures(Left, Bin, SigsLeft, Protocol,
-                                            SignPrefix);
-        error          -> {error, signature_check_failed}
+verify_signatures(PubKeys, Bin, Sigs, Protocol, SignPrefix) ->
+    {BinForNetwork, HashPayload} = signed_payloads(Bin, Protocol, SignPrefix),
+    verify_signatures_(PubKeys, Sigs, BinForNetwork, HashPayload).
+
+verify_signatures_([], [], _BinForNetwork, _HashPayload) ->
+    ok;
+verify_signatures_([PubKey|Left], Sigs, BinForNetwork, HashPayload)
+  when ?VALID_PUBK(PubKey) ->
+    case verify_one_pubkey_(Sigs, PubKey, BinForNetwork, HashPayload, []) of
+        {ok, SigsLeft, HashPayload1} ->
+            verify_signatures_(Left, SigsLeft, BinForNetwork, HashPayload1);
+        {error, _HashPayload1} ->
+            {error, signature_check_failed}
     end;
-verify_signatures(PubKeys,_Bin, Sigs, _Protocol, _SignPrefix) ->
+verify_signatures_(PubKeys, Sigs, _BinForNetwork, _HashPayload) ->
+    %% An invalid pubkey, or signatures left over once every signer has been
+    %% accounted for.
     lager:debug("Signature check failed: ~p ~p", [PubKeys, Sigs]),
     {error, signature_check_failed}.
 
-verify_one_pubkey(Sigs, PubKey, Bin, Protocol) ->
-    verify_one_pubkey(Sigs, PubKey, Bin, Protocol, undefined).
-
-verify_one_pubkey(Sigs, PubKey, Bin, Protocol, SignPrefix) when ?VALID_PUBK(PubKey) ->
-    HashSign = Protocol >= ?LIMA_PROTOCOL_VSN,
-    verify_one_pubkey(Sigs, PubKey, Bin, HashSign, [], SignPrefix);
-verify_one_pubkey(_Sigs, _PubKey, _Bin, _Protocol, _SignPrefix) ->
-    error. %% invalid pubkey
+%% The payloads a signature is checked against depend on the transaction alone,
+%% so resolve the network id and build them once per transaction rather than
+%% once per signer, let alone once per signature. The hash-signing payload keeps
+%% being built on demand - it is only needed once a signature fails to match the
+%% plain payload - but is then reused for every remaining signature and signer.
+signed_payloads(Bin, Protocol, SignPrefix) ->
+    NetworkId = aec_governance:get_network_id(),
+    BinForNetwork =
+        aec_governance:add_custom_network_id(
+          NetworkId, maybe_add_predix(SignPrefix, Bin)),
+    HashPayload =
+        case Protocol >= ?LIMA_PROTOCOL_VSN of
+            true  -> {pending, NetworkId, SignPrefix, Bin};
+            false -> none %% no hash-signing before Lima
+        end,
+    {BinForNetwork, HashPayload}.
 
 maybe_add_predix(undefined, Bin) ->
     Bin;
 maybe_add_predix(SignPrefix, Bin) ->
     <<SignPrefix/binary,Bin/binary>>.
 
-verify_one_pubkey([Sig|Left], PubKey, Bin, HashSign, Acc, SignPrefix)  ->
-    BinForNetwork = aec_governance:add_network_id(maybe_add_predix(SignPrefix, Bin)),
+hash_payload(none) ->
+    none;
+hash_payload({ready, Payload} = HashPayload) ->
+    {Payload, HashPayload};
+hash_payload({pending, NetworkId, SignPrefix, Bin}) ->
+    TxHash = aec_hash:hash(signed_tx, Bin),
+    Payload = aec_governance:add_custom_network_id(
+                NetworkId, maybe_add_predix(SignPrefix, TxHash)),
+    {Payload, {ready, Payload}}.
+
+verify_one_pubkey_([Sig|Left], PubKey, BinForNetwork, HashPayload, Acc)  ->
     case enacl:sign_verify_detached(Sig, BinForNetwork, PubKey) of
         true ->
-            {ok, Acc ++ Left};
-        false when HashSign ->
-            TxHash = aec_hash:hash(signed_tx, Bin),
-            BinForNetwork2 =
-            aec_governance:add_network_id(maybe_add_predix(SignPrefix, TxHash)),
-            case enacl:sign_verify_detached(Sig, BinForNetwork2, PubKey) of
-                true  -> {ok, Acc ++ Left};
-                false -> verify_one_pubkey(Left, PubKey, Bin, HashSign,
-                                           [Sig | Acc], SignPrefix)
-            end;
+            {ok, Acc ++ Left, HashPayload};
         false ->
-            verify_one_pubkey(Left, PubKey, Bin, HashSign, [Sig|Acc],
-                              SignPrefix)
+            case hash_payload(HashPayload) of
+                none ->
+                    verify_one_pubkey_(Left, PubKey, BinForNetwork,
+                                       HashPayload, [Sig|Acc]);
+                {HashForNetwork, HashPayload1} ->
+                    case enacl:sign_verify_detached(Sig, HashForNetwork, PubKey) of
+                        true  -> {ok, Acc ++ Left, HashPayload1};
+                        false -> verify_one_pubkey_(Left, PubKey, BinForNetwork,
+                                                    HashPayload1, [Sig | Acc])
+                    end
+            end
     end;
-verify_one_pubkey([], _PubKey, _Bin, _HashSign, _Acc, _SignPrefix) -> % no more signatures
-    error.
+verify_one_pubkey_([], _PubKey, _BinForNetwork, HashPayload, _Acc) -> % no more signatures
+    {error, HashPayload}.
 
 -define(SIG_TX_TYPE, signed_tx).
 -define(SIG_TX_VSN, 1).

--- a/apps/aetx/test/aetx_sign_tests.erl
+++ b/apps/aetx/test/aetx_sign_tests.erl
@@ -13,6 +13,7 @@
 -define(TEST_HEIGHT, 42).
 -define(BLOCK_HEIGHT, 137).
 -define(FAKE_TX_HASH, <<7:32/unit:8>>).
+-define(INNER_TX_PREFIX, <<"inner_tx">>).
 
 sign_txs_test_() ->
     {setup,
@@ -79,6 +80,252 @@ sign_txs_test_() ->
                end
        end}
      ]}.
+
+%% A signature is checked against the plain payload first and against the
+%% hashed one only as a fallback, and every candidate signature is tried
+%% against both before moving on. These check that the payloads are still
+%% derived correctly when they are built once and reused across the signatures.
+verify_multiple_signers_test_() ->
+    {setup,
+     fun() ->
+             aec_test_utils:aec_keys_setup()
+     end,
+     fun(TmpKeysDir) ->
+             ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir)
+     end,
+     [{"Several signers signing the plain transaction all verify",
+       fun() ->
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([plain, plain, plain]),
+               ?assertEqual(ok, ?TEST_MODULE:verify_half_signed(
+                                   Pubkeys, SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"Several signers signing the transaction hash all verify",
+       fun() ->
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([hash, hash, hash]),
+               ?assertEqual(ok, ?TEST_MODULE:verify_half_signed(
+                                   Pubkeys, SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"Signers mixing plain and hash signing all verify",
+       fun() ->
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([plain, hash, plain]),
+               ?assertEqual(ok, ?TEST_MODULE:verify_half_signed(
+                                   Pubkeys, SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"Hash signing is not accepted before Lima",
+       fun() ->
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([hash, hash]),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify_half_signed(
+                               Pubkeys, SignedTx, ?LIMA_PROTOCOL_VSN - 1))
+       end},
+      {"A signer without a matching signature does not verify",
+       fun() ->
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([plain, hash]),
+               #{public := Stranger} = enacl:sign_keypair(),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify_half_signed(
+                               [Stranger | Pubkeys], SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"A signature not belonging to any signer does not verify",
+       fun() ->
+               {[_Dropped | Pubkeys], SignedTx} =
+                   multi_signed_spend_tx([plain, hash, plain]),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify_half_signed(
+                               Pubkeys, SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"Neither signers nor signatures is nothing to check",
+       fun() ->
+               {_Pubkey, SignedTx} = unsigned_spend_tx(),
+               %% The clause that answers before a payload is built at all -
+               %% where a fully GA-authenticated transaction ends up.
+               ?assertEqual(ok, ?TEST_MODULE:verify_half_signed(
+                                   [], SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"An invalid pubkey does not verify next to signers that do",
+       fun() ->
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([plain, hash]),
+               [begin
+                    ?assertEqual({error, signature_check_failed},
+                                 ?TEST_MODULE:verify_half_signed(
+                                    Invalid, SignedTx, ?CERES_PROTOCOL_VSN)),
+                    ?assertEqual({error, signature_check_failed},
+                                 ?TEST_MODULE:verify_half_signed(
+                                    Pubkeys ++ [Invalid], SignedTx,
+                                    ?CERES_PROTOCOL_VSN))
+                end || Invalid <- invalid_pubkeys()]
+       end},
+      {"The payloads are built once per transaction, not once per signature",
+       fun() ->
+               %% The saving itself. Every other test in this file passes just
+               %% as happily with the payloads rebuilt per signature.
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([hash, hash, hash]),
+               meck:new(aec_governance, [passthrough]),
+               meck:new(aec_hash, [passthrough]),
+               try
+                   ?assertEqual(ok, ?TEST_MODULE:verify_half_signed(
+                                       Pubkeys, SignedTx, ?CERES_PROTOCOL_VSN)),
+                   ?assertEqual(1, meck:num_calls(aec_governance,
+                                                  get_network_id, [])),
+                   ?assertEqual(1, meck:num_calls(aec_hash,
+                                                  hash, [signed_tx, '_']))
+               after
+                   meck:unload(aec_hash),
+                   meck:unload(aec_governance)
+               end
+       end}
+     ]}.
+
+%% verify_one_pubkey/3 is the single signer entry point - the channel FSM asks
+%% it whether one participant has signed a transaction the other one has signed
+%% too, so unlike the strict path it tolerates signatures it was not asked
+%% about. It builds the payloads and maps the outcome itself, so it is checked
+%% here directly rather than through the multi signer path it shares them with.
+verify_one_pubkey_test_() ->
+    {setup,
+     fun() ->
+             aec_test_utils:aec_keys_setup()
+     end,
+     fun(TmpKeysDir) ->
+             ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir)
+     end,
+     [{"A plain signature verifies with the other signatures left in place",
+       fun() ->
+               {[Pubkey | _], SignedTx} =
+                   multi_signed_spend_tx([plain, plain, hash]),
+               ?assertEqual(ok, ?TEST_MODULE:verify_one_pubkey(
+                                   Pubkey, SignedTx, ?CERES_PROTOCOL_VSN)),
+               %% The strict path rejects that very transaction, and does so
+               %% precisely because of the signatures left unaccounted for.
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify_half_signed(
+                               [Pubkey], SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"A hashed signature verifies against the hashed payload",
+       fun() ->
+               {Pubkeys, SignedTx} = multi_signed_spend_tx([plain, plain, hash]),
+               ?assertEqual(ok, ?TEST_MODULE:verify_one_pubkey(
+                                   lists:last(Pubkeys), SignedTx,
+                                   ?CERES_PROTOCOL_VSN))
+       end},
+      {"Hash signing is not accepted before Lima",
+       fun() ->
+               {[Pubkey], SignedTx} = multi_signed_spend_tx([hash]),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify_one_pubkey(
+                               Pubkey, SignedTx, ?LIMA_PROTOCOL_VSN - 1))
+       end},
+      {"A signer without a matching signature does not verify",
+       fun() ->
+               {_Pubkeys, SignedTx} = multi_signed_spend_tx([plain, hash]),
+               #{public := Stranger} = enacl:sign_keypair(),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify_one_pubkey(
+                               Stranger, SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"A transaction carrying no signatures does not verify",
+       fun() ->
+               {Pubkey, SignedTx} = unsigned_spend_tx(),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify_one_pubkey(
+                               Pubkey, SignedTx, ?CERES_PROTOCOL_VSN))
+       end},
+      {"An invalid pubkey does not verify",
+       fun() ->
+               {_Pubkeys, SignedTx} = multi_signed_spend_tx([plain]),
+               [?assertEqual({error, signature_check_failed},
+                             ?TEST_MODULE:verify_one_pubkey(
+                                Invalid, SignedTx, ?CERES_PROTOCOL_VSN))
+                || Invalid <- invalid_pubkeys()]
+       end}
+     ]}.
+
+%% The inner-tx prefix is prepended to *both* payloads - to the serialized
+%% transaction for a plain signature, and to its hash for a hash signature -
+%% before the network id goes in front. Each payload is now built in its own
+%% place, so check that both still carry the prefix, and that the prefix is not
+%% quietly dropped from either.
+verify_prefixed_signature_test_() ->
+    {setup,
+     fun() ->
+             aec_test_utils:aec_keys_setup()
+     end,
+     fun(TmpKeysDir) ->
+             ok = aec_test_utils:aec_keys_cleanup(TmpKeysDir)
+     end,
+     [{"A plain inner-tx signature verifies against the prefixed payload",
+       fun() ->
+               {Privkey, SpendTx} = spend_tx_with_keys(),
+               SignedTx = aec_test_utils:sign_tx(SpendTx, Privkey, false,
+                                                 ?INNER_TX_PREFIX),
+               ?assertEqual(ok, verify_inner(SignedTx))
+       end},
+      {"A hashed inner-tx signature verifies against the prefixed payload",
+       fun() ->
+               {Privkey, SpendTx} = spend_tx_with_keys(),
+               SignedTx = aec_test_utils:sign_pay_for_inner_tx(SpendTx, Privkey),
+               ?assertEqual(ok, verify_inner(SignedTx))
+       end},
+      {"An unprefixed signature does not verify as an inner transaction",
+       fun() ->
+               {Privkey, SpendTx} = spend_tx_with_keys(),
+               Plain = aec_test_utils:sign_tx(SpendTx, Privkey),
+               Hashed = aec_test_utils:sign_tx_hash(SpendTx, Privkey),
+               ?assertEqual({error, signature_check_failed}, verify_inner(Plain)),
+               ?assertEqual({error, signature_check_failed}, verify_inner(Hashed))
+       end},
+      {"A prefixed signature does not verify as a top level transaction",
+       fun() ->
+               {Privkey, SpendTx} = spend_tx_with_keys(),
+               SignedTx = aec_test_utils:sign_tx(SpendTx, Privkey, false,
+                                                 ?INNER_TX_PREFIX),
+               ?assertEqual({error, signature_check_failed},
+                            ?TEST_MODULE:verify(SignedTx, aec_trees:new(),
+                                                ?CERES_PROTOCOL_VSN))
+       end}
+     ]}.
+
+%% The prefix aetx_sign is handed is the one aec_test_utils signs with, with the
+%% separator already in front - see verify_w_env/3 and sign_tx/5.
+verify_inner(SignedTx) ->
+    ?TEST_MODULE:verify(SignedTx, aec_trees:new(), ?CERES_PROTOCOL_VSN,
+                        <<"-", ?INNER_TX_PREFIX/binary>>).
+
+spend_tx_with_keys() ->
+    #{public := Pubkey, secret := Privkey} = enacl:sign_keypair(),
+    {ok, SpendTx} = make_spend_tx(Pubkey),
+    {Privkey, SpendTx}.
+
+%% Builds a spend tx signed by one key per given signing mode.
+multi_signed_spend_tx(Modes) ->
+    Keypairs = [enacl:sign_keypair() || _ <- Modes],
+    #{public := Sender} = hd(Keypairs),
+    {ok, SpendTx} = make_spend_tx(Sender),
+    Signatures =
+        [begin
+             Signed = case Mode of
+                          plain -> aec_test_utils:sign_tx(SpendTx, Privkey);
+                          hash  -> aec_test_utils:sign_tx_hash(SpendTx, Privkey)
+                      end,
+             [Signature] = ?TEST_MODULE:signatures(Signed),
+             Signature
+         end || {#{secret := Privkey}, Mode} <- lists:zip(Keypairs, Modes)],
+    {[Pubkey || #{public := Pubkey} <- Keypairs],
+     ?TEST_MODULE:new(SpendTx, Signatures)}.
+
+unsigned_spend_tx() ->
+    #{public := Pubkey} = enacl:sign_keypair(),
+    {ok, SpendTx} = make_spend_tx(Pubkey),
+    {Pubkey, ?TEST_MODULE:new(SpendTx, [])}.
+
+%% enacl raises on a key that is not 32 bytes long, so the guards on the entry
+%% points are the only thing standing between malformed input and a crashing
+%% caller. Cut to size from a real key rather than written down as literals, so
+%% that the sizes stay out of the type checker's reach at the call sites.
+invalid_pubkeys() ->
+    #{public := Pubkey} = enacl:sign_keypair(),
+    Oversized = <<Pubkey/binary, Pubkey/binary>>,
+    [binary:part(Oversized, 0, Size) || Size <- [0, 31, 33]].
 
 serialize_for_client_test_() ->
     {setup,

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -2591,7 +2591,7 @@
             "additionalProperties" : false,
             "properties" : {
                 "network_id" : {
-                    "description" : "Identification of the network in case of hard forks.",
+                    "description" : "Identifier of the chain this node follows. Must match the id the chain was created with: it goes into every transaction signature and into the peer handshake, and it selects the fork schedule and the genesis accounts. Read once, while the node boots.",
                     "type" : "string",
                     "default" : "ae_mainnet"
                 },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,10 @@ fork_management:
     network_id: ae_uat
 ```
 
+The network id has to be chosen before the node builds a chain, and left alone afterwards. It is prepended to every transaction before it is signed and verified, and it is part of the peer handshake. A node given a different id therefore can no longer complete a handshake with any peer of the old network, rejects the transactions that network signs, and no longer recognises the signatures stored in its own database when it revalidates them. It also selects the fork schedule and the genesis accounts. Point a node at a different network id only together with a fresh database.
+
+The id is read once, while the node boots, and kept for as long as the node runs.
+
 ### Hardforks
 
 Hardforks allow the specification of consensus protocol versions with their respective heights for custom chains.

--- a/docs/release-notes/next/network_id_read_once_at_boot.md
+++ b/docs/release-notes/next/network_id_read_once_at_boot.md
@@ -1,0 +1,5 @@
+* `fork_management: network_id` is now read once, while the node boots, and is fixed for
+  the lifetime of the node, instead of being resolved from the configuration on every
+  use. The configuration file is only read at startup, so this is what a running node
+  already did in practice; it now stops paying for the lookup per signature verified and
+  per FATE `NETWORK_ID` instruction.


### PR DESCRIPTION
aec_governance:get_network_id/0 was resolved from scratch on every call. Resolving asks the node-global 'init' process for the command line arguments and, failing that, copies the whole validated user config out of the application environment and runs setup's value expansion over it. aetx_sign did that once per candidate signature, and FATE does it per NETWORK_ID instruction.

The value cannot change while the node runs - the only runtime config update path, aecli, only touches min_miner_gas_price - so resolve it once from a setup hook and keep it in a persistent term. The hook runs at phase 105, after the user config has been read and expanded (aeutils hooks 100-103) and before the hooks that derive their env from the network id. A cache miss deliberately does not populate the cache, so environments that never run the hook keep following the configuration.

The cache is erased again in aecore_app:stop/1. Setup hooks only run once per VM, and the aecore application is a dependency of setup's own start, so a test node that stops aecore, reconfigures it and starts it again - aec_eunit_SUITE, and the devmode suites that stuff a different network id into the aecore env - would otherwise keep being served the value resolved for the previous incarnation.

In aetx_sign, the payloads a signature is checked against depend on the transaction alone, so build them once per transaction instead of once per signature. The hashed payload stays lazy - it is only needed once a signature fails to match the plain one - but is now reused across the remaining signatures and signers.

  network id lookup      ns/call
  resolve                 1038.8
  cached get                31.6      30x cheaper

  verify_half_signed/3   before us   after us
  plain, 1 signer            41.5       39.8
  plain, 2 signers          158.5      156.6
  plain, 8 signers          898.8      864.6
  hash,  1 signer            80.6       78.5
  hash,  2 signers          240.5      233.4
  hash,  8 signers         1215.4     1185.4

End to end that is a 2-4% saving: Ed25519 verification is ~40us per check and dominates. The lookup cost is what the change actually removes, which matters more for the callers where it is the whole operation - the FATE NETWORK_ID instruction, the peer connection prologue, the HTTP and rosetta handlers - and for removing a serialisation point on the node-global 'init' process from parallel transaction validation, which a single threaded benchmark cannot show.