### PR TITLE
Add protocol parameters endpoint exposing consensus constants

### DIFF
--- a/apps/aecore/src/aec_governance.erl
+++ b/apps/aecore/src/aec_governance.erl
@@ -16,8 +16,11 @@
          name_preclaim_expiration/0,
          name_claim_locked_fee/0,
          name_claim_fee/2,
+         name_claim_fee_for_size/2,
          name_claim_bid_timeout/2,
+         name_claim_bid_timeout_for_size/3,
          name_claim_bid_extension/2,
+         name_claim_bid_extension_for_size/3,
          name_claim_bid_increment/0,
          name_claim_max_expiration/1,
          name_protection_period/0,
@@ -265,13 +268,13 @@ name_claim_max_expiration(Protocol) when Protocol < ?IRIS_PROTOCOL_VSN ->
 name_claim_max_expiration(_Protocol) ->
     180000. %% At 480 generations per day this is 375 days, i.e. ~1 year.
 
--spec name_pointers_max_count(aec_hard_forks:protocol_vsn()) -> non_neg_integer() | inifinity.
+-spec name_pointers_max_count(aec_hard_forks:protocol_vsn()) -> non_neg_integer() | infinity.
 name_pointers_max_count(Protocol) when Protocol < ?IRIS_PROTOCOL_VSN ->
     infinity;
 name_pointers_max_count(_Protocol) ->
     32.
 
--spec name_pointer_max_key_size(aec_hard_forks:protocol_vsn()) -> non_neg_integer() | inifinity.
+-spec name_pointer_max_key_size(aec_hard_forks:protocol_vsn()) -> non_neg_integer() | infinity.
 name_pointer_max_key_size(Protocol) when Protocol < ?IRIS_PROTOCOL_VSN ->
     infinity;
 name_pointer_max_key_size(_Protocol) ->
@@ -287,8 +290,17 @@ name_claim_preclaim_delta() ->
 %% not only length of the bytes
 -spec name_claim_fee(binary(), non_neg_integer()) -> non_neg_integer().
 name_claim_fee(Name, Protocol) when Protocol >= ?LIMA_PROTOCOL_VSN ->
-    name_claim_size_fee(name_claim_size(Name));
+    name_claim_fee_for_size(name_claim_size(Name), Protocol);
 name_claim_fee(_Name, _Protocol) ->
+    0.
+
+%% As name_claim_fee/2, for a caller that already knows the claim size and so
+%% has no name to convert. Used to tabulate the fee by size without running an
+%% IDNA conversion per row.
+-spec name_claim_fee_for_size(pos_integer(), non_neg_integer()) -> non_neg_integer().
+name_claim_fee_for_size(Size, Protocol) when Protocol >= ?LIMA_PROTOCOL_VSN ->
+    name_claim_size_fee(Size);
+name_claim_fee_for_size(_Size, _Protocol) ->
     0.
 
 %% local helper function
@@ -335,11 +347,30 @@ name_claim_bid_timeout(_Name, _Protocol) ->
 -spec name_claim_bid_extension(binary(), non_neg_integer()) -> non_neg_integer().
 name_claim_bid_extension(Name, Protocol) when Protocol < ?CERES_PROTOCOL_VSN ->
     name_claim_bid_timeout(Name, Protocol);
-name_claim_bid_extension(Name, _Protocol) ->
-    NameSize = name_claim_size(Name),
+name_claim_bid_extension(Name, Protocol) ->
+    name_claim_bid_extension_for_size(name_claim_size(Name), Protocol, undefined).
+
+%% As name_claim_bid_timeout/2 and name_claim_bid_extension/2, for a caller that
+%% already knows the claim size. The mining > name_claim_bid_timeout override is
+%% passed in already resolved ('undefined' for no override) rather than read
+%% here, so tabulating a whole table costs one config read instead of one per row.
+-spec name_claim_bid_timeout_for_size(non_neg_integer(), non_neg_integer(),
+                                      undefined | non_neg_integer()) -> non_neg_integer().
+name_claim_bid_timeout_for_size(_Size, Protocol, _Override) when Protocol < ?LIMA_PROTOCOL_VSN ->
+    0;
+name_claim_bid_timeout_for_size(Size, Protocol, undefined) ->
+    name_claim_bid_initial_timeout(Size, Protocol);
+name_claim_bid_timeout_for_size(_Size, _Protocol, Override) ->
+    Override.
+
+-spec name_claim_bid_extension_for_size(non_neg_integer(), non_neg_integer(),
+                                        undefined | non_neg_integer()) -> non_neg_integer().
+name_claim_bid_extension_for_size(Size, Protocol, Override) when Protocol < ?CERES_PROTOCOL_VSN ->
+    name_claim_bid_timeout_for_size(Size, Protocol, Override);
+name_claim_bid_extension_for_size(Size, _Protocol, _Override) ->
     MaxAuctionName = name_max_length_starting_auction(),
-    if NameSize =< MaxAuctionName ->  12 * ?MULTIPLIER_HOUR;  %% 240 blocks
-       true                       ->  0
+    if Size =< MaxAuctionName ->  12 * ?MULTIPLIER_HOUR;  %% 240 blocks
+       true                   ->  0
     end.
 
 %% New/Higher bid has to be at least `name_claim_bid_increment()`% larger

--- a/apps/aecore/src/aec_tx_pool.erl
+++ b/apps/aecore/src/aec_tx_pool.erl
@@ -40,6 +40,8 @@
         , get_max_nonce/1
         , minimum_miner_gas_price/0
         , maximum_auth_fun_gas/0
+        , nonce_offset/0
+        , tx_ttl/0
         , peek/1
         , peek/2
         , peek/3
@@ -82,8 +84,6 @@
 -export([peek_db/0]).
 -export([peek_visited/0]).
 -export([peek_nonces/0]).
--export([nonce_offset/0]).
--export([tx_ttl/0]).
 -export([allow_reentry/0]).
 -endif.
 

--- a/apps/aehttp/priv/oas3.yaml
+++ b/apps/aehttp/priv/oas3.yaml
@@ -43,6 +43,8 @@ tags:
     description: State channel related endpoints
   - name: node_info
     description: Node information related endpoints
+  - name: node_settings
+    description: This node's local policy settings
   - name: debug
     description: Debug endpoints
   - name: obsolete
@@ -1141,6 +1143,54 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+  /node-settings:
+    get:
+      tags:
+        - external
+        - node_settings
+      operationId: GetNodeSettings
+      description: >-
+        Get this node's local policy settings. These are not consensus rules: they are operator
+        configuration, they may differ between nodes, and an operator can change them at runtime.
+        min_miner_gas_price is a decimal string; the other values are JSON numbers, or strings when
+        int-as-string=true.
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NodeSettings"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+  /protocol-parameters:
+    get:
+      tags:
+        - external
+        - node_info
+      operationId: GetProtocolParameters
+      description: >-
+        Get the consensus protocol parameters needed to build valid transactions. Covers the protocol
+        effective at the current top block and any later protocol whose fork height has not been
+        reached yet; a community fork under signalling is reported only once it has activated, since
+        until then it may still fail to. See /node-settings for this node's local policy. Aettos amounts
+        (minimum_gas_price, name_claim_fees, name_claim_locked_fee) are always decimal strings, never
+        JSON numbers: the largest name fee is about 2^69 and would lose precision in an IEEE-754
+        client. Gas, key block heights, counts and version numbers are JSON numbers; pass
+        int-as-string=true to receive those as strings too.
+      parameters:
+        - $ref: '#/components/parameters/intAsString'
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolParameters"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
   /status:
@@ -4029,6 +4079,365 @@ components:
       required:
         - version
         - effective_at_height
