### PR TITLE
Stop re-reading mempool config on push replay

### DIFF
--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -212,7 +212,11 @@ push_(Tx, TxHash, Event, Timeout, Forced) ->
     Push =
         fun() ->
             incr([push]),
-            Res = gen_server:call(?SERVER, {push, Tx, TxHash, Event}, Timeout),
+            %% Read the configured TTL here rather than in the pool process,
+            %% which serialises every push - each read walks the whole user
+            %% config map.
+            Res = gen_server:call(?SERVER, {push, Tx, TxHash, Event, tx_ttl()},
+                                  Timeout),
             instant_tx_confirm_hook(TxHash),
             Res
         end,
@@ -227,10 +231,7 @@ push_(Tx, TxHash, Event, Timeout, Forced) ->
                     incr([push, error]),
                     E;
                 ok ->
-                    incr([push]),
-                    Res = gen_server:call(?SERVER, {push, Tx, TxHash, Event}, Timeout),
-                    instant_tx_confirm_hook(TxHash),
-                    Res
+                    Push()
             end
     end.
 
@@ -389,8 +390,10 @@ init([]) ->
     origins_cache_open(origins_cache()),
     GCHeight = top_height(),
     Handled  = ets:new(init_tx_pool, [private]),
+    %% Read once for the whole restore rather than once per transaction.
+    Info     = {#dbs{}, origins_cache(), GCHeight, tx_ttl()},
     InitF  = fun(TxHash, _) ->
-                     update_pool_on_tx_hash(TxHash, {#dbs{}, origins_cache(), GCHeight}, Handled),
+                     update_pool_on_tx_hash(TxHash, Info, Handled),
                      ok
              end,
     ok = aec_db:ensure_transaction(fun() -> aec_db:fold_mempool(InitF, ok) end),
@@ -405,8 +408,8 @@ handle_call(Req, From, St) ->
 
 handle_call_({get_max_nonce, Sender}, _From, #state{dbs = #dbs{nonce_db = NDb}} = State) ->
     {reply, int_get_max_nonce(NDb, Sender), State};
-handle_call_({push, Tx, Hash, Event}, _From, State) ->
-    {Res, State1} = do_pool_db_put(pool_db_key(Tx, Hash), Tx, Hash, Event, State),
+handle_call_({push, Tx, Hash, Event, ConfigTTL}, _From, State) ->
+    {Res, State1} = do_pool_db_put(pool_db_key(Tx, Hash), Tx, Hash, Event, ConfigTTL, State),
     {reply, Res, State1};
 handle_call_({top_change, Info}, _From, State) ->
     {_, State1} = do_top_change(Info, State),
@@ -911,7 +914,9 @@ do_top_change(Ancestor, Type, OldHash, NewHash, State0) ->
     %% Add back transactions to the pool from discarded part of the chain
     %% Mind that we don't need to add those which are incoming in the fork
     {GCHeight, State} = get_gc_height(State0),
-    Info = {State#state.dbs, State#state.origins_cache, GCHeight},
+    %% Read once for the whole replay rather than once per transaction of
+    %% every block on either side of the fork.
+    Info = {State#state.dbs, State#state.origins_cache, GCHeight, tx_ttl()},
 
     Handled = ets:new(foo, [private, set]),
     aec_db:ensure_activity(async_dirty, fun() ->
@@ -940,7 +945,8 @@ safe_get_tx_hashes(Hash) ->
         {value, Hashes} -> Hashes
     end.
 
-update_pool_on_tx_hash(TxHash, {#dbs{gc_db = GCDb} = Dbs, OriginsCache, GCHeight}, Handled) ->
+update_pool_on_tx_hash(TxHash, {#dbs{gc_db = GCDb} = Dbs, OriginsCache, GCHeight, ConfigTTL},
+                       Handled) ->
     case ets:member(Handled, TxHash) of
         true -> ok;
         false ->
@@ -955,7 +961,7 @@ update_pool_on_tx_hash(TxHash, {#dbs{gc_db = GCDb} = Dbs, OriginsCache, GCHeight
                     add_to_origins_cache(OriginsCache, Tx);
                 true ->
                     Key = pool_db_key(Tx, TxHash),
-                    pool_db_raw_put(Dbs, GCHeight, Key, Tx, TxHash)
+                    pool_db_raw_put(Dbs, GCHeight, ConfigTTL, Key, Tx, TxHash)
             end
     end.
 
@@ -971,20 +977,13 @@ check_pool_db_put(Tx, TxHash, Event) ->
     aec_db:ensure_dirty(fun() -> check_pool_db_put_(Tx, TxHash, Event) end).
 
 check_pool_db_put_(Tx, TxHash, Event) ->
-    AllowReentryOfDeletedTx = allow_reentry(),
     case aec_chain:find_tx_location(TxHash) of
         BlockHash when is_binary(BlockHash) ->
             lager:debug("Already have tx: ~p in ~p", [TxHash, BlockHash]),
             {error, already_accepted};
         mempool ->  ignore;
-        none when AllowReentryOfDeletedTx ->
-            lager:debug("Tx ~p has been deleted already, reintroduce it",
-                        [TxHash]),
-            ok;
-        none when not AllowReentryOfDeletedTx ->
-            lager:debug("Tx ~p has been deleted already, it is not allowed to reenter",
-                        [TxHash]),
-            ignore;
+        none ->
+            check_reentry(TxHash);
         Unknown when Unknown =:= not_found ->
             {Block, BlockHash, Trees} = get_onchain_env(),
             Checks = [ fun check_valid_at_protocol/6
@@ -1005,6 +1004,20 @@ check_pool_db_put_(Tx, TxHash, Event) ->
             end
     end.
 
+%% Read lazily: only a transaction that was already deleted can reenter, so
+%% the ordinary push path should not pay for this config read at all.
+check_reentry(TxHash) ->
+    case allow_reentry() of
+        true ->
+            lager:debug("Tx ~p has been deleted already, reintroduce it",
+                        [TxHash]),
+            ok;
+        false ->
+            lager:debug("Tx ~p has been deleted already, it is not allowed to reenter",
+                        [TxHash]),
+            ignore
+    end.
+
 get_onchain_env() ->
     case aec_chain:top_block_with_state() of
         {B, T} ->
@@ -1016,7 +1029,7 @@ get_onchain_env() ->
             {B, H, T}
     end.
 
-do_pool_db_put(Key, Tx, Hash, Event,
+do_pool_db_put(Key, Tx, Hash, Event, ConfigTTL,
                #state{ dbs = #dbs{db = Db} = Dbs } = St0) ->
     {GCHeight, St} = get_gc_height(St0),
     %% TODO: This check is never going to hit? Hash is part of the Key!?
@@ -1030,7 +1043,7 @@ do_pool_db_put(Key, Tx, Hash, Event,
         false ->
             aec_db:add_tx(Tx),
             aec_events:publish(Event, Tx),
-            pool_db_raw_put(Dbs, GCHeight, Key, Tx, Hash),
+            pool_db_raw_put(Dbs, GCHeight, ConfigTTL, Key, Tx, Hash),
             {ok, St}
     end.
 
@@ -1039,16 +1052,22 @@ pool_db_raw_delete(#dbs{db = Db, visited_db = VDb, nonce_db = NDb}, Key) ->
     ets:delete(VDb, Key),
     ets:delete(Db, Key).
 
+%% ConfigTTL is the configured mempool tx_ttl, i.e. how many blocks a tx may
+%% linger in the pool. Every caller reads it outside the pool process: a push
+%% reads it in the pushing process, and replaying a fork or restoring the
+%% persisted mempool at startup reads it once for the whole batch, since each
+%% read walks the whole user config map.
 pool_db_raw_put(#dbs{db = Db, nonce_db = NDb, gc_db = GCDb},
-                GCHeight0, Key, Tx, TxHash) ->
+                GCHeight0, ConfigTTL, Key, Tx, TxHash) ->
     ets:insert(Db, {Key, #tx{hash = TxHash, signed_tx = Tx}}), %% this resets any failed attempts
     insert_nonce(NDb, Key),
     GCHeight =
         case aetx:ttl(aetx_sign:tx(Tx)) of
-            0 -> %% default no ttl
-                GCHeight0 + tx_ttl();
+            max_ttl -> %% the tx declares no ttl of its own
+                GCHeight0 + ConfigTTL;
             TxTTL ->
-                min(GCHeight0 + tx_ttl(), TxTTL)
+                %% A tx may shorten its stay, but never extend it.
+                min(GCHeight0 + ConfigTTL, TxTTL)
         end,
     enter_tx_gc(GCDb, TxHash, Key, GCHeight).
 

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -565,7 +565,10 @@ int_get_candidate(MaxGas, IgnoreTxs, BlockHash, #dbs{db = Db} = DBs) ->
     lager:debug("size(Db) = ~p", [ets:info(Db, size)]),
     MinMinerGasPrice = aec_tx_pool:minimum_miner_gas_price(),
     MinTxGas = aec_governance:min_tx_gas(),
-    Acc0     = #{ ignore_txs => IgnoreTxs, tree => gb_trees:empty(), txs => [], bad_txs => [] },
+    %% Read once for the whole candidate selection rather than once per
+    %% transaction of the mempool - each read walks the whole user config map.
+    Acc0     = #{ ignore_txs => IgnoreTxs, tree => gb_trees:empty(), txs => [], bad_txs => []
+                , nonce_offset => nonce_offset(), invalid_tx_ttl => invalid_tx_ttl() },
     {ok, RemGas, Acc} = int_get_candidate(Db, MaxGas, MinTxGas, MinMinerGasPrice, Trees,
                                           Header, DBs, Acc0),
     {ok, _, Acc1} = int_get_candidate(
@@ -651,7 +654,8 @@ check_candidate(Db, #dbs{gc_db = GCDb} = _Dbs,
     TxTTL = aetx:ttl(Tx1),
     TxGas = aetx:gas_limit(Tx1, Height, Protocol),
     case Height < TxTTL andalso TxGas > 0
-         andalso ok =:= int_check_account(Tx, AccountsTree, check_candidate)
+         andalso ok =:= int_check_account(Tx, AccountsTree, check_candidate,
+                                          maps:get(nonce_offset, Acc))
          andalso MinMinerGasPrice =< aetx:min_gas_price(Tx1, Height, Protocol) of
         true ->
             case Gas - TxGas of
@@ -669,7 +673,7 @@ check_candidate(Db, #dbs{gc_db = GCDb} = _Dbs,
             end;
         false ->
             %% This is not valid anymore.
-            enter_tx_gc(GCDb, TxHash, Key, Height + invalid_tx_ttl()),
+            enter_tx_gc(GCDb, TxHash, Key, Height + maps:get(invalid_tx_ttl, Acc)),
             {Gas, Acc#{ bad_txs := [{Db, Key, Tx} | maps:get(bad_txs, Acc)] }}
     end.
 
@@ -1149,7 +1153,12 @@ check_account(Tx, _TxHash, _Block, BlockHash, _Trees, Event) ->
     int_check_account(Tx, {block_hash, BlockHash}, Event).
 
 int_check_account(Tx, Source, Event) ->
-    case int_check_account_nonce(Tx, Source, Event) of
+    int_check_account(Tx, Source, Event, undefined).
+
+%% NonceOffset0 is the configured mempool nonce_offset, or 'undefined' to read
+%% it here. Callers that run this once per transaction pass it in instead.
+int_check_account(Tx, Source, Event, NonceOffset0) ->
+    case int_check_account_nonce(Tx, Source, Event, NonceOffset0) of
         ok ->
             int_check_meta_gas(Tx);
         {error, _} = Err -> Err
@@ -1178,7 +1187,7 @@ int_check_meta_gas(SignedTx, MaxAuthFunGas0) ->
         _ -> ok
     end.
 
-int_check_account_nonce(Tx, Source, Event) ->
+int_check_account_nonce(Tx, Source, Event, NonceOffset0) ->
     CheckNonce = nonce_check_by_event(Event),
     %% Check is conservative and only rejects certain cases
     Unsigned = aetx_sign:innermost_tx(Tx),
@@ -1191,7 +1200,10 @@ int_check_account_nonce(Tx, Source, Event) ->
                 {error, no_state_trees} -> nonce_baseline_check(TxNonce, CheckNonce);
                 none -> nonce_baseline_check(TxNonce, CheckNonce);
                 {value, Account} ->
-                    Offset   = nonce_offset(),
+                    Offset   = case NonceOffset0 of
+                                   undefined -> nonce_offset();
+                                   _         -> NonceOffset0
+                               end,
                     AccNonce = aec_accounts:nonce(Account),
                     AccType  = aec_accounts:type(Account),
                     if

--- a/apps/aecore/test/aec_tx_pool_tests.erl
+++ b/apps/aecore/test/aec_tx_pool_tests.erl
@@ -383,7 +383,10 @@ tx_pool_test_() ->
                {ok, CHashFork1} = aec_blocks:hash_internal_representation(KeyBlock2),
 
                meck:expect(aeu_time, now_in_msecs, fun() -> meck:passthrough([]) + 6000 end),
-               STx4 = a_signed_tx(PubKey2, new_pubkey(), 2, 40000),
+               %% A TTL of its own, so that the replay below has to combine it
+               %% with the TTL read once for the whole replay.
+               STx4TTL = 3,
+               STx4 = a_signed_tx(PubKey2, new_pubkey(), 2, 40000, STx4TTL),
                ?assertEqual(ok, aec_tx_pool:push(STx4)),
                {ok, USCandidate4, _} = aec_block_micro_candidate:create(aec_chain:top_block()),
                {ok, Candidate4} = aec_keys:sign_micro_block(USCandidate4),
@@ -418,6 +421,12 @@ tx_pool_test_() ->
 
                %% The not included transaction should now be back in the pool
                ?assertEqual({ok, [STx4]}, aec_tx_pool:peek(infinity)),
+
+               %% ... and the TTL read once for the whole replay must have been
+               %% combined with the tx's own TTL when it was re-added.
+               {GCHeight, Dbs} = aec_tx_pool:gc_height_and_dbs(),
+               ?assertEqual({ok, min(GCHeight + aec_tx_pool:tx_ttl(), STx4TTL)},
+                            gc_ttl_of(STx4, Dbs)),
 
                meck:unload(aec_headers),
                ok
@@ -690,6 +699,59 @@ tx_pool_test_() ->
 
                ok
        end},
+      {"GC height combines the configured tx_ttl with the tx's own TTL",
+       fun() ->
+               aec_test_utils:stop_chain_db(),
+               PK = new_pubkey(),
+               meck:expect(aec_fork_block_settings, genesis_accounts, 0,
+                           [{PK, 100000000}]),
+               aec_consensus:set_genesis_hash(),
+               {GenesisBlock, _} = aec_block_genesis:genesis_block_with_state(),
+               aec_test_utils:start_chain_db(),
+               {ok,_} = aec_chain_state:insert_block(GenesisBlock),
+
+               %% Bring the chain to height 1 and restart the pool, so that its
+               %% GC height is a known, non-zero value. At GC height 0 the two
+               %% operands of the min/2 in pool_db_raw_put/6 commute, which
+               %% would hide a swap of the configured TTL and the tx's own TTL.
+               {ok, KeyBlock1} =
+                   aec_block_key_candidate:create(aec_chain:top_block(), PK, PK),
+               {ok,_} = aec_chain_state:insert_block(KeyBlock1),
+               ok = aec_tx_pool:stop(),
+               {ok, Pid} = aec_tx_pool:start_link(),
+               unlink(Pid), %% Leave it for the cleanup
+               {GCHeight, Dbs} = aec_tx_pool:gc_height_and_dbs(),
+               ?assertEqual(1, GCHeight),
+
+               Horizon = GCHeight + aec_tx_pool:tx_ttl(),
+
+               %% No TTL of its own: collected at the configured horizon.
+               STx1 = a_signed_tx(PK, me, 1, 20000, 0),
+               ?assertEqual(ok, aec_tx_pool:push(STx1)),
+               ?assertEqual({ok, Horizon}, gc_ttl_of(STx1, Dbs)),
+
+               %% A TTL below the horizon shortens the tx's stay ...
+               TTL2 = GCHeight + 1,
+               STx2 = a_signed_tx(PK, me, 2, 20000, TTL2),
+               ?assertEqual(ok, aec_tx_pool:push(STx2)),
+               ?assertEqual({ok, TTL2}, gc_ttl_of(STx2, Dbs)),
+
+               %% ... while a TTL beyond it must not extend it.
+               TTL3 = Horizon + 100,
+               STx3 = a_signed_tx(PK, me, 3, 20000, TTL3),
+               ?assertEqual(ok, aec_tx_pool:push(STx3)),
+               ?assertEqual({ok, Horizon}, gc_ttl_of(STx3, Dbs)),
+
+               %% Restoring the persisted mempool at startup reads the
+               %% configured TTL once for the whole restore - the heights it
+               %% computes must be the same ones.
+               ok = aec_tx_pool:stop(),
+               {ok, Pid2} = aec_tx_pool:start_link(),
+               unlink(Pid2), %% Leave it for the cleanup
+               ?assertEqual({ok, Horizon}, gc_ttl_of(STx1, Dbs)),
+               ?assertEqual({ok, TTL2},    gc_ttl_of(STx2, Dbs)),
+               ?assertEqual({ok, Horizon}, gc_ttl_of(STx3, Dbs))
+       end},
       {"Ensure persistence",
        fun() ->
                aec_test_utils:stop_chain_db(),
@@ -922,6 +984,10 @@ tx_pool_test_() ->
 
 tx_pool_gc(Height) ->
     aec_tx_pool_gc:sync_gc(Height).
+
+%% The height at which the GC will collect the tx, as recorded in the GC db.
+gc_ttl_of(STx, Dbs) ->
+    aec_tx_pool_gc:ttl(aetx_sign:hash(STx), Dbs).
 
 a_signed_tx(Sender, Recipient, Nonce, Fee) ->
     a_signed_tx(Sender, Recipient, Nonce, Fee,0).


### PR DESCRIPTION
Moves the mempool config reads (`tx_ttl`, `nonce_offset`, `invalid_tx_ttl`) out of the serialized `aec_tx_pool` gen_server loop. Each read walks the whole user config map, so doing it per-transaction inside the pool process serialized every push and made fork replay / startup restore / candidate selection pay the cost once per tx.

Now the value is read once per operation in the calling process (once per push, once for a whole fork replay, once for a whole mempool restore, once per candidate selection) and threaded through as an explicit parameter. No caching, no persisted state — each operation still reads fresh config at its start, so a runtime config change is picked up on the next operation exactly as before.

`allow_reentry` is also made lazy: only a tx that was already deleted can reenter, so the ordinary push path no longer pays for that config read at all.

## Also fixes a latent dead-code bug

`pool_db_raw_put`'s no-TTL branch matched integer `0`, but `aetx:ttl/1` returns the atom `max_ttl` (not `0`) for a tx with no TTL — so that clause never actually matched. The code produced correct results only by accident of Erlang term ordering (`min(Int, max_ttl)` always yields the integer). It now matches `max_ttl` explicitly; behavior is unchanged for every input, the reliance on term-ordering is removed.

## Behavior / compatibility

- No client-visible change: a tx with no explicit TTL (the common SDK/wallet case, `ttl = 0` → `max_ttl`) still gets the configured `tx_ttl` horizon; a tx with its own TTL can shorten its stay but never extend it — same as before.
- Fully self-contained: the changed `{push, ...}` gen_server message and the changed-arity internal helpers have no callers outside `aec_tx_pool`. No wire/DB/serialization change.

## Tests

New `aec_tx_pool_tests` coverage for the TTL combination on both the push path and the fork-replay / persisted-mempool-restore paths, deliberately run at a non-zero GC height so the two `min/2` operands don't commute (which would otherwise hide a swap of the configured TTL and the tx's own TTL).