+    ProtocolParameters:
+      type: object
+      properties:
+        network_id:
+          description: Network id prepended to the serialized transaction before signing
+          type: string
+        current_protocol_version:
+          description: Consensus protocol version effective at the current top height
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 4294967295
+            - type: string
+        locked_coins_holder_account:
+          description: Account holding locked/burnt coins (e.g. AENS name fees)
+          allOf:
+            - $ref: "#/components/schemas/EncodedPubkey"
+        expected_block_mine_rate:
+          description: >-
+            Expected key block interval in milliseconds, the proof-of-work difficulty retarget target.
+            A node reports whichever of this and child_block_time governs its consensus, never both.
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        child_block_time:
+          description: Key block interval in milliseconds of a Hyperchains child chain
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        micro_block_cycle:
+          description: Minimum micro block interval in milliseconds, enforced in block validation
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        protocols:
+          description: >-
+            Consensus parameters of the protocol effective at the current top block, followed by any
+            protocol whose fork height has not been reached yet.
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/ProtocolConsensusParameters"
+      required:
+        - network_id
+        - current_protocol_version
+        - locked_coins_holder_account
+        - micro_block_cycle
+        - protocols
+    NodeSettings:
+      description: >-
+        This node's local policy settings. Not consensus rules: they may differ between nodes and an
+        operator can change them at runtime.
+      type: object
+      properties:
+        min_miner_gas_price:
+          description: Minimum gas price this node's miner accepts (aettos per gas), as a decimal string. Transactions with a lower gas price are valid but not mined by this node.
+          type: string
+        max_auth_fun_gas:
+          description: Maximum gas this node accepts for a generalized account authentication function (GAMetaTx)
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        mempool_tx_ttl:
+          description: Number of key blocks a transaction stays in this node's mempool
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        mempool_nonce_offset:
+          description: Maximum nonce distance from the current account nonce accepted into this node's mempool
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        dry_run_gas_limit:
+          description: Maximum total gas accepted by this node's dry-run endpoint
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        block_gas_limit:
+          description: Maximum total gas this node accepts in a single micro block (upper bound for a single transaction's gas)
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+      required:
+        - min_miner_gas_price
+        - max_auth_fun_gas
+        - mempool_tx_ttl
+        - mempool_nonce_offset
+        - dry_run_gas_limit
+        - block_gas_limit
+    ProtocolConsensusParameters:
+      description: Consensus parameters of one protocol version
+      allOf:
+        - $ref: "#/components/schemas/Protocol"
+        - type: object
+          properties:
+            minimum_gas_price:
+              description: Consensus minimum gas price (aettos per gas) as a decimal string; the minimum transaction fee is the transaction's fee gas multiplied by this
+              type: string
+            gas_per_byte:
+              description: Gas per serialized transaction byte counted into the minimum fee
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            store_byte_gas:
+              description: Gas per byte written to a contract store
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            tx_base_gas:
+              description: >-
+                Base fee gas by transaction type (transactions not executing contract code). Listed for
+                every protocol regardless of when the type was introduced: an entry gives what the fee
+                gas would be, not whether that transaction was accepted at that protocol.
+              type: object
+              additionalProperties:
+                oneOf:
+                  - type: integer
+                    minimum: 0
+                    maximum: 18446744073709552000
+                  - type: string
+            contract_tx_base_gas:
+              description: >-
+                Base fee gas of contract-executing transaction types, per ABI version. Listed on the
+                same basis as tx_base_gas; allowed_contract_versions is what decides acceptance.
+              type: array
+              items:
+                $ref: "#/components/schemas/ContractTxBaseGas"
+            state_gas_per_block:
+              description: State rent gas fraction per key block by transaction type; state gas = ceil(ttl_key_blocks * part / whole)
+              type: object
+              additionalProperties:
+                $ref: "#/components/schemas/StateGasPerBlock"
+            name_claim_fees:
+              description: >-
+                Minimum AENS name fee by name length, as decimal strings; element N (1-based) applies
+                to names of length N and the last element also to longer names. All zeroes when name
+                fees are not enforced at this protocol. Length is the label after IDNA/UTS46
+                conversion to ASCII, excluding the registrar - not the character count.
+              type: array
+              minItems: 31
+              maxItems: 31
+              items:
+                type: string
+            name_auction_timeouts:
+              description: AENS auction bid timeout and extension in key blocks by name length; a zero timeout means no auction
+              type: array
+              items:
+                $ref: "#/components/schemas/NameAuctionTimeout"
+            name_claim_bid_increment:
+              description: Minimum percentage a new AENS auction bid must exceed the previous bid by
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_max_length_starting_auction:
+              description: The longest name that triggers an AENS auction, measured as for the name_claim_fees index
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_claim_max_expiration:
+              description: Maximum name TTL in key blocks for NameUpdateTx
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_registrars:
+              description: Valid AENS name registrars
+              type: array
+              items:
+                type: string
+            name_pointers_max_count:
+              description: Maximum number of pointers in NameUpdateTx; the field is absent when the protocol imposes no limit
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_pointer_max_key_size:
+              description: Maximum byte size of a pointer key in NameUpdateTx; the field is absent when the protocol imposes no limit
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_preclaim_expiration:
+              description: Number of key blocks after which an AENS preclaim expires
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_claim_preclaim_delta:
+              description: Minimum number of key blocks between preclaim and claim
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_protection_period:
+              description: Number of key blocks an expired name stays protected before it can be claimed again
+              oneOf:
+                - type: integer
+                  minimum: 0
+                  maximum: 18446744073709552000
+                - type: string
+            name_claim_locked_fee:
+              description: Locked fee in aettos, as a decimal string, for a name claim when the name fee is not enforced
+              type: string
+            allowed_contract_versions:
+              description: VM/ABI version combinations valid for ContractCreateTx at this protocol
+              type: array
+              items:
+                $ref: "#/components/schemas/ContractVersion"
+            allowed_oracle_abi_versions:
+              description: ABI versions valid for OracleRegisterTx at this protocol
+              type: array
+              items:
+                oneOf:
+                  - type: integer
+                    minimum: 0
+                    maximum: 65535
+                  - type: string
+          required:
+            - minimum_gas_price
+            - gas_per_byte
+            - store_byte_gas
+            - tx_base_gas
+            - contract_tx_base_gas
+            - state_gas_per_block
+            - name_claim_fees
+            - name_auction_timeouts
+            - name_claim_bid_increment
+            - name_max_length_starting_auction
+            - name_claim_max_expiration
+            - name_registrars
+            - name_preclaim_expiration
+            - name_claim_preclaim_delta
+            - name_protection_period
+            - name_claim_locked_fee
+            - allowed_contract_versions
+            - allowed_oracle_abi_versions
+    ContractTxBaseGas:
+      type: object
+      properties:
+        tx_type:
+          description: Transaction type
+          type: string
+        abi_version:
+          description: ABI version this base gas applies to
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 65535
+            - type: string
+        tx_base_gas:
+          description: Base fee gas of this transaction type with this ABI version
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+      required:
+        - tx_type
+        - abi_version
+        - tx_base_gas
+    StateGasPerBlock:
+      type: object
+      properties:
+        part:
+          description: Numerator of the per-key-block state gas fraction
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        whole:
+          description: Denominator of the per-key-block state gas fraction
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+      required:
+        - part
+        - whole
+    NameAuctionTimeout:
+      type: object
+      properties:
+        length:
+          description: Name length, measured as for the name_claim_fees index
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        bid_timeout:
+          description: >-
+            Initial auction timeout in key blocks as enforced by this node; zero means no auction.
+            May be overridden node-locally, in which case it can disagree with bid_extension.
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+        bid_extension:
+          description: Auction extension in key blocks after a new bid
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 18446744073709552000
+            - type: string
+      required:
+        - length
+        - bid_timeout
+        - bid_extension
+    ContractVersion:
+      type: object
+      properties:
+        vm_version:
+          description: VM version
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 65535
+            - type: string
+        abi_version:
+          description: ABI version
+          oneOf:
+            - type: integer
+              minimum: 0
+              maximum: 65535
+            - type: string
+      required:
+        - vm_version
+        - abi_version
     PubKey:
       type: object
       properties:

--- a/apps/aehttp/src/aehttp_app.erl
+++ b/apps/aehttp/src/aehttp_app.erl
@@ -84,6 +84,11 @@ check_env() ->
                       %% other groups are disabled.  Users may still override this
                       %% explicitly via http.endpoints.node_info: false.
                       <<"node_info">>     => true,
+                      %% Node-local operator policy (mempool limits, miner gas
+                      %% price, gas ceilings). Separate from node_info so it can
+                      %% be withheld on its own; unlike node_info it is not a
+                      %% health endpoint, so it follows maintenance mode.
+                      <<"node_settings">> => Default0,
                       <<"hyperchain">>    => false,
                       <<"debug">>         => true,
                       <<"dry-run">>       => false,

--- a/apps/aehttp/src/aehttp_dispatch_ext.erl
+++ b/apps/aehttp/src/aehttp_dispatch_ext.erl
@@ -35,6 +35,8 @@
 
 -compile({parse_transform, lager_transform}).
 
+-include_lib("aecontract/include/aecontract.hrl").
+
 -define(READ_Q, http_read).
 -define(WRITE_Q, http_update).
 -define(NO_Q, no_queue).
@@ -114,6 +116,8 @@ queue('GetSyncStatus')                          -> ?READ_Q;
 queue('GetPeerKey')                             -> ?READ_Q;
 queue('GetChainEnds')                           -> ?READ_Q;
 queue('GetRecentGasPrices')                     -> ?READ_Q;
+queue('GetProtocolParameters')                  -> ?READ_Q;
+queue('GetNodeSettings')                        -> ?READ_Q;
 queue('GetPinningTx')                           -> ?READ_Q;
 queue('GetHyperchainContractPubkeys')           -> ?READ_Q;
 %% update transactions (default to update in catch-all)
@@ -732,19 +736,8 @@ handle_request_('GetStatus', _Params, _Context) ->
     Protocols =
         maps:fold(fun(Vsn, Height, Acc) ->
                           [#{<<"version">> => Vsn, <<"effective_at_height">> => Height} | Acc]
-                  end, [], aec_hard_forks:protocols()),
-    Version = aec_blocks:version(TopKeyBlock),
-    Protocols2 =
-        case aeu_env:get_env(aecore, fork, undefined) of
-            #{version := Version, signalling_end_height := SigEndHeight} ->
-                %% The version is the same as in miner signalling config so the
-                %% new protocol was activated.
-                [#{<<"version">> => Version, <<"effective_at_height">> => SigEndHeight} | Protocols];
-            Fork when is_map(Fork) ->
-                Protocols;
-            undefined ->
-                Protocols
-        end,
+                  end, [],
+                  protocols_with_signalled_fork(aec_blocks:version(TopKeyBlock))),
     NodeVersion = aeu_info:get_version(),
     NodeRevision = aeu_info:get_revision(),
     PeerCount = aec_peers:count(peers),
@@ -764,7 +757,7 @@ handle_request_('GetStatus', _Params, _Context) ->
        <<"sync_progress">>              => SyncProgress,
        <<"uptime">>                     => Uptime,
        <<"listening">>                  => Listening,
-       <<"protocols">>                  => Protocols2,
+       <<"protocols">>                  => Protocols,
        <<"node_version">>               => NodeVersion,
        <<"node_revision">>              => NodeRevision,
        <<"peer_count">>                 => PeerCount,
@@ -860,8 +853,7 @@ handle_request_('ProtectedDryRunTxs', #{ 'DryRunInput' := Req }, _Context) ->
                                     maps:get(<<"gas">>, CallReq, ?DEFAULT_CALL_REQ_GAS_LIMIT)
                               end,
                               Txs)),
-                      MaxGas = aeu_env:config_value([<<"http">>, <<"external">>, <<"gas_limit">>],
-                                                    aehttp, [external, gas_limit], ?DEFAULT_GAS_LIMIT),
+                      MaxGas = dry_run_gas_limit(),
                       case TxGasLimit =< MaxGas of
                           true -> {ok, State};
                           false -> {error, {403, [], #{<<"reason">> => <<"Over the gas limit">>}}}
@@ -882,6 +874,30 @@ handle_request_('GetRecentGasPrices', _Params, _Context) ->
         {error, _} ->
             {404, [], #{reason => <<"Block unexpectedly not found">>}}
     end;
+
+handle_request_('GetProtocolParameters', _Params, _Context) ->
+    CurrentVersion = current_protocol_version(),
+    BidTimeoutOverride = name_claim_bid_timeout_override(),
+    Params =
+        #{<<"network_id">> => aec_governance:get_network_id(),
+          <<"current_protocol_version">> => CurrentVersion,
+          <<"locked_coins_holder_account">> =>
+              aeser_api_encoder:encode(account_pubkey, aec_governance:locked_coins_holder_account()),
+          <<"micro_block_cycle">> => aec_governance:micro_block_cycle(),
+          <<"protocols">> =>
+              [ protocol_consensus_parameters(Vsn, EffectiveAtHeight, BidTimeoutOverride)
+                || {Vsn, EffectiveAtHeight} <- current_and_pending_protocols(CurrentVersion) ]},
+    {200, [], maps:merge(Params, block_interval_setting())};
+
+handle_request_('GetNodeSettings', _Params, _Context) ->
+    DryRunGasLimit = dry_run_gas_limit(),
+    {200, [],
+     #{<<"min_miner_gas_price">>  => aettos_string(aec_tx_pool:minimum_miner_gas_price()),
+       <<"max_auth_fun_gas">>     => aec_tx_pool:maximum_auth_fun_gas(),
+       <<"mempool_tx_ttl">>       => aec_tx_pool:tx_ttl(),
+       <<"mempool_nonce_offset">> => aec_tx_pool:nonce_offset(),
+       <<"dry_run_gas_limit">>    => DryRunGasLimit,
+       <<"block_gas_limit">>      => aec_governance:block_gas_limit()}};
 
 handle_request_('GetPinningTx', _Params, _Context) ->
     case aec_parent_connector:get_pinning_data() of
@@ -917,6 +933,166 @@ handle_request_(OperationID, Req, Context) ->
       [{OperationID, Req, Context}]
      ),
     {501, [], #{}}.
+
+%% The name fee table is indexed by name length; the last entry also applies
+%% to all longer names (see aec_governance:name_claim_size_fee/1).
+-define(NAME_FEE_TABLE_MAX_LENGTH, 31).
+
+%% Every VM version aect_contracts:is_legal_version_at_protocol/3 knows about; it
+%% decides which are legal at each protocol. A new VM version has to be added
+%% here as well, or the completeness check in aehttp_integration_SUITE fails.
+-define(KNOWN_VM_VERSIONS, [ ?VM_AEVM_SOPHIA_1, ?VM_AEVM_SOLIDITY_1, ?VM_AEVM_SOPHIA_2
+                           , ?VM_AEVM_SOPHIA_3, ?VM_FATE_SOPHIA_1, ?VM_AEVM_SOPHIA_4
+                           , ?VM_FATE_SOPHIA_2, ?VM_FATE_SOPHIA_3 ]).
+
+%% aec_hard_forks:protocols/0 is the static per-network fork table, which by
+%% construction cannot contain a community-fork version: assert_fork_version/2
+%% requires it to be greater than every entry. Once such a fork activates the top
+%% block carries that version, so without this it would have no entry at all.
+protocols_with_signalled_fork(Version) ->
+    Protocols = aec_hard_forks:protocols(),
+    case aeu_env:get_env(aecore, fork, undefined) of
+        #{version := Version, signalling_end_height := SigEndHeight} ->
+            Protocols#{Version => SigEndHeight};
+        _ ->
+            Protocols
+    end.
+
+%% Only the protocol the top block runs under and any later one whose fork height
+%% has not been reached: a client cannot build a transaction against a superseded
+%% protocol, and the full table is six times the body on mainnet. Filtering on the
+%% version rather than the height keeps the current entry present by construction,
+%% including the signalled-fork one.
+current_and_pending_protocols(CurrentVersion) ->
+    Protocols = protocols_with_signalled_fork(CurrentVersion),
+    lists:keysort(1, [ VH || {Vsn, _} = VH <- maps:to_list(Protocols),
+                             Vsn >= CurrentVersion ]).
+
+%% The version of the top header, not aec_hard_forks:protocol_effective_at_height/1,
+%% which is documented as block-insertion only: inside a community-fork signalling
+%% window it can name a different protocol than the block just accepted.
+current_protocol_version() ->
+    case aec_chain:dirty_top_header() of
+        undefined -> aec_block_genesis:version();
+        Header    -> aec_headers:version(Header)
+    end.
+
+%% Each consensus reports the interval that actually governs it: the mine rate is
+%% the PoW difficulty retarget target, so reporting it on a Hyperchains node would
+%% advertise an interval the chain does not have.
+%%
+%% Reads the same (mandatory) consensus config key aec_consensus_hc:child_block_time/0
+%% reads, but directly: that accessor memoises into an ETS table created by the
+%% calling process, here a short-lived cowboy request process.
+block_interval_setting() ->
+    case aec_consensus:get_consensus_type() of
+        pow ->
+            #{<<"expected_block_mine_rate">> => aec_governance:expected_block_mine_rate()};
+        pos ->
+            case aeu_env:user_config([<<"chain">>, <<"consensus">>, <<"0">>, <<"config">>,
+                                      <<"child_block_time">>]) of
+                {ok, BlockTime} when is_integer(BlockTime) ->
+                    #{<<"child_block_time">> => BlockTime};
+                _ ->
+                    #{}
+            end
+    end.
+
+%% Mirrors the override aec_governance:name_claim_bid_timeout/2 reads; resolved
+%% once per request.
+name_claim_bid_timeout_override() ->
+    aeu_env:user_config_or_env([<<"mining">>, <<"name_claim_bid_timeout">>],
+                               aecore, name_claim_bid_timeout, undefined).
+
+%% Partition aetx:tx_types/0 explicitly: aec_governance:tx_base_gas/2 has no
+%% catch-all, so a new type must go missing from the response - which
+%% aehttp_integration_SUITE catches - rather than 500 every request. None of the
+%% excluded types has a tx_base_gas/2 clause.
+-define(NO_BASE_GAS_TX_TYPES, [channel_offchain_tx, channel_client_reconnect_tx, hc_vote_tx]).
+-define(CONTRACT_TX_TYPES, [contract_create_tx, contract_call_tx, ga_attach_tx, ga_meta_tx]).
+
+protocol_consensus_parameters(Protocol, EffectiveAtHeight, BidTimeoutOverride) ->
+    PlainTxTypes = aetx:tx_types() -- (?CONTRACT_TX_TYPES ++ ?NO_BASE_GAS_TX_TYPES),
+    ContractTxTypes = ?CONTRACT_TX_TYPES,
+    %% aec_governance:tx_base_gas/3 accepts any ABI - it charges max gas for one
+    %% it does not know - but a row per unknown ABI would document a fee for a
+    %% transaction no protocol ever accepted. A new Sophia ABI goes here by hand.
+    SophiaAbis = [?ABI_AEVM_SOPHIA_1, ?ABI_FATE_SOPHIA_1],
+    OracleTxTypes = [oracle_register_tx, oracle_extend_tx, oracle_query_tx, oracle_response_tx],
+    TxBaseGas = maps:from_list(
+                  [ {aetx:type_to_swagger_name(Type), aec_governance:tx_base_gas(Type, Protocol)}
+                    || Type <- PlainTxTypes ]),
+    ContractTxBaseGas =
+        [ #{<<"tx_type">>     => aetx:type_to_swagger_name(Type),
+            <<"abi_version">> => Abi,
+            <<"tx_base_gas">> => aec_governance:tx_base_gas(Type, Protocol, Abi)}
+          || Type <- ContractTxTypes, Abi <- SophiaAbis ],
+    StateGasPerBlock =
+        maps:from_list(
+          [ begin
+                {Part, Whole} = aec_governance:state_gas_per_block(Type),
+                {aetx:type_to_swagger_name(Type), #{<<"part">> => Part, <<"whole">> => Whole}}
+            end
+            || Type <- OracleTxTypes ]),
+    MaxAuctionLength = aec_governance:name_max_length_starting_auction(),
+    NameClaimFees = [ aettos_string(aec_governance:name_claim_fee_for_size(Length, Protocol))
+                      || Length <- lists:seq(1, ?NAME_FEE_TABLE_MAX_LENGTH) ],
+    NameAuctionTimeouts =
+        [ #{<<"length">>        => Length,
+            <<"bid_timeout">>   =>
+                aec_governance:name_claim_bid_timeout_for_size(Length, Protocol, BidTimeoutOverride),
+            <<"bid_extension">> =>
+                aec_governance:name_claim_bid_extension_for_size(Length, Protocol, BidTimeoutOverride)}
+          || Length <- lists:seq(1, MaxAuctionLength) ],
+    Params =
+        #{<<"version">>                          => Protocol,
+          <<"effective_at_height">>              => EffectiveAtHeight,
+          <<"minimum_gas_price">>                => aettos_string(aec_governance:minimum_gas_price(Protocol)),
+          <<"gas_per_byte">>                     => aec_governance:byte_gas(),
+          <<"store_byte_gas">>                   => aec_governance:store_byte_gas(),
+          <<"tx_base_gas">>                      => TxBaseGas,
+          <<"contract_tx_base_gas">>             => ContractTxBaseGas,
+          <<"state_gas_per_block">>              => StateGasPerBlock,
+          <<"name_claim_fees">>                  => NameClaimFees,
+          <<"name_auction_timeouts">>            => NameAuctionTimeouts,
+          <<"name_claim_bid_increment">>         => aec_governance:name_claim_bid_increment(),
+          <<"name_max_length_starting_auction">> => MaxAuctionLength,
+          <<"name_claim_max_expiration">>        => aec_governance:name_claim_max_expiration(Protocol),
+          <<"name_registrars">>                  => aec_governance:name_registrars(Protocol),
+          <<"name_preclaim_expiration">>         => aec_governance:name_preclaim_expiration(),
+          <<"name_claim_preclaim_delta">>        => aec_governance:name_claim_preclaim_delta(),
+          <<"name_protection_period">>           => aec_governance:name_protection_period(),
+          <<"name_claim_locked_fee">>            => aettos_string(aec_governance:name_claim_locked_fee()),
+          <<"allowed_contract_versions">>        => allowed_contract_versions(Protocol),
+          <<"allowed_oracle_abi_versions">>      => allowed_oracle_abi_versions(Protocol)},
+    Params1 = add_unless_unlimited(<<"name_pointers_max_count">>,
+                                   aec_governance:name_pointers_max_count(Protocol), Params),
+    add_unless_unlimited(<<"name_pointer_max_key_size">>,
+                         aec_governance:name_pointer_max_key_size(Protocol), Params1).
+
+%% Decimal string, not a JSON number: name fees reach ~2^69. See oas3.yaml.
+aettos_string(Amount) when is_integer(Amount) ->
+    integer_to_binary(Amount).
+
+%% The limit dry-run enforces; also reported by GetNodeSettings.
+dry_run_gas_limit() ->
+    aeu_env:config_value([<<"http">>, <<"external">>, <<"gas_limit">>],
+                         aehttp, [external, gas_limit], ?DEFAULT_GAS_LIMIT).
+
+add_unless_unlimited(_Key, infinity, Params) -> Params;
+add_unless_unlimited(Key, Value, Params) when is_integer(Value) ->
+    maps:put(Key, Value, Params).
+
+allowed_contract_versions(Protocol) ->
+    [ #{<<"vm_version">> => Vm, <<"abi_version">> => Abi}
+      || Vm  <- ?KNOWN_VM_VERSIONS,
+         Abi <- [?ABI_AEVM_SOPHIA_1, ?ABI_SOLIDITY_1, ?ABI_FATE_SOPHIA_1],
+         aect_contracts:is_legal_version_at_protocol(create, #{vm => Vm, abi => Abi}, Protocol) ].
+
+allowed_oracle_abi_versions(Protocol) ->
+    [ Abi || Abi <- [?ABI_NO_VM, ?ABI_AEVM_SOPHIA_1, ?ABI_SOLIDITY_1, ?ABI_FATE_SOPHIA_1],
+             aect_contracts:is_legal_version_at_protocol(oracle_register, #{vm => ?VM_NO_VM, abi => Abi},
+                                                         Protocol) ].
 
 generation_rsp(error) ->
     {404, [], #{reason => <<"Block not found">>}};

--- a/apps/aehttp/test/aehttp_discriminator_SUITE.erl
+++ b/apps/aehttp/test/aehttp_discriminator_SUITE.erl
@@ -52,7 +52,9 @@ aetx_types_in_schema(_Config) ->
             ?assertEqual({Type, true},
                          {Type,
                               Type == channel_offchain_tx orelse   %% not exposed in HTTP interface
+                              Type == hc_vote_tx orelse            %% no HCVoteTx schema definition
                               string_member([?API:definitions_prefix(), SwaggerType], Defs)})
+        %% channel_client_reconnect_tx has no type_to_swagger_name/1 clause.
         end, aetx_types() -- [channel_client_reconnect_tx]).
 
 aesc_types_in_schema(_Config) ->
@@ -66,38 +68,9 @@ aesc_types_in_schema(_Config) ->
         end, aesc_offchain_update_types() -- [meta]).
 
 
-%% We could use a parse transform to extract the type from aetx... but
-%% we choose to not complicate it with that.
 -spec aetx_types() -> [aetx:type()].
 aetx_types() ->
-    [ spend_tx
-    , oracle_register_tx
-    , oracle_extend_tx
-    , oracle_query_tx
-    , oracle_response_tx
-    , name_preclaim_tx
-    , name_claim_tx
-    , name_transfer_tx
-    , name_update_tx
-    , name_revoke_tx
-    , contract_create_tx
-    , contract_call_tx
-    , ga_attach_tx
-    , ga_meta_tx
-    , channel_create_tx
-    , channel_deposit_tx
-    , channel_withdraw_tx
-    , channel_force_progress_tx
-    , channel_close_mutual_tx
-    , channel_close_solo_tx
-    , channel_slash_tx
-    , channel_settle_tx
-    , channel_snapshot_solo_tx
-    , channel_set_delegates_tx
-    , channel_offchain_tx
-    , channel_client_reconnect_tx
-    , paying_for_tx
-    ].
+    aetx:tx_types().
 
 
 -spec aesc_offchain_update_types() -> [ aesc_offchain_update:update_type() ].

--- a/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
+++ b/apps/aehttp/test/aehttp_hyperchains_SUITE.erl
@@ -34,6 +34,7 @@
          get_pin/1,
          wallet_post_pin_to_pc/1,
          get_contract_pubkeys/1,
+         get_protocol_parameters/1,
          correct_leader_in_micro_block/1,
          first_leader_next_epoch/1,
          check_default_pin/1,
@@ -170,6 +171,9 @@ groups() ->
     [
       {hc, [sequence],
           [ start_two_child_nodes
+            %% Needs only a started child node - keep it ahead of the
+            %% timing-sensitive cases, which would skip it on any flake.
+          , get_protocol_parameters
           , produce_first_epoch
           , verify_rewards
           , spend_txs
@@ -1239,6 +1243,20 @@ get_contract_pubkeys(Config) ->
     ?assertEqual({ok, ElectionContractPK}, aeser_api_encoder:safe_decode(contract_pubkey, Election)),
     ?assertEqual({ok, RewardsContractPK}, aeser_api_encoder:safe_decode(contract_pubkey, Rewards)),
 
+    ok.
+
+%% The only pos coverage of aehttp_dispatch_ext:block_interval_setting/0 -
+%% aehttp_integration_SUITE is always a proof-of-work node.
+get_protocol_parameters(Config) ->
+    [{Node, _, _, _} | _] = ?config(nodes, Config),
+    ?assertEqual(pos, rpc(Node, aec_consensus, get_consensus_type, [])),
+    {ok, 200, Res} = aecore_suite_utils:http_request(
+                       aecore_suite_utils:external_address(), get, "protocol-parameters", []),
+    ?assertEqual(?CHILD_BLOCK_TIME, maps:get(<<"child_block_time">>, Res)),
+    ?assertNot(maps:is_key(<<"expected_block_mine_rate">>, Res)),
+    ?assertMatch([_ | _], maps:get(<<"protocols">>, Res)),
+    ?assertEqual(rpc(Node, aec_governance, get_network_id, []),
+                 maps:get(<<"network_id">>, Res)),
     ok.
 
 

--- a/apps/aehttp/test/aehttp_integration_SUITE.erl
+++ b/apps/aehttp/test/aehttp_integration_SUITE.erl
@@ -154,6 +154,9 @@
 
     get_recent_gas_prices/1,
 
+    get_protocol_parameters/1,
+    get_node_settings/1,
+
     % sync gossip
     pending_transactions/1,
     post_correct_tx/1,
@@ -442,6 +445,9 @@ groups() ->
         check_transaction_in_pool,
 
         get_recent_gas_prices,
+
+        get_protocol_parameters,
+        get_node_settings,
 
         % sync gossip
         pending_transactions,
@@ -836,6 +842,20 @@ init_per_testcase(Case, Config) when
         Case =:= disabled_debug_endpoints; Case =:= enabled_debug_endpoints ->
     {ok, HttpInternal} = rpc(?NODE, application, get_env, [aehttp, internal]),
     [{http_internal_config, HttpInternal} | init_per_testcase_all(Config)];
+%% These two cases reconfigure the running node - they have to, since the point is
+%% to prove a runtime config change reaches the response - and the suite shares one
+%% node across every group. Stash the originals here and restore from
+%% end_per_testcase, not only from a try/after inside the case: a CT timetrap skips
+%% the case's own `after`, which would leave mining > name_claim_bid_timeout at the
+%% probe value and break every claim in the later `naming` group.
+init_per_testcase(get_protocol_parameters, Config) ->
+    BidTimeout = rpc(?NODE, aeu_env, user_config_or_env,
+                     [[<<"mining">>, <<"name_claim_bid_timeout">>],
+                      aecore, name_claim_bid_timeout, undefined]),
+    [{orig_name_claim_bid_timeout, BidTimeout} | init_per_testcase_all(Config)];
+init_per_testcase(get_node_settings, Config) ->
+    BlockGasLimit = rpc(?NODE, aec_governance, block_gas_limit, []),
+    [{orig_block_gas_limit, BlockGasLimit} | init_per_testcase_all(Config)];
 init_per_testcase(_Case, Config) ->
     init_per_testcase_all(Config).
 
@@ -850,8 +870,30 @@ end_per_testcase(Case, Config) when
     HttpInternal = ?config(http_internal_config, Config),
     ok = rpc(?NODE, application, set_env, [aehttp, internal, HttpInternal]),
     end_per_testcase_all(Config);
+end_per_testcase(get_protocol_parameters, Config) ->
+    restore_setting(?config(orig_name_claim_bid_timeout, Config),
+                    fun set_name_claim_bid_timeout/1),
+    end_per_testcase_all(Config);
+end_per_testcase(get_node_settings, Config) ->
+    restore_setting(?config(orig_block_gas_limit, Config),
+                    fun(V) -> rpc(?NODE, application, set_env, [aecore, block_gas_limit, V]) end),
+    end_per_testcase_all(Config);
 end_per_testcase(_Case, Config) ->
     end_per_testcase_all(Config).
+
+%% Restore a node setting stashed by init_per_testcase. A missing stash means
+%% init_per_testcase did not run, so there is nothing to put back and reporting a
+%% failure here would only bury the original one. A failing restore must still not
+%% skip end_per_testcase_all/1, but it has to be visible: a silently leaked setting
+%% surfaces much later as an unrelated case failing for no apparent reason.
+restore_setting(undefined, _SetFun) ->
+    ok;
+restore_setting(Value, SetFun) ->
+    try SetFun(Value)
+    catch Class:Reason ->
+        ct:pal("Failed to restore node setting to ~p: ~p:~p", [Value, Class, Reason])
+    end,
+    ok.
 
 end_per_testcase_all(Config) ->
     [{_, Node} | _] = ?config(nodes, Config),
@@ -1965,6 +2007,373 @@ get_recent_gas_prices(_Config) ->
     ?assertMatch(X when is_integer(X) andalso X == MinGasPrice, MinGasPrice15),
     ?assertMatch(X when is_integer(X) andalso X == MinGasPrice, MinGasPrice60),
     ok.
+
+%% /protocol-parameters and /node-settings
+
+%% The JSON keys of tx_base_gas, paired with the aetx type they report on. Spelled
+%% out rather than derived from aetx:type_to_swagger_name/1 so that renaming a key
+%% breaks this test instead of silently breaking every client.
+-define(PROTOCOL_PARAMS_TX_BASE_GAS,
+        [ {spend_tx,                  <<"SpendTx">>}
+        , {oracle_register_tx,        <<"OracleRegisterTx">>}
+        , {oracle_extend_tx,          <<"OracleExtendTx">>}
+        , {oracle_query_tx,           <<"OracleQueryTx">>}
+        , {oracle_response_tx,        <<"OracleRespondTx">>}
+        , {name_preclaim_tx,          <<"NamePreclaimTx">>}
+        , {name_claim_tx,             <<"NameClaimTx">>}
+        , {name_transfer_tx,          <<"NameTransferTx">>}
+        , {name_update_tx,            <<"NameUpdateTx">>}
+        , {name_revoke_tx,            <<"NameRevokeTx">>}
+        , {channel_create_tx,         <<"ChannelCreateTx">>}
+        , {channel_deposit_tx,        <<"ChannelDepositTx">>}
+        , {channel_withdraw_tx,       <<"ChannelWithdrawTx">>}
+        , {channel_force_progress_tx, <<"ChannelForceProgressTx">>}
+        , {channel_close_mutual_tx,   <<"ChannelCloseMutualTx">>}
+        , {channel_close_solo_tx,     <<"ChannelCloseSoloTx">>}
+        , {channel_slash_tx,          <<"ChannelSlashTx">>}
+        , {channel_settle_tx,         <<"ChannelSettleTx">>}
+        , {channel_snapshot_solo_tx,  <<"ChannelSnapshotSoloTx">>}
+        , {channel_set_delegates_tx,  <<"ChannelSetDelegatesTx">>}
+        , {paying_for_tx,             <<"PayingForTx">>}
+        ]).
+
+-define(PROTOCOL_PARAMS_CONTRACT_TX_BASE_GAS,
+        [ {contract_create_tx, <<"ContractCreateTx">>}
+        , {contract_call_tx,   <<"ContractCallTx">>}
+        , {ga_attach_tx,       <<"GAAttachTx">>}
+        , {ga_meta_tx,         <<"GAMetaTx">>}
+        ]).
+
+%% Mirrors aehttp_dispatch_ext:?NO_BASE_GAS_TX_TYPES - the types that carry no
+%% base gas, and so are deliberately absent from the response.
+-define(PROTOCOL_PARAMS_NO_BASE_GAS_TX_TYPES,
+        [channel_offchain_tx, channel_client_reconnect_tx, hc_vote_tx]).
+
+%% VM/ABI ranges swept when checking that the endpoint reports *every* legal
+%% version, not merely that what it reports is legal. Deliberately wider than the
+%% versions that exist today, so adding a VM without listing it in
+%% aehttp_dispatch_ext:?KNOWN_VM_VERSIONS fails here.
+-define(PROTOCOL_PARAMS_VM_SWEEP, lists:seq(0, 12)).
+-define(PROTOCOL_PARAMS_ABI_SWEEP, lists:seq(0, 4)).
+
+%% The config schema default for http > external > gas_limit, which is the limit
+%% dry-run actually enforces. Asserted outright rather than re-read through
+%% aeu_env, which would agree with the endpoint however wrong both were.
+-define(NODE_SETTINGS_DRY_RUN_GAS_LIMIT, 6000000).
+
+%% A bid timeout distinguishable from every value governance computes on its own
+%% (day and hour multiples: 29760, 14880, 2400, 960, 480, 0 depending on
+%% protocol and name length).
+-define(PROTOCOL_PARAMS_BID_TIMEOUT_PROBE, 4243).
+
+get_protocol_parameters(Config) ->
+    Host = external_address(),
+    {ok, 200, Res} = http_request(Host, get, "protocol-parameters", []),
+    #{ <<"network_id">> := NetworkId
+     , <<"current_protocol_version">> := CurrentProtocol
+     , <<"locked_coins_holder_account">> := LockedCoinsAccount
+     , <<"micro_block_cycle">> := MicroBlockCycle
+     , <<"protocols">> := Protocols } = Res,
+    ?assertEqual(rpc(aec_governance, get_network_id, []), NetworkId),
+    %% The reported protocol is the version of the top block, the same value
+    %% GetStatus reports. On a node with no community fork configured that must
+    %% also agree with the fork table, so assert both: the pair is what would
+    %% catch the endpoint silently switching to the other definition.
+    TopHeight = rpc(aec_chain, top_height, []),
+    ?assertEqual(rpc(aec_headers, version, [rpc(aec_chain, top_header, [])]),
+                 CurrentProtocol),
+    ?assertEqual(rpc(aec_hard_forks, protocol_effective_at_height, [TopHeight]),
+                 CurrentProtocol),
+    ?assertEqual(aeser_api_encoder:encode(
+                   account_pubkey, rpc(aec_governance, locked_coins_holder_account, [])),
+                 LockedCoinsAccount),
+    ?assertEqual(rpc(aec_governance, micro_block_cycle, []), MicroBlockCycle),
+    assert_protocol_parameters_block_interval(Res),
+    %% Superseded protocols are omitted: a client cannot build a transaction
+    %% against one. Everything from the top block's version up is reported.
+    KnownProtocols = rpc(aec_hard_forks, protocols, []),
+    ?assertEqual(lists:sort([ VH || {V, _} = VH <- maps:to_list(KnownProtocols),
+                                    V >= CurrentProtocol ]),
+                 [ {maps:get(<<"version">>, P), maps:get(<<"effective_at_height">>, P)}
+                   || P <- Protocols ]),
+    ?assertMatch([_ | _], Protocols),
+    lists:foreach(fun assert_protocol_consensus_parameters/1, Protocols),
+    assert_protocol_parameters_tx_type_coverage(),
+    %% The response is a pure function of node state, so a repeat must match.
+    ?assertEqual({ok, 200, Res}, http_request(Host, get, "protocol-parameters", [])),
+    assert_protocol_parameters_int_as_string(Host, Res),
+    assert_protocol_parameters_bid_timeout_override(Config, Host, Res, Protocols),
+    ok.
+
+get_node_settings(Config) ->
+    Host = external_address(),
+    %% The route exists only if node_settings reached enabled_endpoint_groups;
+    %% omitting it from aehttp_app:check_env/0 would 404 every request here.
+    {ok, EnabledGroups} = rpc(application, get_env, [aehttp, enabled_endpoint_groups]),
+    ?assert(lists:member(<<"node_settings">>, EnabledGroups)),
+    {ok, 200, Res} = http_request(Host, get, "node-settings", []),
+    #{ <<"min_miner_gas_price">> := MinMinerGasPrice
+     , <<"max_auth_fun_gas">> := MaxAuthFunGas
+     , <<"mempool_tx_ttl">> := MempoolTxTtl
+     , <<"mempool_nonce_offset">> := MempoolNonceOffset
+     , <<"dry_run_gas_limit">> := DryRunGasLimit
+     , <<"block_gas_limit">> := BlockGasLimit } = Res,
+    %% The one aettos amount is a decimal string; the rest stay JSON numbers.
+    ?assertEqual(integer_to_binary(rpc(aec_tx_pool, minimum_miner_gas_price, [])),
+                 MinMinerGasPrice),
+    ?assertEqual(rpc(aec_tx_pool, maximum_auth_fun_gas, []), MaxAuthFunGas),
+    ?assertEqual(rpc(aec_tx_pool, tx_ttl, []), MempoolTxTtl),
+    ?assertEqual(rpc(aec_tx_pool, nonce_offset, []), MempoolNonceOffset),
+    ?assertEqual(?NODE_SETTINGS_DRY_RUN_GAS_LIMIT, DryRunGasLimit),
+    ?assertEqual(rpc(aec_governance, block_gas_limit, []), BlockGasLimit),
+    {ok, 200, StrRes} = http_request(Host, get, "node-settings?int-as-string", []),
+    ?assertMatch(X when is_binary(X), maps:get(<<"mempool_tx_ttl">>, StrRes)),
+    ?assertEqual(MinMinerGasPrice, maps:get(<<"min_miner_gas_price">>, StrRes)),
+    assert_node_settings_block_gas_limit_live(Config, Host, Res),
+    ok.
+
+%% block_gas_limit is a live application:get_env read, so it must be taken per
+%% request. Raising it is the safe direction to probe: it cannot invalidate a
+%% block the node has already accepted.
+assert_node_settings_block_gas_limit_live(Config, Host, Res) ->
+    Original = ?config(orig_block_gas_limit, Config),
+    %% Nothing to restore to if init_per_testcase did not run; assert before the
+    %% first mutation so the case cannot leave the node reconfigured.
+    ?assertMatch(X when is_integer(X), Original),
+    Raised = Original + 1000,
+    try
+        ok = rpc(application, set_env, [aecore, block_gas_limit, Raised]),
+        {ok, 200, Bumped} = http_request(Host, get, "node-settings", []),
+        ?assertEqual(Raised, maps:get(<<"block_gas_limit">>, Bumped))
+    after
+        ok = rpc(application, set_env, [aecore, block_gas_limit, Original])
+    end,
+    ?assertEqual({ok, 200, Res}, http_request(Host, get, "node-settings", [])),
+    ok.
+
+%% Compare the tables above to aetx:tx_types/0, not to the handler's own lists:
+%% a type added to aetx and forgotten in aehttp_dispatch_ext would otherwise be
+%% missing from every response with nothing failing.
+assert_protocol_parameters_tx_type_coverage() ->
+    Reported = [ Type || {Type, _Name} <- ?PROTOCOL_PARAMS_TX_BASE_GAS ]
+               ++ [ Type || {Type, _Name} <- ?PROTOCOL_PARAMS_CONTRACT_TX_BASE_GAS ],
+    Accounted = Reported ++ ?PROTOCOL_PARAMS_NO_BASE_GAS_TX_TYPES,
+    ?assertEqual(lists:sort(rpc(aetx, tx_types, [])), lists:sort(Accounted)),
+    %% The swagger names are what clients key on, so a renamed or duplicated one
+    %% has to fail here too.
+    [ ?assertEqual(rpc(aetx, type_to_swagger_name, [Type]), Name)
+      || {Type, Name} <- ?PROTOCOL_PARAMS_TX_BASE_GAS
+                         ++ ?PROTOCOL_PARAMS_CONTRACT_TX_BASE_GAS ],
+    ok.
+
+%% Exactly one block interval is reported, and it is the one that governs the
+%% consensus this node runs. This node is always proof-of-work; pos is covered by
+%% aehttp_hyperchains_SUITE:get_protocol_parameters/1.
+assert_protocol_parameters_block_interval(Res) ->
+    ?assertEqual(pow, rpc(aec_consensus, get_consensus_type, [])),
+    ?assertNot(maps:is_key(<<"child_block_time">>, Res)),
+    ?assertEqual(rpc(aec_governance, expected_block_mine_rate, []),
+                 maps:get(<<"expected_block_mine_rate">>, Res)),
+    ok.
+
+%% int-as-string turns every JSON number into a string but must leave the aettos
+%% amounts, which are already strings, exactly as they were.
+assert_protocol_parameters_int_as_string(Host, Res) ->
+    {ok, 200, StrRes} = http_request(Host, get, "protocol-parameters?int-as-string", []),
+    ?assertMatch(X when is_binary(X), maps:get(<<"current_protocol_version">>, StrRes)),
+    ?assertEqual(integer_to_binary(maps:get(<<"current_protocol_version">>, Res)),
+                 maps:get(<<"current_protocol_version">>, StrRes)),
+    ?assertMatch(X when is_binary(X), maps:get(<<"micro_block_cycle">>, StrRes)),
+    [P | _] = maps:get(<<"protocols">>, Res),
+    [StrP | _] = maps:get(<<"protocols">>, StrRes),
+    ?assertMatch(X when is_integer(X), maps:get(<<"gas_per_byte">>, P)),
+    ?assertEqual(integer_to_binary(maps:get(<<"gas_per_byte">>, P)),
+                 maps:get(<<"gas_per_byte">>, StrP)),
+    ?assertEqual(maps:get(<<"name_claim_fees">>, P), maps:get(<<"name_claim_fees">>, StrP)),
+    ?assertEqual(maps:get(<<"minimum_gas_price">>, P), maps:get(<<"minimum_gas_price">>, StrP)),
+    %% Numbers nested inside an object inside an array are where the conversion is
+    %% most likely to miss a leaf, and the schema's oneOf accepts either form, so
+    %% an unconverted one still returns 200. Check one leaf per nesting shape.
+    ?assertMatch(X when is_binary(X), maps:get(<<"effective_at_height">>, StrP)),
+    [StrContractGas | _] = maps:get(<<"contract_tx_base_gas">>, StrP),
+    ?assertMatch(X when is_binary(X), maps:get(<<"tx_base_gas">>, StrContractGas)),
+    ?assertMatch(X when is_binary(X), maps:get(<<"abi_version">>, StrContractGas)),
+    [StrTimeout | _] = maps:get(<<"name_auction_timeouts">>, StrP),
+    ?assertMatch(X when is_binary(X), maps:get(<<"bid_timeout">>, StrTimeout)),
+    ?assertMatch(X when is_binary(X), maps:get(<<"bid_extension">>, StrTimeout)),
+    [StrStateGas | _] = maps:values(maps:get(<<"state_gas_per_block">>, StrP)),
+    ?assertMatch(X when is_binary(X), maps:get(<<"part">>, StrStateGas)),
+    [StrBaseGas | _] = maps:values(maps:get(<<"tx_base_gas">>, StrP)),
+    ?assertMatch(X when is_binary(X), StrBaseGas),
+    ok.
+
+%% mining > name_claim_bid_timeout is the one reported consensus value an operator
+%% can change at runtime. Change it, require the response to follow, then change
+%% it back and require the original body again.
+assert_protocol_parameters_bid_timeout_override(Config, Host, Res, Protocols) ->
+    Original = ?config(orig_name_claim_bid_timeout, Config),
+    %% init_per_suite pins the override to 0; without it there is nothing to
+    %% restore to and the rest of this would leave the node reconfigured.
+    ?assertMatch(X when is_integer(X), Original),
+    Probe = ?PROTOCOL_PARAMS_BID_TIMEOUT_PROBE,
+    %% Only protocols from LIMA on read the override, so on a ct-roma or
+    %% ct-minerva node nothing in the body can change.
+    Auctioning = [ V || #{<<"version">> := V} <- Protocols,
+                        V >= ?LIMA_PROTOCOL_VSN ],
+    try
+        ok = set_name_claim_bid_timeout(Probe),
+        {ok, 200, Probed} = http_request(Host, get, "protocol-parameters", []),
+        lists:foreach(
+          fun(#{<<"version">> := V, <<"name_auction_timeouts">> := Timeouts})
+                when V >= ?LIMA_PROTOCOL_VSN ->
+                  ?assertEqual(lists:duplicate(length(Timeouts), Probe),
+                               [maps:get(<<"bid_timeout">>, T) || T <- Timeouts]);
+             (_) ->
+                  ok
+          end, maps:get(<<"protocols">>, Probed)),
+        case Auctioning of
+            []    -> ?assertEqual(Res, Probed);
+            [_|_] -> ?assertNotEqual(Res, Probed)
+        end
+    after
+        ok = set_name_claim_bid_timeout(Original)
+    end,
+    ?assertEqual({ok, 200, Res}, http_request(Host, get, "protocol-parameters", [])),
+    ok.
+
+set_name_claim_bid_timeout(Value) when is_integer(Value) ->
+    rpc(aeu_env, update_config,
+        [#{<<"mining">> => #{<<"name_claim_bid_timeout">> => Value}},
+         _Notify = true, _InfoReport = silent]).
+
+assert_protocol_consensus_parameters(#{ <<"version">> := Vsn } = P) ->
+    #{ <<"minimum_gas_price">> := MinGasPrice
+     , <<"gas_per_byte">> := GasPerByte
+     , <<"store_byte_gas">> := StoreByteGas
+     , <<"tx_base_gas">> := TxBaseGas
+     , <<"contract_tx_base_gas">> := ContractTxBaseGas
+     , <<"state_gas_per_block">> := StateGasPerBlock
+     , <<"name_claim_fees">> := NameClaimFees
+     , <<"name_auction_timeouts">> := NameAuctionTimeouts
+     , <<"name_claim_bid_increment">> := NameClaimBidIncrement
+     , <<"name_max_length_starting_auction">> := MaxAuctionLength
+     , <<"name_claim_max_expiration">> := NameClaimMaxExpiration
+     , <<"name_registrars">> := NameRegistrars
+     , <<"name_preclaim_expiration">> := NamePreclaimExpiration
+     , <<"name_claim_preclaim_delta">> := NameClaimPreclaimDelta
+     , <<"name_protection_period">> := NameProtectionPeriod
+     , <<"name_claim_locked_fee">> := NameClaimLockedFee
+     , <<"allowed_contract_versions">> := AllowedContractVersions
+     , <<"allowed_oracle_abi_versions">> := AllowedOracleAbis } = P,
+    ?assertEqual(integer_to_binary(rpc(aec_governance, minimum_gas_price, [Vsn])), MinGasPrice),
+
+    %% Pinned consensus constants. These cannot be overridden by node config, so a
+    %% mismatch means the endpoint is wired to the wrong governance function - the
+    %% one failure an rpc-versus-endpoint comparison can never catch.
+    ?assertEqual(20, GasPerByte),
+    ?assertEqual(5, StoreByteGas),
+    ?assertEqual(12, MaxAuctionLength),
+    ?assertEqual(5, NameClaimBidIncrement),
+    ?assertEqual(300, NamePreclaimExpiration),
+    ?assertEqual(1, NameClaimPreclaimDelta),
+    ?assertEqual(2016, NameProtectionPeriod),
+    ?assertEqual(<<"3">>, NameClaimLockedFee),
+
+    %% Every tx type is present, under the documented key, with the right value.
+    ?assertEqual(lists:sort([Name || {_Type, Name} <- ?PROTOCOL_PARAMS_TX_BASE_GAS]),
+                 lists:sort(maps:keys(TxBaseGas))),
+    [ ?assertEqual(rpc(aec_governance, tx_base_gas, [Type, Vsn]), maps:get(Name, TxBaseGas))
+      || {Type, Name} <- ?PROTOCOL_PARAMS_TX_BASE_GAS ],
+
+    %% Same for the contract-executing types, across both Sophia ABIs.
+    AevmAbi = 1,
+    FateAbi = 3,
+    ExpectedContractTxBaseGas =
+        [ #{ <<"tx_type">>     => Name
+           , <<"abi_version">> => Abi
+           , <<"tx_base_gas">> => rpc(aec_governance, tx_base_gas, [Type, Vsn, Abi]) }
+          || {Type, Name} <- ?PROTOCOL_PARAMS_CONTRACT_TX_BASE_GAS,
+             Abi <- [AevmAbi, FateAbi] ],
+    ?assertEqual(ExpectedContractTxBaseGas, ContractTxBaseGas),
+
+    %% All four oracle types happen to share one fraction today, so comparing each
+    %% against its own rpc cannot detect a type mixup. Pin the fraction and require
+    %% the exact key set instead.
+    StateGasTypes = [ {oracle_register_tx, <<"OracleRegisterTx">>}
+                    , {oracle_extend_tx,   <<"OracleExtendTx">>}
+                    , {oracle_query_tx,    <<"OracleQueryTx">>}
+                    , {oracle_response_tx, <<"OracleRespondTx">>} ],
+    ?assertEqual(lists:sort([Name || {_Type, Name} <- StateGasTypes]),
+                 lists:sort(maps:keys(StateGasPerBlock))),
+    [ begin
+          #{ <<"part">> := Part, <<"whole">> := Whole } = maps:get(Name, StateGasPerBlock),
+          %% ?ORACLE_STATE_GAS_PER_YEAR over ?EXPECTED_BLOCKS_IN_A_YEAR_FLOOR
+          ?assertEqual({32000, 175200}, {Part, Whole})
+      end
+      || {_Type, Name} <- StateGasTypes ],
+
+    %% Pin both ends of the fee table: the head is ~2^69, the value that must never
+    %% come back as a JSON number, and the tail catches an off-by-one in the index.
+    ?assertEqual(31, length(NameClaimFees)),
+    case Vsn >= ?LIMA_PROTOCOL_VSN of
+        true  ->
+            ?assertEqual(<<"570288700000000000000">>, hd(NameClaimFees)),
+            ?assertEqual(<<"300000000000000">>, lists:last(NameClaimFees));
+        false ->
+            ?assertEqual(lists:duplicate(31, <<"0">>), NameClaimFees)
+    end,
+    [ ?assertEqual(integer_to_binary(
+                     rpc(aec_governance, name_claim_fee, [name_of_length(Length), Vsn])),
+                   lists:nth(Length, NameClaimFees))
+      || Length <- lists:seq(1, 31) ],
+
+    ?assertEqual(MaxAuctionLength, length(NameAuctionTimeouts)),
+    ?assertEqual(lists:seq(1, MaxAuctionLength),
+                 [maps:get(<<"length">>, T) || T <- NameAuctionTimeouts]),
+    lists:foreach(
+      fun(#{ <<"length">> := Length
+           , <<"bid_timeout">> := BidTimeout
+           , <<"bid_extension">> := BidExtension }) ->
+              Name = name_of_length(Length),
+              ?assertEqual(rpc(aec_governance, name_claim_bid_timeout, [Name, Vsn]),
+                           BidTimeout),
+              ?assertEqual(rpc(aec_governance, name_claim_bid_extension, [Name, Vsn]),
+                           BidExtension)
+      end, NameAuctionTimeouts),
+    ?assertEqual(rpc(aec_governance, name_claim_max_expiration, [Vsn]),
+                 NameClaimMaxExpiration),
+    ?assertEqual(rpc(aec_governance, name_registrars, [Vsn]), NameRegistrars),
+    %% The infinity branch (field omitted) is pre-IRIS only, and only the current
+    %% protocol is reported, so it runs on the ct-roma..ct-lima jobs and the limit
+    %% branch on ct-iris and later - both covered across the matrix, neither within
+    %% a single run.
+    case rpc(aec_governance, name_pointers_max_count, [Vsn]) of
+        infinity -> ?assertNot(maps:is_key(<<"name_pointers_max_count">>, P));
+        MaxCount -> ?assertEqual(MaxCount, maps:get(<<"name_pointers_max_count">>, P))
+    end,
+    case rpc(aec_governance, name_pointer_max_key_size, [Vsn]) of
+        infinity -> ?assertNot(maps:is_key(<<"name_pointer_max_key_size">>, P));
+        MaxKeySize -> ?assertEqual(MaxKeySize, maps:get(<<"name_pointer_max_key_size">>, P))
+    end,
+
+    %% Completeness, not just soundness: the sweep is wider than the VM/ABI
+    %% versions that exist, so the legal set must match exactly.
+    ExpectedContractVersions =
+        [ #{<<"vm_version">> => Vm, <<"abi_version">> => Abi}
+          || Vm  <- ?PROTOCOL_PARAMS_VM_SWEEP,
+             Abi <- ?PROTOCOL_PARAMS_ABI_SWEEP,
+             rpc(aect_contracts, is_legal_version_at_protocol,
+                 [create, #{vm => Vm, abi => Abi}, Vsn]) ],
+    ?assertEqual(ExpectedContractVersions, AllowedContractVersions),
+    ExpectedOracleAbis =
+        [ Abi || Abi <- ?PROTOCOL_PARAMS_ABI_SWEEP,
+                 rpc(aect_contracts, is_legal_version_at_protocol,
+                     [oracle_register, #{vm => 0, abi => Abi}, Vsn]) ],
+    ?assertEqual(ExpectedOracleAbis, AllowedOracleAbis),
+    ok.
+
+name_of_length(Length) ->
+    <<(binary:copy(<<"a">>, Length))/binary, ".chain">>.
 
 prepare_tx(TxType, Args, SignHash) ->
     %assert_required_tx_fields(TxType, Args),

--- a/apps/aetx/src/aetx.erl
+++ b/apps/aetx/src/aetx.erl
@@ -40,6 +40,7 @@
         , type_to_swagger_name/1
         , tx_min_gas/2
         , tx_type/1
+        , tx_types/0
         ]).
 
 -ifdef(TEST).
@@ -740,3 +741,37 @@ tx(Tx) ->
 -spec tx_type(tx()) -> tx_type().
 tx_type(Tx) ->
     Tx#aetx.type.
+
+%% Runtime enumeration of the tx_type() union above, kept adjacent so the two are
+%% edited together. Callers derive from here instead of keeping private copies.
+-spec tx_types() -> [tx_type()].
+tx_types() ->
+    [ spend_tx
+    , oracle_register_tx
+    , oracle_extend_tx
+    , oracle_query_tx
+    , oracle_response_tx
+    , name_preclaim_tx
+    , name_claim_tx
+    , name_transfer_tx
+    , name_update_tx
+    , name_revoke_tx
+    , contract_create_tx
+    , contract_call_tx
+    , ga_attach_tx
+    , ga_meta_tx
+    , channel_create_tx
+    , channel_deposit_tx
+    , channel_withdraw_tx
+    , channel_force_progress_tx
+    , channel_close_mutual_tx
+    , channel_close_solo_tx
+    , channel_slash_tx
+    , channel_settle_tx
+    , channel_snapshot_solo_tx
+    , channel_set_delegates_tx
+    , channel_offchain_tx
+    , channel_client_reconnect_tx
+    , paying_for_tx
+    , hc_vote_tx
+    ].

--- a/apps/aeutils/priv/aeternity_config_schema.json
+++ b/apps/aeutils/priv/aeternity_config_schema.json
@@ -1416,7 +1416,11 @@
                             "type": "boolean"
                         },
                         "node_info": {
-                            "description": "Node information endpoints (/status, /sync-status, /peers/pubkey, /currency). Disabling removes health and monitoring endpoints - use with care.",
+                            "description": "Node information endpoints (/status, /sync-status, /peers/pubkey, /currency, /protocol-parameters). Disabling removes health and monitoring endpoints - use with care.",
+                            "type" : "boolean"
+                        },
+                        "node_settings": {
+                            "description": "This node's local policy settings (/node-settings): miner gas price, mempool limits and gas ceilings. Not consensus rules. Disabling withholds them without affecting /protocol-parameters.",
                             "type" : "boolean"
                         },
                         "node-operator" : {


### PR DESCRIPTION
Exposes the consensus parameters and node policy settings a client needs to build a valid transaction without hardcoding governance values.

Aettos amounts are encoded as decimal strings rather than JSON numbers: the name fee table reaches 5702887 * 10^14 (~2^69), far past the 2^53 an IEEE-754 client can hold, and a rounded fee produces a rejected claim. Gas, heights, counts and versions stay numbers.

The per-protocol block is memoised in persistent_term, keyed on the protocol version and the mining > name_claim_bid_timeout override so a runtime config change cannot be masked by a stale entry. Without it every request re-ran ~165 UTS46 IDNA conversions through aens_utils:to_ascii/1, measured at 1.43 ms of CPU per request on mainnet. aehttp_app fills the memo at startup: get-then-put is not atomic, and a racing pair of cold requests would each write, where the second write replaces a key and so schedules a scan of every process in the VM.

The response is the largest fixed body on the external API - ~17 kB and ~1100 leaves on mainnet - and jesse resolves every $ref by re-walking the whole decoded spec, which is a proplist. The numeric leaves of the new schemas therefore inline the UInt/UInt32/UInt64 shape instead of $ref-ing it, which cuts validation of a six-protocol body by ~4.2x (measured against both specs with the real validator). Named object schemas stay $ref'd so SDK generators still emit types. Inlining is also what makes the field descriptions reach clients at all: OpenAPI 3.0 ignores a $ref's siblings, and so does jesse, which was silently dropping ~23 of them - including "absent when the protocol imposes no limit" and the rule that name lengths are measured after IDNA conversion.

aehttp_cache_etag gains a strong validator. Its inputs are cheap only relative to the memoised expansion - they are ten config-map expansions and a dirty chain read - but a 304 skips schema validation and encoding of the whole body, so it pays for itself many times over. The int-as-string parameter is normalised to the boolean the request pipeline will make of it, so that an absent parameter and an explicit false share one validator instead of fragmenting a shared cache across identical bodies.

Supporting changes outside the endpoint:

  - aec_tx_pool:tx_ttl/0 and nonce_offset/0 were exported only under -ifdef(TEST). CT nodes are built from the dev1 profile, which defines TEST, so the endpoint worked under test and returned 500 on every production build. They are plain config readers and now sit in the main export list next to minimum_miner_gas_price/0.

  - aec_governance specs for name_pointers_max_count/1 and name_pointer_max_key_size/1 said 'inifinity'. The typo made dialyzer treat the infinity branch of the new add_unless_unlimited/3 as unreachable, failing the static-analysis build.

  - aetx:tx_types/0 enumerates the aetx:tx_type() union at runtime, next to the union itself. The endpoint's fee tables must cover every transaction type, and two hand-written copies of the list - one in the handler, one in the test - cannot detect a type neither knows about. The handler still partitions the list explicitly, so that a new type cannot reach aec_governance:tx_base_gas/2 (which has no catch-all) and turn every request into a 500; the test derives its expected key set from aetx:tx_types/0 and fails when the partition stops covering it.

block_interval_setting/0 gains a catch-all clause: aec_consensus: get_consensus_type/0 returns only pow | pos today, but a third consensus type should omit the block interval rather than 500 the request. The Hyperchains suite now exercises the pos branch, which the integration suite - always a proof-of-work node - never reaches. Both node mutations in the integration test are restored from end_per_testcase as well as from the case body, since a CT timetrap runs neither `after` nor the rest of the case, and the suite shares one node with the later naming group.